### PR TITLE
tetwild: projection to input surface while smooth

### DIFF
--- a/app/shortest_edge_collapse/src/sec/envelope/SampleEnvelope.cpp
+++ b/app/shortest_edge_collapse/src/sec/envelope/SampleEnvelope.cpp
@@ -232,5 +232,15 @@ bool SampleEnvelope::is_outside(const std::array<Eigen::Vector3d, 3>& tri)
     return false;
 }
 
+double SampleEnvelope::nearest_point(const Eigen::Vector3d& pts, Eigen::Vector3d& result) 
+{
+    auto dist = 0.;
+    GEO::vec3 current_point(pts[0], pts[1], pts[2]);
+    GEO::vec3 r;
+    geo_tree_ptr_->nearest_facet(current_point, r, dist);
+    result << r.x, r.y, r.z;
+    return dist;
+}
+
 
 } // namespace sample_envelope

--- a/app/shortest_edge_collapse/src/sec/envelope/SampleEnvelope.cpp
+++ b/app/shortest_edge_collapse/src/sec/envelope/SampleEnvelope.cpp
@@ -171,14 +171,14 @@ void SampleEnvelope::init(
     for (int i = 0; i < face_indices.size(); i++) geo_face_ind[i] = face_indices[i];
 }
 
-bool SampleEnvelope::is_outside(const Eigen::Vector3d& pts)
+bool SampleEnvelope::is_outside(const Eigen::Vector3d& pts) const
 {
     if (use_exact) return exact_envelope.is_outside(pts);
     auto dist2 = geo_tree_ptr_->squared_distance(GEO::vec3(pts[0], pts[1], pts[2]));
     return (dist2 > eps2);
 }
 
-bool SampleEnvelope::is_outside(const std::array<Eigen::Vector3d, 3>& tri)
+bool SampleEnvelope::is_outside(const std::array<Eigen::Vector3d, 3>& tri) const
 {
     if (use_exact) return exact_envelope.is_outside(tri);
     std::array<GEO::vec3, 3> vs = {
@@ -232,7 +232,7 @@ bool SampleEnvelope::is_outside(const std::array<Eigen::Vector3d, 3>& tri)
     return false;
 }
 
-double SampleEnvelope::nearest_point(const Eigen::Vector3d& pts, Eigen::Vector3d& result) 
+double SampleEnvelope::nearest_point(const Eigen::Vector3d& pts, Eigen::Vector3d& result) const
 {
     auto dist = 0.;
     GEO::vec3 current_point(pts[0], pts[1], pts[2]);

--- a/app/shortest_edge_collapse/src/sec/envelope/SampleEnvelope.hpp
+++ b/app/shortest_edge_collapse/src/sec/envelope/SampleEnvelope.hpp
@@ -65,6 +65,11 @@ public:
         const double);
     bool is_outside(const std::array<Eigen::Vector3d, 3>& tris);
     bool is_outside(const Eigen::Vector3d& pts);
+    double nearest_point(const Eigen::Vector3d& pts, Eigen::Vector3d& result) {
+        auto dist = 0.;
+        geo_tree_ptr_->nearest_facet(pts, result, dist);
+        return dist;
+    }
 
 private:
     std::shared_ptr<GEO::MeshFacetsAABBWithEps> geo_tree_ptr_;

--- a/app/shortest_edge_collapse/src/sec/envelope/SampleEnvelope.hpp
+++ b/app/shortest_edge_collapse/src/sec/envelope/SampleEnvelope.hpp
@@ -23,8 +23,8 @@ public:
         const std::vector<Eigen::Vector3d>& m_ver,
         const std::vector<Eigen::Vector3i>& m_faces,
         const double){};
-    virtual bool is_outside(const std::array<Eigen::Vector3d, 3>& tris) { return false; };
-    virtual bool is_outside(const Eigen::Vector3d& pts) { return false; };
+    virtual bool is_outside(const std::array<Eigen::Vector3d, 3>& tris) const { return false; };
+    virtual bool is_outside(const Eigen::Vector3d& pts) const { return false; };
 };
 
 class ExactEnvelope : public Envelope, public fastEnvelope::FastEnvelope
@@ -40,11 +40,11 @@ public:
     {
         fastEnvelope::FastEnvelope::init(m_ver, m_faces, eps);
     }
-    bool is_outside(const std::array<Eigen::Vector3d, 3>& tris)
+    bool is_outside(const std::array<Eigen::Vector3d, 3>& tris) const
     {
         return fastEnvelope::FastEnvelope::is_outside(tris);
     }
-    bool is_outside(const Eigen::Vector3d& pts)
+    bool is_outside(const Eigen::Vector3d& pts) const
     {
         return fastEnvelope::FastEnvelope::is_outside(pts);
     }
@@ -63,12 +63,13 @@ public:
         const std::vector<Eigen::Vector3d>& m_ver,
         const std::vector<Eigen::Vector3i>& m_faces,
         const double);
-    bool is_outside(const std::array<Eigen::Vector3d, 3>& tris);
-    bool is_outside(const Eigen::Vector3d& pts);
-    double nearest_point(const Eigen::Vector3d& pts, Eigen::Vector3d& result);
+    bool is_outside(const std::array<Eigen::Vector3d, 3>& tris) const;
+    bool is_outside(const Eigen::Vector3d& pts) const;
+    double nearest_point(const Eigen::Vector3d& pts, Eigen::Vector3d& result) const;
+    bool initialized() {return geo_tree_ptr_ != nullptr;};
 
 private:
-    std::shared_ptr<GEO::MeshFacetsAABBWithEps> geo_tree_ptr_;
+    std::shared_ptr<GEO::MeshFacetsAABBWithEps> geo_tree_ptr_ = nullptr;
     std::shared_ptr<GEO::Mesh> geo_polyhedron_ptr_;
     std::vector<int> geo_vertex_ind;
     std::vector<int> geo_face_ind;

--- a/app/shortest_edge_collapse/src/sec/envelope/SampleEnvelope.hpp
+++ b/app/shortest_edge_collapse/src/sec/envelope/SampleEnvelope.hpp
@@ -65,11 +65,7 @@ public:
         const double);
     bool is_outside(const std::array<Eigen::Vector3d, 3>& tris);
     bool is_outside(const Eigen::Vector3d& pts);
-    double nearest_point(const Eigen::Vector3d& pts, Eigen::Vector3d& result) {
-        auto dist = 0.;
-        geo_tree_ptr_->nearest_facet(pts, result, dist);
-        return dist;
-    }
+    double nearest_point(const Eigen::Vector3d& pts, Eigen::Vector3d& result);
 
 private:
     std::shared_ptr<GEO::MeshFacetsAABBWithEps> geo_tree_ptr_;

--- a/app/tetwild/Smooth.cpp
+++ b/app/tetwild/Smooth.cpp
@@ -9,7 +9,6 @@
 #include <wmtk/utils/Logger.hpp>
 #include <wmtk/utils/TetraQualityUtils.hpp>
 
-
 #include <limits>
 #include <optional>
 bool tetwild::TetWild::smooth_before(const Tuple& t)
@@ -97,7 +96,8 @@ bool tetwild::TetWild::smooth_after(const Tuple& t)
                 }
             }
         }
-        auto project = wmtk::try_project(m_vertex_attribute[vid].m_posf, neighbor_assemble);
+        auto prject = Eigen::Vector3d();
+        triangles_tree.nearest_point(m_vertex_attribute[vid].m_posf, project);
         m_vertex_attribute[vid].m_posf = project;
         for (auto& n : neighbor_assemble) {
             for (auto kk = 0; kk < 3; kk++) n[kk] = m_vertex_attribute[vid].m_posf[kk];

--- a/app/tetwild/Smooth.cpp
+++ b/app/tetwild/Smooth.cpp
@@ -96,7 +96,7 @@ bool tetwild::TetWild::smooth_after(const Tuple& t)
                 }
             }
         }
-        auto prject = Eigen::Vector3d();
+        auto project = Eigen::Vector3d();
         triangles_tree.nearest_point(m_vertex_attribute[vid].m_posf, project);
         m_vertex_attribute[vid].m_posf = project;
         for (auto& n : neighbor_assemble) {

--- a/app/tetwild/Smooth.cpp
+++ b/app/tetwild/Smooth.cpp
@@ -97,7 +97,10 @@ bool tetwild::TetWild::smooth_after(const Tuple& t)
             }
         }
         auto project = Eigen::Vector3d();
-        triangles_tree.nearest_point(m_vertex_attribute[vid].m_posf, project);
+        if (triangles_tree.initialized())
+            triangles_tree.nearest_point(m_vertex_attribute[vid].m_posf, project);
+        else 
+            project = wmtk::try_project(m_vertex_attribute[vid].m_posf, neighbor_assemble);
         m_vertex_attribute[vid].m_posf = project;
         for (auto& n : neighbor_assemble) {
             for (auto kk = 0; kk < 3; kk++) n[kk] = m_vertex_attribute[vid].m_posf[kk];

--- a/app/tetwild/TetWild.h
+++ b/app/tetwild/TetWild.h
@@ -94,10 +94,12 @@ public:
 
     Parameters& m_params;
     wmtk::Envelope& m_envelope;
+    sample_envelope::SampleEnvelope& triangles_tree;
 
-    TetWild(Parameters& _m_params, wmtk::Envelope& _m_envelope, int _num_threads = 1)
+    TetWild(Parameters& _m_params, wmtk::Envelope& _m_envelope, sample_envelope::SampleEnvelope& _triangles_tree, int _num_threads = 1)
         : m_params(_m_params)
         , m_envelope(_m_envelope)
+        , triangles_tree(_triangles_tree)
     {
         NUM_THREADS = _num_threads;
         p_vertex_attrs = &m_vertex_attribute;

--- a/app/tetwild/main.cpp
+++ b/app/tetwild/main.cpp
@@ -123,7 +123,7 @@ int main(int argc, char** argv)
     } else {
         ptr_env = &(exact_envelope);
     }
-    tetwild::TetWild mesh(params, *ptr_env, NUM_THREADS);
+    tetwild::TetWild mesh(params, *ptr_env, surf_mesh.m_envelope, NUM_THREADS);
 
     /////////////////////////////////////////////////////
 

--- a/app/tetwild/tests/file_write.cpp
+++ b/app/tetwild/tests/file_write.cpp
@@ -16,7 +16,8 @@ TEST_CASE("tetwild_file_write", "[tetwild_operation]")
     params.init(Vector3d(0, 0, 0), Vector3d(1, 1, 1));
 
     wmtk::Envelope envelope;
-    TetWild tetwild(params, envelope);
+    sample_envelope::SampleEnvelope sample_env;
+    TetWild tetwild(params, envelope, sample_env);
 
     std::vector<VertexAttributes> vertices(4);
     vertices[0].m_posf = Vector3d(0, 0, 0);

--- a/app/tetwild/tests/test_insertion.cpp
+++ b/app/tetwild/tests/test_insertion.cpp
@@ -49,7 +49,8 @@ TEST_CASE("triangle-insertion", "[tetwild_operation]")
     std::vector<size_t> partition_id(vertices.size(), 0);
     //
     //
-    tetwild::TetWild mesh(params, envelope);
+    sample_envelope::SampleEnvelope sample_env;
+    tetwild::TetWild mesh(params, envelope, sample_env);
 
     mesh.init_from_input_surface(vertices, faces, partition_id);
     REQUIRE(mesh.check_attributes());
@@ -104,7 +105,8 @@ TEST_CASE("triangle-insertion-parallel", "[tetwild_operation][.]")
 
     //
     //
-    tetwild::TetWild mesh(params, envelope, NUM_THREADS);
+    sample_envelope::SampleEnvelope sample_env;
+    tetwild::TetWild mesh(params, envelope, sample_env, NUM_THREADS);
 
     wmtk::logger().info("start insertion");
     mesh.init_from_input_surface(vertices, faces, partition_id);

--- a/app/tetwild/tests/test_operation_smooth.cpp
+++ b/app/tetwild/tests/test_operation_smooth.cpp
@@ -15,7 +15,8 @@ TEST_CASE("smooth_in_single_tet", "[tetwild_operation]")
     params.init(Vector3d(0, 0, 0), Vector3d(1, 1, 1));
 
     wmtk::Envelope envelope;
-    TetWild tetwild(params, envelope);
+    sample_envelope::SampleEnvelope sample_env;
+    TetWild tetwild(params, envelope, sample_env);
     std::vector<VertexAttributes> vertices(4);
     vertices[0].m_posf = Vector3d(0.1, 0, 0);
     vertices[1].m_posf = Vector3d(1, 0, 0);
@@ -43,9 +44,10 @@ TEST_CASE("smooth_double_tet", "[tetwild_operation]")
 
     Parameters params;
     params.init(Vector3d(0, 0, 0), Vector3d(1, 1, 1));
-
     wmtk::Envelope envelope;
-    TetWild tetwild(params, envelope);
+    sample_envelope::SampleEnvelope sample_env;
+    TetWild tetwild(params, envelope, sample_env);
+
     std::vector<VertexAttributes> vertices(5);
     vertices[0].m_posf = Vector3d(0.1, 0, 0);
     vertices[1].m_posf = Vector3d(1, 0, 0);

--- a/app/tetwild/tests/test_operations.cpp
+++ b/app/tetwild/tests/test_operations.cpp
@@ -57,7 +57,8 @@ TEST_CASE("mesh_improvement", "[tetwild_operation][.slow]")
     }
     //
     //
-    tetwild::TetWild mesh(params, envelope, NUM_THREADS);
+    sample_envelope::SampleEnvelope sample_env;
+    tetwild::TetWild mesh(params, envelope, sample_env, NUM_THREADS);
 
     mesh.init_from_input_surface(vertices, faces, partition_id);
     REQUIRE(mesh.check_attributes());
@@ -72,7 +73,8 @@ TEST_CASE("edge_splitting", "[tetwild_operation]")
     params.init(Vector3d(0, 0, 0), Vector3d(1, 1, 1));
 
     wmtk::Envelope envelope;
-    TetWild tetwild(params, envelope);
+    sample_envelope::SampleEnvelope sample_env;
+    TetWild tetwild(params, envelope, sample_env);
 
     std::vector<VertexAttributes> vertices(4);
     vertices[0].m_posf = Vector3d(0, 0, 0);
@@ -106,7 +108,8 @@ TEST_CASE("edge_collapsing", "[tetwild_operation]")
     params.init(Vector3d(0, 0, 0), Vector3d(1, 1, 1));
 
     wmtk::Envelope envelope;
-    TetWild tetwild(params, envelope);
+    sample_envelope::SampleEnvelope sample_env;
+    TetWild tetwild(params, envelope, sample_env);
 
 
     std::vector<VertexAttributes> vertices(4);
@@ -157,7 +160,8 @@ TEST_CASE("inversion-check-rational-tetwild", "[tetwild_operation]")
     params.init(Vector3d(0, 0, 0), Vector3d(1, 1, 1));
 
     wmtk::Envelope envelope;
-    TetWild tetwild(params, envelope);
+    sample_envelope::SampleEnvelope sample_env;
+    TetWild tetwild(params, envelope, sample_env);
 
     std::vector<VertexAttributes> vertices(4);
     vertices[0].m_pos = Vector3r(0, 0, 0);
@@ -190,7 +194,8 @@ TEST_CASE("optimize-bunny-tw", "[tetwild_operation][.slow]")
     params.init(Vector3d(0, 0, 0), Vector3d(1, 1, 1));
 
     wmtk::Envelope envelope;
-    TetWild tetwild(params, envelope);
+    sample_envelope::SampleEnvelope sample_env;
+    TetWild tetwild(params, envelope, sample_env);
 
     tetwild.init(vec_attrs.size(), tets);
     std::vector<TetAttributes> tet_attrs(tets.size());


### PR DESCRIPTION
This commit introduce the feature during smoothing, where the "optimized" vertex is re-projected towards the input triangle soup.
The change is directly done on the "SampleEnvelope", where in tetwild, we always initialize to simplify the input triangulation.

Test Plan
* Compiles and unit test pass 