### PR TITLE
Adding top_cell_dimension to replace top_simplex_type as virtual

### DIFF
--- a/src/wmtk/EdgeMesh.hpp
+++ b/src/wmtk/EdgeMesh.hpp
@@ -16,7 +16,7 @@ public:
     EdgeMesh& operator=(const EdgeMesh& o);
     EdgeMesh& operator=(EdgeMesh&& o);
 
-    PrimitiveType top_simplex_type() const override { return PrimitiveType::Edge; }
+    long top_cell_dimension() const override { return 1; }
 
     operations::edge_mesh::EdgeOperationData split_edge(
         const Tuple& t,

--- a/src/wmtk/Mesh.cpp
+++ b/src/wmtk/Mesh.cpp
@@ -25,6 +25,14 @@ Mesh::Mesh(const long& dimension)
 
 Mesh::~Mesh() = default;
 
+PrimitiveType Mesh::top_simplex_type() const
+{
+    long dimension = top_cell_dimension();
+    assert(dimension >= 0);
+    assert(dimension < 4);
+    return static_cast<PrimitiveType>(dimension);
+}
+
 std::vector<Tuple> Mesh::get_all(PrimitiveType type) const
 {
     ConstAccessor<char> flag_accessor = get_flag_accessor(type);
@@ -46,8 +54,12 @@ void Mesh::serialize(MeshWriter& writer)
 }
 
 template <typename T>
-MeshAttributeHandle<T>
-Mesh::register_attribute(const std::string& name, PrimitiveType ptype, long size, bool replace, T default_value)
+MeshAttributeHandle<T> Mesh::register_attribute(
+    const std::string& name,
+    PrimitiveType ptype,
+    long size,
+    bool replace,
+    T default_value)
 {
     return m_attribute_manager.register_attribute<T>(name, ptype, size, replace, default_value);
 }
@@ -279,7 +291,7 @@ void Mesh::register_child_mesh(
     const std::shared_ptr<Mesh>& child_mesh_ptr,
     const std::vector<std::array<Tuple, 2>>& map_tuples)
 {
-    m_multi_mesh_manager.register_child_mesh(*this,child_mesh_ptr, map_tuples);
+    m_multi_mesh_manager.register_child_mesh(*this, child_mesh_ptr, map_tuples);
 }
 
 

--- a/src/wmtk/Mesh.hpp
+++ b/src/wmtk/Mesh.hpp
@@ -48,7 +48,8 @@ public:
     friend class MeshReader;
     friend class MultiMeshManager;
 
-    virtual PrimitiveType top_simplex_type() const = 0;
+    virtual long top_cell_dimension() const = 0;
+    PrimitiveType top_simplex_type() const;
 
     friend class operations::Operation;
 

--- a/src/wmtk/PointMesh.hpp
+++ b/src/wmtk/PointMesh.hpp
@@ -17,7 +17,7 @@ public:
     PointMesh();
     PointMesh(long size);
 
-    PrimitiveType top_simplex_type() const override { return PrimitiveType::Vertex; }
+    long top_cell_dimension() const override { return 0; }
     Tuple switch_tuple(const Tuple& tuple, PrimitiveType type) const override;
     bool is_ccw(const Tuple& tuple) const override;
     bool is_boundary(const Tuple& tuple) const override;

--- a/src/wmtk/TetMesh.hpp
+++ b/src/wmtk/TetMesh.hpp
@@ -19,7 +19,7 @@ public:
     operations::tet_mesh::EdgeOperationData collapse_edge(
         const Tuple& t,
         Accessor<long>& hash_accessor);
-    PrimitiveType top_simplex_type() const override { return PrimitiveType::Tetrahedron; }
+    long top_cell_dimension() const override { return 3; }
     Tuple switch_tuple(const Tuple& tuple, PrimitiveType type) const override;
     bool is_ccw(const Tuple& tuple) const override;
     bool is_boundary(const Tuple& tuple) const override;

--- a/src/wmtk/TriMesh.hpp
+++ b/src/wmtk/TriMesh.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
+#include <wmtk/operations/tri_mesh/EdgeOperationData.hpp>
 #include "Mesh.hpp"
 #include "Tuple.hpp"
-#include <wmtk/operations/tri_mesh/EdgeOperationData.hpp>
 
 #include <Eigen/Core>
 
@@ -17,14 +17,16 @@ public:
     TriMesh& operator=(const TriMesh& o);
     TriMesh& operator=(TriMesh&& o);
 
-    PrimitiveType top_simplex_type() const override { return PrimitiveType::Face; }
+    long top_cell_dimension() const override { return 2; }
     /**
      * @brief split edge t
      *
      * The returned tuple contains the new vertex. The face lies in the region where the input tuple
      * face was, and the edge is oriented in the same direction as in the input.
      */
-    operations::tri_mesh::EdgeOperationData split_edge(const Tuple& t, Accessor<long>& hash_accessor);
+    operations::tri_mesh::EdgeOperationData split_edge(
+        const Tuple& t,
+        Accessor<long>& hash_accessor);
     /**
      * @brief collapse edge t
      *
@@ -33,7 +35,9 @@ public:
      * collapsed. The face is chosen such that the orientation of the tuple is the same as in the
      * input. If this is not possible due to a boundary, the opposite face is chosen.
      */
-    operations::tri_mesh::EdgeOperationData collapse_edge(const Tuple& t, Accessor<long>& hash_accessor);
+    operations::tri_mesh::EdgeOperationData collapse_edge(
+        const Tuple& t,
+        Accessor<long>& hash_accessor);
 
     Tuple switch_tuple(const Tuple& tuple, PrimitiveType type) const override;
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -10,6 +10,7 @@ lagrange_include_modules(io)
 # Sources
 set(TEST_SOURCES
 	test_topology.cpp
+    test_mesh.cpp
     test_autogen.cpp
     test_tuple.cpp
     test_tuple_1d.cpp

--- a/tests/test_mesh.cpp
+++ b/tests/test_mesh.cpp
@@ -1,0 +1,26 @@
+#include <spdlog/spdlog.h>
+#include <catch2/catch_test_macros.hpp>
+#include <wmtk/EdgeMesh.hpp>
+#include <wmtk/Mesh.hpp>
+#include <wmtk/PointMesh.hpp>
+#include <wmtk/TetMesh.hpp>
+#include <wmtk/TriMesh.hpp>
+
+
+TEST_CASE("test_mesh_virtuals", "[mesh]")
+{
+    wmtk::PointMesh pm;
+    wmtk::EdgeMesh em;
+    wmtk::TriMesh fm;
+    wmtk::TetMesh tm;
+
+    REQUIRE(pm.top_cell_dimension() == 0);
+    REQUIRE(em.top_cell_dimension() == 1);
+    REQUIRE(fm.top_cell_dimension() == 2);
+    REQUIRE(tm.top_cell_dimension() == 3);
+
+    REQUIRE(pm.top_simplex_type() == wmtk::PrimitiveType::Vertex);
+    REQUIRE(em.top_simplex_type() == wmtk::PrimitiveType::Edge);
+    REQUIRE(fm.top_simplex_type() == wmtk::PrimitiveType::Face);
+    REQUIRE(tm.top_simplex_type() == wmtk::PrimitiveType::Tetrahedron);
+}


### PR DESCRIPTION
Using `top_cell_dimension` was already planned for implementation for the sake of the `PolygonMesh` class that @rjc8237 is working on, but I realized I wanted to implement a map from PrimitiveType -> dimension anyway for my [MultiMesh](https://github.com/wildmeshing/wildmeshing-toolkit/pull/428)  refactor so I implemented it early.