### PR TITLE
Example Mesh Tests for Testing Tests

### DIFF
--- a/tests/test_example_meshes.cpp
+++ b/tests/test_example_meshes.cpp
@@ -11,14 +11,19 @@ namespace {
 struct MeshDebugInfo
 {
     std::string name = "RENAME ME";
-    long genus = -1;
-    long simply_connected_components = -1;
-    bool is_oriented = false;
+    long boundary_curves = -1;// number of distinct boundary curves in the mesh
+    long genus = -1;// TODO (also what definition of genus?)
+    long simply_connected_components = -1;// TODO (face-face connected topologies)
+    bool is_oriented = false;// TODO (make sure nface neighbors use opposite orientation
+    // the number of simplices (vertex, edge, then face)
     std::array<long, 3> simplex_counts = std::array<long,3>{{-1,-1,-1}};
 };
 void run_debug_trimesh(const DEBUG_TriMesh& m, const MeshDebugInfo& info)
 {
+    fmt::print("Running run_debug_trimesh  on {}\n", info.name);
+
     // validate that the info is ok
+    REQUIRE(info.boundary_curves >= 0);
     REQUIRE(info.genus >= 0);
     REQUIRE(info.simply_connected_components>= 0);
     for(const long count: info.simplex_counts) {
@@ -34,17 +39,22 @@ void run_debug_trimesh(const DEBUG_TriMesh& m, const MeshDebugInfo& info)
     //    CHECK(simplex_count(m,j) == info.simplex_counts);
     //}
 
+    auto [v_count, e_count, f_count] = info.simplex_counts;
     auto v_tups = m.get_all(PrimitiveType::Vertex);
     auto e_tups = m.get_all(PrimitiveType::Edge);
     auto f_tups = m.get_all(PrimitiveType::Face);
+
+    REQUIRE(v_count == v_tups.size());
+    REQUIRE(e_count == e_tups.size());
+    REQUIRE(f_count == f_tups.size());
     for (const auto& v_tup : v_tups) {
-        fmt::print("vertex {} is active", m.id( v_tup, PrimitiveType::Vertex));
+        fmt::print("vertex {} is active\n", m.id( v_tup, PrimitiveType::Vertex));
     }
     for (const auto& e_tup : e_tups) {
         long id = m.id(e_tup, PrimitiveType::Edge);
         long a = m.id(e_tup, PrimitiveType::Vertex);
         long b = m.id(m.switch_tuple(e_tup, PrimitiveType::Vertex), PrimitiveType::Vertex );
-        fmt::print("edge {} is active with vertices {} {}", id, a, b);
+        fmt::print("edge {} is active with vertices {} {}\n", id, a, b);
     }
     for (const auto& f_tup : f_tups) {
         long id = m.id(f_tup, PrimitiveType::Face);
@@ -58,7 +68,7 @@ void run_debug_trimesh(const DEBUG_TriMesh& m, const MeshDebugInfo& info)
                 ),
             PrimitiveType::Vertex
             );
-        fmt::print("face {} is active with vertices {} {} {}", id, a, b, c);
+        fmt::print("face {} is active with vertices {} {} {}\n", id, a, b, c);
     }
 }
 } // namespace
@@ -70,19 +80,94 @@ TEST_CASE("test_debug_trimeshes_single_triangle")
     MeshDebugInfo info;
     info.name = "single_triangle";
     info.genus = 0;
+    info.boundary_curves = 1;
     info.simply_connected_components = 1;
-    info.simplex_counts = std::array<long, 3>{{3, 3, 3}};
+    info.simplex_counts = std::array<long, 3>{{3, 3, 1}};
     run_debug_trimesh(m, info);
 }
 
-TEST_CASE("test_debug_trimeshes_one_ear")
+TEST_CASE("test_debug_trimeshes_quad")
 {
     DEBUG_TriMesh m;
-    m = one_ear();
+    m = quad();
     MeshDebugInfo info;
-    info.name = "one_ear";
+    info.name = "quad";
     info.genus = 0;
+    info.boundary_curves = 1;
     info.simply_connected_components = 1;
-    info.simplex_counts = std::array<long, 3>{{3, 3, 3}};
+    info.simplex_counts = std::array<long, 3>{{4, 5, 2}};
+    run_debug_trimesh(m, info);
+}
+TEST_CASE("test_debug_trimeshes_two_neighbors")
+{
+    DEBUG_TriMesh m;
+    m = two_neighbors();
+    MeshDebugInfo info;
+    info.name = "two_neighbors";
+    info.genus = 0;
+    info.boundary_curves = 1;
+    info.simply_connected_components = 1;
+    info.simplex_counts = std::array<long, 3>{{5, 7, 3}};
+    run_debug_trimesh(m, info);
+}
+TEST_CASE("test_debug_trimeshes_three_neighbors")
+{
+    DEBUG_TriMesh m;
+    m = three_neighbors();
+    MeshDebugInfo info;
+    info.name = "three_neighbors";
+    info.genus = 0;
+    info.boundary_curves = 1;
+    info.simply_connected_components = 1;
+    info.simplex_counts = std::array<long, 3>{{6, 9, 4}};
+    run_debug_trimesh(m, info);
+}
+TEST_CASE("test_debug_trimeshes_three_individuals")
+{
+    DEBUG_TriMesh m;
+    m = three_individuals();
+    MeshDebugInfo info;
+    info.name = "three_individuals";
+    info.genus = 0;
+    info.boundary_curves = 3;// each triangle is individual
+    info.simply_connected_components = 3;
+    info.simplex_counts = std::array<long, 3>{{6, 9, 3}};
+    run_debug_trimesh(m, info);
+}
+TEST_CASE("test_debug_trimeshes_tetrahedron")
+{
+    DEBUG_TriMesh m;
+    m = tetrahedron();
+    MeshDebugInfo info;
+    info.name = "tetrahedron";
+    info.genus = 0;
+    info.boundary_curves = 0;
+    info.simply_connected_components = 1;
+    info.simplex_counts = std::array<long, 3>{{4, 6, 4}};
+    run_debug_trimesh(m, info);
+}
+TEST_CASE("test_debug_trimeshes_hex_plus_two")
+{
+    DEBUG_TriMesh m;
+    m = hex_plus_two();
+    MeshDebugInfo info;
+    info.name = "hex_plus_two";
+    info.genus = 0;
+    info.boundary_curves = 1;
+    info.simply_connected_components = 1;
+    info.simplex_counts = std::array<long, 3>{{9, 16, 8}};
+    run_debug_trimesh(m, info);
+}
+
+TEST_CASE("test_debug_trimeshes_edge_region")
+{
+    DEBUG_TriMesh m;
+    m = edge_region();
+    MeshDebugInfo info;
+    info.name = "edge_region";
+    info.genus = 0;
+    info.boundary_curves = 1;
+    info.simply_connected_components = 1;
+    info.simplex_counts = std::array<long, 3>{{10, 19, 10}};
     run_debug_trimesh(m, info);
 }

--- a/tests/test_example_meshes.cpp
+++ b/tests/test_example_meshes.cpp
@@ -62,9 +62,9 @@ void run_debug_trimesh(const DEBUG_TriMesh& m, const MeshDebugInfo& info)
         long b = m.id(m.switch_tuple(f_tup, PrimitiveType::Vertex), PrimitiveType::Vertex );
         long c = m.id(
             m.switch_tuple(
-                m.switch_tuple(f_tup, PrimitiveType::Vertex
+                m.switch_tuple(f_tup, PrimitiveType::Edge
                     ),
-                PrimitiveType::Edge
+                PrimitiveType::Vertex
                 ),
             PrimitiveType::Vertex
             );

--- a/tests/tools/TriMesh_examples.cpp
+++ b/tests/tools/TriMesh_examples.cpp
@@ -160,4 +160,16 @@ TriMesh strip(long size)
     m.initialize(tris);
     return m;
 }
+
+TriMesh three_individuals()
+{
+    TriMesh m;
+    RowVectors3l tris;
+    tris.resize(3, 3);
+    tris.row(0) << 0, 3, 1;
+    tris.row(1) << 0, 2, 4;
+    tris.row(2) << 2, 1, 5;
+    m.initialize(tris);
+    return m;
+}
 } // namespace wmtk::tests

--- a/tests/tools/TriMesh_examples.hpp
+++ b/tests/tools/TriMesh_examples.hpp
@@ -88,4 +88,19 @@ TriMesh hex_plus_two();
 //   \ / \ / \ /
 //    7---8---9
 TriMesh edge_region();
+
+
+//
+//  4------ 0 ---- 3
+//   |     / \     |
+//   | f1 /   \ f0 |
+//   |   /     \   |
+//   |  /       \  |
+//   2  ---------  1
+//      \       /  .
+//       \ f2  /   .
+//        \   /    .
+//         \ /     .
+//          5
+TriMesh three_individuals();
 } // namespace wmtk::tests


### PR DESCRIPTION
We need to validate our test meshes to make sure we don't waste time building tests with bad topologies. This PR adds a shell for testing the properties of different meshes.
Furthermore, these tests can be used to extract simplex index information which is helpful for writing unit tests.

![20230807_14h42m52s_grim](https://github.com/wildmeshing/wildmeshing-toolkit/assets/802646/7148ef56-e07b-4145-8e3f-faa15ab2304d)
