### PR TITLE
Cleaned CMake warnings and SRC_FILES log

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,7 +50,7 @@ file(GLOB_RECURSE SRC_FILES CONFIGURE_DEPENDS
     "src/*.h"
     "src/*.hpp"
 )
-message("SRC_FILES: ${SRC_FILES}")
+message(DEBUG "SRC_FILES: ${SRC_FILES}")
 
 add_library(wildmeshing_toolkit "${SRC_FILES}")
 add_library(wmtk::toolkit ALIAS wildmeshing_toolkit)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,13 +88,13 @@ target_link_libraries(wildmeshing_toolkit PUBLIC
     igl::core
     igl::predicates
     geogram
-    wmtk::warnings
     TBB::tbb
     mshio::mshio
     metis::metis
     lagrange::core
     Tracy::TracyClient
 )
+target_link_libraries(wildmeshing_toolkit PRIVATE wmtk::warnings)
 
 # ###############################################################################
 # Subdirectories

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,6 +83,7 @@ include(mshio)
 include(metis)
 include(lagrange)
 include(gmp)
+target_link_libraries(wildmeshing_toolkit PRIVATE wmtk::warnings)
 target_link_libraries(wildmeshing_toolkit PUBLIC
     spdlog::spdlog
     igl::core
@@ -94,7 +95,6 @@ target_link_libraries(wildmeshing_toolkit PUBLIC
     lagrange::core
     Tracy::TracyClient
 )
-target_link_libraries(wildmeshing_toolkit PRIVATE wmtk::warnings)
 
 # ###############################################################################
 # Subdirectories


### PR DESCRIPTION
* Make `wmtk::warnings` a private dependency so it doesn't pollute downstream libraries
* Converted `message("SRC_FILES: ${SRC_FILES}")` to debug mode