### PR TITLE
Hackathon/expose attribute dimension

### DIFF
--- a/src/wmtk/Mesh.cpp
+++ b/src/wmtk/Mesh.cpp
@@ -252,7 +252,6 @@ attribute::AttributeScopeHandle Mesh::create_scope()
     return m_attribute_manager.create_scope(*this);
 }
 
-
 template MeshAttributeHandle<char>
 Mesh::register_attribute(const std::string&, PrimitiveType, long, bool);
 template MeshAttributeHandle<long>

--- a/src/wmtk/Mesh.hpp
+++ b/src/wmtk/Mesh.hpp
@@ -103,6 +103,9 @@ public:
     template <typename T>
     ConstAccessor<T> create_accessor(const MeshAttributeHandle<T>& handle) const;
 
+    template <typename T>
+    long get_attribute_dimension(const MeshAttributeHandle<T>& handle) const;
+
 
     // creates a scope as long as the AttributeScopeHandle exists
     [[nodiscard]] attribute::AttributeScopeHandle create_scope();
@@ -347,6 +350,10 @@ MeshAttributeHandle<T> Mesh::get_attribute_handle(
     r.m_base_handle = m_attribute_manager.get<T>(ptype).attribute_handle(name);
     r.m_primitive_type = ptype;
     return r;
+}
+template <typename T>
+long Mesh::get_attribute_dimension(const MeshAttributeHandle<T>& handle) const {
+    return m_attribute_manager.get_attribute_dimension(handle);
 }
 
 inline Tuple Mesh::switch_vertex(const Tuple& tuple) const

--- a/src/wmtk/attribute/AttributeManager.hpp
+++ b/src/wmtk/attribute/AttributeManager.hpp
@@ -65,6 +65,9 @@ struct AttributeManager
     void push_scope();
     void pop_scope(bool apply_updates = true);
     void clear_current_scope();
+
+    template <typename T>
+    long get_attribute_dimension(const MeshAttributeHandle<T>& handle) const;
 };
 
 template <typename T>
@@ -128,6 +131,11 @@ MeshAttributeHandle<T> AttributeManager::register_attribute(
     r.m_base_handle = get<T>(ptype).register_attribute(name, size, replace),
     r.m_primitive_type = ptype;
     return r;
+}
+template <typename T>
+long AttributeManager::get_attribute_dimension(const MeshAttributeHandle<T>& handle) const
+{
+    return get(handle).dimension(handle.m_base_handle);
 }
 } // namespace attribute
 } // namespace wmtk

--- a/src/wmtk/attribute/MeshAttributes.cpp
+++ b/src/wmtk/attribute/MeshAttributes.cpp
@@ -128,6 +128,10 @@ void MeshAttributes<T>::reserve(const long size)
         attr.reserve(size);
     }
 }
+template <typename T>
+    long MeshAttributes<T>::dimension(const AttributeHandle& handle) const {
+        return attribute(handle).dimension();
+    }
 
 
 template class MeshAttributes<char>;

--- a/src/wmtk/attribute/MeshAttributes.hpp
+++ b/src/wmtk/attribute/MeshAttributes.hpp
@@ -48,6 +48,9 @@ public:
     void pop_scope(bool apply_updates = true);
     void clear_current_scope();
 
+
+    long dimension(const AttributeHandle& handle) const;
+
 protected:
     AttributeHandle attribute_handle(const std::string& name) const;
 

--- a/tests/test_accessor.cpp
+++ b/tests/test_accessor.cpp
@@ -60,6 +60,9 @@ TEST_CASE("test_accessor_basic")
     auto long_handle = m.register_attribute<long>("long", wmtk::PrimitiveType::Vertex, 1);
     auto double_handle = m.register_attribute<double>("double", wmtk::PrimitiveType::Vertex, 3);
 
+    REQUIRE(m.get_attribute_dimension(char_handle) == 1);
+    REQUIRE(m.get_attribute_dimension(long_handle) == 1);
+    REQUIRE(m.get_attribute_dimension(double_handle) == 3);
 
     auto char_acc = m.create_accessor(char_handle);
     auto long_acc = m.create_accessor(long_handle);


### PR DESCRIPTION
exposes attribute dimension without creating an accessor