### PR TITLE
Fixing TriMeshTuple eid member name

### DIFF
--- a/src/wmtk/TriMeshTuple.cpp
+++ b/src/wmtk/TriMeshTuple.cpp
@@ -9,7 +9,7 @@ void TriMeshTuple::update_hash(const TriMesh& m)
 
 std::string TriMeshTuple::info() const
 {
-    return fmt::format("tuple: v{} e{} f{} (h{})", m_vid, m_eid, m_fid, m_hash);
+    return fmt::format("tuple: v{} e{} f{} (h{})", m_vid, m_local_eid, m_fid, m_hash);
 }
 
 void TriMeshTuple::print_info() const
@@ -19,7 +19,7 @@ void TriMeshTuple::print_info() const
 
 size_t TriMeshTuple::eid_unsafe(const TriMesh& m) const
 {
-    return m_fid * 3 + m_eid;
+    return m_fid * 3 + m_local_eid;
 }
 
 size_t TriMeshTuple::eid(const TriMesh& m) const
@@ -34,7 +34,7 @@ size_t TriMeshTuple::eid(const TriMesh& m) const
             return min_fid * 3 + 3 - i - j;
         }
     }
-    return m_fid * 3 + m_eid;
+    return m_fid * 3 + m_local_eid;
 }
 
 
@@ -47,7 +47,7 @@ TriMeshTuple TriMeshTuple::switch_vertex(const TriMesh& m) const
     const int v2 = m.m_tri_connectivity[m_fid][2];
 
     TriMeshTuple loc = *this;
-    switch (m_eid) {
+    switch (m_local_eid) {
     case 0:
         assert(m_vid == v1 || m_vid == v2);
         loc.m_vid = m_vid == v1 ? v2 : v1;
@@ -77,16 +77,16 @@ TriMeshTuple TriMeshTuple::switch_edge(const TriMesh& m) const
     TriMeshTuple loc = *this;
     switch (lvid) {
     case 0:
-        assert(m_eid == 1 || m_eid == 2);
-        loc.m_eid = m_eid == 1 ? 2 : 1;
+        assert(m_local_eid == 1 || m_local_eid == 2);
+        loc.m_local_eid = m_local_eid == 1 ? 2 : 1;
         break;
     case 1:
-        assert(m_eid == 0 || m_eid == 2);
-        loc.m_eid = m_eid == 0 ? 2 : 0;
+        assert(m_local_eid == 0 || m_local_eid == 2);
+        loc.m_local_eid = m_local_eid == 0 ? 2 : 0;
         break;
     case 2:
-        assert(m_eid == 0 || m_eid == 1);
-        loc.m_eid = m_eid == 0 ? 1 : 0;
+        assert(m_local_eid == 0 || m_local_eid == 1);
+        loc.m_local_eid = m_local_eid == 0 ? 1 : 0;
         break;
     default:;
     }
@@ -136,11 +136,11 @@ std::optional<TriMeshTuple> TriMeshTuple::switch_face(const TriMesh& m) const
 
         // Assign the edge id depending on the table
         if (lv0_2 == 0 && lv1_2 == 1) {
-            loc.m_eid = 2;
+            loc.m_local_eid = 2;
         } else if (lv0_2 == 1 && lv1_2 == 2) {
-            loc.m_eid = 0;
+            loc.m_local_eid = 0;
         } else if (lv0_2 == 0 && lv1_2 == 2) {
-            loc.m_eid = 1;
+            loc.m_local_eid = 1;
         } else {
             assert(false);
         }
@@ -153,7 +153,7 @@ std::optional<TriMeshTuple> TriMeshTuple::switch_face(const TriMesh& m) const
 
 bool TriMeshTuple::is_ccw(const TriMesh& m) const
 {
-    if (m.m_tri_connectivity[m_fid][(m_eid + 1) % 3] == m_vid)
+    if (m.m_tri_connectivity[m_fid][(m_local_eid + 1) % 3] == m_vid)
         return true;
     else
         return false;
@@ -187,7 +187,7 @@ bool TriMeshTuple::is_valid(const TriMesh& m) const
 #ifndef NDEBUG
     //  Condition 0: Elements exist
     assert(m_vid < m.vert_capacity());
-    assert(m_eid <= 2);
+    assert(m_local_eid <= 2);
     assert(m_fid <= m.tri_capacity());
 
     // Condition 1: tid and vid are consistent
@@ -198,7 +198,7 @@ bool TriMeshTuple::is_valid(const TriMesh& m) const
     const int v0 = m.m_tri_connectivity[m_fid][0];
     const int v1 = m.m_tri_connectivity[m_fid][1];
     const int v2 = m.m_tri_connectivity[m_fid][2];
-    switch (m_eid) {
+    switch (m_local_eid) {
     case 0: assert(m_vid == v1 || m_vid == v2); break;
     case 1: assert(m_vid == v0 || m_vid == v2); break;
     case 2: assert(m_vid == v0 || m_vid == v1); break;

--- a/src/wmtk/TriMeshTuple.h
+++ b/src/wmtk/TriMeshTuple.h
@@ -12,7 +12,7 @@ class TriMeshTuple
 {
 private:
     size_t m_vid = -1;
-    size_t m_eid = -1;
+    size_t m_local_eid = -1;
     size_t m_fid = -1;
     size_t m_hash = -1;
 
@@ -40,9 +40,9 @@ public:
     TriMeshTuple(TriMeshTuple&& other) = default;
     TriMeshTuple& operator=(const TriMeshTuple& other) = default;
     TriMeshTuple& operator=(TriMeshTuple&& other) = default;
-    TriMeshTuple(size_t vid, size_t eid, size_t fid, const TriMesh& m)
+    TriMeshTuple(size_t vid, size_t local_eid, size_t fid, const TriMesh& m)
         : m_vid(vid)
-        , m_eid(eid)
+        , m_local_eid(local_eid)
         , m_fid(fid)
     {
         update_hash(m);
@@ -82,7 +82,7 @@ public:
      * @return size_t
      * @note use mostly for constructing consistent tuples in operations
      */
-    size_t local_eid(const TriMesh&) const { return m_eid; }
+    size_t local_eid(const TriMesh&) const { return m_local_eid; }
     /**
      * Switch operation.
      *
@@ -125,13 +125,13 @@ public:
 
     std::tuple<size_t, size_t, size_t, size_t> as_stl_tuple() const
     {
-        return std::tie(m_vid, m_eid, m_fid, m_hash);
+        return std::tie(m_vid, m_local_eid, m_fid, m_hash);
     }
     friend bool operator<(const TriMeshTuple& a, const TriMeshTuple& t)
     {
         return (
-            std::tie(a.m_vid, a.m_eid, a.m_fid, a.m_hash) <
-            std::tie(t.m_vid, t.m_eid, t.m_fid, t.m_hash));
+            std::tie(a.m_vid, a.m_local_eid, a.m_fid, a.m_hash) <
+            std::tie(t.m_vid, t.m_local_eid, t.m_fid, t.m_hash));
         // return a.as_stl_tuple() < t.as_stl_tuple();
     }
 };


### PR DESCRIPTION
It seems rather odd that TriMeshTuple has a member called `m_eid` but the member function `eid()` is not a getter. Instead `local_eid()` is the getter for `m_eid`:
```
size_t local_eid(const TriMesh&) const { return m_eid; }
```

This PR simply changes references to m_eid to m_local_eid (and changes the constructor for TriMeshTuple to specify that it's a local_eid)