### PR TITLE
Expose ExecutionScheduler variables and adjust operation return tuple

### DIFF
--- a/src/wmtk/ExecutionScheduler.hpp
+++ b/src/wmtk/ExecutionScheduler.hpp
@@ -352,9 +352,10 @@ public:
         return m_parallel_queues;
     }
 
-protected:
     std::atomic<int> m_cnt_success = std::atomic<int>(0);
     std::atomic<int> m_cnt_fail = std::atomic<int>(0);
+
+protected:
     tbb::concurrent_priority_queue<Elem> m_serial_queue;
     std::vector<tbb::concurrent_priority_queue<Elem>> m_parallel_queues;
 };

--- a/src/wmtk/TetMesh.h
+++ b/src/wmtk/TetMesh.h
@@ -6,18 +6,18 @@
 #include <wmtk/utils/Logger.hpp>
 
 #include <tbb/concurrent_vector.h>
-#include <tbb/spin_mutex.h>
 #include <tbb/enumerable_thread_specific.h>
+#include <tbb/spin_mutex.h>
 
 #include <Tracy.hpp>
 
 #include <array>
 #include <cassert>
+#include <limits>
 #include <map>
 #include <optional>
 #include <queue>
 #include <vector>
-#include <limits>
 
 namespace wmtk {
 class TetMesh
@@ -53,6 +53,9 @@ public:
         size_t m_global_tid = std::numeric_limits<size_t>::max();
 
         int m_hash = 0;
+
+    public:
+        void update_hash(const TetMesh& m) { m_hash = m.m_tet_connectivity[m_global_tid].hash; }
 
     private:
         /**
@@ -489,11 +492,13 @@ public:
     AbstractAttributeContainer *p_vertex_attrs, *p_edge_attrs, *p_face_attrs, *p_tet_attrs;
     AbstractAttributeContainer vertex_attrs, edge_attrs, face_attrs, tet_attrs;
 
+protected:
+    vector<TetrahedronConnectivity> m_tet_connectivity;
 
 private:
     // Stores the connectivity of the mesh
     vector<VertexConnectivity> m_vertex_connectivity;
-    vector<TetrahedronConnectivity> m_tet_connectivity;
+    // vector<TetrahedronConnectivity> m_tet_connectivity;
     std::atomic_long current_vert_size;
     std::atomic_long current_tet_size;
     tbb::spin_mutex vertex_connectivity_lock;

--- a/src/wmtk/TetMeshEdgeCollapsingConn.cpp
+++ b/src/wmtk/TetMeshEdgeCollapsingConn.cpp
@@ -237,12 +237,14 @@ bool wmtk::TetMesh::collapse_edge(const Tuple& loc0, std::vector<Tuple>& new_edg
 
     release_protect_attributes();
 
-    for (size_t t_id : new_tet_id) {
-        for (int j = 0; j < 6; j++) {
-            new_edges.push_back(tuple_from_edge(t_id, j));
-        }
-    }
-    unique_edge_tuples(*this, new_edges);
+    // for (size_t t_id : new_tet_id) {
+    //     for (int j = 0; j < 6; j++) {
+    //         new_edges.push_back(tuple_from_edge(t_id, j));
+    //     }
+    // }
+    // unique_edge_tuples(*this, new_edges);
+    new_loc.update_hash(*this);
+    new_edges = {{new_loc}};
 
     return true;
 }

--- a/src/wmtk/TetMeshEdgeSplittingConn.cpp
+++ b/src/wmtk/TetMeshEdgeSplittingConn.cpp
@@ -91,13 +91,14 @@ bool wmtk::TetMesh::split_edge(const Tuple& loc0, std::vector<Tuple>& new_edges)
     release_protect_attributes();
 
     // new_edges
-    assert(std::is_sorted(new_tet_id.begin(), new_tet_id.end()));
-    for (size_t t_id : new_tet_id) {
-        for (int j = 0; j < 6; j++) {
-            new_edges.push_back(tuple_from_edge(t_id, j));
-        }
-    }
-    unique_edge_tuples(*this, new_edges);
+    // assert(std::is_sorted(new_tet_id.begin(), new_tet_id.end()));
+    // for (size_t t_id : new_tet_id) {
+    //     for (int j = 0; j < 6; j++) {
+    //         new_edges.push_back(tuple_from_edge(t_id, j));
+    //     }
+    // }
+    // unique_edge_tuples(*this, new_edges);
+    new_edges = {{new_loc}};
 
     return true;
 }

--- a/src/wmtk/TriMesh.cpp
+++ b/src/wmtk/TriMesh.cpp
@@ -611,6 +611,7 @@ bool TriMesh::swap_edge(const Tuple& t, std::vector<Tuple>& new_tris)
 
         return false;
     }
+    new_tris = {new_t}; // Same as passed to swap_edge_after
     release_protect_attributes();
     return true;
 }

--- a/src/wmtk/TriMesh.cpp
+++ b/src/wmtk/TriMesh.cpp
@@ -611,8 +611,11 @@ bool TriMesh::swap_edge(const Tuple& t, std::vector<Tuple>& new_tris)
 
         return false;
     }
-    new_tris = {new_t}; // Same as passed to swap_edge_after
     release_protect_attributes();
+
+    return_t.update_hash(*this);
+    new_tris = {{return_t}};
+
     return true;
 }
 

--- a/src/wmtk/TriMesh.cpp
+++ b/src/wmtk/TriMesh.cpp
@@ -368,6 +368,10 @@ bool TriMesh::split_edge(const Tuple& t, std::vector<Tuple>& new_tris)
         return false;
     }
     release_protect_attributes();
+
+    return_tuple.update_hash(*this);
+    new_tris = {{return_tuple}};
+
     return true;
 }
 
@@ -528,6 +532,10 @@ bool TriMesh::collapse_edge(const Tuple& loc0, std::vector<Tuple>& new_tris)
         return false;
     }
     release_protect_attributes();
+
+    return_t.update_hash(*this);
+    new_tris = {{return_t}};
+
     return true;
 }
 

--- a/src/wmtk/TriMesh.cpp
+++ b/src/wmtk/TriMesh.cpp
@@ -613,8 +613,8 @@ bool TriMesh::swap_edge(const Tuple& t, std::vector<Tuple>& new_tris)
     }
     release_protect_attributes();
 
-    return_t.update_hash(*this);
-    new_tris = {{return_t}};
+    new_t.update_hash(*this);
+    new_tris = {{new_t}};
 
     return true;
 }

--- a/src/wmtk/TriMesh.h
+++ b/src/wmtk/TriMesh.h
@@ -34,9 +34,9 @@ public:
         size_t m_fid = -1;
         size_t m_hash = -1;
 
+    public:
         void update_hash(const TriMesh& m);
 
-    public:
         void print_info();
 
         //         v2        /
@@ -278,9 +278,12 @@ public:
     AbstractAttributeContainer* p_edge_attrs = nullptr;
     AbstractAttributeContainer* p_face_attrs = nullptr;
 
+protected:
+    vector<TriangleConnectivity> m_tri_connectivity;
+
 private:
     vector<VertexConnectivity> m_vertex_connectivity;
-    vector<TriangleConnectivity> m_tri_connectivity;
+    // vector<TriangleConnectivity> m_tri_connectivity;
     std::atomic_long current_vert_size;
     std::atomic_long current_tri_size;
     tbb::spin_mutex vertex_connectivity_lock;


### PR DESCRIPTION
* (ToDo before merging) I changed the operation's return type to be the same as the `*_after` functions input. This will probably break some stuff in other examples. I also need to double-check check I did this for every op, not just the ones I needed.