### PR TITLE
making is_boundary interfaces take in a primitive type

### DIFF
--- a/src/wmtk/EdgeMesh.cpp
+++ b/src/wmtk/EdgeMesh.cpp
@@ -53,9 +53,19 @@ long EdgeMesh::id(const Tuple& tuple, PrimitiveType type) const
     }
 }
 
-bool EdgeMesh::is_boundary(const Tuple& tuple) const
+bool EdgeMesh::is_boundary(const Tuple& tuple, PrimitiveType pt) const
 {
-    return is_boundary_vertex(tuple);
+    switch (pt) {
+    case PrimitiveType::Vertex: return is_boundary_vertex(tuple);
+    case PrimitiveType::Edge:
+    case PrimitiveType::Face:
+    case PrimitiveType::Tetrahedron:
+    case PrimitiveType::HalfEdge:
+    default: break;
+    }
+    throw std::runtime_error(
+        "tried to compute hte boundary of an edge mesh for an invalid simplex dimension");
+    return false;
 }
 
 bool EdgeMesh::is_boundary_vertex(const Tuple& tuple) const

--- a/src/wmtk/EdgeMesh.hpp
+++ b/src/wmtk/EdgeMesh.hpp
@@ -35,12 +35,9 @@ public:
     Tuple switch_tuple(const Tuple& tuple, PrimitiveType type) const override;
 
     bool is_ccw(const Tuple& tuple) const override;
-    bool is_boundary(const Tuple& tuple) const override;
-    bool is_boundary_vertex(const Tuple& tuple) const override;
-    bool is_boundary_edge(const Tuple& tuple) const override
-    {
-        throw std::runtime_error("This function doesn't make sense for EdgeMesh");
-    }
+    using Mesh::is_boundary;
+    bool is_boundary(const Tuple& tuple, PrimitiveType) const override;
+    bool is_boundary_vertex(const Tuple& tuple) const;
 
     void initialize(Eigen::Ref<const RowVectors2l> E);
 

--- a/src/wmtk/EdgeMeshOperationExecutor.cpp
+++ b/src/wmtk/EdgeMeshOperationExecutor.cpp
@@ -23,11 +23,11 @@ EdgeMesh::EdgeMeshOperationExecutor::EdgeMeshOperationExecutor(
 
     // update hash on neighborhood
     cell_ids_to_update_hash.emplace_back(m_mesh.id_edge(m_operating_tuple));
-    if (!m_mesh.is_boundary(m_operating_tuple)) {
+    if (!m_mesh.is_boundary_vertex(m_operating_tuple)) {
         m_neighbor_eids[0] = m_mesh.id_edge(m_mesh.switch_edge(m_operating_tuple));
         cell_ids_to_update_hash.emplace_back(m_neighbor_eids[0]);
     }
-    if (!m_mesh.is_boundary(operating_tuple_switch_vertex)) {
+    if (!m_mesh.is_boundary_vertex(operating_tuple_switch_vertex)) {
         m_neighbor_eids[1] = m_mesh.id_edge(m_mesh.switch_edge(operating_tuple_switch_vertex));
         cell_ids_to_update_hash.emplace_back(m_neighbor_eids[1]);
     }
@@ -168,8 +168,8 @@ void EdgeMesh::EdgeMeshOperationExecutor::collapse_edge()
 Tuple EdgeMesh::EdgeMeshOperationExecutor::collapse_edge_single_mesh()
 {
     // check if the collapse is valid
-    if (m_is_self_loop || (m_mesh.is_boundary(m_operating_tuple) &&
-                           m_mesh.is_boundary(m_mesh.switch_vertex(m_operating_tuple)))) {
+    if (m_is_self_loop || (m_mesh.is_boundary_vertex(m_operating_tuple) &&
+                           m_mesh.is_boundary_vertex(m_mesh.switch_vertex(m_operating_tuple)))) {
         return Tuple();
     }
 

--- a/src/wmtk/Mesh.cpp
+++ b/src/wmtk/Mesh.cpp
@@ -119,6 +119,20 @@ long Mesh::capacity(PrimitiveType type) const
     return m_attribute_manager.m_capacities.at(get_primitive_type_id(type));
 }
 
+
+bool Mesh::is_boundary(const Tuple& tuple) const
+{
+    long my_dim = top_cell_dimension() - 1;
+    PrimitiveType pt = static_cast<PrimitiveType>(my_dim);
+    return is_boundary(tuple, pt);
+}
+
+bool Mesh::is_boundary(const Simplex& s) const
+{
+    return is_boundary(s.tuple(), s.primitive_type());
+}
+
+
 bool Mesh::is_hash_valid(const Tuple& tuple, const ConstAccessor<long>& hash_accessor) const
 {
     const long cid = tuple.m_global_cid;

--- a/src/wmtk/Mesh.hpp
+++ b/src/wmtk/Mesh.hpp
@@ -288,16 +288,24 @@ public:
      */
     virtual bool is_ccw(const Tuple& tuple) const = 0;
     /**
-     * @brief check if all tuple simplices besides the cell are on the boundary
+     * @brief check if a simplex of codimension 1 is a boundary simplex
      *
      * @param tuple
      * @return true if all tuple simplices besides the cell are on the boundary
      * @return false otherwise
      */
-    virtual bool is_boundary(const Tuple& tuple) const = 0;
+    bool is_boundary(const Tuple& codim_1_simplex) const;
 
-    virtual bool is_boundary_vertex(const Tuple& vertex) const = 0;
-    virtual bool is_boundary_edge(const Tuple& vertex) const = 0;
+    /**
+     * @brief check if a simplex lies on a boundary or not
+     *
+     * @param simplex
+     * @return true if this simplex lies on the boundary of the mesh
+     * @return false otherwise
+     */
+    bool is_boundary(const Simplex& tuple) const;
+    virtual bool is_boundary(const Tuple& tuple, PrimitiveType pt) const = 0;
+
 
     bool is_hash_valid(const Tuple& tuple, const ConstAccessor<long>& hash_accessor) const;
 

--- a/src/wmtk/Mesh.hpp
+++ b/src/wmtk/Mesh.hpp
@@ -294,7 +294,7 @@ public:
      * @return true if all tuple simplices besides the cell are on the boundary
      * @return false otherwise
      */
-    bool is_boundary(const Tuple& codim_1_simplex) const;
+     [[deprecated("use is_boundary(Tuple,PrimitiveType) instead")]] bool is_boundary(const Tuple& codim_1_simplex) const;
 
     /**
      * @brief check if a simplex lies on a boundary or not
@@ -304,6 +304,13 @@ public:
      * @return false otherwise
      */
     bool is_boundary(const Simplex& tuple) const;
+    /**
+     * @brief check if a simplex (encoded as a tuple/primitive pair) lies on a boundary or not
+     *
+     * @param simplex
+     * @return true if this simplex lies on the boundary of the mesh
+     * @return false otherwise
+     */
     virtual bool is_boundary(const Tuple& tuple, PrimitiveType pt) const = 0;
 
 

--- a/src/wmtk/PointMesh.cpp
+++ b/src/wmtk/PointMesh.cpp
@@ -26,8 +26,19 @@ bool PointMesh::is_ccw(const Tuple&) const
     // trivial orientation so nothing can happen
     return true;
 }
-bool PointMesh::is_boundary(const Tuple&) const
+bool PointMesh::is_boundary(const Tuple& tuple, PrimitiveType pt) const
 {
+    switch (pt) {
+    case PrimitiveType::Vertex: return is_boundary_vertex(tuple);
+    case PrimitiveType::Edge:
+    case PrimitiveType::Face:
+    case PrimitiveType::Tetrahedron:
+    case PrimitiveType::HalfEdge:
+    default: break;
+    }
+    throw std::runtime_error(
+        "tried to compute hte boundary of an edge mesh for an invalid simplex dimension");
+    return false;
     // every point is on the interior as it has no boundary simplices
     return false;
 }

--- a/src/wmtk/PointMesh.hpp
+++ b/src/wmtk/PointMesh.hpp
@@ -20,10 +20,9 @@ public:
     long top_cell_dimension() const override { return 0; }
     [[noreturn]] Tuple switch_tuple(const Tuple& tuple, PrimitiveType type) const override;
     bool is_ccw(const Tuple& tuple) const override;
-    bool is_boundary(const Tuple& tuple) const override;
-    bool is_boundary_vertex(const Tuple& tuple) const override;
-    // TODO: should just write is_boundary(PrimitiveType)
-    bool is_boundary_edge(const Tuple& tuple) const override { return true; }
+    using Mesh::is_boundary;
+    bool is_boundary(const Tuple& tuple, PrimitiveType pt) const override;
+    bool is_boundary_vertex(const Tuple& tuple) const;
 
     void initialize(long count);
 

--- a/src/wmtk/SimplicialComplex.cpp
+++ b/src/wmtk/SimplicialComplex.cpp
@@ -161,7 +161,7 @@ bool SimplicialComplex::link_cond_bd_2d(const Mesh& m, Tuple t)
         // get one_ring_edges from open_star
         auto one_ring_edges = open_star(m, input_v).get_simplices(PrimitiveType::Edge);
         for (const auto& _e : one_ring_edges) {
-            if (m.is_boundary(_e.tuple())) {
+            if (m.is_boundary(_e.tuple(), PrimitiveType::Edge)) {
                 if (m.simplices_are_equal(Simplex(PrimitiveType::Vertex, _e.tuple()), input_v)) {
                     ret.push_back(m.switch_tuple(_e.tuple(), PrimitiveType::Vertex));
                 } else {
@@ -175,7 +175,7 @@ bool SimplicialComplex::link_cond_bd_2d(const Mesh& m, Tuple t)
     // if there are any common edges connected with w in lnk_w^0(a)∩lnk_w^0(b)
     auto bd_neighbors_a = get_bd_edges(t);
     auto bd_neighbors_b = get_bd_edges(m.switch_tuple(t, PrimitiveType::Vertex));
-    if (m.is_boundary(t)) {
+    if (m.is_boundary(t, PrimitiveType::Edge)) {
         assert(bd_neighbors_a.size() == 2); // if guarantee 2-manifold
         assert(bd_neighbors_b.size() == 2); // if guarantee 2-manifold
         for (auto e_a : bd_neighbors_a) {
@@ -206,7 +206,7 @@ bool SimplicialComplex::link_cond_bd_2d(const Mesh& m, Tuple t)
 bool SimplicialComplex::edge_collapse_possible_2d(const TriMesh& m, const Tuple& t)
 {
     // cannot collapse edges connecting two boundaries unless the edge itself is a boundary
-    if (m.is_boundary_vertex(t) && m.is_boundary_vertex(m.switch_vertex(t)) && !m.is_boundary(t)) {
+    if (m.is_boundary_vertex(t) && m.is_boundary_vertex(m.switch_vertex(t)) && !m.is_boundary_edge(t)) {
         return false;
     }
 
@@ -215,7 +215,7 @@ bool SimplicialComplex::edge_collapse_possible_2d(const TriMesh& m, const Tuple&
     const Tuple h0 = m.next_edge(t);
     const Tuple h0_next = m.next_edge(h0);
 
-    if (!m.is_boundary(h0)) {
+    if (!m.is_boundary_edge(h0)) {
         const Tuple h0_opp = opp(h0);
         if (h0_opp == h0_next) {
             return false;
@@ -223,14 +223,14 @@ bool SimplicialComplex::edge_collapse_possible_2d(const TriMesh& m, const Tuple&
     }
 
     // valence 1 check
-    if (!m.is_boundary(t)) {
+    if (!m.is_boundary_edge(t)) {
         const Tuple t_opp = opp(t);
         const Tuple h1 = m.next_edge(t_opp);
         const Tuple h1_next = m.next_edge(h1);
         if (h0 == t_opp && h1 == t) {
             return false;
         }
-        if (!m.is_boundary(h1)) {
+        if (!m.is_boundary_edge(h1)) {
             const Tuple h1_opp = opp(h1);
             if (h1_opp == h1_next) {
                 return false;
@@ -255,18 +255,18 @@ std::vector<Simplex> SimplicialComplex::vertex_one_ring(const TriMesh& m, Tuple 
     Tuple iter = t;
     do {
         one_ring.emplace_back(Simplex::vertex(m.switch_vertex(iter)));
-        if (m.is_boundary(iter)) {
+        if (m.is_boundary_edge(iter)) {
             break;
         }
         iter = m.switch_edge(m.switch_face(iter));
     } while (iter != t);
 
     // in case of a boundary, collect the other side too
-    if (iter != t || m.is_boundary(t)) {
+    if (iter != t || m.is_boundary_edge(t)) {
         iter = m.switch_edge(t);
         do {
             one_ring.emplace_back(Simplex::vertex(m.switch_vertex(iter)));
-            if (m.is_boundary(iter)) {
+            if (m.is_boundary_edge(iter)) {
                 break;
             }
             iter = m.switch_edge(m.switch_face(iter));

--- a/src/wmtk/TetMesh.cpp
+++ b/src/wmtk/TetMesh.cpp
@@ -366,7 +366,23 @@ bool TetMesh::is_valid(const Tuple& tuple, ConstAccessor<long>& hash_accessor) c
     return Mesh::is_hash_valid(tuple, hash_accessor);
 }
 
-bool TetMesh::is_boundary(const Tuple& tuple) const
+bool TetMesh::is_boundary(const Tuple& tuple, PrimitiveType pt) const
+{
+    switch (pt) {
+    case PrimitiveType::Vertex: return is_boundary_vertex(tuple);
+    case PrimitiveType::Edge: return is_boundary_edge(tuple);
+    case PrimitiveType::Face: return is_boundary_face(tuple);
+    case PrimitiveType::Tetrahedron:
+    case PrimitiveType::HalfEdge:
+    default: break;
+    }
+    throw std::runtime_error(
+        "tried to compute hte boundary of an edge mesh for an invalid simplex dimension");
+    return false;
+}
+
+
+bool TetMesh::is_boundary_face(const Tuple& tuple) const
 {
     ConstAccessor<long> tt_accessor = create_accessor<long>(m_tt_handle);
     return tt_accessor.vector_attribute(tuple)(tuple.m_local_fid) < 0;

--- a/src/wmtk/TetMesh.hpp
+++ b/src/wmtk/TetMesh.hpp
@@ -28,9 +28,11 @@ public:
     long top_cell_dimension() const override { return 3; }
     Tuple switch_tuple(const Tuple& tuple, PrimitiveType type) const override;
     bool is_ccw(const Tuple& tuple) const override;
-    bool is_boundary(const Tuple& tuple) const override;
-    bool is_boundary_vertex(const Tuple& tuple) const override;
-    bool is_boundary_edge(const Tuple& tuple) const override;
+    using Mesh::is_boundary;
+    bool is_boundary(const Tuple& tuple, PrimitiveType pt) const override;
+    bool is_boundary_vertex(const Tuple& tuple) const;
+    bool is_boundary_edge(const Tuple& tuple) const;
+    bool is_boundary_face(const Tuple& tuple) const;
 
     bool is_valid(const Tuple& tuple, ConstAccessor<long>& hash_accessor) const override;
 

--- a/src/wmtk/TetMeshOperationExecutor.cpp
+++ b/src/wmtk/TetMeshOperationExecutor.cpp
@@ -21,7 +21,7 @@ TetMesh::TetMeshOperationExecutor::get_incident_tets_and_faces(Tuple t)
 
     bool loop_flag = false;
 
-    while (!m_mesh.is_boundary(iter_tuple)) {
+    while (!m_mesh.is_boundary_face(iter_tuple)) {
         iter_tuple = m_mesh.switch_tetrahedron(iter_tuple);
 
         // if no boundary, break;
@@ -52,7 +52,7 @@ TetMesh::TetMeshOperationExecutor::get_incident_tets_and_faces(Tuple t)
 
         // go to the left boundary
         iter_tuple = m_mesh.switch_face(t);
-        while (!m_mesh.is_boundary(iter_tuple)) {
+        while (!m_mesh.is_boundary_face(iter_tuple)) {
             iter_tuple = m_mesh.switch_face(m_mesh.switch_tetrahedron(iter_tuple));
         }
 
@@ -62,7 +62,7 @@ TetMesh::TetMeshOperationExecutor::get_incident_tets_and_faces(Tuple t)
         incident_tets.emplace_back(iter_tuple);
         incident_faces.emplace_back(iter_tuple);
 
-        while (!m_mesh.is_boundary(iter_tuple)) {
+        while (!m_mesh.is_boundary_face(iter_tuple)) {
             iter_tuple = m_mesh.switch_face(m_mesh.switch_tetrahedron(iter_tuple));
             incident_tets.emplace_back(iter_tuple);
             incident_faces.emplace_back(iter_tuple);
@@ -297,7 +297,7 @@ void TetMesh::TetMeshOperationExecutor::split_edge()
 
         // get ears here
         Tuple ear1 = m_mesh.switch_face(m_mesh.switch_edge(incident_tets[i]));
-        if (!m_mesh.is_boundary(ear1)) {
+        if (!m_mesh.is_boundary_face(ear1)) {
             ear1 = m_mesh.switch_tuple(ear1, PrimitiveType::Tetrahedron);
             tsd.ear_tet_1 = EarTet{m_mesh.id_tet(ear1), m_mesh.id_face(ear1)};
         } else {
@@ -305,7 +305,7 @@ void TetMesh::TetMeshOperationExecutor::split_edge()
         }
 
         Tuple ear2 = m_mesh.switch_face(m_mesh.switch_edge(m_mesh.switch_vertex(incident_tets[i])));
-        if (!m_mesh.is_boundary(ear2)) {
+        if (!m_mesh.is_boundary_face(ear2)) {
             ear2 = m_mesh.switch_tuple(ear2, PrimitiveType::Tetrahedron);
             tsd.ear_tet_2 = EarTet{m_mesh.id_tet(ear2), m_mesh.id_face(ear2)};
         } else {
@@ -681,7 +681,7 @@ void TetMesh::TetMeshOperationExecutor::collapse_edge()
 
         // get ears
         Tuple ear1 = m_mesh.switch_face(m_mesh.switch_edge(tet));
-        if (!m_mesh.is_boundary(ear1)) {
+        if (!m_mesh.is_boundary_face(ear1)) {
             ear1 = m_mesh.switch_tuple(ear1, PrimitiveType::Tetrahedron);
             tcd.ear_tet_1 = EarTet{m_mesh.id_tet(ear1), m_mesh.id_face(ear1)};
         } else {
@@ -689,7 +689,7 @@ void TetMesh::TetMeshOperationExecutor::collapse_edge()
         }
 
         Tuple ear2 = m_mesh.switch_face(m_mesh.switch_edge(m_mesh.switch_vertex(tet)));
-        if (!m_mesh.is_boundary(ear2)) {
+        if (!m_mesh.is_boundary_face(ear2)) {
             ear2 = m_mesh.switch_tuple(ear2, PrimitiveType::Tetrahedron);
             tcd.ear_tet_2 = EarTet{m_mesh.id_tet(ear2), m_mesh.id_face(ear2)};
         } else {

--- a/src/wmtk/TriMesh.cpp
+++ b/src/wmtk/TriMesh.cpp
@@ -95,7 +95,7 @@ bool TriMesh::is_boundary_vertex(const Tuple& vertex) const
 
     Tuple t = vertex;
     do {
-        if (is_boundary(t)) {
+        if (is_boundary_edge(t)) {
             return true;
         }
         t = switch_edge(switch_face(t));

--- a/src/wmtk/TriMesh.cpp
+++ b/src/wmtk/TriMesh.cpp
@@ -61,9 +61,19 @@ long TriMesh::id(const Tuple& tuple, PrimitiveType type) const
     }
 }
 
-bool TriMesh::is_boundary(const Tuple& tuple) const
+bool TriMesh::is_boundary(const Tuple& tuple, PrimitiveType pt) const
 {
-    return is_boundary_edge(tuple);
+    switch (pt) {
+    case PrimitiveType::Vertex: return is_boundary_vertex(tuple);
+    case PrimitiveType::Edge: return is_boundary_edge(tuple);
+    case PrimitiveType::Face:
+    case PrimitiveType::Tetrahedron:
+    case PrimitiveType::HalfEdge:
+    default: break;
+    }
+    throw std::runtime_error(
+        "tried to compute hte boundary of an edge mesh for an invalid simplex dimension");
+    return false;
 }
 
 bool TriMesh::is_boundary_edge(const Tuple& tuple) const

--- a/src/wmtk/TriMesh.hpp
+++ b/src/wmtk/TriMesh.hpp
@@ -59,9 +59,10 @@ public:
     Tuple prev_edge(const Tuple& tuple) const { return switch_vertex(switch_edge(tuple)); }
 
     bool is_ccw(const Tuple& tuple) const override;
-    bool is_boundary(const Tuple& tuple) const override;
-    bool is_boundary_vertex(const Tuple& tuple) const override;
-    bool is_boundary_edge(const Tuple& tuple) const override;
+    using Mesh::is_boundary;
+    bool is_boundary(const Tuple& tuple, PrimitiveType pt) const override;
+    bool is_boundary_vertex(const Tuple& tuple) const;
+    bool is_boundary_edge(const Tuple& tuple) const;
 
     void initialize(
         Eigen::Ref<const RowVectors3l> FV,

--- a/src/wmtk/invariants/CMakeLists.txt
+++ b/src/wmtk/invariants/CMakeLists.txt
@@ -9,6 +9,8 @@ set(SRC_FILES
     MeshInvariant.cpp
     InvariantCollection.hpp
     InvariantCollection.cpp
+    InteriorSimplexInvariant.hpp
+    InteriorSimplexInvariant.cpp
     InteriorVertexInvariant.hpp
     InteriorVertexInvariant.cpp
     InteriorEdgeInvariant.hpp

--- a/src/wmtk/invariants/InteriorEdgeInvariant.cpp
+++ b/src/wmtk/invariants/InteriorEdgeInvariant.cpp
@@ -1,10 +1,8 @@
 #include "InteriorEdgeInvariant.hpp"
 #include <wmtk/Mesh.hpp>
 
-namespace wmtk {
-bool InteriorEdgeInvariant::before(const Tuple& t) const
-{
-    const bool result = !mesh().is_boundary_edge(t);
-    return result;
-}
-} // namespace wmtk
+namespace wmtk::invariants {
+InteriorEdgeInvariant::InteriorEdgeInvariant(const Mesh& m)
+    : InteriorSimplexInvariant(m, PrimitiveType::Edge)
+{}
+} // namespace wmtk::invariants

--- a/src/wmtk/invariants/InteriorEdgeInvariant.hpp
+++ b/src/wmtk/invariants/InteriorEdgeInvariant.hpp
@@ -1,11 +1,14 @@
 #pragma once
 
-#include "MeshInvariant.hpp"
+#include "InteriorSimplexInvariant.hpp"
 
 namespace wmtk {
-class InteriorEdgeInvariant : public MeshInvariant
+namespace invariants {
+class InteriorEdgeInvariant : public InteriorSimplexInvariant
 {
-    using MeshInvariant::MeshInvariant;
-    bool before(const Tuple& t) const override;
+public:
+    InteriorEdgeInvariant(const Mesh& m);
 };
+} // namespace invariants
+using InteriorEdgeInvariant = invariants::InteriorEdgeInvariant;
 } // namespace wmtk

--- a/src/wmtk/invariants/InteriorSimplexInvariant.cpp
+++ b/src/wmtk/invariants/InteriorSimplexInvariant.cpp
@@ -1,0 +1,14 @@
+#include "InteriorSimplexInvariant.hpp"
+#include <wmtk/Mesh.hpp>
+
+namespace wmtk::invariants {
+InteriorSimplexInvariant::InteriorSimplexInvariant(const Mesh& m, PrimitiveType pt)
+    : MeshInvariant(m)
+    , m_primitive_type(pt)
+{}
+bool InteriorSimplexInvariant::before(const Tuple& t) const
+{
+    const bool result = !mesh().is_boundary(t, m_primitive_type);
+    return result;
+}
+} // namespace wmtk::invariants

--- a/src/wmtk/invariants/InteriorSimplexInvariant.hpp
+++ b/src/wmtk/invariants/InteriorSimplexInvariant.hpp
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "MeshInvariant.hpp"
+
+namespace wmtk {
+namespace invariants {
+class InteriorSimplexInvariant : public MeshInvariant
+{
+public:
+    using MeshInvariant::MeshInvariant;
+    InteriorSimplexInvariant(const Mesh& m, PrimitiveType pt);
+    bool before(const Tuple& t) const override;
+
+private:
+    PrimitiveType m_primitive_type;
+};
+} // namespace invariants
+} // namespace wmtk

--- a/src/wmtk/invariants/InteriorVertexInvariant.cpp
+++ b/src/wmtk/invariants/InteriorVertexInvariant.cpp
@@ -1,10 +1,8 @@
 #include "InteriorVertexInvariant.hpp"
 #include <wmtk/Mesh.hpp>
 
-namespace wmtk {
-bool InteriorVertexInvariant::before(const Tuple& t) const
-{
-    const bool result = !mesh().is_boundary_vertex(t);
-    return result;
-}
-} // namespace wmtk
+namespace wmtk::invariants {
+InteriorVertexInvariant::InteriorVertexInvariant(const Mesh& m)
+    : InteriorSimplexInvariant(m, PrimitiveType::Vertex)
+{}
+} // namespace wmtk::invariants

--- a/src/wmtk/invariants/InteriorVertexInvariant.hpp
+++ b/src/wmtk/invariants/InteriorVertexInvariant.hpp
@@ -1,11 +1,14 @@
 #pragma once
 
-#include "MeshInvariant.hpp"
+#include "InteriorSimplexInvariant.hpp"
 
 namespace wmtk {
-class InteriorVertexInvariant : public MeshInvariant
+namespace invariants {
+class InteriorVertexInvariant : public InteriorSimplexInvariant
 {
-    using MeshInvariant::MeshInvariant;
-    bool before(const Tuple& t) const override;
+public:
+    InteriorVertexInvariant(const Mesh& m);
 };
+} // namespace invariants
+using InteriorVertexInvariant = invariants::InteriorVertexInvariant;
 } // namespace wmtk

--- a/src/wmtk/operations/tri_mesh/VertexTangentialLaplacianSmooth.cpp
+++ b/src/wmtk/operations/tri_mesh/VertexTangentialLaplacianSmooth.cpp
@@ -35,13 +35,13 @@ bool VertexTangentialLaplacianSmooth::execute()
     if (m_settings.smooth_settings.smooth_boundary && mesh().is_boundary_vertex(tup)) {
         //
         Tuple t0 = tup;
-        while (!mesh().is_boundary(t0)) {
+        while (!mesh().is_boundary_edge(t0)) {
             t0 = mesh().switch_edge(mesh().switch_face(t0));
         }
         const Tuple v0 = mesh().switch_vertex(t0);
 
         Tuple t1 = mesh().switch_edge(tup);
-        while (!mesh().is_boundary(t1)) {
+        while (!mesh().is_boundary_edge(t1)) {
             t1 = mesh().switch_edge(mesh().switch_face(t1));
         }
         const Tuple v1 = mesh().switch_vertex(t1);

--- a/src/wmtk/simplex/top_dimension_cofaces.cpp
+++ b/src/wmtk/simplex/top_dimension_cofaces.cpp
@@ -36,11 +36,11 @@ std::vector<Tuple> top_dimension_cofaces_tuples_vertex(const TriMesh& mesh, cons
         }
         collection.emplace_back(t);
 
-        if (!mesh.is_boundary(t)) {
+        if (!mesh.is_boundary_edge(t)) {
             q.push(mesh.switch_face(t));
         }
         const Tuple t_other = mesh.switch_edge(t);
-        if (!mesh.is_boundary(t_other)) {
+        if (!mesh.is_boundary_edge(t_other)) {
             q.push(mesh.switch_face(t_other));
         }
     }
@@ -50,7 +50,7 @@ std::vector<Tuple> top_dimension_cofaces_tuples_edge(const TriMesh& mesh, const 
 {
     std::vector<Tuple> collection;
     collection.emplace_back(t);
-    if (!mesh.is_boundary(t)) {
+    if (!mesh.is_boundary_edge(t)) {
         collection.emplace_back(mesh.switch_face(t));
     }
 
@@ -85,13 +85,13 @@ std::vector<Tuple> top_dimension_cofaces_tuples_vertex(const TetMesh& mesh, cons
         const Tuple t2 = mesh.switch_face(t);
         const Tuple t3 = mesh.switch_tuples(t, {PrimitiveType::Edge, PrimitiveType::Face});
 
-        if (!mesh.is_boundary(t1)) {
+        if (!mesh.is_boundary_face(t1)) {
             q.push(mesh.switch_tetrahedron(t1));
         }
-        if (!mesh.is_boundary(t2)) {
+        if (!mesh.is_boundary_face(t2)) {
             q.push(mesh.switch_tetrahedron(t2));
         }
-        if (!mesh.is_boundary(t3)) {
+        if (!mesh.is_boundary_face(t3)) {
             q.push(mesh.switch_tetrahedron(t3));
         }
     }
@@ -120,10 +120,10 @@ std::vector<Tuple> top_dimension_cofaces_tuples_edge(const TetMesh& mesh, const 
         const Tuple& t1 = t;
         const Tuple t2 = mesh.switch_face(t);
 
-        if (!mesh.is_boundary(t1)) {
+        if (!mesh.is_boundary_face(t1)) {
             q.push(mesh.switch_tetrahedron(t1));
         }
-        if (!mesh.is_boundary(t2)) {
+        if (!mesh.is_boundary_face(t2)) {
             q.push(mesh.switch_tetrahedron(t2));
         }
     }
@@ -133,7 +133,7 @@ std::vector<Tuple> top_dimension_cofaces_tuples_edge(const TetMesh& mesh, const 
 std::vector<Tuple> top_dimension_cofaces_tuples_face(const TetMesh& mesh, const Tuple& input)
 {
     std::vector<Tuple> collection = {input};
-    if (!mesh.is_boundary(input)) {
+    if (!mesh.is_boundary_face(input)) {
         collection.emplace_back(mesh.switch_tetrahedron(input));
     }
     return collection;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -11,6 +11,7 @@ set(TEST_SOURCES
 	test_topology.cpp
     test_mesh.cpp
     test_autogen.cpp
+    test_boundary.cpp
     test_tuple.cpp
     test_tuple_1d.cpp
     test_tuple_2d.cpp

--- a/tests/components/test_component_isotropic_remeshing.cpp
+++ b/tests/components/test_component_isotropic_remeshing.cpp
@@ -633,7 +633,7 @@ TEST_CASE("remeshing_with_boundary", "[components][isotropic_remeshing][2D]")
 
         size_t n_boundary_edges = 0;
         for (const Tuple& e : mesh.get_all(PrimitiveType::Edge)) {
-            if (mesh.is_boundary(e)) {
+            if (mesh.is_boundary_edge(e)) {
                 ++n_boundary_edges;
             }
         }
@@ -647,7 +647,7 @@ TEST_CASE("remeshing_with_boundary", "[components][isotropic_remeshing][2D]")
 
         size_t n_boundary_edges = 0;
         for (const Tuple& e : mesh.get_all(PrimitiveType::Edge)) {
-            if (mesh.is_boundary(e)) {
+            if (mesh.is_boundary_edge(e)) {
                 ++n_boundary_edges;
             }
         }

--- a/tests/test_boundary.cpp
+++ b/tests/test_boundary.cpp
@@ -1,0 +1,33 @@
+#include <spdlog/spdlog.h>
+#include <catch2/catch_test_macros.hpp>
+#include <wmtk/EdgeMesh.hpp>
+#include <wmtk/Mesh.hpp>
+#include <wmtk/PointMesh.hpp>
+#include <wmtk/TetMesh.hpp>
+#include <wmtk/TriMesh.hpp>
+#include "tools/TriMesh_examples.hpp"
+#include "tools/EdgeMesh_examples.hpp"
+#include "tools/TetMesh_examples.hpp"
+
+
+TEST_CASE("test_mesh_boundary", "[mesh]")
+{
+    wmtk::PointMesh pm(10);
+    wmtk::EdgeMesh em = wmtk::tests::single_line();
+    wmtk::TriMesh fm = wmtk::tests::single_triangle();
+    wmtk::TetMesh tm = wmtk::tests_3d::single_tet();
+
+    CHECK_THROWS(pm.is_boundary({}, wmtk::PrimitiveType::Edge));
+    CHECK_THROWS(pm.is_boundary({}, wmtk::PrimitiveType::Face));
+    CHECK_THROWS(pm.is_boundary({}, wmtk::PrimitiveType::Tetrahedron));
+    CHECK_THROWS(pm.is_boundary({}, wmtk::PrimitiveType::HalfEdge));
+
+    CHECK_THROWS(em.is_boundary({}, wmtk::PrimitiveType::Face));
+    CHECK_THROWS(em.is_boundary({}, wmtk::PrimitiveType::Tetrahedron));
+    CHECK_THROWS(em.is_boundary({}, wmtk::PrimitiveType::HalfEdge));
+
+    CHECK_THROWS(fm.is_boundary({}, wmtk::PrimitiveType::Tetrahedron));
+    CHECK_THROWS(fm.is_boundary({}, wmtk::PrimitiveType::HalfEdge));
+
+    CHECK_THROWS(tm.is_boundary({}, wmtk::PrimitiveType::HalfEdge));
+}

--- a/tests/test_example_meshes.cpp
+++ b/tests/test_example_meshes.cpp
@@ -58,7 +58,7 @@ int trimesh_simply_connected_components(const DEBUG_TriMesh& m, std::vector<int>
             auto f_tuple = m.tuple_from_face_id(cur_fid);
             // push all adjacent faces
             for (int j = 0; j < 3; ++j) {
-                if (!m.is_boundary(f_tuple)) {
+                if (!m.is_boundary_edge(f_tuple)) {
                     auto adj_face_tuple = m.switch_tuple(f_tuple, PrimitiveType::Face);
                     long adj_fid = m.id(adj_face_tuple, PrimitiveType::Face);
                     if (component_ids[adj_fid] == -1) {
@@ -87,7 +87,7 @@ int trimesh_boundary_loops_count(const DEBUG_TriMesh& m)
     const auto all_edge_tuples = m.get_all(PrimitiveType::Edge);
     int boundary_loop_id = 0;
     for (auto edge_tuple : all_edge_tuples) {
-        if (!m.is_boundary(edge_tuple)) {
+        if (!m.is_boundary_edge(edge_tuple)) {
             continue;
         }
         const long eid = m.id(edge_tuple, PrimitiveType::Edge);
@@ -103,7 +103,7 @@ int trimesh_boundary_loops_count(const DEBUG_TriMesh& m)
 
             // find next boundary edge
             cur_edge = m.switch_edge(m.switch_vertex(cur_edge));
-            while (!m.is_boundary(cur_edge)) {
+            while (!m.is_boundary_edge(cur_edge)) {
                 cur_edge = m.switch_edge(m.switch_face(cur_edge));
             }
 

--- a/tests/test_simplex_collection.cpp
+++ b/tests/test_simplex_collection.cpp
@@ -59,7 +59,7 @@ TEST_CASE("simplex_comparison", "[simplex_collection][2D]")
             const simplex::Simplex s0(PV, t);
             const simplex::Simplex s1(PV, m.switch_tuple(t, PE));
             CHECK(m.simplices_are_equal(s0, s1));
-            if (m.is_boundary(t)) {
+            if (m.is_boundary_edge(t)) {
                 continue;
             }
             const simplex::Simplex s2(PV, m.switch_tuple(t, PF));
@@ -76,7 +76,7 @@ TEST_CASE("simplex_comparison", "[simplex_collection][2D]")
             const simplex::Simplex s1(PE, m.switch_tuple(t, PV));
             CHECK_FALSE(m.simplex_is_less(s0, s1));
             CHECK_FALSE(m.simplex_is_less(s1, s0));
-            if (m.is_boundary(t)) {
+            if (m.is_boundary_edge(t)) {
                 continue;
             }
             const simplex::Simplex s2(PE, m.switch_tuple(t, PF));

--- a/tests/test_simplicial_complex.cpp
+++ b/tests/test_simplicial_complex.cpp
@@ -34,7 +34,7 @@ TEST_CASE("simplex_comparison", "[simplicial_complex][2D]")
             const Simplex s0(PV, t);
             const Simplex s1(PV, m.switch_tuple(t, PE));
             CHECK(m.simplices_are_equal(s0, s1));
-            if (m.is_boundary(t)) {
+            if (m.is_boundary_edge(t)) {
                 continue;
             }
             const Simplex s2(PV, m.switch_tuple(t, PF));
@@ -51,7 +51,7 @@ TEST_CASE("simplex_comparison", "[simplicial_complex][2D]")
             const Simplex s1(PE, m.switch_tuple(t, PV));
             CHECK_FALSE(m.simplex_is_less(s0, s1));
             CHECK_FALSE(m.simplex_is_less(s1, s0));
-            if (m.is_boundary(t)) {
+            if (m.is_boundary_edge(t)) {
                 continue;
             }
             const Simplex s2(PE, m.switch_tuple(t, PF));

--- a/tests/test_tuple_1d.cpp
+++ b/tests/test_tuple_1d.cpp
@@ -178,7 +178,7 @@ TEST_CASE("1D_random_switches", "[tuple_operation],[tuple_1d]")
                 switch (rand() % 2) {
                 case 0: t = m.switch_tuple(t, PrimitiveType::Vertex); break;
                 case 1:
-                    if (!m.is_boundary(t)) {
+                    if (!m.is_boundary_vertex(t)) {
                         t = m.switch_tuple(t, PrimitiveType::Edge);
                     }
                     break;
@@ -198,7 +198,7 @@ TEST_CASE("1D_random_switches", "[tuple_operation],[tuple_1d]")
                 switch (rand() % 2) {
                 case 0: t = m.switch_tuple(t, PrimitiveType::Vertex); break;
                 case 1:
-                    if (!m.is_boundary(t)) {
+                    if (!m.is_boundary_vertex(t)) {
                         t = m.switch_tuple(t, PrimitiveType::Edge);
                     }
                     break;
@@ -248,7 +248,7 @@ TEST_CASE("1D_is_boundary", "[tuple_1d]")
     // count boundary vertices
     size_t n_boundary_vertices = 0;
     for (const Tuple& v : m.get_all(PrimitiveType::Vertex)) {
-        if (m.is_boundary(v)) {
+        if (m.is_boundary_vertex(v)) {
             ++n_boundary_vertices;
         }
     }
@@ -289,7 +289,7 @@ TEST_CASE("1D_double_switches", "[tuple_operation],[tuple_1d]")
     for (const auto& t : vertices) {
         const Tuple t_after_v = m.switch_vertex(m.switch_vertex(t));
         CHECK(t == t_after_v);
-        if (!m.is_boundary(t)) {
+        if (!m.is_boundary_vertex(t)) {
             const Tuple t_after_e = m.switch_edge(m.switch_edge(t));
             CHECK(t == t_after_e);
         }
@@ -300,7 +300,7 @@ TEST_CASE("1D_double_switches", "[tuple_operation],[tuple_1d]")
     for (const auto& t : edges) {
         const Tuple t_after_v = m.switch_vertex(m.switch_vertex(t));
         CHECK(t == t_after_v);
-        if (!m.is_boundary(t)) {
+        if (!m.is_boundary_vertex(t)) {
             const Tuple t_after_e = m.switch_edge(m.switch_edge(t));
             CHECK(t == t_after_e);
         }

--- a/tests/test_tuple_2d.cpp
+++ b/tests/test_tuple_2d.cpp
@@ -127,7 +127,7 @@ TEST_CASE("2D_random_switches", "[tuple_operation],[tuple_2d]")
                 case 0: t = m.switch_tuple(t, PrimitiveType::Vertex); break;
                 case 1: t = m.switch_tuple(t, PrimitiveType::Edge); break;
                 case 2:
-                    if (!m.is_boundary(t)) {
+                    if (!m.is_boundary_edge(t)) {
                         t = m.switch_tuple(t, PrimitiveType::Face);
                     }
                     break;
@@ -148,7 +148,7 @@ TEST_CASE("2D_random_switches", "[tuple_operation],[tuple_2d]")
                 case 0: t = m.switch_tuple(t, PrimitiveType::Vertex); break;
                 case 1: t = m.switch_tuple(t, PrimitiveType::Edge); break;
                 case 2:
-                    if (!m.is_boundary(t)) {
+                    if (!m.is_boundary_edge(t)) {
                         t = m.switch_tuple(t, PrimitiveType::Face);
                     }
                     break;
@@ -169,7 +169,7 @@ TEST_CASE("2D_random_switches", "[tuple_operation],[tuple_2d]")
                 case 0: t = m.switch_tuple(t, PrimitiveType::Vertex); break;
                 case 1: t = m.switch_tuple(t, PrimitiveType::Edge); break;
                 case 2:
-                    if (!m.is_boundary(t)) {
+                    if (!m.is_boundary_edge(t)) {
                         t = m.switch_tuple(t, PrimitiveType::Face);
                     }
                     break;
@@ -214,7 +214,7 @@ TEST_CASE("2D_double_switches", "[tuple_operation],[tuple_2d]")
             CHECK(tuple_equal(m, t, t_after_v));
             const Tuple t_after_e = m.switch_edge(m.switch_edge(t));
             CHECK(tuple_equal(m, t, t_after_e));
-            if (!m.is_boundary(t)) {
+            if (!m.is_boundary_edge(t)) {
                 const Tuple t_after_f = m.switch_face(m.switch_face(t));
                 CHECK(tuple_equal(m, t, t_after_f));
             }
@@ -229,7 +229,7 @@ TEST_CASE("2D_double_switches", "[tuple_operation],[tuple_2d]")
             CHECK(tuple_equal(m, t, t_after_v));
             const Tuple t_after_e = m.switch_edge(m.switch_edge(t));
             CHECK(tuple_equal(m, t, t_after_e));
-            if (!m.is_boundary(t)) {
+            if (!m.is_boundary_edge(t)) {
                 const Tuple t_after_f = m.switch_face(m.switch_face(t));
                 CHECK(tuple_equal(m, t, t_after_f));
             }
@@ -244,7 +244,7 @@ TEST_CASE("2D_double_switches", "[tuple_operation],[tuple_2d]")
             CHECK(tuple_equal(m, t, t_after_v));
             const Tuple t_after_e = m.switch_edge(m.switch_edge(t));
             CHECK(tuple_equal(m, t, t_after_e));
-            if (!m.is_boundary(t)) {
+            if (!m.is_boundary_edge(t)) {
                 const Tuple t_after_f = m.switch_face(m.switch_face(t));
                 CHECK(tuple_equal(m, t, t_after_f));
             }
@@ -272,7 +272,7 @@ TEST_CASE("2D_switch_sequences", "[tuple_operation],[tuple_2d]")
                 m.switch_tuples_unsafe(t, {PrimitiveType::Vertex, PrimitiveType::Edge});
             CHECK(tuple_equal(m, t_long, t_short));
             CHECK(tuple_equal(m, t_long, t_short_u));
-            if (!m.is_boundary(t)) {
+            if (!m.is_boundary_edge(t)) {
                 const Tuple _t_long = m.switch_edge(m.switch_face(t));
                 const Tuple _t_short =
                     m.switch_tuples(t, {PrimitiveType::Face, PrimitiveType::Edge});
@@ -340,7 +340,7 @@ TEST_CASE("2D_one_ring_iteration", "[tuple_operation],[tuple_2d]")
         // face-edge switch
         Tuple t_iter = t;
         for (size_t i = 0; i < 6; ++i) {
-            if (m.is_boundary(t_iter)) {
+            if (m.is_boundary_edge(t_iter)) {
                 break;
             }
             t_iter = m.switch_tuple(t_iter, PrimitiveType::Face);
@@ -349,12 +349,12 @@ TEST_CASE("2D_one_ring_iteration", "[tuple_operation],[tuple_2d]")
                 break;
             }
         }
-        CHECK((tuple_equal(m, t, t_iter) || m.is_boundary(t_iter)));
+        CHECK((tuple_equal(m, t, t_iter) || m.is_boundary_edge(t_iter)));
         // edge-face switch
         t_iter = t;
         for (size_t i = 0; i < 6; ++i) {
             t_iter = m.switch_tuple(t_iter, PrimitiveType::Edge);
-            if (m.is_boundary(t_iter)) {
+            if (m.is_boundary_edge(t_iter)) {
                 break;
             }
             t_iter = m.switch_tuple(t_iter, PrimitiveType::Face);
@@ -362,7 +362,7 @@ TEST_CASE("2D_one_ring_iteration", "[tuple_operation],[tuple_2d]")
                 break;
             }
         }
-        CHECK((tuple_equal(m, t, t_iter) || m.is_boundary(t_iter)));
+        CHECK((tuple_equal(m, t, t_iter) || m.is_boundary_edge(t_iter)));
     }
 }
 
@@ -372,7 +372,7 @@ TEST_CASE("2D_is_boundary", "[tuple_2d]")
 
     size_t n_boundary_edges = 0;
     for (const Tuple& e : m.get_all(PrimitiveType::Edge)) {
-        if (m.is_boundary(e)) {
+        if (m.is_boundary_edge(e)) {
             ++n_boundary_edges;
         }
     }
@@ -388,14 +388,14 @@ TEST_CASE("2D_is_boundary", "[tuple_2d]")
 
 
     const Tuple t1 = m.edge_tuple_between_v1_v2(0, 1, 1);
-    CHECK(m.is_boundary(t1));
+    CHECK(m.is_boundary_edge(t1));
     CHECK(m.is_boundary_vertex(t1));
 
     const Tuple t2 = m.switch_edge(t1);
-    CHECK(!m.is_boundary(t2));
+    CHECK(!m.is_boundary_edge(t2));
     CHECK(m.is_boundary_vertex(t2));
 
     const Tuple t3 = m.switch_vertex(t2);
-    CHECK(!m.is_boundary(t3));
+    CHECK(!m.is_boundary_edge(t3));
     CHECK(!m.is_boundary_vertex(t3));
 }

--- a/tests/tools/DEBUG_MultiMeshManager.cpp
+++ b/tests/tools/DEBUG_MultiMeshManager.cpp
@@ -93,8 +93,8 @@ void DEBUG_MultiMeshManager::check_child_map_valid(const Mesh& my_mesh, const Ch
             auto child_to_parent_accessor =
                 child_mesh.create_const_accessor(child_to_parent_handle);
             for (int i = 0; i < 3; i++) {
-                if (!child_mesh.is_boundary(cur_child_tuple)) {
-                    REQUIRE(!my_mesh.is_boundary(cur_parent_tuple));
+                if (!child_mesh.is_boundary(cur_child_tuple, PrimitiveType::Edge)) {
+                    REQUIRE(!my_mesh.is_boundary(cur_parent_tuple, PrimitiveType::Edge));
 
                     Tuple child_tuple_opp = child_mesh.switch_face(cur_child_tuple);
                     Tuple parent_tuple_opp = my_mesh.switch_face(cur_parent_tuple);
@@ -110,7 +110,7 @@ void DEBUG_MultiMeshManager::check_child_map_valid(const Mesh& my_mesh, const Ch
             }
         } else if (
             map_type == PrimitiveType::Edge && my_mesh.top_simplex_type() == PrimitiveType::Face) {
-            if (!my_mesh.is_boundary(parent_tuple_from_child)) {
+            if (!my_mesh.is_boundary(parent_tuple_from_child, PrimitiveType::Edge)) {
                 auto parent_to_child_accessor =
                     my_mesh.create_const_accessor(parent_to_child_handle);
                 const Tuple parent_tuple_opp = my_mesh.switch_face(parent_tuple_from_child);


### PR DESCRIPTION
now there is only one is_boundary virtual which takes in a tuple and primitive type,
all other ones are treated as implementation details