### PR TITLE
Stride Aware Attributes

### DIFF
--- a/src/wmtk/Attribute.cpp
+++ b/src/wmtk/Attribute.cpp
@@ -1,0 +1,82 @@
+#include "Attribute.hpp"
+#include <wmtk/io/MeshWriter.hpp>
+#include <wmtk/utils/Rational.hpp>
+
+namespace wmtk {
+
+template <typename T>
+void Attribute<T>::serialize(const std::string& name, const int dim, MeshWriter& writer) const
+{
+    writer.write(name, dim, stride(), m_data);
+}
+
+template <typename T>
+Attribute<T>::Attribute(long size, long stride)
+    : m_data(size * stride, T(0))
+    , m_stride(stride)
+{}
+
+template <typename T>
+bool operator==(const Attribute<T>& o) const
+{
+    return m_stride == o.m_stride && m_data == o.m_data;
+}
+
+template <typename T>
+void Attribute<T>::reserve(const long size)
+{
+    m_data.resize(m_stride * size, T(0));
+}
+template <typename T>
+long Attribute<T>::size() const
+{
+    return m_data.size() / m_stride;
+}
+template <typename T>
+long Attribute<T>::stride() const
+{
+    return m_stride;
+}
+
+template <typename T>
+void Attribute<T>::set(std::vector<T> val)
+{
+    assert(val.size() % m_stride == 0);
+    m_data = std::move(val);
+}
+template <typename T>
+auto Attribute<T>::vector_attribute(const long index) const -> ConstMapResult
+{
+    const long start = index * m_stride;
+    return ConstMapResult(m_data.data() + start, m_stride);
+}
+
+
+template <typename T>
+typename Attribute<T>::MapResult Attribute<T>::vector_attribute(
+    const AttributeHandle& handle,
+    const long index)
+{
+    const long start = index * m_stride;
+    return MapResult(m_data.data() + start, m_stride);
+}
+
+template <typename T>
+T Attribute<T>::scalar_attribute(const long index) const
+{
+    assert(m_stride == 1);
+    return m_data[index];
+}
+
+template <typename T>
+T& Attribute<T>::scalar_attribute(const long index)
+{
+    assert(m_stride == 1);
+    return m_data[index];
+}
+
+template class Attribute<char>;
+template class Attribute<long>;
+template class Attribute<double>;
+template class Attribute<Rational>;
+} // namespace wmtk

--- a/src/wmtk/Attribute.cpp
+++ b/src/wmtk/Attribute.cpp
@@ -11,13 +11,17 @@ void Attribute<T>::serialize(const std::string& name, const int dim, MeshWriter&
 }
 
 template <typename T>
-Attribute<T>::Attribute(long size, long stride)
-    : m_data(size * stride, T(0))
-    , m_stride(stride)
-{}
+Attribute<T>::Attribute(long stride, long size)
+    : m_stride(stride)
+{
+    if (size > 0) {
+        m_data = std::vector<T>(size * stride, T(0));
+    }
+}
+
 
 template <typename T>
-bool operator==(const Attribute<T>& o) const
+bool Attribute<T>::operator==(const Attribute<T>& o) const
 {
     return m_stride == o.m_stride && m_data == o.m_data;
 }
@@ -25,7 +29,9 @@ bool operator==(const Attribute<T>& o) const
 template <typename T>
 void Attribute<T>::reserve(const long size)
 {
-    m_data.resize(m_stride * size, T(0));
+    if (size > m_data.size()) {
+        m_data.resize(m_stride * size, T(0));
+    }
 }
 template <typename T>
 long Attribute<T>::size() const
@@ -53,9 +59,7 @@ auto Attribute<T>::vector_attribute(const long index) const -> ConstMapResult
 
 
 template <typename T>
-typename Attribute<T>::MapResult Attribute<T>::vector_attribute(
-    const AttributeHandle& handle,
-    const long index)
+typename Attribute<T>::MapResult Attribute<T>::vector_attribute(const long index)
 {
     const long start = index * m_stride;
     return MapResult(m_data.data() + start, m_stride);

--- a/src/wmtk/Attribute.hpp
+++ b/src/wmtk/Attribute.hpp
@@ -14,7 +14,8 @@ public:
 
     void serialize(const std::string& name, const int dim, MeshWriter& writer) const;
 
-    Attribute(long size, long stride);
+    // if size < 0 then the internal data is not initialized
+    Attribute(long stride, long size);
     ConstMapResult vector_attribute(const long index) const;
     MapResult vector_attribute(const long index);
 

--- a/src/wmtk/Attribute.hpp
+++ b/src/wmtk/Attribute.hpp
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <Eigen/Core>
+#include <vector>
+
+namespace wmtk {
+class MeshWriter;
+template <typename T>
+class Attribute
+{
+public:
+    using MapResult = Eigen::Map<Eigen::Matrix<T, Eigen::Dynamic, 1>>;
+    using ConstMapResult = Eigen::Map<const Eigen::Matrix<T, Eigen::Dynamic, 1>>;
+
+    void serialize(const std::string& name, const int dim, MeshWriter& writer) const;
+
+    Attribute(long size, long stride);
+    ConstMapResult vector_attribute(const long index) const;
+    MapResult vector_attribute(const long index);
+
+    T scalar_attribute(const long index) const;
+    T& scalar_attribute(const long index);
+
+    void set(std::vector<T> val);
+    long size() const;
+    long stride() const;
+    void reserve(const long size);
+
+    bool operator==(const Attribute<T>& o) const;
+
+private:
+    std::vector<T> m_data;
+    long m_stride = -1;
+};
+} // namespace wmtk

--- a/src/wmtk/AttributeHandle.hpp
+++ b/src/wmtk/AttributeHandle.hpp
@@ -12,15 +12,11 @@ protected:
     template <typename T>
     friend class MeshAttributes;
     long index = -1;
-    long stride = -1;
 
 public:
-    bool valid() const { return index >= 0 && stride >= 0; }
+    bool valid() const { return index >= 0; }
 
-    bool operator==(const AttributeHandle& other) const
-    {
-        return index == other.index && stride == other.stride;
-    }
+    bool operator==(const AttributeHandle& other) const { return index == other.index; }
 };
 
 template <typename T>

--- a/src/wmtk/CMakeLists.txt
+++ b/src/wmtk/CMakeLists.txt
@@ -5,6 +5,8 @@ set(SRC_FILES
     AttributeHandle.hpp
     Mesh.cpp
     Mesh.hpp
+    Attribute.hpp
+    Attribute.cpp
     MeshAttributes.cpp
     MeshAttributes.hpp
     PointMesh.cpp

--- a/src/wmtk/MeshAttributes.cpp
+++ b/src/wmtk/MeshAttributes.cpp
@@ -36,7 +36,7 @@ MeshAttributes<T>::register_attribute(const std::string& name, long stride, bool
         handle.index = it->second.index;
     } else {
         handle.index = m_attributes.size();
-        m_attributes.emplace_back(size(), stride);
+        m_attributes.emplace_back(stride, size());
     }
     m_handles[name] = handle;
 

--- a/src/wmtk/MeshAttributes.hpp
+++ b/src/wmtk/MeshAttributes.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
+#include "Attribute.hpp"
 #include "AttributeHandle.hpp"
 
-#include <wmtk/io/MeshWriter.hpp>
 
 #include <Eigen/Core>
 
@@ -12,6 +12,7 @@
 
 namespace wmtk {
 
+class MeshWriter;
 class Mesh;
 template <typename T, bool isConst>
 class Accessor;
@@ -30,7 +31,7 @@ class MeshAttributes
 public:
     MeshAttributes();
 
-    void serialize(const int dim, MeshWriter& writer);
+    void serialize(const int dim, MeshWriter& writer) const;
 
     AttributeHandle register_attribute(const std::string& name, long size, bool replace = false);
 
@@ -48,15 +49,16 @@ protected:
     T scalar_attribute(const AttributeHandle& handle, const long index) const;
     T& scalar_attribute(const AttributeHandle& handle, const long index);
 
-    void set(const AttributeHandle& handle, const std::vector<T>& val);
+    // pass by value due to
+    //https://clang.llvm.org/extra/clang-tidy/checks/modernize/pass-by-value.html
+    void set(const AttributeHandle& handle, std::vector<T> val);
 
 private:
     std::map<std::string, AttributeHandle> m_handles;
 
-    long m_initial_stride = -1;
-    long m_internal_size = -1;
+    long m_size = -1;
 
-    std::vector<std::vector<T>> m_attributes;
+    std::vector<Attribute<T>> m_attributes;
 };
 
 


### PR DESCRIPTION
Moved the responsibility of tracking stride from the `AttributeHandle` to a new `Attribute` class that wraps a `std::vector`. This choice removes the need for `m_initial_stride` and the semantics of `m_initial_size` to hallucinate the size of a `MeshAttributes<T>`. Instead `MeshAttributes<T>` always stores the desired size of attributes held within it (which can be used to report `size()` properly) and each attribute is in charge of its particular stride-based resize.