### PR TITLE
Remove PrimitiveType::Invalid

### DIFF
--- a/src/wmtk/AttributeHandle.hpp
+++ b/src/wmtk/AttributeHandle.hpp
@@ -1,20 +1,30 @@
 #pragma once
 #include "Primitive.hpp"
+#include <type_traits>
 namespace wmtk {
 template <typename T>
 class MeshAttributes;
 template <typename T, bool IsConst>
 class Accessor;
+template <typename T>
+class MeshAttribteHandle;
 
 class AttributeHandle
 {
 protected:
     template <typename T>
     friend class MeshAttributes;
+    template <typename T>
+    friend class MeshAttributeHandle;
     long index = -1;
-
+    AttributeHandle(long i): index(i) {}
 public:
-    bool valid() const { return index >= 0; }
+    AttributeHandle() = default;
+    AttributeHandle(const AttributeHandle&) = default;
+    AttributeHandle(AttributeHandle&&) = default;
+    AttributeHandle& operator=(const AttributeHandle&) = default;
+    AttributeHandle& operator=(AttributeHandle&&) = default;
+
 
     bool operator==(const AttributeHandle& other) const { return index == other.index; }
 };
@@ -28,12 +38,18 @@ private:
     template <typename U, bool IsConst>
     friend class Accessor;
     AttributeHandle m_base_handle;
-    PrimitiveType m_primitive_type = PrimitiveType::Invalid;
+    PrimitiveType m_primitive_type;
 
+    MeshAttributeHandle(AttributeHandle ah, PrimitiveType pt): m_base_handle(ah), m_primitive_type(pt)  {}
+    MeshAttributeHandle(long index, PrimitiveType pt): MeshAttributeHandle(AttributeHandle(index),pt) {}
 public:
-    bool valid() const
-    {
-        return m_base_handle.valid() && m_primitive_type != PrimitiveType::Invalid;
-    }
+    MeshAttributeHandle() = default;
+    MeshAttributeHandle(const MeshAttributeHandle&) = default;
+    MeshAttributeHandle(MeshAttributeHandle&&) = default;
+    MeshAttributeHandle& operator=(const MeshAttributeHandle&) = default;
+    MeshAttributeHandle& operator=(MeshAttributeHandle&&) = default;
+
+    template <typename U>
+    bool operator==(const MeshAttributeHandle& o) const { return std::is_same_v<T,U> && m_base_handle == o.m_base_handle && m_primitive_type == o.m_primitive_type; }
 };
 } // namespace wmtk

--- a/src/wmtk/Primitive.hpp
+++ b/src/wmtk/Primitive.hpp
@@ -4,7 +4,7 @@
 
 namespace wmtk {
 
-enum class PrimitiveType { Invalid = -1, Vertex = 0, Edge = 1, Face = 2, Tetrahedron = 3 };
+enum class PrimitiveType { Vertex = 0, Edge = 1, Face = 2, Tetrahedron = 3 };
 
 constexpr long get_simplex_dimension(PrimitiveType t)
 {
@@ -13,7 +13,6 @@ constexpr long get_simplex_dimension(PrimitiveType t)
     case PrimitiveType::Edge: return 1;
     case PrimitiveType::Face: return 2;
     case PrimitiveType::Tetrahedron: return 3;
-    case PrimitiveType::Invalid: return -1;
     default: break; // just return at the end because compilers can be finicky
     }
 

--- a/src/wmtk/Simplex.hpp
+++ b/src/wmtk/Simplex.hpp
@@ -7,7 +7,7 @@ namespace wmtk {
 
 class Simplex
 {
-    PrimitiveType _ptype = PrimitiveType::Invalid;
+    PrimitiveType _ptype;
     Tuple _tuple;
 
 public:

--- a/src/wmtk/SimplicialComplex.cpp
+++ b/src/wmtk/SimplicialComplex.cpp
@@ -23,7 +23,6 @@ std::vector<Simplex> SimplicialComplex::get_simplex_vector() const
 
 bool SimplicialComplex::add_simplex(const Simplex& s)
 {
-    assert(s.primitive_type() != PrimitiveType::Invalid);
     const auto [it, was_successful] = _simplices.insert(s);
     return was_successful;
 }
@@ -134,7 +133,6 @@ SimplicialComplex SimplicialComplex::boundary(const Simplex& s, const Mesh& m)
         /* code */
         break;
     case PV: break;
-    case PrimitiveType::Invalid: assert(false); break;
     default: assert(false); break;
     }
 
@@ -201,7 +199,6 @@ SimplicialComplex SimplicialComplex::closed_star(const Simplex& s, const Mesh& m
             break;
         case PF: sc.add_simplex(s); break;
         case PT: assert(false); break;
-        case PrimitiveType::Invalid: assert(false); break;
         default: assert(false); break;
         }
     } else if (cell_dim == 3) {
@@ -255,10 +252,6 @@ SimplicialComplex SimplicialComplex::closed_star(const Simplex& s, const Mesh& m
         }
         case PT: {
             sc.add_simplex(s);
-            break;
-        }
-        case PrimitiveType::Invalid: {
-            assert(false);
             break;
         }
         default: {


### PR DESCRIPTION
This "invalid" primitivetype is becoming a source of compilation warnings and from what i can tell it's only used as a default initialized value for classes that should not be default initialized and to create asserts.  Is it ok to remove it? I think it came from the SimplicialComplex.hpp effort?