### PR TITLE
Accessors use more inheritance

### DIFF
--- a/components/wmtk_components/isotropic_remeshing/isotropic_remeshing.cpp
+++ b/components/wmtk_components/isotropic_remeshing/isotropic_remeshing.cpp
@@ -22,7 +22,7 @@ double relative_to_absolute_length(const TriMesh& mesh, const double length_rel)
     p_max.setConstant(std::numeric_limits<double>::max());
 
     for (const Tuple& v : mesh.get_all(PrimitiveType::Vertex)) {
-        const Eigen::Vector3d p = pos.vector_attribute(v);
+        const Eigen::Vector3d p = pos.const_vector_attribute(v);
         p_max[0] = std::max(p_max[0], p[0]);
         p_max[1] = std::max(p_max[1], p[1]);
         p_max[2] = std::max(p_max[2], p[2]);

--- a/src/wmtk/Accessor.cpp
+++ b/src/wmtk/Accessor.cpp
@@ -200,6 +200,19 @@ std::optional<long> Accessor<T, IsConst>::stack_depth() const
     }
 }
 
+
+template <typename T>
+auto MutableAccessor<T>::vector_attribute(const long index) -> MapResultT
+{
+    return cacheable_vector_attribute(index);
+}
+
+
+template <typename T>
+auto MutableAccessor<T>::scalar_attribute(const long index) -> TT
+{
+    return cacheable_scalar_attribute(index);
+}
 template class Accessor<char, true>;
 template class Accessor<long, true>;
 template class Accessor<double, true>;

--- a/src/wmtk/Accessor.hpp
+++ b/src/wmtk/Accessor.hpp
@@ -1,28 +1,38 @@
 #pragma once
 
-#include <memory>
-#include <optional>
-#include <type_traits>
-#include "Tuple.hpp"
-#include "attribute/AccessorBase.hpp"
-#include "attribute/AttributeAccessMode.hpp"
-#include "attribute/AttributeHandle.hpp"
+// #include <memory>
+// #include <optional>
+// #include <type_traits>
+// #include "Tuple.hpp"
+//#include "attribute/AccessorBase.hpp"
+//#include "attribute/AttributeAccessMode.hpp"
+//#include "attribute/AttributeHandle.hpp"
+#include "attribute/ConstAccessor.hpp"
+#include "attribute/MutableAccessor.hpp"
 
 #include <Eigen/Dense>
 
 namespace wmtk {
-class Mesh;
-class TriMesh;
-class TetMesh;
-class PointMesh;
-template <typename T>
-class AttributeScopeStack;
-
-template <typename T>
-class AttributeCache;
+// class Mesh;
+// class TriMesh;
+// class TetMesh;
+// class PointMesh;
+// namespace attribute {
+// template <typename T>
+// class AttributeScopeStack;
+//
+// template <typename T>
+// class AttributeCache;
+//} // namespace attribute
 
 template <typename T, bool IsConst = false>
-class Accessor : public AccessorBase<T>
+using Accessor =
+    std::conditional_t<IsConst, attribute::ConstAccessor<T>, attribute::MutableAccessor<T>>;
+
+
+/*
+template <typename T, bool IsConst = false>
+class Accessor : public attribute::AccessorBase<T>
 {
 public:
     friend class Mesh;
@@ -31,8 +41,8 @@ public:
     friend class TetMesh;
     using Scalar = T;
 
-    friend class AttributeCache<T>;
-    using BaseType = AccessorBase<T>;
+    friend class attribute::AttributeCache<T>;
+    using BaseType = attribute::AccessorBase<T>;
     using MeshType = std::conditional_t<IsConst, const Mesh, Mesh>; // const correct Mesh object
 
     using MapResult = typename BaseType::MapResult; // Eigen::Map<VectorX<T>>
@@ -70,8 +80,8 @@ public:
 
     // returns the size of the underlying attribute
 
-    using BaseType::reserved_size; // const() -> long
     using BaseType::dimension; // const() -> long
+    using BaseType::reserved_size; // const() -> long
 
     using BaseType::attribute; // access to Attribute object being used here
     using BaseType::set_attribute; // (const vector<T>&) -> void
@@ -102,7 +112,7 @@ private:
     MeshType& m_mesh;
     AttributeAccessMode m_mode;
 
-    AttributeScopeStack<T>* m_cache_stack = nullptr;
+    attribute::AttributeScopeStack<T>* m_cache_stack = nullptr;
 };
 
 // template <typename T>
@@ -111,6 +121,7 @@ private:
 // Accessor(const Mesh& mesh, const MeshAttributeHandle<T>&) -> Accessor<const T>;
 
 
+*/
 template <typename T>
 using ConstAccessor = Accessor<T, true>;
 } // namespace wmtk

--- a/src/wmtk/CMakeLists.txt
+++ b/src/wmtk/CMakeLists.txt
@@ -1,6 +1,5 @@
 
 set(SRC_FILES
-    Accessor.cpp
     Accessor.hpp
     Mesh.cpp
     Mesh.hpp

--- a/src/wmtk/Mesh.cpp
+++ b/src/wmtk/Mesh.cpp
@@ -28,11 +28,12 @@ Mesh::~Mesh() = default;
 std::vector<Tuple> Mesh::get_all(PrimitiveType type) const
 {
     ConstAccessor<char> flag_accessor = get_flag_accessor(type);
+    const attribute::CachingAccessor<char>& flag_accessor_indices = flag_accessor.index_access();
     std::vector<Tuple> ret;
     long cap = capacity(type);
     ret.reserve(cap);
     for (size_t index = 0; index < cap; ++index) {
-        if ((flag_accessor.scalar_attribute(index) & 1)) {
+        if ((flag_accessor_indices.const_scalar_attribute(index) & 1)) {
             ret.emplace_back(tuple_from_id(type, index));
         }
     }
@@ -81,9 +82,10 @@ std::vector<long> Mesh::request_simplex_indices(PrimitiveType type, long count)
 
     m_attribute_manager.m_capacities[simplex_dim] = new_capacity;
 
+    attribute::CachingAccessor<char>& flag_accessor_indices = flag_accessor.index_access();
 
     for (const long simplex_index : ret) {
-        flag_accessor.scalar_attribute(simplex_index) |= 0x1;
+        flag_accessor_indices.scalar_attribute(simplex_index) |= 0x1;
     }
 
     return ret;
@@ -164,12 +166,22 @@ Accessor<long> Mesh::get_cell_hash_accessor()
 void Mesh::update_cell_hash(const Tuple& cell, Accessor<long>& hash_accessor)
 {
     const long cid = cell.m_global_cid;
-    ++hash_accessor.scalar_attribute(cid);
+    update_cell_hash(cid, hash_accessor);
+}
+void Mesh::update_cell_hash(const long cid, Accessor<long>& hash_accessor)
+{
+    ++hash_accessor.index_access().scalar_attribute(cid);
 }
 
 void Mesh::update_cell_hashes(const std::vector<Tuple>& cells, Accessor<long>& hash_accessor)
 {
     for (const Tuple& t : cells) {
+        update_cell_hash(t, hash_accessor);
+    }
+}
+void Mesh::update_cell_hashes(const std::vector<long>& cells, Accessor<long>& hash_accessor)
+{
+    for (const long t : cells) {
         update_cell_hash(t, hash_accessor);
     }
 }
@@ -180,17 +192,11 @@ void Mesh::update_cell_hashes_slow(const std::vector<Tuple>& cells)
     update_cell_hashes(cells, hash_accessor);
 }
 
-Tuple Mesh::resurrect_tuple(const Tuple& tuple, const Accessor<long>& hash_accessor) const
-{
-    Tuple t = tuple;
-    t.m_hash = hash_accessor.scalar_attribute(tuple.m_global_cid);
-    return t;
-}
 
 Tuple Mesh::resurrect_tuple(const Tuple& tuple, const ConstAccessor<long>& hash_accessor) const
 {
     Tuple t = tuple;
-    t.m_hash = hash_accessor.scalar_attribute(tuple.m_global_cid);
+    t.m_hash = get_cell_hash(tuple.m_global_cid, hash_accessor);
     return t;
 }
 
@@ -202,7 +208,7 @@ Tuple Mesh::resurrect_tuple_slow(const Tuple& tuple)
 
 long Mesh::get_cell_hash(long cell_index, const ConstAccessor<long>& hash_accessor) const
 {
-    return hash_accessor.scalar_attribute(cell_index);
+    return hash_accessor.index_access().const_scalar_attribute(cell_index);
 }
 
 long Mesh::get_cell_hash_slow(long cell_index) const
@@ -241,7 +247,7 @@ std::vector<std::vector<long>> Mesh::simplices_to_gids(
     return gids;
 }
 
-AttributeScopeHandle Mesh::create_scope()
+attribute::AttributeScopeHandle Mesh::create_scope()
 {
     return m_attribute_manager.create_scope(*this);
 }

--- a/src/wmtk/Mesh.hpp
+++ b/src/wmtk/Mesh.hpp
@@ -15,7 +15,12 @@
 
 namespace wmtk {
 // thread management tool that we will PImpl
+namespace attribute {
 class AttributeScopeManager;
+template <typename T>
+class TupleAccessor;
+
+}
 namespace operations {
 class Operation;
 }
@@ -24,7 +29,9 @@ class Mesh
 {
 public:
     template <typename T>
-    friend class AccessorBase;
+    friend class attribute::AccessorBase;
+    template <typename T>
+    friend class attribute::TupleAccessor;
     friend class ParaviewWriter;
     friend class MeshReader;
     friend class operations::Operation;
@@ -92,7 +99,7 @@ public:
 
 
     // creates a scope as long as the AttributeScopeHandle exists
-    [[nodiscard]] AttributeScopeHandle create_scope();
+    [[nodiscard]] attribute::AttributeScopeHandle create_scope();
 
 
     ConstAccessor<char> get_flag_accessor(PrimitiveType type) const;
@@ -132,19 +139,23 @@ protected: // member functions
     /**
      * @brief same as `update_cell_hashes` but slow because it creates a new accessor
      */
-    void update_cell_hashes_slow(const std::vector<Tuple>& cells);
+    /**
+     * @brief update hash in given cell
+     *
+     * @param cell tuple in which the hash should be updated
+     * @param hash_accessor hash accessor
+     */
+    void update_cell_hash(const long cell_index, Accessor<long>& hash_accessor);
 
     /**
-     * @brief DEPRECATED return the same tuple but with updated hash
+     * @brief update hashes in given cells
      *
-     * This function should only be used in operations to create a valid return tuple in a known
-     * position.
-     *
-     * @param tuple tuple with potentially outdated hash
+     * @param cells vector of tuples in which the hash should be updated
      * @param hash_accessor hash accessor
-     * @return tuple with updated hash
      */
-    Tuple resurrect_tuple(const Tuple& tuple, const Accessor<long>& hash_accessor) const;
+    void update_cell_hashes(const std::vector<long>& cell_indices, Accessor<long>& hash_accessor);
+
+    void update_cell_hashes_slow(const std::vector<Tuple>& cells);
 
     /**
      * @brief return the same tuple but with updated hash
@@ -280,7 +291,7 @@ protected:
     //[[nodiscard]] AccessorScopeHandle push_accesor_scope();
 
 private: // members
-    AttributeManager m_attribute_manager;
+    attribute::AttributeManager m_attribute_manager;
 
     // PImpl'd manager of per-thread update stacks
     // Every time a new access scope is requested the manager creates another level of indirection

--- a/src/wmtk/MultiMeshManager.cpp
+++ b/src/wmtk/MultiMeshManager.cpp
@@ -47,7 +47,7 @@ namespace wmtk
     std::tuple<Tuple, Tuple> MultiMeshManager::read_tuple_map_attribute(MeshAttributeHandle<long> map_handle, const Mesh& source_mesh, const Tuple& source_tuple)
     {
         auto map_accessor = source_mesh.create_accessor(map_handle);
-        auto map = map_accessor.vector_attribute(source_tuple);
+        auto map = map_accessor.const_vector_attribute(source_tuple);
 
         return std::make_tuple(Tuple(map(0), map(1), map(2), map(3), map(4)), Tuple(map(5), map(6), map(7), map(8), map(9)));
     }

--- a/src/wmtk/PointMesh.cpp
+++ b/src/wmtk/PointMesh.cpp
@@ -44,7 +44,7 @@ void PointMesh::initialize(long count)
     reserve_attributes_to_fit();
     Accessor<char> v_flag_accessor = get_flag_accessor(PrimitiveType::Vertex);
     for (long i = 0; i < capacity(PrimitiveType::Vertex); ++i) {
-        v_flag_accessor.scalar_attribute(i) |= 0x1;
+        v_flag_accessor.index_access().scalar_attribute(i) |= 0x1;
     }
 }
 

--- a/src/wmtk/TetMesh.cpp
+++ b/src/wmtk/TetMesh.cpp
@@ -58,26 +58,26 @@ void TetMesh::initialize(
 
     // iterate over the matrices and fill attributes
     for (long i = 0; i < capacity(PrimitiveType::Tetrahedron); ++i) {
-        tv_accessor.vector_attribute(i) = TV.row(i).transpose();
-        te_accessor.vector_attribute(i) = TE.row(i).transpose();
-        tf_accessor.vector_attribute(i) = TF.row(i).transpose();
-        tt_accessor.vector_attribute(i) = TT.row(i).transpose();
-        t_flag_accessor.scalar_attribute(i) |= 0x1;
+        tv_accessor.index_access().vector_attribute(i) = TV.row(i).transpose();
+        te_accessor.index_access().vector_attribute(i) = TE.row(i).transpose();
+        tf_accessor.index_access().vector_attribute(i) = TF.row(i).transpose();
+        tt_accessor.index_access().vector_attribute(i) = TT.row(i).transpose();
+        t_flag_accessor.index_access().scalar_attribute(i) |= 0x1;
     }
     // m_vt
     for (long i = 0; i < capacity(PrimitiveType::Vertex); ++i) {
-        vt_accessor.scalar_attribute(i) = VT(i);
-        v_flag_accessor.scalar_attribute(i) |= 0x1;
+        vt_accessor.index_access().scalar_attribute(i) = VT(i);
+        v_flag_accessor.index_access().scalar_attribute(i) |= 0x1;
     }
     // m_et
     for (long i = 0; i < capacity(PrimitiveType::Edge); ++i) {
-        et_accessor.scalar_attribute(i) = ET(i);
-        e_flag_accessor.scalar_attribute(i) |= 0x1;
+        et_accessor.index_access().scalar_attribute(i) = ET(i);
+        e_flag_accessor.index_access().scalar_attribute(i) |= 0x1;
     }
     // m_ft
     for (long i = 0; i < capacity(PrimitiveType::Face); ++i) {
-        ft_accessor.scalar_attribute(i) = FT(i);
-        f_flag_accessor.scalar_attribute(i) |= 0x1;
+        ft_accessor.index_access().scalar_attribute(i) = FT(i);
+        f_flag_accessor.index_access().scalar_attribute(i) |= 0x1;
     }
 }
 
@@ -98,9 +98,9 @@ long TetMesh::_debug_id(const Tuple& tuple, PrimitiveType type) const
 Tuple TetMesh::vertex_tuple_from_id(long id) const
 {
     ConstAccessor<long> vt_accessor = create_accessor<long>(m_vt_handle);
-    auto t = vt_accessor.scalar_attribute(id);
+    long t = vt_accessor.index_access().scalar_attribute(id);
     ConstAccessor<long> tv_accessor = create_accessor<long>(m_tv_handle);
-    auto tv = tv_accessor.vector_attribute(t);
+    auto tv = tv_accessor.index_access().vector_attribute(t);
     long lvid = -1, leid = -1, lfid = -1;
 
     for (long i = 0; i < 4; ++i) {
@@ -128,9 +128,9 @@ Tuple TetMesh::vertex_tuple_from_id(long id) const
 Tuple TetMesh::edge_tuple_from_id(long id) const
 {
     ConstAccessor<long> et_accessor = create_accessor<long>(m_et_handle);
-    auto t = et_accessor.scalar_attribute(id);
+    long t = et_accessor.index_access().scalar_attribute(id);
     ConstAccessor<long> te_accessor = create_accessor<long>(m_te_handle);
-    auto te = te_accessor.vector_attribute(t);
+    auto te = te_accessor.index_access().vector_attribute(t);
 
     long lvid = -1, leid = -1, lfid = -1;
 
@@ -159,9 +159,9 @@ Tuple TetMesh::edge_tuple_from_id(long id) const
 Tuple TetMesh::face_tuple_from_id(long id) const
 {
     ConstAccessor<long> ft_accessor = create_accessor<long>(m_ft_handle);
-    auto t = ft_accessor.scalar_attribute(id);
+    long t = ft_accessor.index_access().scalar_attribute(id);
     ConstAccessor<long> tf_accessor = create_accessor<long>(m_tf_handle);
-    auto tf = tf_accessor.vector_attribute(t);
+    auto tf = tf_accessor.index_access().vector_attribute(t);
 
     long lvid = -1, leid = -1, lfid = -1;
 

--- a/src/wmtk/TriMesh.cpp
+++ b/src/wmtk/TriMesh.cpp
@@ -119,10 +119,10 @@ Tuple TriMesh::switch_tuple(const Tuple& tuple, PrimitiveType type) const
         long lvid_new = -1, leid_new = -1;
 
         ConstAccessor<long> fv_accessor = create_const_accessor<long>(m_fv_handle);
-        auto fv = fv_accessor.vector_attribute(gcid_new);
+        auto fv = fv_accessor.index_access().vector_attribute(gcid_new);
 
         ConstAccessor<long> fe_accessor = create_const_accessor<long>(m_fe_handle);
-        auto fe = fe_accessor.vector_attribute(gcid_new);
+        auto fe = fe_accessor.index_access().vector_attribute(gcid_new);
 
         for (long i = 0; i < 3; ++i) {
             if (fe(i) == geid) {
@@ -189,21 +189,21 @@ void TriMesh::initialize(
 
     // iterate over the matrices and fill attributes
     for (long i = 0; i < capacity(PrimitiveType::Face); ++i) {
-        fv_accessor.vector_attribute(i) = FV.row(i).transpose();
-        fe_accessor.vector_attribute(i) = FE.row(i).transpose();
-        ff_accessor.vector_attribute(i) = FF.row(i).transpose();
+        fv_accessor.index_access().vector_attribute(i) = FV.row(i).transpose();
+        fe_accessor.index_access().vector_attribute(i) = FE.row(i).transpose();
+        ff_accessor.index_access().vector_attribute(i) = FF.row(i).transpose();
 
-        f_flag_accessor.scalar_attribute(i) |= 0x1;
+        f_flag_accessor.index_access().scalar_attribute(i) |= 0x1;
     }
     // m_vf
     for (long i = 0; i < capacity(PrimitiveType::Vertex); ++i) {
-        vf_accessor.scalar_attribute(i) = VF(i);
-        v_flag_accessor.scalar_attribute(i) |= 0x1;
+        vf_accessor.index_access().scalar_attribute(i) = VF(i);
+        v_flag_accessor.index_access().scalar_attribute(i) |= 0x1;
     }
     // m_ef
     for (long i = 0; i < capacity(PrimitiveType::Edge); ++i) {
-        ef_accessor.scalar_attribute(i) = EF(i);
-        e_flag_accessor.scalar_attribute(i) |= 0x1;
+        ef_accessor.index_access().scalar_attribute(i) = EF(i);
+        e_flag_accessor.index_access().scalar_attribute(i) |= 0x1;
     }
 }
 
@@ -243,9 +243,9 @@ Tuple TriMesh::tuple_from_id(const PrimitiveType type, const long gid) const
 Tuple TriMesh::vertex_tuple_from_id(long id) const
 {
     ConstAccessor<long> vf_accessor = create_const_accessor<long>(m_vf_handle);
-    auto f = vf_accessor.scalar_attribute(id);
+    auto f = vf_accessor.index_access().scalar_attribute(id);
     ConstAccessor<long> fv_accessor = create_const_accessor<long>(m_fv_handle);
-    auto fv = fv_accessor.vector_attribute(f);
+    auto fv = fv_accessor.index_access().vector_attribute(f);
     for (long i = 0; i < 3; ++i) {
         if (fv(i) == id) {
             assert(autogen::auto_2d_table_complete_vertex[i][0] == i);
@@ -267,9 +267,9 @@ Tuple TriMesh::vertex_tuple_from_id(long id) const
 Tuple TriMesh::edge_tuple_from_id(long id) const
 {
     ConstAccessor<long> ef_accessor = create_const_accessor<long>(m_ef_handle);
-    auto f = ef_accessor.scalar_attribute(id);
+    auto f = ef_accessor.index_access().scalar_attribute(id);
     ConstAccessor<long> fe_accessor = create_const_accessor<long>(m_fe_handle);
-    auto fe = fe_accessor.vector_attribute(f);
+    auto fe = fe_accessor.index_access().vector_attribute(f);
     for (long i = 0; i < 3; ++i) {
         if (fe(i) == id) {
             assert(autogen::auto_2d_table_complete_edge[i][1] == i);
@@ -330,13 +330,13 @@ bool TriMesh::is_connectivity_valid() const
 
     // EF and FE
     for (long i = 0; i < capacity(PrimitiveType::Edge); ++i) {
-        if (e_flag_accessor.scalar_attribute(i) == 0) {
+        if (e_flag_accessor.index_access().scalar_attribute(i) == 0) {
             wmtk::logger().debug("Edge {} is deleted", i);
             continue;
         }
         int cnt = 0;
         for (long j = 0; j < 3; ++j) {
-            if (fe_accessor.vector_attribute(ef_accessor.scalar_attribute(i))[j] == i) {
+            if (fe_accessor.index_access().vector_attribute(ef_accessor.index_access().scalar_attribute(i))[j] == i) {
                 cnt++;
             }
         }
@@ -348,13 +348,13 @@ bool TriMesh::is_connectivity_valid() const
 
     // VF and FV
     for (long i = 0; i < capacity(PrimitiveType::Vertex); ++i) {
-        if (v_flag_accessor.scalar_attribute(i) == 0) {
+        if (v_flag_accessor.index_access().scalar_attribute(i) == 0) {
             wmtk::logger().debug("Vertex {} is deleted", i);
             continue;
         }
         int cnt = 0;
         for (long j = 0; j < 3; ++j) {
-            if (fv_accessor.vector_attribute(vf_accessor.scalar_attribute(i))[j] == i) {
+            if (fv_accessor.index_access().vector_attribute(vf_accessor.index_access().scalar_attribute(i))[j] == i) {
                 cnt++;
             }
         }
@@ -366,14 +366,14 @@ bool TriMesh::is_connectivity_valid() const
 
     // FE and EF
     for (long i = 0; i < capacity(PrimitiveType::Face); ++i) {
-        if (f_flag_accessor.scalar_attribute(i) == 0) {
+        if (f_flag_accessor.index_access().scalar_attribute(i) == 0) {
             wmtk::logger().debug("Face {} is deleted", i);
             continue;
         }
         for (long j = 0; j < 3; ++j) {
-            long nb = ff_accessor.vector_attribute(i)[j];
+            long nb = ff_accessor.index_access().vector_attribute(i)[j];
             if (nb == -1) {
-                if (ef_accessor.scalar_attribute(fe_accessor.vector_attribute(i)[j]) != i) {
+                if (ef_accessor.index_access().const_scalar_attribute(fe_accessor.index_access().const_vector_attribute(i)[j]) != i) {
                     // std::cout << "FF and FE not compatible" << std::endl;
                     return false;
                 }
@@ -383,7 +383,7 @@ bool TriMesh::is_connectivity_valid() const
             int cnt = 0;
             int id_in_nb;
             for (long k = 0; k < 3; ++k) {
-                if (ff_accessor.vector_attribute(nb)[k] == i) {
+                if (ff_accessor.index_access().const_vector_attribute(nb)[k] == i) {
                     cnt++;
                     id_in_nb = k;
                 }
@@ -394,7 +394,7 @@ bool TriMesh::is_connectivity_valid() const
                 return false;
             }
 
-            if (fe_accessor.vector_attribute(i)[j] != fe_accessor.vector_attribute(nb)[id_in_nb]) {
+            if (fe_accessor.index_access().const_vector_attribute(i)[j] != fe_accessor.index_access().const_vector_attribute(nb)[id_in_nb]) {
                 // std::cout << "FF and FE not compatible" << std::endl;
                 return false;
             }

--- a/src/wmtk/TriMesh.hpp
+++ b/src/wmtk/TriMesh.hpp
@@ -85,12 +85,12 @@ protected:
     Tuple tuple_from_id(const PrimitiveType type, const long gid) const override;
 
 protected:
-    MeshAttributeHandle<long> m_vf_handle;
-    MeshAttributeHandle<long> m_ef_handle;
+    attribute::MeshAttributeHandle<long> m_vf_handle;
+    attribute::MeshAttributeHandle<long> m_ef_handle;
 
-    MeshAttributeHandle<long> m_fv_handle;
-    MeshAttributeHandle<long> m_fe_handle;
-    MeshAttributeHandle<long> m_ff_handle;
+    attribute::MeshAttributeHandle<long> m_fv_handle;
+    attribute::MeshAttributeHandle<long> m_fe_handle;
+    attribute::MeshAttributeHandle<long> m_ff_handle;
 
     Tuple vertex_tuple_from_id(long id) const;
     Tuple edge_tuple_from_id(long id) const;

--- a/src/wmtk/TriMeshOperationExecutor.cpp
+++ b/src/wmtk/TriMeshOperationExecutor.cpp
@@ -519,7 +519,7 @@ void TriMesh::TriMeshOperationExecutor::update_hash_in_map(TriMesh& child_mesh)
     {
         auto [t_parent_old, t_child_old] = MultiMeshManager::read_tuple_map_attribute(m_mesh.multi_mesh_manager.map_to_child_handles[child_id], m_mesh, m_mesh.tuple_from_id(m_mesh.top_simplex_type(), parent_cell_id));
 
-        long parent_cell_hash = hash_at_cell(parent_cell_id);
+        long parent_cell_hash = m_mesh.get_cell_hash_slow(parent_cell_id);
         Tuple t_parent_new = t_parent_old.with_updated_hash(parent_cell_hash);
 
         if (t_child_old.is_null())
@@ -528,7 +528,7 @@ void TriMesh::TriMeshOperationExecutor::update_hash_in_map(TriMesh& child_mesh)
         }
         else
         {
-            long child_cell_hash = child_hash_accessor.scalar_attribute(t_child_old.m_global_cid);
+            long child_cell_hash = child_hash_accessor.index_access().const_scalar_attribute(t_child_old.m_global_cid);
             Tuple t_child_new = t_child_old.with_updated_hash(child_cell_hash);
             MultiMeshManager::write_tuple_map_attribute(m_mesh.multi_mesh_manager.map_to_child_handles[child_id], m_mesh, t_parent_new, t_child_new);
 

--- a/src/wmtk/TriMeshOperationExecutor.cpp
+++ b/src/wmtk/TriMeshOperationExecutor.cpp
@@ -93,16 +93,14 @@ void TriMesh::TriMeshOperationExecutor::delete_simplices()
 {
     for (size_t d = 0; d < simplex_ids_to_delete.size(); ++d) {
         for (const long id : simplex_ids_to_delete[d]) {
-            flag_accessors[d].scalar_attribute(id) = 0;
+            flag_accessors[d].index_access().scalar_attribute(id) = 0;
         }
     }
 }
 
 void TriMesh::TriMeshOperationExecutor::update_cell_hash()
 {
-    for (const long& cell_id : cell_ids_to_update_hash) {
-        ++hash_accessor.scalar_attribute(cell_id);
-    }
+    m_mesh.update_cell_hashes(cell_ids_to_update_hash, hash_accessor);
 }
 
 const std::array<std::vector<long>, 3>
@@ -162,8 +160,8 @@ void TriMesh::TriMeshOperationExecutor::update_ids_in_ear(
     //      -----
     if (ear_fid < 0) return;
 
-    auto ear_ff = ff_accessor.vector_attribute(ear_fid);
-    auto ear_fe = fe_accessor.vector_attribute(ear_fid);
+    auto ear_ff = ff_accessor.index_access().vector_attribute(ear_fid);
+    auto ear_fe = fe_accessor.index_access().vector_attribute(ear_fid);
     for (int i = 0; i < 3; ++i) {
         if (ear_ff[i] == old_fid) {
             ear_ff[i] = new_fid;
@@ -172,7 +170,7 @@ void TriMesh::TriMeshOperationExecutor::update_ids_in_ear(
         }
     }
 
-    ef_accessor.scalar_attribute(new_eid) = ear_fid;
+    ef_accessor.index_access().scalar_attribute(new_eid) = ear_fid;
 }
 
 void TriMesh::TriMeshOperationExecutor::connect_ears()
@@ -206,12 +204,12 @@ void TriMesh::TriMeshOperationExecutor::connect_ears()
         assert(ef0 != ef1);
 
         // change face for v2
-        long& v2_face = vf_accessor.scalar_attribute(v2);
+        long& v2_face = vf_accessor.index_access().scalar_attribute(v2);
         // use ef0 if it exists
         v2_face = (ef0 < 0) ? ef1 : ef0;
 
-        ef_accessor.scalar_attribute(ee1) = v2_face;
-        vf_accessor.scalar_attribute(v1) = v2_face;
+        ef_accessor.index_access().scalar_attribute(ee1) = v2_face;
+        vf_accessor.index_access().scalar_attribute(v1) = v2_face;
 
         // change FF and FE for ears
         update_ids_in_ear(ef0, ef1, f_old, ee1);
@@ -229,8 +227,8 @@ void TriMesh::TriMeshOperationExecutor::connect_faces_across_spine()
     const long f_old_bottom = m_incident_face_datas[1].fid;
     const long f0_bottom = m_incident_face_datas[1].split_f0;
     const long f1_bottom = m_incident_face_datas[1].split_f1;
-    auto ff_old_top = ff_accessor.vector_attribute(f_old_top);
-    auto ff_old_bottom = ff_accessor.vector_attribute(f_old_bottom);
+    auto ff_old_top = ff_accessor.index_access().vector_attribute(f_old_top);
+    auto ff_old_bottom = ff_accessor.index_access().vector_attribute(f_old_bottom);
     assert(m_mesh.capacity(PrimitiveType::Face) > f0_top);
     assert(m_mesh.capacity(PrimitiveType::Face) > f1_top);
     assert(m_mesh.capacity(PrimitiveType::Face) > f0_bottom);
@@ -250,10 +248,10 @@ void TriMesh::TriMeshOperationExecutor::connect_faces_across_spine()
     assert(local_eid_top > -1);
     assert(local_eid_bottom > -1);
     // TODO write test for assumming top and bottom new fids are in right correspondence
-    ff_accessor.vector_attribute(f0_top)[local_eid_top] = f0_bottom;
-    ff_accessor.vector_attribute(f0_bottom)[local_eid_bottom] = f0_top;
-    ff_accessor.vector_attribute(f1_top)[local_eid_top] = f1_bottom;
-    ff_accessor.vector_attribute(f1_bottom)[local_eid_bottom] = f1_top;
+    ff_accessor.index_access().vector_attribute(f0_top)[local_eid_top] = f0_bottom;
+    ff_accessor.index_access().vector_attribute(f0_bottom)[local_eid_bottom] = f0_top;
+    ff_accessor.index_access().vector_attribute(f1_top)[local_eid_top] = f1_bottom;
+    ff_accessor.index_access().vector_attribute(f1_bottom)[local_eid_bottom] = f1_top;
 }
 
 void TriMesh::TriMeshOperationExecutor::replace_incident_face(
@@ -301,12 +299,12 @@ void TriMesh::TriMeshOperationExecutor::replace_incident_face(
     {
         update_ids_in_ear(ef0, f0, f_old, ee0);
 
-        auto fv = fv_accessor.vector_attribute(f0);
-        auto fe = fe_accessor.vector_attribute(f0);
-        auto ff = ff_accessor.vector_attribute(f0);
-        fv = fv_accessor.vector_attribute(f_old);
-        fe = fe_accessor.vector_attribute(f_old);
-        ff = ff_accessor.vector_attribute(f_old);
+        auto fv = fv_accessor.index_access().vector_attribute(f0);
+        auto fe = fe_accessor.index_access().vector_attribute(f0);
+        auto ff = ff_accessor.index_access().vector_attribute(f0);
+        fv = fv_accessor.index_access().vector_attribute(f_old);
+        fe = fe_accessor.index_access().vector_attribute(f_old);
+        ff = ff_accessor.index_access().vector_attribute(f_old);
         // correct old connectivity
         for (size_t i = 0; i < 3; ++i) {
             if (fe[i] == ee1) {
@@ -327,12 +325,12 @@ void TriMesh::TriMeshOperationExecutor::replace_incident_face(
     {
         update_ids_in_ear(ef1, f1, f_old, ee1);
 
-        auto fv = fv_accessor.vector_attribute(f1);
-        auto fe = fe_accessor.vector_attribute(f1);
-        auto ff = ff_accessor.vector_attribute(f1);
-        fv = fv_accessor.vector_attribute(f_old);
-        fe = fe_accessor.vector_attribute(f_old);
-        ff = ff_accessor.vector_attribute(f_old);
+        auto fv = fv_accessor.index_access().vector_attribute(f1);
+        auto fe = fe_accessor.index_access().vector_attribute(f1);
+        auto ff = ff_accessor.index_access().vector_attribute(f1);
+        fv = fv_accessor.index_access().vector_attribute(f_old);
+        fe = fe_accessor.index_access().vector_attribute(f_old);
+        ff = ff_accessor.index_access().vector_attribute(f_old);
         // correct old connectivity
         for (size_t i = 0; i < 3; ++i) {
             if (fe[i] == ee0) {
@@ -351,16 +349,16 @@ void TriMesh::TriMeshOperationExecutor::replace_incident_face(
     }
 
     // assign each edge one face
-    ef_accessor.scalar_attribute(ee0) = f0;
-    ef_accessor.scalar_attribute(ee1) = f1;
-    ef_accessor.scalar_attribute(oe) = f0;
-    ef_accessor.scalar_attribute(se0) = f0;
-    ef_accessor.scalar_attribute(se1) = f1;
+    ef_accessor.index_access().scalar_attribute(ee0) = f0;
+    ef_accessor.index_access().scalar_attribute(ee1) = f1;
+    ef_accessor.index_access().scalar_attribute(oe) = f0;
+    ef_accessor.index_access().scalar_attribute(se0) = f0;
+    ef_accessor.index_access().scalar_attribute(se1) = f1;
     // assign each vertex one face
-    vf_accessor.scalar_attribute(v0) = f0;
-    vf_accessor.scalar_attribute(v1) = f1;
-    vf_accessor.scalar_attribute(v2) = f0;
-    vf_accessor.scalar_attribute(v_new) = f0;
+    vf_accessor.index_access().scalar_attribute(v0) = f0;
+    vf_accessor.index_access().scalar_attribute(v1) = f1;
+    vf_accessor.index_access().scalar_attribute(v2) = f0;
+    vf_accessor.index_access().scalar_attribute(v_new) = f0;
 
     // face neighbors on the other side of the spine are updated separately
 
@@ -422,7 +420,7 @@ Tuple TriMesh::TriMeshOperationExecutor::collapse_edge()
     // replace v0 by v1 in incident faces
     for (const Simplex& f : v0_star.get_faces()) {
         const long fid = m_mesh.id(f);
-        auto fv = fv_accessor.vector_attribute(fid);
+        auto fv = fv_accessor.index_access().vector_attribute(fid);
         for (long i = 0; i < 3; ++i) {
             if (fv[i] == v0) {
                 fv[i] = v1;

--- a/src/wmtk/TriMeshOperationExecutor.hpp
+++ b/src/wmtk/TriMeshOperationExecutor.hpp
@@ -113,7 +113,6 @@ public:
     TriMesh& m_mesh;
     Tuple m_operating_tuple;
 
-    long hash_at_cell(const long cell) { return hash_accessor.scalar_attribute(cell); }
 
 private:
     // common simplicies

--- a/src/wmtk/attribute/AccessorBase.cpp
+++ b/src/wmtk/attribute/AccessorBase.cpp
@@ -5,18 +5,36 @@
 #include "MeshAttributes.hpp"
 #include "wmtk/Mesh.hpp"
 
-namespace wmtk {
+namespace wmtk::attribute {
 template <typename T>
 AccessorBase<T>::AccessorBase(Mesh& m, const MeshAttributeHandle<T>& handle)
-    : AccessorBase(m.m_attribute_manager, handle)
-{}
-
-
-template <typename T>
-AccessorBase<T>::AccessorBase(AttributeManager& am, const MeshAttributeHandle<T>& handle)
-    : m_attribute_manager(am)
+    : m_mesh(m)
     , m_handle(handle)
 {}
+
+template <typename T>
+Mesh& AccessorBase<T>::mesh()
+{
+    return m_mesh;
+}
+template <typename T>
+const Mesh& AccessorBase<T>::mesh() const
+{
+    return m_mesh;
+}
+
+template <typename T>
+const AttributeManager& AccessorBase<T>::attribute_manager() const
+{
+    return mesh().m_attribute_manager;
+}
+
+template <typename T>
+AttributeManager& AccessorBase<T>::attribute_manager()
+{
+    return mesh().m_attribute_manager;
+}
+
 
 template <typename T>
 AccessorBase<T>::~AccessorBase() = default;
@@ -37,12 +55,12 @@ long AccessorBase<T>::dimension() const
 template <typename T>
 auto AccessorBase<T>::attributes() -> MeshAttributes<T>&
 {
-    return m_attribute_manager.get(m_handle);
+    return attribute_manager().get(m_handle);
 }
 template <typename T>
 auto AccessorBase<T>::attributes() const -> const MeshAttributes<T>&
 {
-    return m_attribute_manager.get(m_handle);
+    return attribute_manager().get(m_handle);
 }
 template <typename T>
 auto AccessorBase<T>::attribute() -> Attribute<T>&
@@ -64,12 +82,6 @@ template <typename T>
 PrimitiveType AccessorBase<T>::primitive_type() const
 {
     return handle().m_primitive_type;
-}
-template <typename T>
-long AccessorBase<T>::index(const Mesh& mesh, const Tuple& t) const
-{
-    assert(mesh.is_valid_slow(t));
-    return mesh.id(t, m_handle.m_primitive_type);
 }
 
 template <typename T>
@@ -111,4 +123,4 @@ template class AccessorBase<char>;
 template class AccessorBase<long>;
 template class AccessorBase<double>;
 template class AccessorBase<Rational>;
-} // namespace wmtk
+} // namespace wmtk::attribute

--- a/src/wmtk/attribute/AccessorBase.hpp
+++ b/src/wmtk/attribute/AccessorBase.hpp
@@ -9,16 +9,16 @@
 
 #include <Eigen/Dense>
 
-namespace wmtk {
+namespace wmtk::attribute {
 
 template <typename T>
 class MeshAttributes;
 template <typename T>
 class AccessorCache;
 
-
 // The basic implementation of an accessor using indices.
-// This should never be
+// This should never be externally used except within the main accessor
+// interface, in unit tests, or in topological updates
 template <typename _T>
 class AccessorBase
 {
@@ -55,20 +55,21 @@ public:
 
     ~AccessorBase();
     AccessorBase(Mesh& m, const MeshAttributeHandle<T>& handle);
-    AccessorBase(AttributeManager& m, const MeshAttributeHandle<T>& handle);
 
     const MeshAttributeHandle<T>& handle() const;
     PrimitiveType primitive_type() const;
 
-    // convenience function for use within Accessor
-    // Mainly here to avoid having to friend an Accessor to Mesh as well
-    long index(const Mesh& m, const Tuple& t) const;
+    Mesh& mesh();
+    const Mesh& mesh() const;
+
 
 protected:
-    // Mesh& m_mesh;
-    AttributeManager& m_attribute_manager;
+    Mesh& m_mesh;
     MeshAttributeHandle<T> m_handle;
+
+    const AttributeManager& attribute_manager() const;
+    AttributeManager& attribute_manager();
 };
 
 
-} // namespace wmtk
+} // namespace wmtk::attribute

--- a/src/wmtk/attribute/Attribute.cpp
+++ b/src/wmtk/attribute/Attribute.cpp
@@ -3,7 +3,7 @@
 #include <wmtk/io/MeshWriter.hpp>
 #include <wmtk/utils/Rational.hpp>
 
-namespace wmtk {
+namespace wmtk::attribute {
 
 
 template <typename T>
@@ -162,4 +162,4 @@ template class Attribute<char>;
 template class Attribute<long>;
 template class Attribute<double>;
 template class Attribute<Rational>;
-} // namespace wmtk
+} // namespace wmtk::attribute

--- a/src/wmtk/attribute/Attribute.hpp
+++ b/src/wmtk/attribute/Attribute.hpp
@@ -6,6 +6,8 @@
 
 namespace wmtk {
 class MeshWriter;
+
+namespace attribute {
 template <typename T>
 class AccessorBase;
 
@@ -45,7 +47,8 @@ public:
     T& scalar_attribute(const long index);
 
     void set(std::vector<T> val);
-    // The total number of elements in a vector. This is greater than the number of active values in the attribute, and the set of active values is handled by a higher level abstraction
+    // The total number of elements in a vector. This is greater than the number of active values in
+    // the attribute, and the set of active values is handled by a higher level abstraction
     long reserved_size() const;
     // The number of data for each element in the vector
     long dimension() const;
@@ -65,4 +68,5 @@ private:
     std::unique_ptr<PerThreadAttributeScopeStacks<T>> m_scope_stacks;
     long m_dimension = -1;
 };
+} // namespace attribute
 } // namespace wmtk

--- a/src/wmtk/attribute/AttributeCache.cpp
+++ b/src/wmtk/attribute/AttributeCache.cpp
@@ -1,7 +1,7 @@
 #include "AttributeCache.hpp"
 #include <wmtk/utils/Rational.hpp>
 
-namespace wmtk {
+namespace wmtk::attribute {
 
 
 template <typename T>

--- a/src/wmtk/attribute/AttributeCache.hpp
+++ b/src/wmtk/attribute/AttributeCache.hpp
@@ -6,7 +6,7 @@
 #include "AttributeCacheData.hpp"
 
 
-namespace wmtk {
+namespace wmtk::attribute {
 template <typename T>
 class AttributeCache
 {

--- a/src/wmtk/attribute/AttributeHandle.hpp
+++ b/src/wmtk/attribute/AttributeHandle.hpp
@@ -2,14 +2,16 @@
 #include <type_traits>
 #include "wmtk/Primitive.hpp"
 namespace wmtk {
+    class Mesh;
+namespace attribute {
 template <typename T>
 class MeshAttributes;
-template <typename T, bool IsConst>
-class Accessor;
 template <typename T>
 class AccessorBase;
 template <typename T>
-class MeshAttribteHandle;
+class TupleAccessor;
+template <typename T>
+class MeshAttributeHandle;
 struct AttributeManager;
 
 class AttributeHandle
@@ -40,9 +42,10 @@ template <typename T>
 class MeshAttributeHandle
 {
 private:
-    friend class Mesh;
+    friend class wmtk::Mesh;
     friend class MeshAttributes<T>;
     friend class AccessorBase<T>;
+    friend class TupleAccessor<T>;
     friend struct AttributeManager;
     AttributeHandle m_base_handle;
     PrimitiveType m_primitive_type;
@@ -69,4 +72,8 @@ public:
                m_primitive_type == o.m_primitive_type;
     }
 };
+} // namespace attribute
+using AttributeHandle = attribute::AttributeHandle;
+template <typename T>
+using MeshAttributeHandle = attribute::MeshAttributeHandle<T>;
 } // namespace wmtk

--- a/src/wmtk/attribute/AttributeManager.cpp
+++ b/src/wmtk/attribute/AttributeManager.cpp
@@ -2,7 +2,7 @@
 #include <wmtk/io/MeshWriter.hpp>
 #include <wmtk/io/ParaviewWriter.hpp>
 #include "PerThreadAttributeScopeStacks.hpp"
-namespace wmtk {
+namespace wmtk::attribute {
 AttributeManager::AttributeManager(long size)
     : m_char_attributes(size)
     , m_long_attributes(size)
@@ -120,4 +120,4 @@ void AttributeManager::clear_current_scope()
         ma.clear_current_scope();
     }
 }
-} // namespace wmtk
+} // namespace wmtk::attribute

--- a/src/wmtk/attribute/AttributeManager.hpp
+++ b/src/wmtk/attribute/AttributeManager.hpp
@@ -7,10 +7,11 @@
 
 namespace wmtk {
 class Mesh;
-template <typename T>
-class MeshAttributes;
 class MeshWriter;
 
+namespace attribute {
+template <typename T>
+class MeshAttributes;
 struct AttributeManager
 {
     AttributeManager(long size);
@@ -80,7 +81,7 @@ const MeshAttributes<T>& AttributeManager::get(PrimitiveType ptype) const
         return m_double_attributes[index];
     }
     if constexpr (std::is_same_v<T, Rational>) {
-        return m_rational_attributes;
+        return m_rational_attributes[index];
     }
 }
 
@@ -128,4 +129,5 @@ MeshAttributeHandle<T> AttributeManager::register_attribute(
     r.m_primitive_type = ptype;
     return r;
 }
+} // namespace attribute
 } // namespace wmtk

--- a/src/wmtk/attribute/AttributeScope.cpp
+++ b/src/wmtk/attribute/AttributeScope.cpp
@@ -1,6 +1,6 @@
 #include "AttributeScope.hpp"
 #include <wmtk/utils/Rational.hpp>
-namespace wmtk {
+namespace wmtk::attribute {
 
 template <typename T>
 AttributeScope<T>::AttributeScope() = default;
@@ -154,4 +154,4 @@ template class AttributeScope<long>;
 template class AttributeScope<double>;
 template class AttributeScope<char>;
 template class AttributeScope<Rational>;
-} // namespace wmtk
+} // namespace wmtk::attribute

--- a/src/wmtk/attribute/AttributeScope.hpp
+++ b/src/wmtk/attribute/AttributeScope.hpp
@@ -1,23 +1,24 @@
 #pragma once
 
 #include <memory>
+#include "Attribute.hpp"
 #include "AttributeAccessMode.hpp"
 #include "AttributeCache.hpp"
 
 namespace wmtk {
 
-template <typename T, bool IsConst>
-class Accessor;
 
+namespace attribute {
 template <typename T>
 class AttributeScopeStack;
+template <typename T>
+class CachingAccessor;
 
 template <typename T>
 class AttributeScope : public AttributeCache<T>
 {
 public:
-    template <typename U, bool IsConst>
-    friend class Accessor;
+    friend class CachingAccessor<T>;
     friend class AttributeScopeStack<T>;
     AttributeScope();
     ~AttributeScope();
@@ -71,4 +72,5 @@ private:
     long m_checkpoint_index = -1;
 };
 
+} // namespace attribute
 } // namespace wmtk

--- a/src/wmtk/attribute/AttributeScopeHandle.cpp
+++ b/src/wmtk/attribute/AttributeScopeHandle.cpp
@@ -1,7 +1,7 @@
 #include "AttributeScopeHandle.hpp"
 #include "AttributeManager.hpp"
 #include "AttributeScope.hpp"
-namespace wmtk {
+namespace wmtk::attribute {
 AttributeScopeHandle::AttributeScopeHandle(AttributeManager& manager)
     : m_manager(manager)
 {
@@ -18,4 +18,4 @@ AttributeScopeHandle::~AttributeScopeHandle()
 {
     m_manager.pop_scope(!m_failed);
 }
-} // namespace wmtk
+} // namespace wmtk::attribute

--- a/src/wmtk/attribute/AttributeScopeHandle.hpp
+++ b/src/wmtk/attribute/AttributeScopeHandle.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-namespace wmtk {
+namespace wmtk::attribute {
 struct AttributeManager;
 class AttributeScopeHandle
 {
@@ -15,4 +15,4 @@ private:
     AttributeManager& m_manager;
     bool m_failed = false;
 };
-} // namespace wmtk
+} // namespace wmtk::attribute

--- a/src/wmtk/attribute/AttributeScopeStack.cpp
+++ b/src/wmtk/attribute/AttributeScopeStack.cpp
@@ -3,7 +3,7 @@
 #include "Attribute.hpp"
 #include "AttributeScope.hpp"
 
-namespace wmtk {
+namespace wmtk::attribute {
 
 template <typename T>
 AttributeScopeStack<T>::AttributeScopeStack() = default;
@@ -85,7 +85,7 @@ long AttributeScopeStack<T>::add_checkpoint()
     return r;
 }
 template <typename T>
-AttributeScope<T> const * AttributeScopeStack<T>::get_checkpoint(long index) const
+AttributeScope<T> const* AttributeScopeStack<T>::get_checkpoint(long index) const
 {
     if (m_checkpoints.empty()) {
         return nullptr;
@@ -97,4 +97,4 @@ template class AttributeScopeStack<long>;
 template class AttributeScopeStack<double>;
 template class AttributeScopeStack<char>;
 template class AttributeScopeStack<Rational>;
-} // namespace wmtk
+} // namespace wmtk::attribute

--- a/src/wmtk/attribute/AttributeScopeStack.hpp
+++ b/src/wmtk/attribute/AttributeScopeStack.hpp
@@ -1,10 +1,11 @@
 #pragma once
 #include <memory>
-#include "AttributeHandle.hpp"
 #include <vector>
+#include "AttributeHandle.hpp"
 
 namespace wmtk {
 class Mesh;
+namespace attribute {
 template <typename T>
 class Attribute;
 template <typename T>
@@ -36,9 +37,10 @@ struct AttributeScopeStack
 
 protected:
     std::unique_ptr<AttributeScope<T>> m_leaf;
-    std::vector<AttributeScope<T>const *> m_checkpoints;
+    std::vector<AttributeScope<T> const*> m_checkpoints;
     // Mesh& m_mesh;
     // AttributeManager& m_attribute_manager;
     // MeshAttributeHandle<T> m_handle;
 };
+} // namespace attribute
 } // namespace wmtk

--- a/src/wmtk/attribute/CMakeLists.txt
+++ b/src/wmtk/attribute/CMakeLists.txt
@@ -5,8 +5,6 @@ set(SRC_FILES
     AttributeCache.cpp
     AttributeCache.hpp
     AttributeHandle.hpp
-    AccessorBase.cpp
-    AccessorBase.hpp
     AttributeScope.hpp
     AttributeScope.cpp
     MeshAttributes.cpp
@@ -21,5 +19,20 @@ set(SRC_FILES
     PerThreadAttributeScopeStacks.cpp
     AttributeScopeHandle.hpp
     AttributeScopeHandle.cpp
+
+    AccessorBase.cpp
+    AccessorBase.hpp
+
+    CachingAccessor.cpp
+    CachingAccessor.hpp
+    
+    TupleAccessor.cpp
+    TupleAccessor.hpp
+    
+    ConstAccessor.cpp
+    ConstAccessor.hpp
+
+    MutableAccessor.cpp
+    MutableAccessor.hpp
 )
 target_sources(wildmeshing_toolkit PRIVATE ${SRC_FILES})

--- a/src/wmtk/attribute/CachingAccessor.cpp
+++ b/src/wmtk/attribute/CachingAccessor.cpp
@@ -1,0 +1,94 @@
+
+#include "CachingAccessor.hpp"
+#include <wmtk/utils/Rational.hpp>
+#include "AttributeScope.hpp"
+#include "AttributeScopeStack.hpp"
+
+namespace wmtk::attribute {
+
+template <typename T>
+CachingAccessor<T>::CachingAccessor(
+    Mesh& mesh,
+    const MeshAttributeHandle<T>& handle,
+    AttributeAccessMode mode)
+    : BaseType(mesh, handle)
+    , m_mode(mode)
+{
+    m_cache_stack = attribute().get_local_scope_stack_ptr();
+}
+
+template <typename T>
+CachingAccessor<T>::~CachingAccessor() = default;
+template <typename T>
+bool CachingAccessor<T>::has_stack() const
+{
+    return m_cache_stack && !m_cache_stack->empty();
+}
+
+template <typename T>
+std::optional<long> CachingAccessor<T>::stack_depth() const
+{
+    if (m_cache_stack != nullptr) {
+        return m_cache_stack->depth();
+    } else {
+        return {};
+    }
+}
+
+template <typename T>
+auto CachingAccessor<T>::vector_attribute(const long index) -> MapResult
+{
+    if (has_stack()) {
+        return m_cache_stack->current_scope_ptr()->vector_attribute(*this, m_mode, index);
+    } else {
+        return BaseType::vector_attribute(index);
+    }
+}
+
+
+template <typename T>
+auto CachingAccessor<T>::scalar_attribute(const long index) -> T&
+{
+    if (has_stack()) {
+        return m_cache_stack->current_scope_ptr()->scalar_attribute(*this, m_mode, index);
+    } else {
+        return BaseType::scalar_attribute(index);
+    }
+}
+
+template <typename T>
+auto CachingAccessor<T>::const_vector_attribute(const long index) const -> ConstMapResult
+{
+    if (has_stack()) {
+        return m_cache_stack->current_scope_ptr()->const_vector_attribute(*this, m_mode, index);
+    } else {
+        return BaseType::const_vector_attribute(index);
+    }
+}
+
+
+template <typename T>
+auto CachingAccessor<T>::const_scalar_attribute(const long index) const -> T
+{
+    if (has_stack()) {
+        return m_cache_stack->current_scope_ptr()->const_scalar_attribute(*this, m_mode, index);
+    } else {
+        return BaseType::const_scalar_attribute(index);
+    }
+}
+
+template <typename T>
+auto CachingAccessor<T>::vector_attribute(const long index) const -> ConstMapResult
+{
+    return const_vector_attribute(index);
+}
+template <typename T>
+T CachingAccessor<T>::scalar_attribute(const long index) const
+{
+    return const_scalar_attribute(index);
+}
+template class CachingAccessor<char>;
+template class CachingAccessor<long>;
+template class CachingAccessor<double>;
+template class CachingAccessor<Rational>;
+} // namespace wmtk::attribute

--- a/src/wmtk/attribute/CachingAccessor.hpp
+++ b/src/wmtk/attribute/CachingAccessor.hpp
@@ -1,0 +1,85 @@
+#pragma once
+
+#include <optional>
+#include "AccessorBase.hpp"
+#include "AttributeAccessMode.hpp"
+
+namespace wmtk {
+class Mesh;
+class TetMesh;
+class TriMesh;
+} // namespace wmtk
+namespace wmtk::attribute {
+
+template <typename T>
+class AttributeCache;
+
+template <typename T>
+class CachingAccessor : public AccessorBase<T>
+{
+public:
+    friend class wmtk::Mesh;
+    friend class wmtk::TetMesh;
+    friend class wmtk::TriMesh;
+    using Scalar = T;
+
+    friend class AttributeCache<T>;
+    using BaseType = AccessorBase<T>;
+
+    using ConstMapResult = typename BaseType::ConstMapResult; // Eigen::Map<const VectorX<T>>
+    using MapResult = typename BaseType::MapResult; // Eigen::Map<VectorX<T>>
+
+
+    CachingAccessor(
+        Mesh& m,
+        const MeshAttributeHandle<T>& handle,
+        AttributeAccessMode access_mode = AttributeAccessMode::Immediate);
+
+    ~CachingAccessor();
+    CachingAccessor(const CachingAccessor&) = delete;
+    CachingAccessor& operator=(const CachingAccessor&) = delete;
+
+    AttributeAccessMode access_mode() const;
+
+
+    // returns the size of the underlying attribute
+
+    //using BaseType::dimension; // const() -> long
+    //using BaseType::reserved_size; // const() -> long
+
+    //using BaseType::attribute; // access to Attribute object being used here
+    //using BaseType::set_attribute; // (const vector<T>&) -> void
+    // shows the depth of scope stacks if they exist, mostly for debug
+    std::optional<long> stack_depth() const;
+
+    bool has_stack() const;
+
+    ConstMapResult const_vector_attribute(const long index) const;
+
+    T const_scalar_attribute(const long index) const;
+
+    MapResult vector_attribute(const long index);
+
+    T& scalar_attribute(const long index);
+
+    // deprecated because we should be more explicit in const/nonconst on internal interfaces
+    ConstMapResult vector_attribute(const long index) const;
+    //[[deprecated]] ConstMapResult vector_attribute(const long index) const;
+    // deprecated because we should be more explicit in const/nonconst on internal interfaces
+    T scalar_attribute(const long index) const;
+    //[[deprecated]] T scalar_attribute(const long index) const;
+
+    using BaseType::attribute;
+    using BaseType::mesh;
+
+protected:
+
+    BaseType& base_type() { return *this; }
+    const BaseType& base_type() const { return *this; }
+
+private:
+    AttributeAccessMode m_mode;
+
+    AttributeScopeStack<T>* m_cache_stack = nullptr;
+};
+} // namespace wmtk::attribute

--- a/src/wmtk/attribute/ConstAccessor.cpp
+++ b/src/wmtk/attribute/ConstAccessor.cpp
@@ -1,0 +1,35 @@
+#include "ConstAccessor.hpp"
+#include <wmtk/Mesh.hpp>
+#include "AttributeManager.hpp"
+#include "AttributeScope.hpp"
+#include "AttributeScopeStack.hpp"
+#include "MeshAttributes.hpp"
+
+namespace wmtk::attribute {
+
+template <typename T>
+ConstAccessor<T>::ConstAccessor(
+    const Mesh& mesh,
+    const MeshAttributeHandle<T>& handle,
+    AttributeAccessMode mode)
+    : TupleBaseType(const_cast<Mesh&>(mesh), handle, mode)
+{}
+//===================================================
+// These following methods just forward to to const names
+template <typename T>
+auto ConstAccessor<T>::vector_attribute(const Tuple& t) const -> ConstMapResult
+{
+    return const_vector_attribute(t);
+}
+template <typename T>
+T ConstAccessor<T>::scalar_attribute(const Tuple& t) const
+{
+    return const_scalar_attribute(t);
+}
+//===================================================
+
+
+template class ConstAccessor<char>;
+template class ConstAccessor<long>;
+template class ConstAccessor<double>;
+} // namespace wmtk::attribute

--- a/src/wmtk/attribute/ConstAccessor.hpp
+++ b/src/wmtk/attribute/ConstAccessor.hpp
@@ -1,0 +1,71 @@
+#pragma once
+
+#include "TupleAccessor.hpp"
+
+namespace wmtk {
+class Mesh;
+class TriMesh;
+class TetMesh;
+class TriMeshOperationExecutor;
+} // namespace wmtk
+namespace wmtk::attribute {
+
+
+template <typename T>
+class ConstAccessor : protected TupleAccessor<T>
+{
+public:
+    friend class wmtk::Mesh;
+    friend class wmtk::TetMesh;
+    friend class wmtk::TriMesh;
+    friend class wmtk::PointMesh;
+    friend class wmtk::TriMeshOperationExecutor;
+    using Scalar = T;
+
+    friend class AttributeCache<T>;
+
+    using BaseType = AccessorBase<T>;
+    using TupleBaseType = TupleAccessor<T>;
+    using CachingBaseType = CachingAccessor<T>;
+
+    using ConstMapResult = typename BaseType::ConstMapResult; // Eigen::Map<const VectorX<T>>
+
+    ConstAccessor(
+        const Mesh& m,
+        const MeshAttributeHandle<T>& handle,
+        AttributeAccessMode access_mode = AttributeAccessMode::Immediate);
+
+
+    using TupleBaseType::const_scalar_attribute;
+    using TupleBaseType::const_vector_attribute;
+
+
+    ConstMapResult vector_attribute(const Tuple& t) const;
+    T scalar_attribute(const Tuple& t) const;
+
+    // returns the size of the underlying attribute
+
+    using BaseType::dimension; // const() -> long
+    using BaseType::reserved_size; // const() -> long
+
+    using BaseType::attribute; // access to Attribute object being used here
+    // shows the depth of scope stacks if they exist, mostly for debug
+
+    using CachingBaseType::stack_depth;
+    using CachingBaseType::has_stack;
+
+protected:
+    using TupleBaseType::caching_base_type;
+    using TupleBaseType::base_type;
+    using TupleBaseType::scalar_attribute;
+    using TupleBaseType::vector_attribute;
+
+
+    TupleBaseType& tuple_base_type() { return *this; }
+    const TupleBaseType& tuple_base_type() const { return *this; }
+
+
+    const CachingBaseType& index_access() const { return caching_base_type(); }
+};
+
+} // namespace wmtk::attribute

--- a/src/wmtk/attribute/MeshAttributes.cpp
+++ b/src/wmtk/attribute/MeshAttributes.cpp
@@ -7,7 +7,7 @@
 #include <cassert>
 #include <utility>
 
-namespace wmtk {
+namespace wmtk::attribute {
 
 template <typename T>
 MeshAttributes<T>::MeshAttributes()
@@ -135,4 +135,4 @@ template class MeshAttributes<long>;
 template class MeshAttributes<double>;
 template class MeshAttributes<Rational>;
 
-} // namespace wmtk
+} // namespace wmtk::attribute

--- a/src/wmtk/attribute/MeshAttributes.hpp
+++ b/src/wmtk/attribute/MeshAttributes.hpp
@@ -14,6 +14,7 @@ namespace wmtk {
 
 class MeshWriter;
 class Mesh;
+namespace attribute {
 template <typename T>
 class AccessorBase;
 
@@ -21,7 +22,7 @@ template <typename T>
 class MeshAttributes
 {
     friend class AccessorBase<T>;
-    friend class Mesh;
+    friend class wmtk::Mesh;
 
     typedef Eigen::Map<Eigen::Matrix<T, Eigen::Dynamic, 1>> MapResult;
     typedef Eigen::Map<const Eigen::Matrix<T, Eigen::Dynamic, 1>> ConstMapResult;
@@ -68,6 +69,5 @@ private:
 
     std::vector<Attribute<T>> m_attributes;
 };
-
-
+} // namespace attribute
 } // namespace wmtk

--- a/src/wmtk/attribute/MutableAccessor.cpp
+++ b/src/wmtk/attribute/MutableAccessor.cpp
@@ -1,0 +1,18 @@
+#include "MutableAccessor.hpp"
+
+
+namespace wmtk::attribute {
+
+
+// template <typename T>
+// MutableAccessor<T>::MutableAccessor(
+//     Mesh& mesh,
+//     const MeshAttributeHandle<T>& handle,
+//     AttributeAccessMode mode)
+//     : ConstAccessorType(mesh, handle, mode)
+//{}
+
+template class MutableAccessor<char>;
+template class MutableAccessor<long>;
+template class MutableAccessor<double>;
+} // namespace wmtk::attribute

--- a/src/wmtk/attribute/MutableAccessor.hpp
+++ b/src/wmtk/attribute/MutableAccessor.hpp
@@ -1,0 +1,42 @@
+#pragma once
+#include "ConstAccessor.hpp"
+
+
+namespace wmtk {
+class Mesh;
+class TriMesh;
+class TetMesh;
+} // namespace wmtk
+namespace wmtk::attribute {
+template <typename T>
+class MutableAccessor : public ConstAccessor<T>
+{
+public:
+    friend class wmtk::Mesh;
+    friend class wmtk::TetMesh;
+    friend class wmtk::TriMesh;
+    friend class wmtk::PointMesh;
+    friend class wmtk::TriMeshOperationExecutor;
+    using CachingBaseType = CachingAccessor<T>;
+    using ConstAccessorType = ConstAccessor<T>;
+
+    using ConstAccessorType::ConstAccessorType;
+
+    using ConstAccessorType::const_scalar_attribute;
+    using ConstAccessorType::const_vector_attribute;
+    using ConstAccessorType::dimension;
+    using ConstAccessorType::reserved_size;
+    using ConstAccessorType::scalar_attribute;
+    using ConstAccessorType::vector_attribute;
+
+
+    using CachingBaseType::stack_depth;
+    using CachingBaseType::has_stack;
+protected:
+    using ConstAccessorType::base_type;
+    using ConstAccessorType::caching_base_type;
+    using ConstAccessorType::index_access;
+    using ConstAccessorType::tuple_base_type;
+    CachingBaseType& index_access() { return caching_base_type(); }
+};
+} // namespace wmtk::attribute

--- a/src/wmtk/attribute/PerThreadAttributeScopeStacks.cpp
+++ b/src/wmtk/attribute/PerThreadAttributeScopeStacks.cpp
@@ -2,10 +2,10 @@
 #include <wmtk/utils/Rational.hpp>
 
 
-namespace wmtk {
+namespace wmtk::attribute {
 template class PerThreadAttributeScopeStacks<long>;
 template class PerThreadAttributeScopeStacks<double>;
 template class PerThreadAttributeScopeStacks<char>;
 template class PerThreadAttributeScopeStacks<Rational>;
 
-} // namespace wmtk
+} // namespace wmtk::attribute

--- a/src/wmtk/attribute/PerThreadAttributeScopeStacks.hpp
+++ b/src/wmtk/attribute/PerThreadAttributeScopeStacks.hpp
@@ -3,7 +3,7 @@
 #include "AttributeScopeStack.hpp"
 
 
-namespace wmtk {
+namespace wmtk::attribute {
 
 template <typename T>
 struct PerThreadAttributeScopeStacks
@@ -12,4 +12,4 @@ struct PerThreadAttributeScopeStacks
     const AttributeScopeStack<T>& local() const { return m_stacks.local(); }
     mutable tbb::enumerable_thread_specific<AttributeScopeStack<T>> m_stacks;
 };
-} // namespace wmtk
+} // namespace wmtk::attribute

--- a/src/wmtk/attribute/TupleAccessor.cpp
+++ b/src/wmtk/attribute/TupleAccessor.cpp
@@ -1,0 +1,44 @@
+#include "TupleAccessor.hpp"
+#include <wmtk/Mesh.hpp>
+#include <wmtk/utils/Rational.hpp>
+
+namespace wmtk::attribute {
+
+template <typename T>
+auto TupleAccessor<T>::const_vector_attribute(const Tuple& t) const -> ConstMapResult
+{
+    const long idx = index(t);
+    return CachingBaseType::const_vector_attribute(idx);
+}
+
+template <typename T>
+auto TupleAccessor<T>::vector_attribute(const Tuple& t) -> MapResult
+{
+    const long idx = index(t);
+    return CachingBaseType::vector_attribute(idx);
+}
+
+template <typename T>
+auto TupleAccessor<T>::scalar_attribute(const Tuple& t) -> T&
+{
+    const long idx = index(t);
+    return CachingBaseType::scalar_attribute(idx);
+}
+
+template <typename T>
+T TupleAccessor<T>::const_scalar_attribute(const Tuple& t) const
+{
+    const long idx = index(t);
+    return CachingBaseType::const_scalar_attribute(idx);
+}
+template <typename T>
+long TupleAccessor<T>::index(const Tuple& t) const
+{
+    assert(mesh().is_valid_slow(t));
+    return mesh().id(t, BaseType::handle().m_primitive_type);
+}
+template class TupleAccessor<char>;
+template class TupleAccessor<long>;
+template class TupleAccessor<double>;
+template class TupleAccessor<Rational>;
+} // namespace wmtk::attribute

--- a/src/wmtk/attribute/TupleAccessor.hpp
+++ b/src/wmtk/attribute/TupleAccessor.hpp
@@ -1,0 +1,51 @@
+#pragma once
+#include "CachingAccessor.hpp"
+
+namespace wmtk {
+class Mesh;
+class TetMesh;
+class TriMesh;
+} // namespace wmtk
+namespace wmtk::attribute {
+template <typename T>
+class TupleAccessor : protected CachingAccessor<T>
+{
+public:
+    friend class wmtk::Mesh;
+    friend class wmtk::TetMesh;
+    friend class wmtk::TriMesh;
+    using Scalar = T;
+
+    friend class AttributeCache<T>;
+    using BaseType = AccessorBase<T>;
+    using CachingBaseType = CachingAccessor<T>;
+
+    using ConstMapResult = typename BaseType::ConstMapResult; // Eigen::Map<const VectorX<T>>
+    using MapResult = typename BaseType::MapResult; // Eigen::Map<VectorX<T>>
+
+    using CachingBaseType::CachingBaseType;
+
+    TupleAccessor(const TupleAccessor&) = delete;
+    TupleAccessor& operator=(const TupleAccessor&) = delete;
+
+
+    T const_scalar_attribute(const Tuple& t) const;
+    T& scalar_attribute(const Tuple& t);
+
+    ConstMapResult const_vector_attribute(const Tuple& t) const;
+    MapResult vector_attribute(const Tuple& t);
+
+    long index(const Tuple& t) const;
+    using BaseType::dimension; // const() -> long
+    using BaseType::reserved_size; // const() -> long
+
+    using BaseType::attribute; // access to Attribute object being used here
+    using CachingBaseType::mesh;
+    using CachingBaseType::stack_depth;
+    using CachingBaseType::has_stack;
+protected:
+    using CachingBaseType::base_type;
+    CachingBaseType& caching_base_type() { return *this; }
+    const CachingBaseType& caching_base_type() const { return *this; }
+};
+} // namespace wmtk::attribute

--- a/src/wmtk/invariants/MaxEdgeLengthInvariant.cpp
+++ b/src/wmtk/invariants/MaxEdgeLengthInvariant.cpp
@@ -2,13 +2,20 @@
 #include <wmtk/Mesh.hpp>
 
 namespace wmtk {
-    MaxEdgeLengthInvariant::MaxEdgeLengthInvariant(const Mesh& m, const MeshAttributeHandle<double>& coordinate, double threshold_squared): MeshInvariant(m), m_coordinate_handle(coordinate), m_threshold_squared(threshold_squared) {}
+MaxEdgeLengthInvariant::MaxEdgeLengthInvariant(
+    const Mesh& m,
+    const MeshAttributeHandle<double>& coordinate,
+    double threshold_squared)
+    : MeshInvariant(m)
+    , m_coordinate_handle(coordinate)
+    , m_threshold_squared(threshold_squared)
+{}
 bool MaxEdgeLengthInvariant::before(const Tuple& t) const
 {
-   ConstAccessor<double> accessor = mesh().create_accessor(m_coordinate_handle);
+    ConstAccessor<double> accessor = mesh().create_accessor(m_coordinate_handle);
 
-    auto p0 = accessor.vector_attribute(t);
-    auto p1 = accessor.vector_attribute(mesh().switch_vertex(t));
+    auto p0 = accessor.const_vector_attribute(t);
+    auto p1 = accessor.const_vector_attribute(mesh().switch_vertex(t));
     const double l_squared = (p1 - p0).squaredNorm();
     return l_squared < m_threshold_squared;
 }

--- a/src/wmtk/invariants/MinEdgeLengthInvariant.cpp
+++ b/src/wmtk/invariants/MinEdgeLengthInvariant.cpp
@@ -15,8 +15,8 @@ bool MinEdgeLengthInvariant::before(const Tuple& t) const
 {
     ConstAccessor<double> accessor = mesh().create_accessor(m_coordinate_handle);
 
-    auto p0 = accessor.vector_attribute(t);
-    auto p1 = accessor.vector_attribute(mesh().switch_vertex(t));
+    auto p0 = accessor.const_vector_attribute(t);
+    auto p1 = accessor.const_vector_attribute(mesh().switch_vertex(t));
     const double l_squared = (p1 - p0).squaredNorm();
     return l_squared > m_threshold_squared;
 }

--- a/src/wmtk/io/MeshReader.cpp
+++ b/src/wmtk/io/MeshReader.cpp
@@ -76,9 +76,9 @@ void MeshReader::set_attribute(
     Mesh& mesh)
 {
     auto handle = mesh.register_attribute<T>(name, pt, stride, true);
-    auto accessor = mesh.create_accessor(handle);
+    auto accessor = attribute::AccessorBase<T>(mesh, handle);
 
-    static_cast<AccessorBase<T>&>(accessor).set_attribute(v);
+    accessor.set_attribute(v);
 }
 
 

--- a/src/wmtk/utils/mesh_utils.cpp
+++ b/src/wmtk/utils/mesh_utils.cpp
@@ -1,8 +1,9 @@
 #include "mesh_utils.hpp"
+#include <wmtk/TriMesh.hpp>
 
 namespace wmtk::mesh_utils {
 Eigen::Vector3d
-compute_face_normal_area_weighted(const Mesh& m, const Accessor<double>& pos, const Tuple& f)
+compute_face_normal_area_weighted(const TriMesh& m, const Accessor<double>& pos, const Tuple& f)
 {
     const Tuple v0 = f;
     const Tuple v1 = m.switch_vertex(f);
@@ -14,12 +15,12 @@ compute_face_normal_area_weighted(const Mesh& m, const Accessor<double>& pos, co
     return ((p0 - p2).cross(p1 - p2));
 }
 
-Eigen::Vector3d compute_face_normal(const Mesh& m, const Accessor<double>& pos, const Tuple& f)
+Eigen::Vector3d compute_face_normal(const TriMesh& m, const Accessor<double>& pos, const Tuple& f)
 {
     return compute_face_normal_area_weighted(m, pos, f).normalized();
 }
 
-Eigen::Vector3d compute_vertex_normal(const Mesh& m, const Accessor<double>& pos, const Tuple& v)
+Eigen::Vector3d compute_vertex_normal(const TriMesh& m, const Accessor<double>& pos, const Tuple& v)
 {
     const SimplicialComplex closed_star = SimplicialComplex::closed_star(m, Simplex::vertex(v));
 

--- a/src/wmtk/utils/mesh_utils.hpp
+++ b/src/wmtk/utils/mesh_utils.hpp
@@ -13,8 +13,8 @@ inline MeshAttributeHandle<typename Mat::Scalar> set_matrix_attribute(
     const PrimitiveType& type,
     Mesh& mesh)
 {
-    MeshAttributeHandle<typename Mat::Scalar> handle =
-        mesh.register_attribute<typename Mat::Scalar>(name, type, data.cols());
+    attribute::MeshAttributeHandle<typename Mat::Scalar> handle =
+        mesh.template register_attribute<typename Mat::Scalar>(name, type, data.cols());
 
     auto accessor = mesh.create_accessor(handle);
     const auto tuples = mesh.get_all(type);
@@ -30,16 +30,17 @@ inline MeshAttributeHandle<typename Mat::Scalar> set_matrix_attribute(
  * @brief compute area vector of face
  */
 Eigen::Vector3d
-compute_face_normal_area_weighted(const Mesh& m, const Accessor<double>& pos, const Tuple& f);
+compute_face_normal_area_weighted(const TriMesh& m, const Accessor<double>& pos, const Tuple& f);
 
 /**
  * @brief compute the normalized face normal based on the vertex positions
  */
-Eigen::Vector3d compute_face_normal(const Mesh& m, const Accessor<double>& pos, const Tuple& f);
+Eigen::Vector3d compute_face_normal(const TriMesh& m, const Accessor<double>& pos, const Tuple& f);
 
 /**
  * @brief compute the normalized vertex normal from the incident area weighted face normals
  */
-Eigen::Vector3d compute_vertex_normal(const Mesh& m, const Accessor<double>& pos, const Tuple& v);
+Eigen::Vector3d
+compute_vertex_normal(const TriMesh& m, const Accessor<double>& pos, const Tuple& v);
 
 } // namespace wmtk::mesh_utils

--- a/tests/test_2d_operations.cpp
+++ b/tests/test_2d_operations.cpp
@@ -433,11 +433,11 @@ TEST_CASE("hash_update", "[operations][2D]")
         auto executor = m.get_tmoe(edge, hash_accessor);
         auto& ha = executor.hash_accessor;
 
-        CHECK(executor.hash_at_cell(0) == 0);
+        CHECK(m.get_cell_hash_slow(0) == 0);
 
         executor.update_cell_hash();
 
-        CHECK(executor.hash_at_cell(0) == 1);
+        CHECK(m.get_cell_hash_slow(0) == 1);
     }
     SECTION("edge_region")
     {
@@ -450,29 +450,29 @@ TEST_CASE("hash_update", "[operations][2D]")
         auto executor = m.get_tmoe(edge, hash_accessor);
         auto& ha = executor.hash_accessor;
 
-        CHECK(executor.hash_at_cell(0) == 0);
-        CHECK(executor.hash_at_cell(1) == 0);
-        CHECK(executor.hash_at_cell(2) == 0);
-        CHECK(executor.hash_at_cell(3) == 0);
-        CHECK(executor.hash_at_cell(4) == 0);
-        CHECK(executor.hash_at_cell(5) == 0);
-        CHECK(executor.hash_at_cell(6) == 0);
-        CHECK(executor.hash_at_cell(7) == 0);
-        CHECK(executor.hash_at_cell(8) == 0);
-        CHECK(executor.hash_at_cell(9) == 0);
+        CHECK(m.get_cell_hash_slow(0) == 0);
+        CHECK(m.get_cell_hash_slow(1) == 0);
+        CHECK(m.get_cell_hash_slow(2) == 0);
+        CHECK(m.get_cell_hash_slow(3) == 0);
+        CHECK(m.get_cell_hash_slow(4) == 0);
+        CHECK(m.get_cell_hash_slow(5) == 0);
+        CHECK(m.get_cell_hash_slow(6) == 0);
+        CHECK(m.get_cell_hash_slow(7) == 0);
+        CHECK(m.get_cell_hash_slow(8) == 0);
+        CHECK(m.get_cell_hash_slow(9) == 0);
 
         executor.update_cell_hash();
 
-        CHECK(executor.hash_at_cell(0) == 1);
-        CHECK(executor.hash_at_cell(1) == 1);
-        CHECK(executor.hash_at_cell(2) == 1);
-        CHECK(executor.hash_at_cell(3) == 0);
-        CHECK(executor.hash_at_cell(4) == 0);
-        CHECK(executor.hash_at_cell(5) == 1);
-        CHECK(executor.hash_at_cell(6) == 1);
-        CHECK(executor.hash_at_cell(7) == 1);
-        CHECK(executor.hash_at_cell(8) == 0);
-        CHECK(executor.hash_at_cell(9) == 0);
+        CHECK(m.get_cell_hash_slow(0) == 1);
+        CHECK(m.get_cell_hash_slow(1) == 1);
+        CHECK(m.get_cell_hash_slow(2) == 1);
+        CHECK(m.get_cell_hash_slow(3) == 0);
+        CHECK(m.get_cell_hash_slow(4) == 0);
+        CHECK(m.get_cell_hash_slow(5) == 1);
+        CHECK(m.get_cell_hash_slow(6) == 1);
+        CHECK(m.get_cell_hash_slow(7) == 1);
+        CHECK(m.get_cell_hash_slow(8) == 0);
+        CHECK(m.get_cell_hash_slow(9) == 0);
     }
 }
 

--- a/tests/test_accessor.cpp
+++ b/tests/test_accessor.cpp
@@ -13,7 +13,7 @@ void populate(DEBUG_PointMesh& m, VectorAcc& va, bool for_zeros = false)
 {
     auto vertices = m.get_all(wmtk::PrimitiveType::Vertex);
     size_t dimension = va.dimension();
-    Eigen::Matrix<typename VectorAcc::T, Eigen::Dynamic, 1> x;
+    Eigen::Matrix<typename VectorAcc::Scalar, Eigen::Dynamic, 1> x;
     for (const wmtk::Tuple& tup : vertices) {
         long id = m.id(tup);
         auto v = va.vector_attribute(tup);
@@ -29,7 +29,7 @@ void check(DEBUG_PointMesh& m, VectorAcc& va, bool for_zeros = false)
 {
     auto vertices = m.get_all(wmtk::PrimitiveType::Vertex);
     size_t dimension = va.dimension();
-    Eigen::Matrix<typename VectorAcc::T, Eigen::Dynamic, 1> x;
+    Eigen::Matrix<typename VectorAcc::Scalar, Eigen::Dynamic, 1> x;
     bool is_scalar = va.dimension() == 1;
     x.resize(va.dimension());
     for (const wmtk::Tuple& tup : vertices) {
@@ -65,6 +65,10 @@ TEST_CASE("test_accessor_basic")
     auto long_acc = m.create_accessor(long_handle);
     auto double_acc = m.create_accessor(double_handle);
 
+    auto char_bacc = m.create_base_accessor(char_handle);
+    auto long_bacc = m.create_base_accessor(long_handle);
+    auto double_bacc = m.create_base_accessor(double_handle);
+
     auto vertices = m.get_all(wmtk::PrimitiveType::Vertex);
 
     // check characteristics are all right
@@ -90,17 +94,17 @@ TEST_CASE("test_accessor_basic")
     {
         std::vector<char> d(size);
         std::iota(d.begin(), d.end(), char(0));
-        static_cast<wmtk::AccessorBase<char>&>(char_acc).set_attribute(d);
+        char_bacc.set_attribute(d);
     }
     {
         std::vector<long> d(size);
         std::iota(d.begin(), d.end(), long(0));
-        static_cast<wmtk::AccessorBase<long>&>(long_acc).set_attribute(d);
+        long_bacc.set_attribute(d);
     }
     {
         std::vector<double> d(3 * size);
         std::iota(d.begin(), d.end(), double(0));
-        static_cast<wmtk::AccessorBase<double>&>(double_acc).set_attribute(d);
+        double_bacc.set_attribute(d);
     }
     for (const wmtk::Tuple& tup : vertices) {
         long id = m.id(tup);

--- a/tests/tools/DEBUG_PointMesh.hpp
+++ b/tests/tools/DEBUG_PointMesh.hpp
@@ -11,15 +11,15 @@ public:
         return PointMesh::id(tup, wmtk::PrimitiveType::Vertex);
     }
     template <typename T>
-    AccessorBase<T> create_base_accessor(const MeshAttributeHandle<T>& handle)
+    attribute::AccessorBase<T> create_base_accessor(const MeshAttributeHandle<T>& handle)
     {
-        return AccessorBase<T>(*this, handle);
+        return attribute::AccessorBase<T>(*this, handle);
     }
 
     template <typename T>
-    AccessorBase<T> create_const_base_accessor(const MeshAttributeHandle<T>& handle) const
+    attribute::AccessorBase<T> create_const_base_accessor(const MeshAttributeHandle<T>& handle) const
     {
-        return AccessorBase<T>(const_cast<DEBUG_PointMesh&>(*this), handle);
+        return attribute::AccessorBase<T>(const_cast<DEBUG_PointMesh&>(*this), handle);
     }
 };
 } // namespace wmtk::tests

--- a/tests/tools/DEBUG_TriMesh.cpp
+++ b/tests/tools/DEBUG_TriMesh.cpp
@@ -30,8 +30,8 @@ auto DEBUG_TriMesh::edge_tuple_between_v1_v2(const long v1, const long v2, const
     ConstAccessor<long> fv = create_accessor<long>(m_fv_handle);
     auto fv_base = create_base_accessor<long>(m_fv_handle);
     Tuple face = face_tuple_from_id(fid);
-    auto fv0 = fv.vector_attribute(face);
-    REQUIRE(fv0 == fv_base.vector_attribute(fid));
+    auto fv0 = fv.const_vector_attribute(face);
+    REQUIRE(fv0 == fv_base.const_vector_attribute(fid));
     long local_vid1 = -1, local_vid2 = -1;
     for (long i = 0; i < fv0.size(); ++i) {
         if (fv0[i] == v1) {

--- a/tests/tools/DEBUG_TriMesh.cpp
+++ b/tests/tools/DEBUG_TriMesh.cpp
@@ -29,8 +29,8 @@ void DEBUG_TriMesh::print_vf() const
     auto f_flag_accessor = get_flag_accessor(PrimitiveType::Face);
     for (long id = 0; id < capacity(PrimitiveType::Face); ++id)
     {
-        auto fv = fv_accessor.vector_attribute(id);
-        if (f_flag_accessor.scalar_attribute(tuple_from_id(PrimitiveType::Face, id)) == 0)
+        auto fv = fv_accessor.const_vector_attribute(id);
+        if (f_flag_accessor.const_scalar_attribute(tuple_from_id(PrimitiveType::Face, id)) == 0)
         {
             std::cout << "face " << id << " is deleted" << std::endl;
         }
@@ -74,7 +74,7 @@ auto DEBUG_TriMesh::edge_tuple_from_vids(const long v1, const long v2) const -> 
     for (long fid = 0; fid < capacity(PrimitiveType::Face); ++fid) {
     
         Tuple face = face_tuple_from_id(fid);
-        auto fv0 = fv.vector_attribute(face);
+        auto fv0 = fv.const_vector_attribute(face);
         long local_vid1 = -1, local_vid2 = -1;
         for (long i = 0; i < fv0.size(); ++i) {
             if (fv0[i] == v1) {
@@ -99,7 +99,7 @@ auto DEBUG_TriMesh::face_tuple_from_vids(const long v1, const long v2, const lon
     for (long fid = 0; fid < capacity(PrimitiveType::Face); ++fid) {
     
         Tuple face = face_tuple_from_id(fid);
-        auto fv0 = fv.vector_attribute(face);
+        auto fv0 = fv.const_vector_attribute(face);
         bool find_v1 = false, find_v2 = false, find_v3 = false;
         for (long i = 0; i < fv0.size(); ++i) {
             if (fv0[i] == v1) {

--- a/tests/tools/DEBUG_TriMesh.hpp
+++ b/tests/tools/DEBUG_TriMesh.hpp
@@ -23,18 +23,18 @@ public:
 
     Tuple tuple_from_face_id(const long fid) const;
     template <typename T>
-    AccessorBase<T> create_base_accessor(const MeshAttributeHandle<T>& handle)
+    attribute::AccessorBase<T> create_base_accessor(const MeshAttributeHandle<T>& handle)
     {
-        return AccessorBase<T>(*this, handle);
+        return attribute::AccessorBase<T>(*this, handle);
     }
 
     template <typename T>
-    AccessorBase<T> create_const_base_accessor(const MeshAttributeHandle<T>& handle) const
+    attribute::AccessorBase<T> create_const_base_accessor(const MeshAttributeHandle<T>& handle) const
     {
-        return AccessorBase<T>(const_cast<DEBUG_TriMesh&>(*this), handle);
+        return attribute::AccessorBase<T>(const_cast<DEBUG_TriMesh&>(*this), handle);
     }
     template <typename T>
-    AccessorBase<T> create_base_accessor(const MeshAttributeHandle<T>& handle) const
+    attribute::AccessorBase<T> create_base_accessor(const MeshAttributeHandle<T>& handle) const
     {
         return create_const_base_accessor(handle);
     }


### PR DESCRIPTION
Isolated the implementations of different sorts of accessor functions to increase clarity and utilize inheritance so non-const accessors can be implicitly converted to const accessors.

* AccessorBase does raw writing into attributes
* CachingAccessor utilizes attributes' caching abilities when available
* TupleAccessor disables index-based access and implements tuple-based access
* ConstAccessor enables const tuple-based access
* MutableAccessor enables const and non-const tuple-based access

Accessor<T,IsConst> now is a typedef for ConstAccessor or MutableAccessor depending on IsConst

Also, added protectedmember functions to let accessor friends cast to lower level accessors when necessary. These should be easy to identify / avoided in general code