### PR TITLE
Make rng deterministic.

### DIFF
--- a/app/tests/test_harmonic_triangulations.cpp
+++ b/app/tests/test_harmonic_triangulations.cpp
@@ -152,8 +152,8 @@ TEST_CASE("parallel_harmonic-tet-swaps", "[parallel_harmtri][.slow]")
 
 TEST_CASE("gaussian-harmonic")
 {
-    static std::mt19937 gen{std::random_device{}()};
-    static std::normal_distribution<> dist;
+    std::mt19937 gen;
+    std::normal_distribution<> dist;
 
     auto vec_attrs = std::vector<Eigen::Vector3d>();
     auto tets = std::vector<std::array<size_t, 4>>();
@@ -192,8 +192,8 @@ TEST_CASE("gaussian-harmonic")
 
 TEST_CASE("gaussian-harmonic-single")
 {
-    static std::mt19937 gen{std::random_device{}()};
-    static std::normal_distribution<> dist;
+    std::mt19937 gen;
+    std::normal_distribution<> dist;
 
     auto vec_attrs = std::vector<Eigen::Vector3d>();
     auto tets = std::vector<std::array<size_t, 4>>();


### PR DESCRIPTION
Random number generation for unit test should be deterministic. Also no need to make the variables static.