### PR TITLE
Paired Operation Swap

### DIFF
--- a/app/adaptive_tessellation/AdaptiveTessellation.cpp
+++ b/app/adaptive_tessellation/AdaptiveTessellation.cpp
@@ -1586,4 +1586,5 @@ void AdaptiveTessellation::assign_edge_curveid()
     }
 }
 
+
 } // namespace adaptive_tessellation

--- a/app/adaptive_tessellation/AdaptiveTessellation.h
+++ b/app/adaptive_tessellation/AdaptiveTessellation.h
@@ -283,5 +283,8 @@ public:
         //     assert(!is_inverted(tri));
         // }
     }
+
+
+
 };
 } // namespace adaptive_tessellation

--- a/app/adaptive_tessellation/Split.h
+++ b/app/adaptive_tessellation/Split.h
@@ -11,9 +11,9 @@
 #include <wmtk/utils/TupleUtils.hpp>
 #include "AdaptiveTessellation.h"
 #include "wmtk/ExecutionScheduler.hpp"
-using namespace adaptive_tessellation;
 using namespace wmtk;
 
+namespace adaptive_tessellation {
 class AdaptiveTessellationSplitEdgeOperation : public wmtk::TriMeshOperationShim<
                                                    AdaptiveTessellation,
                                                    AdaptiveTessellationSplitEdgeOperation,
@@ -75,3 +75,4 @@ public:
     bool before(AdaptiveTessellation& m, const Tuple& t);
     bool after(AdaptiveTessellation& m, ExecuteReturnData& ret_data);
 };
+}

--- a/app/adaptive_tessellation/Swap.cpp
+++ b/app/adaptive_tessellation/Swap.cpp
@@ -1,4 +1,4 @@
-#include "AdaptiveTessellation.h"
+#include "Swap.h"
 #include "wmtk/ExecutionScheduler.hpp"
 
 #include <Eigen/src/Core/util/Constants.h>
@@ -16,48 +16,111 @@
 using namespace adaptive_tessellation;
 using namespace wmtk;
 
+AdaptiveTessellationSwapEdgeOperation::AdaptiveTessellationSwapEdgeOperation() = default;
+AdaptiveTessellationSwapEdgeOperation::~AdaptiveTessellationSwapEdgeOperation() = default;
 
-namespace {
-class AdaptiveTessellationSwapEdgeOperation : public wmtk::TriMeshOperationShim<
-                                                  AdaptiveTessellation,
-                                                  AdaptiveTessellationSwapEdgeOperation,
-                                                  wmtk::TriMeshSwapEdgeOperation>
+
+auto AdaptiveTessellationSwapEdgeOperation::execute(AdaptiveTessellation& m, const Tuple& t)
+    -> ExecuteReturnData
 {
-public:
-    ExecuteReturnData execute(AdaptiveTessellation& m, const Tuple& t)
-    {
-        return wmtk::TriMeshSwapEdgeOperation::execute(m, t);
-    }
-    bool before(AdaptiveTessellation& m, const Tuple& t)
-    {
-        if (wmtk::TriMeshSwapEdgeOperation::before(m, t)) {
-            return true;
-            //return  m.swap_before(t);
-        }
+    return wmtk::TriMeshSwapEdgeOperation::execute(m, t);
+}
+bool AdaptiveTessellationSwapEdgeOperation::before(AdaptiveTessellation& m, const Tuple& t)
+{
+    if (m.is_seam_edge(t)) {
         return false;
     }
-    bool after(AdaptiveTessellation& m, ExecuteReturnData& ret_data)
-    {
-        if (wmtk::TriMeshSwapEdgeOperation::after(m, ret_data)) {
-            return true;
-            //ret_data.success |= m.swap_after(ret_data.tuple);
-        }
-        return ret_data;
-    }
-    bool invariants(AdaptiveTessellation& m, ExecuteReturnData& ret_data)
-    {
-        if (wmtk::TriMeshSwapEdgeOperation::invariants(m, ret_data)) {
-            ret_data.success |= m.invariants(ret_data.new_tris);
-        }
-        return ret_data;
-    }
-};
 
-    template <typename Executor>
-    void addCustomOps(Executor& e) {
-
-        e.add_operation(std::make_shared<AdaptiveTessellationSwapEdgeOperation>());
+    auto& vids_to_mirror_edge = vid_edge_to_mirror_edge.local();
+    for (const Tuple& edge_tuple : m.triangle_boundary_edge_tuples(t)) {
+        if (auto opt = m.get_sibling_edge(edge_tuple); opt) {
+            // then this is a mirror edge
+            size_t vid0 = t.vid(m);
+            size_t vid1 = t.switch_vertex(m).vid(m);
+            vids_to_mirror_edge[std::array<size_t, 2>{{vid0, vid1}}] = *opt;
+        }
     }
+
+
+    if (wmtk::TriMeshSwapEdgeOperation::before(m, t)) {
+        return true;
+        // return  m.swap_before(t);
+    }
+    return false;
+}
+bool AdaptiveTessellationSwapEdgeOperation::after(
+    AdaptiveTessellation& m,
+    ExecuteReturnData& ret_data)
+{
+    if (wmtk::TriMeshSwapEdgeOperation::after(m, ret_data)) {
+        const auto mod_tups = modified_tuples(m);
+        const auto& tri_con = tri_connectivity(m);
+
+        // wipe out existing face attribute data beacuse it's invalidated
+        for (const Tuple& tri : mod_tups) {
+            m.face_attrs[tri.fid(m)] = {};
+            for (const Tuple& edge : m.triangle_boundary_edge_tuples(tri)) {
+                m.edge_attrs[edge.eid(m)] = {};
+            }
+        }
+
+        auto find_edge_tup =
+            [&tri_con, &mod_tups, &m](const size_t vid0, const size_t vid1) -> Tuple {
+            // go through the (two) triangles to find the edge
+            for (const Tuple& tri : mod_tups) {
+                const size_t fid = tri.fid(m);
+                const auto& con = tri_con[fid].m_indices;
+
+                // go through the vertices in the triangle to find the right local_eid (j) if it
+                // exists
+                for (size_t j = 0; j < con.size(); ++j) {
+                    size_t jp1 = (j + 1) % con.size();
+                    size_t jp2 = (j + 2) % con.size();
+
+                    // if we find the pair of vertices use the ordering to return a tuple
+                    if (con[jp1] == vid0 && con[jp2] == vid1) {
+                        return Tuple(vid0, j, fid, m);
+                    } else if (con[jp1] == vid1 && con[jp2] == vid0) {
+                        return Tuple(vid1, j, fid, m);
+                    }
+                }
+            }
+            assert(false); // if vid pairs were in the map then they must be on the boundary
+                           // and still edges
+            return {};
+        };
+
+        for (const auto& [vids, mirror_edge] : vid_edge_to_mirror_edge.local()) {
+            // use vids to find an edge in the current triangle
+            const auto [vid0, vid1] = vids;
+            const Tuple edge_tup = find_edge_tup(vid0, vid1);
+#if defined(_DEBUG)
+            { // make sure that the edge tuple returned is appropriate
+                assert(edge_tup.is_valid(m));
+                const size_t vid = edge_tup.vid(m);
+                assert(vid0 == vid || vid1 == vid);
+                const size_t ovid = edge_tup.switch_vertex(m).vid(m);
+                assert(vid0 == ovid || vid1 == ovid);
+                assert(vid != ovid);
+            }
+#endif
+            m.set_mirror_edge_data(edge_tup, mirror_edge);
+            m.set_mirror_edge_data(mirror_edge, edge_tup);
+            m.edge_attrs[edge_tup.eid(m)].curve_id = m.edge_attrs[mirror_edge.eid(m)].curve_id;
+        }
+
+        return true;
+        // ret_data.success |= m.swap_after(ret_data.tuple);
+    }
+    return ret_data;
+}
+
+namespace {
+template <typename Executor>
+void addCustomOps(Executor& e)
+{
+    e.add_operation(std::make_shared<AdaptiveTessellationSwapEdgeOperation>());
+}
 
 
 auto swap_renew = [](auto& m, auto op, auto& tris) {
@@ -165,7 +228,7 @@ auto swap_accuracy_cost = [](auto& m, const TriMesh::Tuple& e, const double vale
     }
     return -std::numeric_limits<double>::infinity();
 };
-}
+} // namespace
 
 void AdaptiveTessellation::swap_all_edges()
 {
@@ -221,7 +284,6 @@ void AdaptiveTessellation::swap_all_edges()
 }
 bool AdaptiveTessellation::swap_edge_before(const Tuple& t)
 {
-
     if (is_boundary_edge(t)) return false;
     if (is_boundary_vertex(t))
         vertex_attrs[cache.local().v1].boundary_vertex = true;

--- a/app/adaptive_tessellation/Swap.h
+++ b/app/adaptive_tessellation/Swap.h
@@ -1,0 +1,24 @@
+#pragma once
+#include <wmtk/TriMeshOperation.h>
+#include "AdaptiveTessellation.h"
+
+namespace adaptive_tessellation
+{
+    class AdaptiveTessellationSwapEdgeOperation : public wmtk::TriMeshOperationShim<
+                                                      AdaptiveTessellation,
+                                                      AdaptiveTessellationSwapEdgeOperation,
+                                                      wmtk::TriMeshSwapEdgeOperation>
+    {
+    public:
+        AdaptiveTessellationSwapEdgeOperation ();
+        ~AdaptiveTessellationSwapEdgeOperation ();
+        ExecuteReturnData execute(AdaptiveTessellation& m, const Tuple& t);
+        bool before(AdaptiveTessellation& m, const Tuple& t);
+        bool after(AdaptiveTessellation& m, ExecuteReturnData& ret_data);
+
+
+        // maps from an edge represented by two vids to the mirror edge's tuple
+        tbb::enumerable_thread_specific<std::map<std::array<size_t, 2>, Tuple>>
+            vid_edge_to_mirror_edge;
+    };
+}

--- a/src/wmtk/TriMesh.cpp
+++ b/src/wmtk/TriMesh.cpp
@@ -567,3 +567,16 @@ std::array<std::optional<size_t>, 3> TriMesh::release_protected_attributes()
     }
     return updates;
 }
+
+auto TriMesh::triangle_boundary_edge_tuples(const Tuple& triangle) const -> std::array<Tuple, 3>
+{
+    assert(is_valid(triangle));
+    const size_t fid = triangle.fid(*this);
+
+    return {{
+        tuple_from_edge(fid,0),
+        tuple_from_edge(fid,1),
+        tuple_from_edge(fid,2)
+    }};
+
+}

--- a/src/wmtk/TriMesh.h
+++ b/src/wmtk/TriMesh.h
@@ -1,9 +1,9 @@
 #pragma once
 
 #define USE_OPERATION_LOGGER
+#include <wmtk/TriMeshTuple.h>
 #include <wmtk/utils/VectorUtils.h>
 #include <wmtk/AttributeCollection.hpp>
-#include <wmtk/TriMeshTuple.h>
 #include <wmtk/utils/Logger.hpp>
 
 // clang-format off
@@ -37,7 +37,6 @@ class AttributeCollectionRecorder;
 class TriMesh
 {
 public:
-
     using Tuple = TriMeshTuple;
     friend class TriMeshTuple;
     /**
@@ -383,6 +382,13 @@ public:
         return Tuple(vid, local_eid, fid, *this);
     }
 
+    /**
+     * Generate the tuples for the tuples at the boundary of a triangle
+     * @param triangle for which we are computing the boundary of
+     * @return array of tuples storing the three edges
+     */
+    std::array<Tuple, 3> triangle_boundary_edge_tuples(const Tuple& triangle) const;
+
     // private:
 protected:
     /**
@@ -413,7 +419,7 @@ protected:
      * @brief End the modification phase
      *
      */
-    std::array<std::optional<size_t>,3> release_protected_attributes();
+    std::array<std::optional<size_t>, 3> release_protected_attributes();
 
     /**
      * @brief End Caching connectivity

--- a/src/wmtk/TriMeshOperation.cpp
+++ b/src/wmtk/TriMeshOperation.cpp
@@ -299,20 +299,25 @@ auto TriMeshSwapEdgeOperation::execute(TriMesh& m, const Tuple& t) -> ExecuteRet
     vertex_connectivity[vid4].m_conn_tris.push_back(test_fid2);
     vector_unique(vertex_connectivity[vid4].m_conn_tris);
     // change the tuple to the new edge tuple
-    return_tuple = m.init_from_edge(vid4, vid3, test_fid2);
+    Tuple& new_tuple_loc = m_new_tuple.local();
+    new_tuple_loc = m.init_from_edge(vid4, vid3, test_fid2);
+    return_tuple = new_tuple_loc;
 
     assert(return_tuple.switch_vertex(m).vid(m) != vid1);
     assert(return_tuple.switch_vertex(m).vid(m) != vid2);
     assert(return_tuple.is_valid(m));
-    auto new_other_face_opt = return_tuple.switch_face(m);
-    if (new_other_face_opt) {
-        new_tris = {return_tuple, new_other_face_opt.value()};
-    } else {
-        return ret_data;
-    }
+    new_tris = modified_tuples(m);
 
     ret_data.success = true;
     return ret_data;
+}
+
+auto TriMeshSwapEdgeOperation::modified_tuples(const TriMesh& m) -> std::vector<Tuple> {
+    const Tuple& new_tuple= m_new_tuple.local();
+    assert(new_tuple.is_valid(m));
+    auto new_other_face_opt = new_tuple.switch_face(m);
+    assert(new_other_face_opt);
+    return  {new_tuple, new_other_face_opt.value()};
 }
 bool TriMeshSwapEdgeOperation::before(TriMesh& mesh, const Tuple& t)
 {

--- a/src/wmtk/TriMeshOperation.h
+++ b/src/wmtk/TriMeshOperation.h
@@ -32,6 +32,7 @@ protected:
     virtual bool invariants(TriMesh& m, ExecuteReturnData& ret_data);
 
 
+
     // forwarding of operations in TriMesh
     static wmtk::AttributeCollection<VertexConnectivity>& vertex_connectivity(TriMesh& m);
     static wmtk::AttributeCollection<TriangleConnectivity>& tri_connectivity(TriMesh& m);
@@ -153,6 +154,10 @@ public:
     bool before(TriMesh& m, const Tuple& t) override;
     bool after(TriMesh& m, ExecuteReturnData& ret_data) override;
     std::string name() const override;
+
+    std::vector<Tuple> modified_tuples(const TriMesh& m) ;
+private:
+    tbb::enumerable_thread_specific<Tuple> m_new_tuple;
 };
 
 /**

--- a/src/wmtk/TriMeshTuple.h
+++ b/src/wmtk/TriMeshTuple.h
@@ -1,6 +1,11 @@
 
 #pragma once
 
+#include <cstddef>
+#include <wmtk/utils/Logger.hpp>
+#include <string>
+#include <optional>
+#include <tbb/enumerable_thread_specific.h>
 
 namespace wmtk {
 class TriMesh;


### PR DESCRIPTION
Implements paired swap operations - works by reading off the boundary VIDs and their associated seam/curve if pertinent to a per-thread map in the operation and then identifying equivalent new edges using the VIDS and then re-applying the mirrored edge + curve id