### PR TITLE
Added Morton Z Order routines

### DIFF
--- a/src/wmtk/image/TextureIntegral.cpp
+++ b/src/wmtk/image/TextureIntegral.cpp
@@ -273,10 +273,7 @@ double get_error_per_triangle_adaptive(
                 ++num_inside;
                 Eigen::Matrix<T, 3, 1> p_tri =
                     get_p_interpolated(box.center().x(), box.center().y());
-                Eigen::Matrix<T, 3, 1> p_displaced;
-                for (size_t k = 0; k < 3; ++k) {
-                    p_displaced[k] = images[k].get_raw_image()(x, y);
-                }
+                Eigen::Matrix<T, 3, 1> p_displaced = internal::fetch_texels(images, x, y).cast<T>();
                 value += (p_displaced - p_tri).squaredNorm() * pixel_size(0) * pixel_size(1);
                 if (0) {
                     wmtk::ClippedQuadrature rules;

--- a/src/wmtk/image/TextureIntegral.cpp
+++ b/src/wmtk/image/TextureIntegral.cpp
@@ -491,7 +491,7 @@ auto TextureIntegral::get_error_one_triangle(const DTriangle& input_triangle) co
                 IntegrationMethod::Adaptive>(input_triangle, order);
         }
     }
-    return {};
+    throw std::runtime_error("Invalid sampling method or integration method");
 }
 
 } // namespace wmtk

--- a/src/wmtk/image/helpers.h
+++ b/src/wmtk/image/helpers.h
@@ -151,18 +151,21 @@ inline uint32_t to_morton_z_order(uint16_t x, uint16_t y)
 template <size_t N>
 inline std::array<wmtk::Image, N> convert_image_to_morton_z_order(const std::array<wmtk::Image, N>& linear_image)
 {
-    auto zorder_image = linear_image;
-    auto num_planes = linear_image.size();
+    std::array<wmtk::Image, N> zorder_image;
+    auto planes = linear_image.size();
     auto width = linear_image[0].width();
     auto height = linear_image[0].height();
-    for (int k = 0; k < num_planes; ++k)
+    for (int k = 0; k < planes; ++k)
     {
+        zorder_image[k] = wmtk::Image(height, width);
+        auto&& zorder_plane = zorder_image[k].get_raw_image_mutable().data();
+        auto&& linear_plane = linear_image[k].get_raw_image();
         for (int y = 0; y < height; ++y)
         {
             for (int x = 0; x < width; ++x)
             {
                 auto zoffset = wmtk::internal::to_morton_z_order(x, y);
-                zorder_image[k].get_raw_image().data()[zoffset] = linear_image[k].get_raw_image().coeff(x, y);
+                zorder_plane[zoffset] = linear_plane(x, y);
             }
         }
     }

--- a/src/wmtk/image/helpers.h
+++ b/src/wmtk/image/helpers.h
@@ -143,7 +143,7 @@ Eigen::Vector<float, N> sample_bilinear(const std::array<wmtk::Image, N>& images
 template <size_t N>
 Eigen::Vector<float, N> sample_bicubic(const std::array<wmtk::Image, N>& images, float u, float v)
 {
-#if 0
+#if 1
     auto w = images[0].width();
     auto h = images[0].height();
     // x, y are between 0 and 1

--- a/src/wmtk/image/helpers.h
+++ b/src/wmtk/image/helpers.h
@@ -39,7 +39,7 @@ inline float fetch_texel(const wmtk::Image& image, int offset)
 
 inline float fetch_texel(const wmtk::Image& image, int x, int y)
 {
-    return image.get_raw_image()(x, y);
+    return image.get_raw_image()(y, x);
 }
 
 template <size_t N>

--- a/src/wmtk/utils/Displacement.h
+++ b/src/wmtk/utils/Displacement.h
@@ -189,7 +189,6 @@ public:
         auto num_pixels = std::max(abs(xx2 - xx1), abs(yy2 - yy1)) + 1;
         assert(num_pixels > 0);
         const double pixel_size = bbox.diagonal().maxCoeff() / num_pixels;
-        typedef std::integral_constant<int, 2> cached_t;
 
         // calculate the barycentric coordinate of the a point using u, v cooridnates
         // returns the 3d coordinate on the current mesh

--- a/src/wmtk/utils/Image.h
+++ b/src/wmtk/utils/Image.h
@@ -26,7 +26,7 @@ public:
     Image() = default;
     Image(int height_, int width_) { m_image.resize(height_, width_); };
 
-    ImageMatrixf& get_raw_image() { return m_image; }
+    ImageMatrixf& get_raw_image_mutable() { return m_image; }
     const ImageMatrixf& get_raw_image() const { return m_image; }
 
 public:

--- a/src/wmtk/utils/Image.h
+++ b/src/wmtk/utils/Image.h
@@ -26,6 +26,7 @@ public:
     Image() = default;
     Image(int height_, int width_) { m_image.resize(height_, width_); };
 
+    ImageMatrixf& get_raw_image() { return m_image; }
     const ImageMatrixf& get_raw_image() const { return m_image; }
 
 public:

--- a/src/wmtk/utils/Image.h
+++ b/src/wmtk/utils/Image.h
@@ -27,7 +27,7 @@ public:
     Image() = default;
     Image(int height_, int width_) { m_image.resize(height_, width_); };
 
-    ImageMatrixf& get_raw_image_mutable() { return m_image; }
+    ImageMatrixf& ref_raw_image() { return m_image; }
     const ImageMatrixf& get_raw_image() const { return m_image; }
 
 public:

--- a/tests/test_integral.cpp
+++ b/tests/test_integral.cpp
@@ -149,7 +149,7 @@ void test_integral_reference(
         expected[f] = displacement.get_error_per_triangle(triangle);
     });
 
-    for (int f = 0; f < mesh.get_num_facets(); ++f) {
+    for (int f = 0; f < static_cast<int>(mesh.get_num_facets()); ++f) {
         wmtk::logger().debug(
             "error: {}",
             std::abs(expected[f] - computed_errors[f] * scale * scale));
@@ -224,6 +224,18 @@ void test_sampling(std::array<wmtk::Image, 3> displaced)
             }
         }
     }
+
+    // Check two bicubic sampling implementations on random positions
+    std::uniform_real_distribution<float> dist_uv(0.0f, 1.0f);
+    for (int k = 0; k < 100; ++k) {
+        const float u = dist_uv(gen);
+        const float v = dist_uv(gen);
+        const auto bicubic_new = wmtk::internal::sample_bicubic(displaced, u, v);
+        const auto bicubic_old = wmtk::internal::sample_bicubic_old(displaced, u, v);
+        for (size_t i = 0; i < 3; ++i) {
+            REQUIRE(bicubic_new[i] == bicubic_old[i]);
+        }
+    }
 }
 
 } // namespace
@@ -267,9 +279,9 @@ TEST_CASE("Morton Z-Order", "[utils][integral]")
     auto displacement_image_zorder =
         wmtk::internal::convert_image_to_morton_z_order(displacement_image_linear);
 
-    auto planes = displacement_image_linear.size();
-    auto width = displacement_image_linear[0].width();
-    auto height = displacement_image_linear[0].height();
+    auto planes = static_cast<int>(displacement_image_linear.size());
+    auto width = static_cast<int>(displacement_image_linear[0].width());
+    auto height = static_cast<int>(displacement_image_linear[0].height());
     for (int k = 0; k < planes; ++k) {
         for (int y = 0; y < height; ++y) {
             for (int x = 0; x < width; ++x) {

--- a/tests/test_integral.cpp
+++ b/tests/test_integral.cpp
@@ -264,17 +264,15 @@ TEST_CASE("Morton Z-Order", "[utils][integral]")
     std::string displaced_positions = WMTK_DATA_DIR "/images/hemisphere_512_displaced.exr";
 
     auto displacement_image_linear = load_rgb_image(displaced_positions);
-    auto displacement_image_zorder = wmtk::internal::convert_image_to_morton_z_order(displacement_image_linear);
+    auto displacement_image_zorder =
+        wmtk::internal::convert_image_to_morton_z_order(displacement_image_linear);
 
     auto planes = displacement_image_linear.size();
     auto width = displacement_image_linear[0].width();
     auto height = displacement_image_linear[0].height();
-    for (int k = 0; k < planes; ++k)
-    {
-        for (int y = 0; y < height; ++y)
-        {
-            for (int x = 0; x < width; ++x)
-            {
+    for (int k = 0; k < planes; ++k) {
+        for (int y = 0; y < height; ++y) {
+            for (int x = 0; x < width; ++x) {
                 auto zorder = wmtk::internal::fetch_texels_zorder(displacement_image_zorder, x, y);
                 auto linear = wmtk::internal::fetch_texels(displacement_image_linear, x, y);
                 REQUIRE(zorder == linear);
@@ -338,7 +336,7 @@ TEST_CASE("Texture Integral Benchmark", "[utils][!benchmark]")
 
     auto displacement_image_linear = load_rgb_image(displaced_positions);
     wmtk::TextureIntegral integral(displacement_image_linear);
-    
+
     BENCHMARK("Bicubic + Exact")
     {
         integral.set_sampling_method(wmtk::TextureIntegral::SamplingMethod::Bicubic);


### PR DESCRIPTION
This can be useful to attain better cache locality when sampling the displacement maps, but in practice it did not make any noticeable difference on my machine (Intel Xeon W-3365, 32 cores / 64 threads, 2.7GHz to 4GHz, with 128GB RAM).