### PR TITLE
hide version number

### DIFF
--- a/app/tetwild/EdgeCollapsing.cpp
+++ b/app/tetwild/EdgeCollapsing.cpp
@@ -2,8 +2,8 @@
 // Created by Yixin Hu on 12/7/21.
 //
 
-#include "TetWild.h"
 #include "Logger.hpp"
+#include "TetWild.h"
 
 void tetwild::TetWild::collapse_all_edges()
 {
@@ -30,7 +30,6 @@ void tetwild::TetWild::collapse_all_edges()
         ec_queue.pop();
 
         // check timestamp
-        if (!loc.is_version_number_valid(*this)) continue;
         if (!loc.is_valid(*this)) continue;
         { // check weight
             Tuple& v1 = loc;

--- a/app/tetwild/EdgeCollapsing.cpp
+++ b/app/tetwild/EdgeCollapsing.cpp
@@ -7,7 +7,7 @@
 
 void tetwild::TetWild::collapse_all_edges()
 {
-    reset_timestamp();
+    compact();
 
     std::vector<Tuple> edges = get_edges();
 

--- a/app/tetwild/EdgeSplitting.cpp
+++ b/app/tetwild/EdgeSplitting.cpp
@@ -7,7 +7,7 @@
 
 void tetwild::TetWild::split_all_edges()
 {
-    reset_timestamp();
+    compact();
 
     std::vector<Tuple> edges = get_edges();
 

--- a/app/tetwild/EdgeSplitting.cpp
+++ b/app/tetwild/EdgeSplitting.cpp
@@ -2,8 +2,8 @@
 // Created by Yixin Hu on 12/7/21.
 //
 
-#include "TetWild.h"
 #include "Logger.hpp"
+#include "TetWild.h"
 
 void tetwild::TetWild::split_all_edges()
 {
@@ -31,7 +31,7 @@ void tetwild::TetWild::split_all_edges()
         es_queue.pop();
 
         // check timestamp
-        if (!loc.is_version_number_valid(*this)) continue;
+        if (!loc.is_valid(*this)) continue;
 
         std::vector<Tuple> new_edges;
         if (split_edge(loc, new_edges)) {

--- a/src/EdgeSplittingConn.cpp
+++ b/src/EdgeSplittingConn.cpp
@@ -44,10 +44,13 @@ bool wmtk::TetMesh::split_edge(const Tuple& loc0, std::vector<Tuple>& new_edges)
         int j = m_tet_connectivity[t_id].find(v1_id);
         m_tet_connectivity[new_t_id] = m_tet_connectivity[t_id];
         m_tet_connectivity[new_t_id][j] = v_id;
+        m_tet_connectivity[new_t_id].timestamp = 0;
 
         //
         m_vertex_connectivity[v_id].m_conn_tets.push_back(t_id);
         m_vertex_connectivity[v_id].m_conn_tets.push_back(new_t_id);
+        m_tet_connectivity[t_id].timestamp++; // new timestamp is +1 old one
+
         //
         for (int j = 0; j < 4; j++) {
             if (m_tet_connectivity[t_id][j] != v1_id && m_tet_connectivity[t_id][j] != v2_id)
@@ -59,9 +62,6 @@ bool wmtk::TetMesh::split_edge(const Tuple& loc0, std::vector<Tuple>& new_edges)
         //
         vector_erase(m_vertex_connectivity[v2_id].m_conn_tets, t_id);
         m_vertex_connectivity[v2_id].m_conn_tets.push_back(new_t_id);
-
-        m_tet_connectivity[new_t_id].timestamp++; // new timestamp is +1 old one
-        m_tet_connectivity[t_id].timestamp++; // new timestamp is +1 old one
     }
     // sort m_conn_tets
     vector_sort(m_vertex_connectivity[v_id].m_conn_tets);
@@ -108,7 +108,6 @@ bool wmtk::TetMesh::split_edge(const Tuple& loc0, std::vector<Tuple>& new_edges)
         for (int i = 0; i < old_tets.size(); i++) {
             int t_id = old_tets[i].first;
             m_tet_connectivity[t_id] = old_tets[i].second;
-            m_tet_connectivity[t_id].timestamp--; // Decrease the vnumber, **necessary**
         }
         for (int i = 0; i < old_vertices.size(); i++) {
             int v_id = old_vertices[i].first;

--- a/src/EdgeSplittingConn.cpp
+++ b/src/EdgeSplittingConn.cpp
@@ -137,8 +137,6 @@ bool wmtk::TetMesh::split_edge(const Tuple& loc0, std::vector<Tuple>& new_edges)
     }
 
     // new_edges
-    for (size_t t_id : n12_t_ids) m_tet_connectivity[t_id].set_version_number(m_tet_connectivity[t_id].timestamp + 1);
-    for (size_t t_id : new_t_ids) m_tet_connectivity[t_id].set_version_number(0);
     for (size_t t_id : n12_t_ids) {
         for (int j = 0; j < 6; j++) {
             new_edges.push_back(tuple_from_edge(t_id, j));

--- a/src/EdgeSplittingConn.cpp
+++ b/src/EdgeSplittingConn.cpp
@@ -137,6 +137,8 @@ bool wmtk::TetMesh::split_edge(const Tuple& loc0, std::vector<Tuple>& new_edges)
     }
 
     // new_edges
+    for (size_t t_id : n12_t_ids) m_tet_connectivity[t_id].set_version_number(m_tet_connectivity[t_id].timestamp + 1);
+    for (size_t t_id : new_t_ids) m_tet_connectivity[t_id].set_version_number(0);
     for (size_t t_id : n12_t_ids) {
         for (int j = 0; j < 6; j++) {
             new_edges.push_back(tuple_from_edge(t_id, j));

--- a/src/EdgeSplittingConn.cpp
+++ b/src/EdgeSplittingConn.cpp
@@ -108,6 +108,7 @@ bool wmtk::TetMesh::split_edge(const Tuple& loc0, std::vector<Tuple>& new_edges)
         for (int i = 0; i < old_tets.size(); i++) {
             int t_id = old_tets[i].first;
             m_tet_connectivity[t_id] = old_tets[i].second;
+            m_tet_connectivity[t_id].timestamp--; // Decrease the vnumber, **necessary**
         }
         for (int i = 0; i < old_vertices.size(); i++) {
             int v_id = old_vertices[i].first;

--- a/src/TetMesh.cpp
+++ b/src/TetMesh.cpp
@@ -160,3 +160,10 @@ bool wmtk::TetMesh::smooth_vertex(const Tuple& loc0)
 
     return true;
 }
+
+
+void wmtk::TetMesh::compact()
+{
+    // TODO: implement me
+    for (auto& t : m_tet_connectivity) t.timestamp = 0;
+}

--- a/src/TetMesh.cpp
+++ b/src/TetMesh.cpp
@@ -16,6 +16,7 @@ int wmtk::TetMesh::find_next_empty_slot_t() // todo: always append in the end
         }
     }
     m_tet_connectivity.emplace_back();
+    m_tet_connectivity.back().timestamp = -1;
     return m_tet_connectivity.size() - 1;
 }
 
@@ -66,7 +67,7 @@ bool wmtk::TetMesh::check_mesh_connectivity_validity() const
         for (int j = 0; j < 4; j++) conn_tets[m_tet_connectivity[i][j]].push_back(i);
     }
 
-    //check conn_tets duplication, order, amount ...
+    // check conn_tets duplication, order, amount ...
     for (size_t i = 0; i < m_vertex_connectivity.size(); i++) {
         if (m_vertex_connectivity[i].m_is_removed) continue;
         assert(
@@ -74,18 +75,19 @@ bool wmtk::TetMesh::check_mesh_connectivity_validity() const
             "m_vertex_connectivity[i].m_conn_tets!=conn_tets[i]");
     }
 
-    //check is_removed
+    // check is_removed
     for (size_t i = 0; i < m_tet_connectivity.size(); i++) {
-        for(int j=0;j<4;j++)
-            assert(!m_vertex_connectivity[m_tet_connectivity[i][j]].m_is_removed
-                   &&"m_vertex_connectivity[m_tet_connectivity[i][j]].m_is_removed");
+        for (int j = 0; j < 4; j++)
+            assert(
+                !m_vertex_connectivity[m_tet_connectivity[i][j]].m_is_removed &&
+                "m_vertex_connectivity[m_tet_connectivity[i][j]].m_is_removed");
     }
     for (size_t i = 0; i < m_vertex_connectivity.size(); i++) {
         for (int tid : m_vertex_connectivity[i].m_conn_tets)
             assert(!m_tet_connectivity[tid].m_is_removed && "m_tet_connectivity[tid].m_is_removed");
     }
 
-    //check tuple
+    // check tuple
     for (size_t i = 0; i < m_vertex_connectivity.size(); i++) {
         Tuple loc = tuple_from_vertex(i);
         check_tuple_validity(loc);
@@ -97,7 +99,7 @@ bool wmtk::TetMesh::check_mesh_connectivity_validity() const
         check_tuple_validity(locv);
         check_tuple_validity(loce);
         check_tuple_validity(locf);
-        if(loct.has_value()) {
+        if (loct.has_value()) {
             check_tuple_validity(loct.value());
         }
     }
@@ -112,7 +114,7 @@ bool wmtk::TetMesh::check_mesh_connectivity_validity() const
         check_tuple_validity(locv);
         check_tuple_validity(loce);
         check_tuple_validity(locf);
-        if(loct.has_value()) {
+        if (loct.has_value()) {
             check_tuple_validity(loct.value());
         }
     }
@@ -137,16 +139,16 @@ std::vector<wmtk::TetMesh::Tuple> wmtk::TetMesh::get_vertices() const
         assert(!vc.m_conn_tets.empty());
         auto tid = vc[0];
         auto local_vid = m_tet_connectivity[tid].find(i);
-        
-        // note: the following conversion of local_vid-eid is **heavily** dependent on the specifics of
-        // `m_local_edges`
+
+        // note: the following conversion of local_vid-eid is **heavily** dependent on the specifics
+        // of `m_local_edges`
         auto local_eid = local_vid;
-        if (local_vid >= 2) local_eid = 5; 
+        if (local_vid >= 2) local_eid = 5;
         edges.emplace_back(tuple_from_edge(tid, local_eid));
         if (local_vid == 3) edges.back() = switch_vertex(edges.back());
-        edges.back().update_version_number(*this);
+
         assert(edges.back().vid() == i);
-        assert(edges.back().is_version_number_valid(*this));
+        assert(edges.back().is_valid(*this));
     }
     return edges;
 }

--- a/src/TetMesh.h
+++ b/src/TetMesh.h
@@ -88,14 +88,9 @@ public:
          * Check if the current tuple is already invalid (removed during editing).
          *
          * @param m TetMesh where the tuple belongs.
-         * @return if not removed
+         * @return if not removed and thet connectivity is up to date
          */
         bool is_valid(const TetMesh& m) const;
-
-
-        void update_version_number(const TetMesh& m);
-        int get_version_number();
-        bool is_version_number_valid(const TetMesh& m) const;
 
         void print_info() const;
         void print_info(const TetMesh& m) const;
@@ -284,7 +279,6 @@ public:
 
     void reset_timestamp()
     {
-        m_timestamp = 0;
         for (auto& t : m_tet_connectivity) t.timestamp = 0;
     }
 
@@ -316,8 +310,6 @@ private:
     int find_next_empty_slot_t();
     int find_next_empty_slot_v();
 
-    int m_timestamp = 0;
-
 protected:
     //// Split the edge in the tuple
     // Checks if the split should be performed or not (user controlled)
@@ -332,8 +324,8 @@ protected:
     // If it returns false then the operation is undone (the tuple indexes a vertex and tet that
     // survived)
     virtual bool collapse_after(const std::vector<Tuple>& locs) { return true; }
-    virtual bool smooth_before(const Tuple &t) { return true; } 
-    virtual bool smooth_after(const Tuple &t) { return true; } 
+    virtual bool smooth_before(const Tuple& t) { return true; }
+    virtual bool smooth_after(const Tuple& t) { return true; }
     // todo: quality, inversion, envelope: change v1 pos before this, only need to change partial
     // attributes
 

--- a/src/TetMesh.h
+++ b/src/TetMesh.h
@@ -274,13 +274,12 @@ public:
     void swap_edge(const Tuple& t, int type);
     bool smooth_vertex(const Tuple& t);
 
-    void
-    compact(); // cleans up the deleted vertices or tetrahedra, and fixes the corresponding indices
-
-    void reset_timestamp()
-    {
-        for (auto& t : m_tet_connectivity) t.timestamp = 0;
-    }
+    /**
+     * @brief cleans up the deleted vertices or tetrahedra, fixes the corresponding indices, and
+     * reset the version number. WARNING: it invalidates all tuples!
+     *
+     */
+    void compact();
 
     /**
      * Get all unique undirected edges in the mesh.

--- a/src/TetMesh.h
+++ b/src/TetMesh.h
@@ -88,7 +88,7 @@ public:
          * Check if the current tuple is already invalid (removed during editing).
          *
          * @param m TetMesh where the tuple belongs.
-         * @return if not removed and thet connectivity is up to date
+         * @return if not removed and the tuple is up to date with respect to the connectivity.
          */
         bool is_valid(const TetMesh& m) const;
 

--- a/src/Tuple.cpp
+++ b/src/Tuple.cpp
@@ -61,22 +61,7 @@ bool TetMesh::Tuple::is_valid(const TetMesh& m) const
 {
     if (m.m_vertex_connectivity[m_vid].m_is_removed || m.m_tet_connectivity[m_tid].m_is_removed)
         return false;
-    return true;
-}
 
-void TetMesh::Tuple::update_version_number(const TetMesh& m)
-{
-    assert(m_timestamp <= m.m_tet_connectivity[m_tid].timestamp);
-    m_timestamp = m.m_tet_connectivity[m_tid].timestamp;
-}
-
-int TetMesh::Tuple::get_version_number()
-{
-    return m_timestamp;
-}
-
-bool TetMesh::Tuple::is_version_number_valid(const TetMesh& m) const
-{
     if (m_timestamp != m.m_tet_connectivity[m_tid].timestamp) return false;
     return true;
 }

--- a/tests/test_operations.cpp
+++ b/tests/test_operations.cpp
@@ -6,7 +6,13 @@ using namespace wmtk;
 
 TEST_CASE("edge_splitting", "[test_operation]")
 {
-    // TODO
+    auto mesh = TetMesh();
+    mesh.init(5, {{{0, 1, 2, 3}}, {{0, 1, 2, 4}}});
+    const auto tuple = mesh.tuple_from_face(0, 0);
+    std::vector<TetMesh::Tuple> dummy;
+    REQUIRE(mesh.split_edge(tuple, dummy));
+    REQUIRE_FALSE(tuple.is_valid(mesh));
+    REQUIRE(mesh.check_mesh_connectivity_validity());
 }
 
 TEST_CASE("rollback_split_operation", "[test_operation]")

--- a/tests/test_operations.cpp
+++ b/tests/test_operations.cpp
@@ -8,3 +8,18 @@ TEST_CASE("edge_splitting", "[test_operation]")
 {
     // TODO
 }
+
+TEST_CASE("rollback_split_operation", "[test_operation]")
+{
+    class NoSplitMesh : public TetMesh
+    {
+    public:
+        bool split_after(const std::vector<TetMesh::Tuple>& locs) override { return false; };
+    };
+    auto mesh = NoSplitMesh();
+    mesh.init(5, {{{0, 1, 2, 3}}, {{0, 1, 2, 4}}});
+    const auto tuple = mesh.tuple_from_face(0, 0);
+    std::vector<TetMesh::Tuple> dummy;
+    REQUIRE_FALSE(mesh.split_edge(tuple, dummy));
+    REQUIRE(tuple.is_valid(mesh));
+}


### PR DESCRIPTION
* Merged `is_valid` with `loc.is_version_number_valid`
* Removed global version from mesh
* Removed `update_version_number`, the version is created correctly in the inits
* Updated edge split with new v number semantics @Yixin-Hu check please :)
* Updated `get_vertices` @jiangzhongshi check please :)
* `find_next_empty_slot_t` creates a new tet with vnumber -1, it gets increased after, check me