### PR TITLE
resolves condensing notation for multiple mesh operations

### DIFF
--- a/src/wmtk/Mesh.cpp
+++ b/src/wmtk/Mesh.cpp
@@ -259,4 +259,17 @@ Mesh::register_attribute(const std::string&, PrimitiveType, long, bool);
 template MeshAttributeHandle<double>
 Mesh::register_attribute(const std::string&, PrimitiveType, long, bool);
 
+Tuple Mesh::switch_tuples(
+    const Tuple& tuple,
+    const std::initializer_list<PrimitiveType>& op_sequence) const
+{
+    return switch_tuples<std::initializer_list<PrimitiveType>>(tuple, op_sequence);
+}
+Tuple Mesh::switch_tuples_unsafe(
+    const Tuple& tuple,
+    const std::initializer_list<PrimitiveType>& op_sequence) const
+{
+    return switch_tuples_unsafe<std::initializer_list<PrimitiveType>>(tuple, op_sequence);
+}
+
 } // namespace wmtk

--- a/src/wmtk/Mesh.hpp
+++ b/src/wmtk/Mesh.hpp
@@ -409,6 +409,7 @@ template <typename ContainerType>
 #endif
 Tuple Mesh::switch_tuples(const Tuple& tuple, const ContainerType& sequence) const
 {
+    static_assert(std::is_same_v<typename ContainerType::value_type, PrimitiveType>);
     Tuple r = tuple;
     const PrimitiveType top_type = top_simplex_type();
     for (const PrimitiveType primitive : sequence) {
@@ -430,6 +431,7 @@ template <typename ContainerType>
 #endif
 Tuple Mesh::switch_tuples_unsafe(const Tuple& tuple, const ContainerType& sequence) const
 {
+    static_assert(std::is_same_v<typename ContainerType::value_type, PrimitiveType>);
     Tuple r = tuple;
     for (const PrimitiveType primitive : sequence) {
         r = switch_tuple(r, primitive);

--- a/src/wmtk/Mesh.hpp
+++ b/src/wmtk/Mesh.hpp
@@ -1,6 +1,11 @@
 #pragma once
 
+#include <Eigen/Core>
+#include <initializer_list>
+#include <memory>
+#include <wmtk/io/ParaviewWriter.hpp>
 #include "Accessor.hpp"
+#include "MultiMeshManager.hpp"
 #include "Primitive.hpp"
 #include "Simplex.hpp"
 #include "Tuple.hpp"
@@ -8,10 +13,11 @@
 #include "attribute/AttributeManager.hpp"
 #include "attribute/AttributeScopeHandle.hpp"
 #include "attribute/MeshAttributes.hpp"
-#include "MultiMeshManager.hpp"
-#include <wmtk/io/ParaviewWriter.hpp>
-#include <Eigen/Core>
-#include <memory>
+
+// if we have concepts then switch_tuples uses forward_iterator concept
+#if defined(__cpp_concepts)
+#include <iterator>
+#endif
 
 namespace wmtk {
 // thread management tool that we will PImpl
@@ -20,14 +26,13 @@ class AttributeScopeManager;
 template <typename T>
 class TupleAccessor;
 
-}
+} // namespace attribute
 namespace operations {
 class Operation;
 }
 
 class Mesh : public std::enable_shared_from_this<Mesh>
 {
-
 public:
     template <typename T>
     friend class attribute::AccessorBase;
@@ -229,6 +234,30 @@ public:
     Tuple switch_tetrahedron(const Tuple& tuple) const;
 
 
+    // Performs a sequence of switch_tuple operations in the order specified in op_sequence.
+    // in debug mode this will assert a failure, in release this will return a null tuple
+#if defined(__cpp_concepts)
+    template <std::forward_iterator ContainerType>
+#else
+    template <typename ContainerType>
+#endif
+    Tuple switch_tuples(const Tuple& tuple, const ContainerType& op_sequence) const;
+    // annoying initializer list prototype to catch switch_tuples(t, {PV,PE})
+    Tuple switch_tuples(const Tuple& tuple, const std::initializer_list<PrimitiveType>& op_sequence)
+        const;
+
+    // Performs a sequence of switch_tuple operations in the order specified in op_sequence.
+#if defined(__cpp_concepts)
+    template <std::forward_iterator ContainerType>
+#else
+    template <typename ContainerType>
+#endif
+    Tuple switch_tuples_unsafe(const Tuple& tuple, const ContainerType& op_sequence) const;
+    // annoying initializer list prototype to catch switch_tuples(t, {PV,PE})
+    Tuple switch_tuples_unsafe(
+        const Tuple& tuple,
+        const std::initializer_list<PrimitiveType>& op_sequence) const;
+
     void set_capacities_from_flags();
     /**
      * @brief read in the m_capacities return the upper bound for the number of entities of the
@@ -352,7 +381,8 @@ MeshAttributeHandle<T> Mesh::get_attribute_handle(
     return r;
 }
 template <typename T>
-long Mesh::get_attribute_dimension(const MeshAttributeHandle<T>& handle) const {
+long Mesh::get_attribute_dimension(const MeshAttributeHandle<T>& handle) const
+{
     return m_attribute_manager.get_attribute_dimension(handle);
 }
 
@@ -371,6 +401,40 @@ inline Tuple Mesh::switch_face(const Tuple& tuple) const
 inline Tuple Mesh::switch_tetrahedron(const Tuple& tuple) const
 {
     return switch_tuple(tuple, PrimitiveType::Tetrahedron);
+}
+#if defined(__cpp_concepts)
+template <std::forward_iterator ContainerType>
+#else
+template <typename ContainerType>
+#endif
+Tuple Mesh::switch_tuples(const Tuple& tuple, const ContainerType& sequence) const
+{
+    Tuple r = tuple;
+    const PrimitiveType top_type = top_simplex_type();
+    for (const PrimitiveType primitive : sequence) {
+        // for top level simplices we cannot navigate across boundaries
+        if (primitive == top_type && is_boundary(r)) {
+            assert(!is_boundary(r));
+            r = {};
+            return r;
+        }
+        r = switch_tuple(r, primitive);
+    }
+    return r;
+}
+
+#if defined(__cpp_concepts)
+template <std::forward_iterator ContainerType>
+#else
+template <typename ContainerType>
+#endif
+Tuple Mesh::switch_tuples_unsafe(const Tuple& tuple, const ContainerType& sequence) const
+{
+    Tuple r = tuple;
+    for (const PrimitiveType primitive : sequence) {
+        r = switch_tuple(r, primitive);
+    }
+    return r;
 }
 
 } // namespace wmtk

--- a/tests/test_2d_operations.cpp
+++ b/tests/test_2d_operations.cpp
@@ -431,7 +431,7 @@ TEST_CASE("hash_update", "[operations][2D]")
 
         Accessor<long> hash_accessor = m.get_cell_hash_accessor();
         auto executor = m.get_tmoe(edge, hash_accessor);
-        auto& ha = executor.hash_accessor;
+        //auto& ha = executor.hash_accessor;
 
         CHECK(m.get_cell_hash_slow(0) == 0);
 
@@ -448,7 +448,7 @@ TEST_CASE("hash_update", "[operations][2D]")
 
         Accessor<long> hash_accessor = m.get_cell_hash_accessor();
         auto executor = m.get_tmoe(edge, hash_accessor);
-        auto& ha = executor.hash_accessor;
+        //auto& ha = executor.hash_accessor;
 
         CHECK(m.get_cell_hash_slow(0) == 0);
         CHECK(m.get_cell_hash_slow(1) == 0);

--- a/tests/test_tuple_2d.cpp
+++ b/tests/test_tuple_2d.cpp
@@ -13,7 +13,7 @@ using namespace wmtk::tests;
 
 TEST_CASE("2D_initialize", "[mesh_creation],[tuple_2d]")
 {
-    TriMesh m;
+    DEBUG_TriMesh m;
     RowVectors3l tris;
     tris.resize(1, 3);
     tris.row(0) = Eigen::Matrix<long, 3, 1>{0, 1, 2};
@@ -43,7 +43,7 @@ TEST_CASE("2D_initialize", "[mesh_creation],[tuple_2d]")
 
 TEST_CASE("2D_1_triangle", "[tuple_generation],[tuple_2d]")
 {
-    TriMesh m = single_triangle();
+    DEBUG_TriMesh m = single_triangle();
 
     SECTION("vertices")
     {
@@ -79,7 +79,7 @@ TEST_CASE("2D_2_triangles", "[tuple_generation],[tuple_2d]")
     //     \ /    /
     // 	    v0    /
 
-    TriMesh m;
+    DEBUG_TriMesh m;
     {
         RowVectors3l tris;
         tris.resize(2, 3);
@@ -116,7 +116,7 @@ TEST_CASE("2D_2_triangles", "[tuple_generation],[tuple_2d]")
 // for every quiry do a require
 TEST_CASE("2D_random_switches", "[tuple_operation],[tuple_2d]")
 {
-    TriMesh m = interior_edge();
+    DEBUG_TriMesh m = interior_edge();
 
     SECTION("vertices")
     {
@@ -204,7 +204,7 @@ TEST_CASE("2D_double_switches", "[tuple_operation],[tuple_2d]")
     // (2) t.switch_edge().switch_edge() == t
     // (3) t.switch_tri().switch_tri() == t
 
-    TriMesh m = interior_edge();
+    DEBUG_TriMesh m = interior_edge();
 
     SECTION("vertices")
     {
@@ -253,9 +253,43 @@ TEST_CASE("2D_double_switches", "[tuple_operation],[tuple_2d]")
     }
 }
 
+TEST_CASE("2D_switch_sequences", "[tuple_operation],[tuple_2d]")
+{
+    // checking for every tuple t:
+    // (1) t.switch_vertex().switch_edge() == t.switch_tuples(t,{V,E});
+    // (2) t.switch_edge().switch_vertex() == t.switch_tuples(t,{E,V});
+    // (3) t.switch_tri().switch_edge() == t = t.switch_tuples(t,{T,E})
+
+    DEBUG_TriMesh m = interior_edge();
+
+    SECTION("vertices")
+    {
+        const std::vector<Tuple> vertices = m.get_all(PrimitiveType::Vertex);
+        REQUIRE(vertices.size() == 5);
+        for (const auto& t : vertices) {
+            const Tuple t_long = m.switch_edge(m.switch_vertex(t));
+            const Tuple t_short = m.switch_tuples(t, {PrimitiveType::Vertex, PrimitiveType::Edge});
+            const Tuple t_short_u =
+                m.switch_tuples_unsafe(t, {PrimitiveType::Vertex, PrimitiveType::Edge});
+            CHECK(tuple_equal(m, t_long, t_short));
+            CHECK(tuple_equal(m, t_long, t_short_u));
+            if (!m.is_boundary(t)) {
+                const Tuple _t_long = m.switch_edge(m.switch_face(t));
+                const Tuple _t_short =
+                    m.switch_tuples(t, {PrimitiveType::Face, PrimitiveType::Edge});
+                const Tuple _t_short_u =
+                    m.switch_tuples_unsafe(t, {PrimitiveType::Face, PrimitiveType::Edge});
+
+                CHECK(tuple_equal(m, _t_long, _t_short));
+                CHECK(tuple_equal(m, _t_long, _t_short_u));
+            }
+        }
+    }
+}
+
 TEST_CASE("2D_next_next_next", "[tuple_operation],[tuple_2d]")
 {
-    TriMesh m = interior_edge();
+    DEBUG_TriMesh m = interior_edge();
 
     SECTION("vertices")
     {
@@ -288,7 +322,7 @@ TEST_CASE("2D_next_next_next", "[tuple_operation],[tuple_2d]")
 
 TEST_CASE("2D_one_ring_iteration", "[tuple_operation],[tuple_2d]")
 {
-    TriMesh m;
+    DEBUG_TriMesh m;
     {
         RowVectors3l tris;
         tris.resize(6, 3);


### PR DESCRIPTION
now you can use switch_tuples(t, {PV,PE}) to make notation more concise