### PR TITLE
Added missing include

### DIFF
--- a/src/wmtk/utils/Delaunay.hpp
+++ b/src/wmtk/utils/Delaunay.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstddef>
 #include <array>
 #include <vector>
 


### PR DESCRIPTION
I was getting an error when compiling:
```
error: ‘size_t’ was not declared in this scope; did you mean ‘std::size_t’?
```
when using `g++ (GCC) 11.2.0`.

Fixed this by including `cstddef`.