### PR TITLE
Generic Reference Return Types

### DIFF
--- a/src/wmtk/utils/metaprogramming/DerivedReferenceWrapperVariantTraits.hpp
+++ b/src/wmtk/utils/metaprogramming/DerivedReferenceWrapperVariantTraits.hpp
@@ -1,0 +1,22 @@
+#pragma once
+#include <tuple>
+
+#include "ReferenceWrapperVariant.hpp"
+namespace wmtk::utils::metaprogramming {
+template <typename BaseType_, typename... DerivedTypes>
+struct DerivedReferenceWrapperVariantTraits
+{
+    using BaseType = BaseType_;
+
+    // we keep a plain derived type tuple for convenience
+    using DerivedTypesTuple = std::tuple<DerivedTypes...>;
+    // we keep reference types of derived type tuple for convenience
+    using ReferenceTuple = std::tuple<std::reference_wrapper<DerivedTypes>...>;
+
+    // The reference class for this type
+    using ReferenceVariant = std::variant<std::reference_wrapper<DerivedTypes>...>;
+
+    static size_t get_index(const BaseType& t);
+};
+
+} // namespace wmtk::utils::metaprogramming

--- a/src/wmtk/utils/metaprogramming/README.md
+++ b/src/wmtk/utils/metaprogramming/README.md
@@ -1,0 +1,2 @@
+In general we want to avoid doing too much metaprogramming, but sometimes it's helpful.
+Here's an isolatd place to store it all

--- a/src/wmtk/utils/metaprogramming/ReferenceWrappedFunctorReturnCache.hpp
+++ b/src/wmtk/utils/metaprogramming/ReferenceWrappedFunctorReturnCache.hpp
@@ -1,0 +1,91 @@
+#pragma once
+#include <map>
+#include <tuple>
+
+#include "ReferenceWrappedFunctorReturnType.hpp"
+namespace wmtk::utils::metaprogramming {
+
+// Interface for reading off the return values from data
+template <typename Functor, typename BaseVariantTraitsType, typename... OtherArgumentTypes>
+class ReferenceWrappedFunctorReturnCache
+{
+public:
+    using TypeHelper =
+        ReferenceWrappedFunctorReturnType<Functor, BaseVariantTraitsType, OtherArgumentTypes...>;
+    using ReturnVariant = typename TypeHelper::type;
+
+    using RefVariantType = typename BaseVariantTraitsType::ReferenceVariant;
+    using BaseType = typename BaseVariantTraitsType::BaseType;
+    using TupleType = typename BaseVariantTraitsType::DerivedTypesTuple;
+    using RefTupleType = typename BaseVariantTraitsType::ReferenceTuple;
+
+    // Add new data by giving the InputType
+    // InputType is used to make sure the pair of Input/Output is valid and to
+    // extract an id
+    // NOTE this passes value then key because the key can have variable arguments :(
+    template <typename InputType, typename ReturnType>
+    void add(ReturnType&& return_data, const InputType& input, const OtherArgumentTypes&... args)
+    {
+        using ReturnType_t = std::decay_t<ReturnType>;
+        static_assert(
+            !std::is_same_v<std::decay_t<InputType>, BaseType>,
+            "Don't pass in a input, use variant/visitor to get its "
+            "derived type");
+        // static_assert(
+        //     !std::
+        //         holds_alternative<std::reference_wrapper<std::decay_t<InputType>>,
+        //         RefVariantType>,
+        //     "the input type must be seen in the set of valid input variants");
+        //  if the user passed in a input class lets try re-invoking with a
+        //  derived type
+        auto id = get_id(input, args...);
+        using ExpectedReturnType = typename TypeHelper::template ReturnType<InputType>;
+
+        static_assert(
+            std::is_convertible_v<ReturnType_t, ExpectedReturnType>,
+            "Second argument should be the return value of a Functor "
+            "(or convertible at "
+            "least) ");
+
+        m_data.emplace(
+            id,
+            ReturnVariant(
+                std::in_place_type_t<ExpectedReturnType>{},
+                std::forward<ReturnType>(return_data)));
+    }
+
+
+    // get the type specific input
+    template <typename InputType>
+    auto get(const InputType& input, const OtherArgumentTypes&... ts) const
+    {
+        static_assert(
+            !std::is_same_v<std::decay_t<InputType>, BaseType>,
+            "Don't pass in a input, use variant/visitor to get its "
+            "derived type");
+        using ExpectedReturnType = typename TypeHelper::template ReturnType<InputType>;
+
+        return std::get<ExpectedReturnType>(get_variant(input, ts...));
+    }
+
+    // let user get the variant for a specific Input derivate
+    const auto& get_variant(const BaseType& input, const OtherArgumentTypes&... ts) const
+    {
+        auto id = get_id(input, ts...);
+        return m_data.at(id);
+    }
+
+private:
+    // a pointer to an input and some other arguments
+    using KeyType = std::tuple<const BaseType*, OtherArgumentTypes...>;
+
+    auto get_id(const BaseType& input, const OtherArgumentTypes&... ts) const
+    {
+        // other applications might use a fancier version of get_id
+        return KeyType(&input, ts...);
+    }
+
+    std::map<KeyType, ReturnVariant> m_data;
+};
+
+} // namespace wmtk::utils::metaprogramming

--- a/src/wmtk/utils/metaprogramming/ReferenceWrappedFunctorReturnType.hpp
+++ b/src/wmtk/utils/metaprogramming/ReferenceWrappedFunctorReturnType.hpp
@@ -2,6 +2,7 @@
 #include <tuple>
 
 #include "DerivedReferenceWrapperVariantTraits.hpp"
+#include "unwrap_ref.hpp"
 namespace wmtk::utils::metaprogramming {
 
 namespace detail {
@@ -18,7 +19,7 @@ struct ReferenceWrappedFunctorReturnType<Functor, std::tuple<VTs...>, Ts...>
     // For a specific type in the variant, get the return type
     template <typename T>
     using ReturnType =
-        std::decay_t<std::invoke_result_t<Functor, std::unwrap_ref_decay_t<T>&, const Ts&...>>;
+        std::decay_t<std::invoke_result_t<Functor, unwrap_ref_decay_t<T>&, const Ts&...>>;
 
     // Get an overall variant for the types
     using type = std::variant<ReturnType<VTs>...>;

--- a/src/wmtk/utils/metaprogramming/ReferenceWrappedFunctorReturnType.hpp
+++ b/src/wmtk/utils/metaprogramming/ReferenceWrappedFunctorReturnType.hpp
@@ -1,0 +1,34 @@
+#pragma once
+#include <tuple>
+
+#include "DerivedReferenceWrapperVariantTraits.hpp"
+namespace wmtk::utils::metaprogramming {
+
+namespace detail {
+// A helper class for specifying per-type return types from an input functor
+// Assumes the argument is the variant type being selected form, all other
+// arguments are passed in as const references
+template <typename Functor, typename... Ts>
+struct ReferenceWrappedFunctorReturnType
+{
+};
+template <typename Functor, typename... VTs, typename... Ts>
+struct ReferenceWrappedFunctorReturnType<Functor, std::tuple<VTs...>, Ts...>
+{
+    // For a specific type in the variant, get the return type
+    template <typename T>
+    using ReturnType =
+        std::decay_t<std::invoke_result_t<Functor, std::unwrap_ref_decay_t<T>&, const Ts&...>>;
+
+    // Get an overall variant for the types
+    using type = std::variant<ReturnType<VTs>...>;
+};
+} // namespace detail
+
+template <typename Functor, typename ReferenceWrapperTraits, typename... Ts>
+using ReferenceWrappedFunctorReturnType = detail::ReferenceWrappedFunctorReturnType<
+    Functor,
+    typename ReferenceWrapperTraits::ReferenceTuple,
+    Ts...>;
+
+} // namespace wmtk::utils::metaprogramming

--- a/src/wmtk/utils/metaprogramming/ReferenceWrapperVariant.hpp
+++ b/src/wmtk/utils/metaprogramming/ReferenceWrapperVariant.hpp
@@ -1,0 +1,44 @@
+#include <functional>
+#include <type_traits>
+#include <utility>
+#include <variant>
+
+#pragma once
+// Re-implement unwrap ref in case it doesn't exist with our current compiler
+// Implementation is the Possible Implementation from:
+// https://en.cppreference.com/w/cpp/utility/functional/unwrap_reference
+#if !defined(__cpp_lib_unwrap_ref)
+namespace std {
+
+template <class T>
+struct unwrap_reference
+{
+    using type = T;
+};
+template <class U>
+struct unwrap_reference<std::reference_wrapper<U>>
+{
+    using type = U&;
+};
+
+template <class T>
+struct unwrap_ref_decay : std::unwrap_reference<std::decay_t<T>>
+{
+};
+
+template <class T>
+using unwrap_ref_decay_t = typename unwrap_ref_decay<T>::type;
+} // namespace std
+#endif
+namespace wmtk::utils::metaprogramming {
+
+// My target application's "Input" class is quite heavy and the Input objects
+// persist for long periods of time relative to what this is being used for, so
+// I want to use a variant of references rather than values
+//
+// Here's a helper definition for making variants of references
+template <typename... T>
+using ReferenceWrapperVariant = std::variant<std::reference_wrapper<T>...>;
+
+
+} // namespace wmtk::utils::metaprogramming

--- a/src/wmtk/utils/metaprogramming/ReferenceWrapperVariant.hpp
+++ b/src/wmtk/utils/metaprogramming/ReferenceWrapperVariant.hpp
@@ -1,35 +1,9 @@
+#pragma once
 #include <functional>
 #include <type_traits>
 #include <utility>
 #include <variant>
 
-#pragma once
-// Re-implement unwrap ref in case it doesn't exist with our current compiler
-// Implementation is the Possible Implementation from:
-// https://en.cppreference.com/w/cpp/utility/functional/unwrap_reference
-#if !defined(__cpp_lib_unwrap_ref)
-namespace std {
-
-template <class T>
-struct unwrap_reference
-{
-    using type = T;
-};
-template <class U>
-struct unwrap_reference<std::reference_wrapper<U>>
-{
-    using type = U&;
-};
-
-template <class T>
-struct unwrap_ref_decay : std::unwrap_reference<std::decay_t<T>>
-{
-};
-
-template <class T>
-using unwrap_ref_decay_t = typename unwrap_ref_decay<T>::type;
-} // namespace std
-#endif
 namespace wmtk::utils::metaprogramming {
 
 // My target application's "Input" class is quite heavy and the Input objects

--- a/src/wmtk/utils/metaprogramming/as_variant.hpp
+++ b/src/wmtk/utils/metaprogramming/as_variant.hpp
@@ -1,0 +1,62 @@
+#pragma once
+
+#include "DerivedReferenceWrapperVariantTraits.hpp"
+namespace wmtk::utils::metaprogramming {
+namespace detail {
+
+template <typename BaseVariantTraitsType, typename TupleType, size_t Index>
+struct as_variant_impl
+{
+    using RetType = typename BaseVariantTraitsType::ReferenceVariant;
+    using BaseType = typename BaseVariantTraitsType::BaseType;
+    static RetType exec(BaseType& value, size_t index);
+};
+template <typename BaseVariantTraitsType, typename... DerivedTypes, size_t Index>
+struct as_variant_impl<BaseVariantTraitsType, std::tuple<DerivedTypes...>, Index>
+{
+    using RetType = typename BaseVariantTraitsType::ReferenceVariant;
+    using BaseType = typename BaseVariantTraitsType::BaseType;
+    using TupleType = typename BaseVariantTraitsType::DerivedTypesTuple;
+    using RefTupleType = typename BaseVariantTraitsType::ReferenceTuple;
+
+    using MyRefType = std::tuple_element_t<Index, RefTupleType>;
+    using MyDerivedType = std::tuple_element_t<Index, TupleType>;
+
+    using FirstRefType = std::tuple_element_t<0, RefTupleType>;
+    using FirstDerivedType = std::tuple_element_t<0, TupleType>;
+    static RetType exec(BaseType& value, size_t index)
+    {
+        // handle case that the type isn't found / settle base case
+        if constexpr (Index < sizeof...(DerivedTypes)) {
+            if (index == Index) {
+                return RetType(
+                    std::in_place_type_t<MyRefType>{},
+                    static_cast<MyDerivedType&>(value));
+            } else {
+                if constexpr (Index + 1 < sizeof...(DerivedTypes)) {
+                    return as_variant_impl<BaseVariantTraitsType, TupleType, Index + 1>::exec(
+                        value,
+                        index);
+                }
+            }
+        }
+        throw "Invalid Input";
+        // This should never happen, just making a dummy to suppress warnings
+        return RetType(
+            std::in_place_type_t<FirstRefType>{},
+            reinterpret_cast<FirstDerivedType&>(value));
+    }
+};
+} // namespace detail
+
+template <typename BaseVariantTraitsType>
+typename BaseVariantTraitsType::ReferenceVariant as_variant(
+    typename BaseVariantTraitsType::BaseType& value)
+{
+    using impl = detail::as_variant_impl<
+        BaseVariantTraitsType,
+        typename BaseVariantTraitsType::DerivedTypesTuple,
+        0>;
+    return impl::exec(value, BaseVariantTraitsType::get_index(value));
+}
+} // namespace wmtk::utils::metaprogramming

--- a/src/wmtk/utils/metaprogramming/unwrap_ref.hpp
+++ b/src/wmtk/utils/metaprogramming/unwrap_ref.hpp
@@ -1,0 +1,32 @@
+
+#pragma once
+#include <functional>
+#include <type_traits>
+#include <utility>
+#include <variant>
+
+
+namespace wmtk::utils::metaprogramming {
+// Re-implement unwrap ref in case it doesn't exist with our current compiler
+// Implementation is the Possible Implementation from:
+// https://en.cppreference.com/w/cpp/utility/functional/unwrap_reference
+
+template <class T>
+struct unwrap_reference
+{
+    using type = T;
+};
+template <class U>
+struct unwrap_reference<std::reference_wrapper<U>>
+{
+    using type = U&;
+};
+
+template <class T>
+struct unwrap_ref_decay : unwrap_reference<std::decay_t<T>>
+{
+};
+
+template <class T>
+using unwrap_ref_decay_t = typename unwrap_ref_decay<T>::type;
+} // namespace wmtk::utils::metaprogramming

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -24,7 +24,7 @@ set(TEST_SOURCES
     test_example_meshes.cpp
     test_3d_operations.cpp
     test_multi_mesh.cpp
-    tests/test_variant_metaprogramming.cpp
+    test_variant_metaprogramming.cpp
 
 
     tools/DEBUG_PointMesh.hpp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -24,6 +24,9 @@ set(TEST_SOURCES
     test_example_meshes.cpp
     test_3d_operations.cpp
     test_multi_mesh.cpp
+    tests/test_variant_metaprogramming.cpp
+
+
     tools/DEBUG_PointMesh.hpp
     tools/DEBUG_TriMesh.hpp
     tools/DEBUG_TriMesh.cpp

--- a/tests/test_variant_metaprogramming.cpp
+++ b/tests/test_variant_metaprogramming.cpp
@@ -1,0 +1,102 @@
+#include <catch2/catch_test_macros.hpp>
+#include <wmtk/utils/metaprogramming/as_variant.hpp>
+
+namespace {
+// Declare a base type that has some sort of ID member and a way of identifying
+// an appropriate derived type
+struct Input
+{
+    int type = -1;
+    int id;
+};
+
+// Some example derived types
+struct A : public Input
+{
+    A(int id_)
+        : Input{0, id_}
+    {}
+};
+
+struct B : public Input
+{
+    B(int id_)
+        : Input{1, id_}
+    {}
+};
+
+struct C : public Input
+{
+    C(int id_)
+        : Input{2, id_}
+    {}
+};
+
+
+using TestRefType =
+    wmtk::utils::metaprogramming::DerivedReferenceWrapperVariantTraits<Input, A, B, C>;
+
+} // namespace
+
+namespace wmtk::utils::metaprogramming {
+template <>
+size_t TestRefType::get_index(const Input& input)
+{
+    return input.type;
+}
+} // namespace wmtk::utils::metaprogramming
+
+
+TEST_CASE("test_variant_multiprogramming", "[metaprogramming]")
+{
+    static_assert(std::is_same_v<TestRefType::BaseType, Input>);
+    static_assert(std::is_same_v<TestRefType::DerivedTypesTuple, std::tuple<A, B, C>>);
+    static_assert(std::is_same_v<
+                  TestRefType::ReferenceTuple,
+                  std::tuple<
+                      std::reference_wrapper<A>,
+                      std::reference_wrapper<B>,
+                      std::reference_wrapper<C>>>);
+
+    A a(0);
+    B b(2);
+    C c(4);
+    CHECK(TestRefType::get_index(a) == 0);
+    CHECK(TestRefType::get_index(b) == 1);
+    CHECK(TestRefType::get_index(c) == 2);
+
+    auto a_ref = wmtk::utils::metaprogramming::as_variant<TestRefType>(a);
+    auto b_ref = wmtk::utils::metaprogramming::as_variant<TestRefType>(b);
+    auto c_ref = wmtk::utils::metaprogramming::as_variant<TestRefType>(c);
+
+    // double check that we get the expected indices in the variant
+    CHECK(a_ref.index() == 0);
+    CHECK(b_ref.index() == 1);
+    CHECK(c_ref.index() == 2);
+
+    // try checking the runtime usage of these variants
+    std::visit(
+        [&]<typename T>(const T&) {
+            //
+            constexpr bool same = std::is_same_v<T, std::reference_wrapper<A>>;
+            CHECK(same);
+            //
+        },
+        a_ref);
+    std::visit(
+        [&]<typename T>(const T&) {
+            //
+            constexpr bool same = std::is_same_v<T, std::reference_wrapper<B>>;
+            CHECK(same);
+            //
+        },
+        b_ref);
+    std::visit(
+        [&]<typename T>(const T&) {
+            //
+            constexpr bool same = std::is_same_v<T, std::reference_wrapper<C>>;
+            CHECK(same);
+            //
+        },
+        c_ref);
+}

--- a/tests/test_variant_metaprogramming.cpp
+++ b/tests/test_variant_metaprogramming.cpp
@@ -95,6 +95,11 @@ TEST_CASE("test_variant_multiprogramming", "[metaprogramming]")
     auto b_ref = wmtk::utils::metaprogramming::as_variant<TestRefType>(b);
     auto c_ref = wmtk::utils::metaprogramming::as_variant<TestRefType>(c);
 
+    {
+        Input i{3, 3};
+        CHECK_THROWS(wmtk::utils::metaprogramming::as_variant<TestRefType>(i));
+    }
+
     // double check that we get the expected indices in the variant
     CHECK(a_ref.index() == 0);
     CHECK(b_ref.index() == 1);

--- a/tests/test_variant_metaprogramming.cpp
+++ b/tests/test_variant_metaprogramming.cpp
@@ -47,7 +47,7 @@ struct TestFunctor
     template <typename T>
     auto operator()(T& input) const
     {
-        using TT = std::unwrap_ref_decay_t<T>;
+        using TT = wmtk::utils::metaprogramming::unwrap_ref_decay_t<T>;
         return std::tuple<TT, int>(input, input.id);
     };
 };
@@ -57,7 +57,7 @@ struct TestFunctor2Args
     template <typename T>
     auto operator()(T& input, int data) const
     {
-        using TT = std::unwrap_ref_decay_t<T>;
+        using TT = wmtk::utils::metaprogramming::unwrap_ref_decay_t<T>;
         return std::tuple<TT, int>(input, input.id * data);
     };
 };

--- a/tests/test_variant_metaprogramming.cpp
+++ b/tests/test_variant_metaprogramming.cpp
@@ -107,7 +107,8 @@ TEST_CASE("test_variant_multiprogramming", "[metaprogramming]")
 
     // try checking the runtime usage of these variants
     std::visit(
-        [&]<typename T>(const T&) {
+        [&](const auto& test) {
+            using T = std::decay_t<decltype(test)>;
             //
             constexpr bool same = std::is_same_v<T, std::reference_wrapper<A>>;
             CHECK(same);
@@ -115,7 +116,8 @@ TEST_CASE("test_variant_multiprogramming", "[metaprogramming]")
         },
         a_ref);
     std::visit(
-        [&]<typename T>(const T&) {
+        [&](const auto& test2) {
+            using T = std::decay_t<decltype(test2)>;
             //
             constexpr bool same = std::is_same_v<T, std::reference_wrapper<B>>;
             CHECK(same);
@@ -123,7 +125,8 @@ TEST_CASE("test_variant_multiprogramming", "[metaprogramming]")
         },
         b_ref);
     std::visit(
-        [&]<typename T>(const T&) {
+        [&](const auto& test2) {
+            using T = std::decay_t<decltype(test2)>;
             //
             constexpr bool same = std::is_same_v<T, std::reference_wrapper<C>>;
             CHECK(same);


### PR DESCRIPTION
Our atomic operations have prototypes like 
* EdgeMesh,Tuple -> EdgeMeshExecutorData
* TriMesh ,Tuple-> TriMeshExecutorData
* TetMesh ,Tuple-> TetMeshExecutorData

These need to be stored during the entire multimesh traversal so that compound operations can extract information from the last operation on any particular mesh. Because this involves different input and output types it's better to use `std::variant` - but the input types are all references so some manipulation around `std::reference_wrapper` is needed. This PR provides a somewhat ugly interface that will be kept internal for executing on generic variants.

A key function here is the implied ability to call `as_variant<Traits>(Mesh&)` that returns a `std::variant<EdgeMesh&,TriMesh&,TetMesh&>`  so we can just call 

```
// assume as_mesh_variant aliases to as_variant<MeshVarTraits>
Mesh m = ...;
auto mesh_ref_var = as_mesh_variant(mesh);

std::visit([&]template <typename T>(const T& mesh) {
using MeshType = unwrap_ref_t<T>;
if constexpr(std::is_same_v<MeshType, TriMesh>) {
// do tri mesh specific things
}
}, mesh_var);
```
If we use Functor classes (as seen in unit tests) then users can create custom multimesh visitors using functor structs + polymorphism and even cache the return types.