### PR TITLE
Fix operations to succeed only with conjunction of checks

### DIFF
--- a/app/adaptive_tessellation/Collapse.cpp
+++ b/app/adaptive_tessellation/Collapse.cpp
@@ -44,14 +44,14 @@ public:
     bool after(AdaptiveTessellation& m, ExecuteReturnData& ret_data)
     {
         if (wmtk::TriMeshEdgeCollapseOperation::after(m, ret_data)) {
-            ret_data.success |= m.collapse_edge_after(ret_data.tuple);
+            ret_data.success &= m.collapse_edge_after(ret_data.tuple);
         }
         return ret_data;
     }
     bool invariants(AdaptiveTessellation& m, ExecuteReturnData& ret_data)
     {
         if (wmtk::TriMeshEdgeCollapseOperation::invariants(m, ret_data)) {
-            ret_data.success |= m.invariants(ret_data.new_tris);
+            ret_data.success &= m.invariants(ret_data.new_tris);
         }
         return ret_data;
     }

--- a/app/adaptive_tessellation/Smooth.cpp
+++ b/app/adaptive_tessellation/Smooth.cpp
@@ -39,14 +39,14 @@ public:
     bool after(AdaptiveTessellation& m, ExecuteReturnData& ret_data)
     {
         if (wmtk::TriMeshSmoothVertexOperation::after(m, ret_data)) {
-            ret_data.success |= m.smooth_after(ret_data.tuple);
+            ret_data.success &= m.smooth_after(ret_data.tuple);
         }
         return ret_data;
     }
     bool invariants(AdaptiveTessellation& m, ExecuteReturnData& ret_data)
     {
         if (wmtk::TriMeshSmoothVertexOperation::invariants(m, ret_data)) {
-            ret_data.success |= m.invariants(ret_data.new_tris);
+            ret_data.success &= m.invariants(ret_data.new_tris);
         }
         return ret_data;
     }

--- a/app/adaptive_tessellation/Swap.cpp
+++ b/app/adaptive_tessellation/Swap.cpp
@@ -29,33 +29,31 @@ public:
     bool before(AdaptiveTessellation& m, const Tuple& t)
     {
         if (wmtk::TriMeshSwapEdgeOperation::before(m, t)) {
-            return true;
-            //return  m.swap_before(t);
+            return m.swap_edge_before(t);
         }
         return false;
     }
     bool after(AdaptiveTessellation& m, ExecuteReturnData& ret_data)
     {
         if (wmtk::TriMeshSwapEdgeOperation::after(m, ret_data)) {
-            return true;
-            //ret_data.success |= m.swap_after(ret_data.tuple);
+            ret_data.success &= m.swap_edge_after(ret_data.tuple);
         }
         return ret_data;
     }
     bool invariants(AdaptiveTessellation& m, ExecuteReturnData& ret_data)
     {
         if (wmtk::TriMeshSwapEdgeOperation::invariants(m, ret_data)) {
-            ret_data.success |= m.invariants(ret_data.new_tris);
+            ret_data.success &= m.invariants(ret_data.new_tris);
         }
         return ret_data;
     }
 };
 
-    template <typename Executor>
-    void addCustomOps(Executor& e) {
-
-        e.add_operation(std::make_shared<AdaptiveTessellationSwapEdgeOperation>());
-    }
+template <typename Executor>
+void addCustomOps(Executor& e)
+{
+    e.add_operation(std::make_shared<AdaptiveTessellationSwapEdgeOperation>());
+}
 
 
 auto swap_renew = [](auto& m, auto op, auto& tris) {
@@ -110,7 +108,7 @@ auto swap_accuracy_cost = [](auto& m, const TriMesh::Tuple& e) {
     } else
         return 0.;
 };
-}
+} // namespace
 
 void AdaptiveTessellation::swap_all_edges()
 {
@@ -150,6 +148,7 @@ void AdaptiveTessellation::swap_all_edges()
     };
     if (NUM_THREADS > 0) {
         auto executor = wmtk::ExecutePass<AdaptiveTessellation, ExecutionPolicy::kPartition>();
+        addCustomOps(executor);
         executor.lock_vertices = [](auto& m, const auto& e, int task_id) {
             return m.try_set_edge_mutex_two_ring(e, task_id);
         };
@@ -161,7 +160,6 @@ void AdaptiveTessellation::swap_all_edges()
 }
 bool AdaptiveTessellation::swap_edge_before(const Tuple& t)
 {
-
     if (is_boundary_edge(t)) return false;
     if (is_boundary_vertex(t))
         vertex_attrs[cache.local().v1].boundary_vertex = true;

--- a/app/remeshing/src/remeshing/UniformRemeshingOperations.h
+++ b/app/remeshing/src/remeshing/UniformRemeshingOperations.h
@@ -55,14 +55,14 @@ public:
     bool after(UniformRemeshing& m, ExecuteReturnData& ret_data)
     {
         if (wmtk::TriMeshSplitEdgeOperation::after(m, ret_data)) {
-            ret_data.success |= m.split_edge_after(ret_data.tuple);
+            ret_data.success &= m.split_edge_after(ret_data.tuple);
         }
         return ret_data;
     }
     bool invariants(UniformRemeshing& m, ExecuteReturnData& ret_data)
     {
         if (wmtk::TriMeshSplitEdgeOperation::invariants(m, ret_data)) {
-            ret_data.success |= m.invariants(ret_data.new_tris);
+            ret_data.success &= m.invariants(ret_data.new_tris);
         }
         return ret_data;
     }
@@ -88,14 +88,14 @@ public:
     bool after(UniformRemeshing& m, ExecuteReturnData& ret_data)
     {
         if (wmtk::TriMeshSwapEdgeOperation::after(m, ret_data)) {
-            ret_data.success |= m.swap_edge_after(ret_data.tuple);
+            ret_data.success &= m.swap_edge_after(ret_data.tuple);
         }
         return ret_data;
     }
     bool invariants(UniformRemeshing& m, ExecuteReturnData& ret_data)
     {
         if (wmtk::TriMeshSwapEdgeOperation::invariants(m, ret_data)) {
-            ret_data.success |= m.invariants(ret_data.new_tris);
+            ret_data.success &= m.invariants(ret_data.new_tris);
         }
         return ret_data;
     }
@@ -122,14 +122,14 @@ public:
     bool after(UniformRemeshing& m, ExecuteReturnData& ret_data)
     {
         if (wmtk::TriMeshSmoothVertexOperation::after(m, ret_data)) {
-            ret_data.success |= m.smooth_after(ret_data.tuple);
+            ret_data.success &= m.smooth_after(ret_data.tuple);
         }
         return ret_data;
     }
     bool invariants(UniformRemeshing& m, ExecuteReturnData& ret_data)
     {
         if (wmtk::TriMeshSmoothVertexOperation::invariants(m, ret_data)) {
-            ret_data.success |= m.invariants(ret_data.new_tris);
+            ret_data.success &= m.invariants(ret_data.new_tris);
         }
         return ret_data;
     }

--- a/src/wmtk/TriMeshOperation.h
+++ b/src/wmtk/TriMeshOperation.h
@@ -13,7 +13,7 @@ public:
     {
         Tuple tuple;
         std::vector<Tuple> new_tris;
-        bool success = false;
+        bool success = true;
         operator bool() const { return success;}
     };
 

--- a/src/wmtk/TriMeshTuple.h
+++ b/src/wmtk/TriMeshTuple.h
@@ -1,136 +1,138 @@
-
 #pragma once
 
+#include <array>
+#include <optional>
+#include <string>
+#include <tuple>
 
 namespace wmtk {
-    class TriMesh;
-    // Cell TriMeshTuple Navigator
-    class TriMeshTuple
+class TriMesh;
+// Cell TriMeshTuple Navigator
+class TriMeshTuple
+{
+private:
+    size_t m_vid = -1;
+    size_t m_eid = -1;
+    size_t m_fid = -1;
+    size_t m_hash = -1;
+
+    void update_hash(const TriMesh& m);
+
+public:
+    void print_info() const;
+    std::string info() const;
+
+    //         v2        /
+    //       /    \      /
+    //  e1  /      \  e0 /
+    //     v0 - - - v1   /
+    //         e2        /
+    /**
+     * Construct a new TriMeshTuple object with global vertex/triangle index and local edge index
+     *
+     * @param vid vertex id
+     * @param eid edge id (local)
+     * @param fid face id
+     * @note edge ordering
+     */
+    TriMeshTuple() = default;
+    TriMeshTuple(const TriMeshTuple& other) = default;
+    TriMeshTuple(TriMeshTuple&& other) = default;
+    TriMeshTuple& operator=(const TriMeshTuple& other) = default;
+    TriMeshTuple& operator=(TriMeshTuple&& other) = default;
+    TriMeshTuple(size_t vid, size_t eid, size_t fid, const TriMesh& m)
+        : m_vid(vid)
+        , m_eid(eid)
+        , m_fid(fid)
     {
-    private:
-        friend class TriMeshTriMeshTupleData;
-        size_t m_vid = -1;
-        size_t m_eid = -1;
-        size_t m_fid = -1;
-        size_t m_hash = -1;
-
-        void update_hash(const TriMesh& m);
-
-    public:
-        void print_info() const;
-        std::string info() const;
-
-        //         v2        /
-        //       /    \      /
-        //  e1  /      \  e0 /
-        //     v0 - - - v1   /
-        //         e2        /
-        /**
-         * Construct a new TriMeshTuple object with global vertex/triangle index and local edge index
-         *
-         * @param vid vertex id
-         * @param eid edge id (local)
-         * @param fid face id
-         * @note edge ordering
-         */
-        TriMeshTuple() = default;
-        TriMeshTuple(const TriMeshTuple& other) = default;
-        TriMeshTuple(TriMeshTuple&& other) = default;
-        TriMeshTuple& operator=(const TriMeshTuple& other) = default;
-        TriMeshTuple& operator=(TriMeshTuple&& other) = default;
-        TriMeshTuple(size_t vid, size_t eid, size_t fid, const TriMesh& m)
-            : m_vid(vid)
-            , m_eid(eid)
-            , m_fid(fid)
-        {
-            update_hash(m);
-        }
+        update_hash(m);
+    }
 
 
-        /**
-         * returns global vertex id.
-         * @param m TriMesh where the tuple belongs.
-         * @return size_t
-         */
-        inline size_t vid(const TriMesh&) const { return m_vid; }
+    /**
+     * returns global vertex id.
+     * @param m TriMesh where the tuple belongs.
+     * @return size_t
+     */
+    inline size_t vid(const TriMesh&) const { return m_vid; }
 
-        /**
-         * returns a global unique face id
-         *
-         * @param m TriMesh where the tuple belongs.
-         * @return size_t
-         */
-        inline size_t fid(const TriMesh&) const { return m_fid; }
+    /**
+     * returns a global unique face id
+     *
+     * @param m TriMesh where the tuple belongs.
+     * @return size_t
+     */
+    inline size_t fid(const TriMesh&) const { return m_fid; }
 
 
-        /**
-         * returns a global unique edge id
-         *
-         * @param m TriMesh where the tuple belongs.
-         * @return size_t
-         * @note The global id may not be consecutive. The edges are undirected and different tetra
-         * share the same edge.
-         */
-        size_t eid(const TriMesh& m) const;
-        size_t eid_unsafe(const TriMesh& m) const;
-        /**
-         * returns the local eid of the tuple
-         *
-         * @param m TriMesh where the tuple belongs.
-         * @return size_t
-         * @note use mostly for constructing consistent tuples in operations
-         */
-        size_t local_eid(const TriMesh&) const { return m_eid; }
-        /**
-         * Switch operation.
-         *
-         * @param m Mesh
-         * @return another TriMeshTuple that share the same face, edge, but different vertex.
-         */
-        TriMeshTuple switch_vertex(const TriMesh& m) const;
-        /**
-         *
-         * @param m
-         * @return another TriMeshTuple that share the same face, vertex, but different edge.
-         */
-        TriMeshTuple switch_edge(const TriMesh& m) const;
-        /**
-         * Switch operation for the adjacent triangle
-         *
-         * @param m Mesh
-         * @return TriMeshTuple for the edge-adjacent triangle, sharing same edge, and vertex.
-         * @note nullopt if the TriMeshTuple of the switch goes off the boundary.
-         */
-        std::optional<TriMeshTuple> switch_face(const TriMesh& m) const;
+    /**
+     * returns a global unique edge id
+     *
+     * @param m TriMesh where the tuple belongs.
+     * @return size_t
+     * @note The global id may not be consecutive. The edges are undirected and different tetra
+     * share the same edge.
+     */
+    size_t eid(const TriMesh& m) const;
+    size_t eid_unsafe(const TriMesh& m) const;
+    /**
+     * returns the local eid of the tuple
+     *
+     * @param m TriMesh where the tuple belongs.
+     * @return size_t
+     * @note use mostly for constructing consistent tuples in operations
+     */
+    size_t local_eid(const TriMesh&) const { return m_eid; }
+    /**
+     * Switch operation.
+     *
+     * @param m Mesh
+     * @return another TriMeshTuple that share the same face, edge, but different vertex.
+     */
+    TriMeshTuple switch_vertex(const TriMesh& m) const;
+    /**
+     *
+     * @param m
+     * @return another TriMeshTuple that share the same face, vertex, but different edge.
+     */
+    TriMeshTuple switch_edge(const TriMesh& m) const;
+    /**
+     * Switch operation for the adjacent triangle
+     *
+     * @param m Mesh
+     * @return TriMeshTuple for the edge-adjacent triangle, sharing same edge, and vertex.
+     * @note nullopt if the TriMeshTuple of the switch goes off the boundary.
+     */
+    std::optional<TriMeshTuple> switch_face(const TriMesh& m) const;
 
-        /**
-         * @brief check if a TriMeshTuple is valid
-         *
-         * @param m the Mesh
-         * @return false if 1. the fid of the TriMeshTuple is -1, 2. either the vertex or the face
-         * refered to by the TriMeshTuple is removed, 3. the hash of the TriMeshTuple is not the same as
-         * the hash of the triangle it refers to in the mesh
-         *
-         */
-        bool is_valid(const TriMesh& m) const;
+    /**
+     * @brief check if a TriMeshTuple is valid
+     *
+     * @param m the Mesh
+     * @return false if 1. the fid of the TriMeshTuple is -1, 2. either the vertex or the face
+     * refered to by the TriMeshTuple is removed, 3. the hash of the TriMeshTuple is not the same as
+     * the hash of the triangle it refers to in the mesh
+     *
+     */
+    bool is_valid(const TriMesh& m) const;
 
-        bool is_ccw(const TriMesh& m) const;
-        /**
-         * Positively oriented 3 vertices (represented by TriMeshTuples) in a tri.
-         * @return std::array<TriMeshTuple, 3> each tuple owns a different vertex.
-         */
-        std::array<TriMeshTuple, 3> oriented_tri_vertices(const TriMesh& m) const;
+    bool is_ccw(const TriMesh& m) const;
+    /**
+     * Positively oriented 3 vertices (represented by TriMeshTuples) in a tri.
+     * @return std::array<TriMeshTuple, 3> each tuple owns a different vertex.
+     */
+    std::array<TriMeshTuple, 3> oriented_tri_vertices(const TriMesh& m) const;
 
-        std::tuple<size_t, size_t, size_t, size_t> as_stl_tuple() const
-        {
-            return std::tie(m_vid, m_eid, m_fid, m_hash);
-        }
-        friend bool operator<(const TriMeshTuple& a, const TriMeshTuple& t)
-        {
-            return (
-                std::tie(a.m_vid, a.m_eid, a.m_fid, a.m_hash) <
-                std::tie(t.m_vid, t.m_eid, t.m_fid, t.m_hash));
-            // return a.as_stl_tuple() < t.as_stl_tuple();
-        }
-    };
-}
+    std::tuple<size_t, size_t, size_t, size_t> as_stl_tuple() const
+    {
+        return std::tie(m_vid, m_eid, m_fid, m_hash);
+    }
+    friend bool operator<(const TriMeshTuple& a, const TriMeshTuple& t)
+    {
+        return (
+            std::tie(a.m_vid, a.m_eid, a.m_fid, a.m_hash) <
+            std::tie(t.m_vid, t.m_eid, t.m_fid, t.m_hash));
+        // return a.as_stl_tuple() < t.as_stl_tuple();
+    }
+};
+} // namespace wmtk


### PR DESCRIPTION
Previously operations were using |= instead of &= which was just plain wrong. this pr fixes this .

minor edit: this moves the vertex mutex code out of the header file.
