### PR TITLE
Remove simplex comparisons from Mesh class, moved to a util 

### DIFF
--- a/src/wmtk/Mesh.cpp
+++ b/src/wmtk/Mesh.cpp
@@ -145,18 +145,6 @@ bool Mesh::is_valid_slow(const Tuple& tuple) const
     return is_valid(tuple, hash_accessor);
 }
 
-bool Mesh::simplices_are_equal(const Simplex& s0, const Simplex& s1) const
-{
-    return (s0.primitive_type() == s1.primitive_type()) && (id(s0) == id(s1));
-}
-
-bool Mesh::simplex_is_less(const Simplex& s0, const Simplex& s1) const
-{
-    if (s0.primitive_type() == s1.primitive_type()) {
-        return id(s0) < id(s1);
-    }
-    return s0.primitive_type() < s1.primitive_type();
-}
 
 void Mesh::reserve_attributes_to_fit()
 {

--- a/src/wmtk/Mesh.hpp
+++ b/src/wmtk/Mesh.hpp
@@ -40,6 +40,13 @@ namespace utils {
 class UpdateEdgeOperationMultiMeshMapFunctor;
 }
 } // namespace operations
+
+namespace simplex {
+    namespace utils {
+        class SimplexComparisons;
+    }
+}
+
 namespace multimesh {
 template <long cell_dimension, typename NodeFunctor, typename EdgeFunctor>
 class MultiMeshVisitor;
@@ -62,6 +69,7 @@ public:
     template <typename Visitor>
     friend class multimesh::MultiMeshVisitorExecutor;
     friend class operations::utils::UpdateEdgeOperationMultiMeshMapFunctor;
+    friend class simplex::utils::SimplexComparisons;
 
     friend std::shared_ptr<Mesh> multimesh::utils::extract_and_register_child_mesh_from_tag_handle(
         Mesh& m,
@@ -334,9 +342,6 @@ public:
     bool is_valid_slow(const Tuple& tuple) const;
 
 
-    bool simplices_are_equal(const Simplex& s0, const Simplex& s1) const;
-
-    bool simplex_is_less(const Simplex& s0, const Simplex& s1) const;
 
 
     //============================

--- a/src/wmtk/SimplicialComplex.cpp
+++ b/src/wmtk/SimplicialComplex.cpp
@@ -163,7 +163,8 @@ bool SimplicialComplex::link_cond_bd_2d(const Mesh& m, Tuple t)
         auto one_ring_edges = open_star(m, input_v).get_simplices(PrimitiveType::Edge);
         for (const auto& _e : one_ring_edges) {
             if (m.is_boundary(_e.tuple(), PrimitiveType::Edge)) {
-                if (m.simplices_are_equal(Simplex(PrimitiveType::Vertex, _e.tuple()), input_v)) {
+                if(simplex::utils::SimplexComparisons::equal(m,
+                        Simplex(PrimitiveType::Vertex, _e.tuple()), input_v)) {
                     ret.push_back(m.switch_tuple(_e.tuple(), PrimitiveType::Vertex));
                 } else {
                     ret.push_back(_e.tuple());
@@ -181,7 +182,7 @@ bool SimplicialComplex::link_cond_bd_2d(const Mesh& m, Tuple t)
         assert(bd_neighbors_b.size() == 2); // if guarantee 2-manifold
         for (auto e_a : bd_neighbors_a) {
             for (auto e_b : bd_neighbors_b) {
-                if (m.simplices_are_equal(
+                if(simplex::utils::SimplexComparisons::equal(m,
                         Simplex(PrimitiveType::Vertex, e_a),
                         Simplex(PrimitiveType::Vertex, e_b))) {
                     // find common edge, link condition fails
@@ -209,7 +210,7 @@ bool SimplicialComplex::link_cond_bd_1d(const Mesh& m, Tuple t)
     if (m.is_boundary(t) && m.is_boundary(t_switch_v)) {
         return false;
     }
-    if (m.simplices_are_equal(
+                if(simplex::utils::SimplexComparisons::equal(m,
             Simplex(PrimitiveType::Vertex, t),
             Simplex(PrimitiveType::Vertex, t_switch_v))) {
         return false;

--- a/src/wmtk/SimplicialComplex.hpp
+++ b/src/wmtk/SimplicialComplex.hpp
@@ -5,25 +5,14 @@
 #include <vector>
 #include "Mesh.hpp"
 #include "Simplex.hpp"
+#include "simplex/internal/SimplexLessFunctor.hpp"
 
 namespace wmtk {
 
 namespace internal {
 
 
-struct SimplexLessFunctor
-{
-    const Mesh* m;
-
-    SimplexLessFunctor(const Mesh& mm)
-        : m(&mm)
-    {}
-
-    bool operator()(const Simplex& s0, const Simplex& s1) const
-    {
-        return m->simplex_is_less(s0, s1);
-    }
-};
+using SimplexLessFunctor =  wmtk::simplex::internal::SimplexLessFunctor;
 
 using SimplexSet = std::set<Simplex, SimplexLessFunctor>;
 

--- a/src/wmtk/TetMeshOperationExecutor.cpp
+++ b/src/wmtk/TetMeshOperationExecutor.cpp
@@ -95,17 +95,17 @@ TetMesh::TetMeshOperationExecutor::get_incident_tet_data(Tuple t)
     // make sure that edge and vertex of the tuple is the same
     const SimplicialComplex sc = SimplicialComplex::boundary(m_mesh, Simplex::tetrahedron(t));
     for (const Simplex& s : sc.get_edges()) {
-        if (m_mesh.simplices_are_equal(Simplex::edge(t), s)) {
+        if (simplex::utils::SimplexComparisons::equal(m_mesh,Simplex::edge(t), s)) {
             break;
         }
         t = s.tuple();
     }
-    assert(m_mesh.simplices_are_equal(Simplex::edge(t), Simplex::edge(m_operating_tuple)));
+    assert(simplex::utils::SimplexComparisons::equal(m_mesh,Simplex::edge(t), Simplex::edge(m_operating_tuple)));
 
-    if (!m_mesh.simplices_are_equal(Simplex::vertex(t), Simplex::vertex(m_operating_tuple))) {
+    if (!simplex::utils::SimplexComparisons::equal(m_mesh,Simplex::vertex(t), Simplex::vertex(m_operating_tuple))) {
         t = m_mesh.switch_vertex(t);
     }
-    assert(m_mesh.simplices_are_equal(Simplex::vertex(t), Simplex::vertex(m_operating_tuple)));
+    assert(simplex::utils::SimplexComparisons::equal(m_mesh,Simplex::vertex(t), Simplex::vertex(m_operating_tuple)));
 
 
     const Tuple ear1_face = m_mesh.switch_face(m_mesh.switch_edge(t));

--- a/src/wmtk/TriMeshOperationExecutor.cpp
+++ b/src/wmtk/TriMeshOperationExecutor.cpp
@@ -2,6 +2,7 @@
 #include "TriMeshOperationExecutor.hpp"
 #include <wmtk/simplex/faces.hpp>
 #include <wmtk/simplex/top_dimension_cofaces.hpp>
+#include <wmtk/simplex/utils/SimplexComparisons.hpp>
 #include "SimplicialComplex.hpp"
 namespace wmtk {
 
@@ -16,17 +17,17 @@ auto TriMesh::TriMeshOperationExecutor::get_incident_face_data(Tuple t) -> Incid
 
     // make sure that edge and vertex of the tuple are the same
     for (int i = 0; i < 3; ++i) {
-        if (m_mesh.simplices_are_equal(Simplex::edge(t), Simplex::edge(m_operating_tuple))) {
+        if (simplex::utils::SimplexComparisons::equal(m_mesh,Simplex::edge(t), Simplex::edge(m_operating_tuple))) {
             break;
         }
         t = m_mesh.next_edge(t);
     }
-    assert(m_mesh.simplices_are_equal(Simplex::edge(t), Simplex::edge(m_operating_tuple)));
+    assert(simplex::utils::SimplexComparisons::equal(m_mesh,Simplex::edge(t), Simplex::edge(m_operating_tuple)));
 
-    if (!m_mesh.simplices_are_equal(Simplex::vertex(t), Simplex::vertex(m_operating_tuple))) {
+    if (!simplex::utils::SimplexComparisons::equal(m_mesh,Simplex::vertex(t), Simplex::vertex(m_operating_tuple))) {
         t = m_mesh.switch_vertex(t);
     }
-    assert(m_mesh.simplices_are_equal(Simplex::vertex(t), Simplex::vertex(m_operating_tuple)));
+    assert(simplex::utils::SimplexComparisons::equal(m_mesh,Simplex::vertex(t), Simplex::vertex(m_operating_tuple)));
 
     const std::array<Tuple, 2> ear_edges{
         {m_mesh.switch_edge(t), m_mesh.switch_edge(m_mesh.switch_vertex(t))}};

--- a/src/wmtk/function/AutodiffFunction.hpp
+++ b/src/wmtk/function/AutodiffFunction.hpp
@@ -4,6 +4,7 @@
 #include <wmtk/function/utils/AutoDiffRAII.hpp>
 #include <wmtk/function/utils/AutoDiffUtils.hpp>
 #include "PerSimplexDifferentiableFunction.hpp"
+#include <wmtk/simplex/utils/SimplexComparisons.hpp>
 namespace wmtk::function {
 /**
  * @brief This is an extension of the PerSimplexDifferentiableFunction class that uses autodiff
@@ -76,7 +77,7 @@ std::array<AutodiffFunction::DSVec, N> AutodiffFunction::get_variable_coordinate
         Tuple domain_tuple = domain_tuples[i];
         Simplex domain_simplex(get_coordinate_attribute_primitive_type(), domain_tuple);
         if (variable_simplex_opt.has_value() &&
-            mesh().simplices_are_equal(domain_simplex, variable_simplex_opt.value())) {
+            wmtk::simplex::utils::SimplexComparisons::equal(mesh(),domain_simplex, variable_simplex_opt.value())) {
             Simplex variable_simplex = variable_simplex_opt.value();
             coordinates[i] =
                 utils::as_DScalar<DScalar>(pos.const_vector_attribute(variable_simplex.tuple()));

--- a/src/wmtk/simplex/internal/SimplexEqualFunctor.hpp
+++ b/src/wmtk/simplex/internal/SimplexEqualFunctor.hpp
@@ -2,6 +2,7 @@
 
 #include <wmtk/Mesh.hpp>
 #include <wmtk/simplex/Simplex.hpp>
+#include <wmtk/simplex/utils/SimplexComparisons.hpp>
 
 namespace wmtk::simplex::internal {
 struct SimplexEqualFunctor
@@ -14,7 +15,7 @@ struct SimplexEqualFunctor
 
     bool operator()(const Simplex& s0, const Simplex& s1) const
     {
-        return m.simplices_are_equal(s0, s1);
+        return utils::SimplexComparisons::equal(m, s0, s1);
     }
 };
 } // namespace wmtk::simplex::internal

--- a/src/wmtk/simplex/internal/SimplexLessFunctor.hpp
+++ b/src/wmtk/simplex/internal/SimplexLessFunctor.hpp
@@ -2,6 +2,7 @@
 
 #include <wmtk/Mesh.hpp>
 #include <wmtk/simplex/Simplex.hpp>
+#include <wmtk/simplex/utils/SimplexComparisons.hpp>
 
 namespace wmtk::simplex::internal {
 struct SimplexLessFunctor
@@ -14,7 +15,7 @@ struct SimplexLessFunctor
 
     bool operator()(const Simplex& s0, const Simplex& s1) const
     {
-        return m.simplex_is_less(s0, s1);
+        return utils::SimplexComparisons::less(m, s0, s1);
     }
 };
 } // namespace wmtk::simplex::internal

--- a/src/wmtk/simplex/link_condition.cpp
+++ b/src/wmtk/simplex/link_condition.cpp
@@ -1,4 +1,5 @@
 #include "link_condition.hpp"
+#include "utils/SimplexComparisons.hpp"
 #include "link.hpp"
 #include "open_star.hpp"
 
@@ -24,9 +25,12 @@ bool link_condition(const EdgeMesh& mesh, const Tuple& edge)
     if (mesh.is_boundary_vertex(edge) && mesh.is_boundary_vertex(edge_switch_v)) {
         return false;
     }
-    if (mesh.simplices_are_equal(
-            Simplex(PrimitiveType::Vertex, edge),
-            Simplex(PrimitiveType::Vertex, edge_switch_v))) {
+    if (utils::SimplexComparisons::equal(
+            mesh,
+            edge,
+            PrimitiveType::Vertex,
+            edge_switch_v,
+            PrimitiveType::Vertex)) {
         return false;
     }
     return true;
@@ -49,7 +53,10 @@ bool link_condition(const TriMesh& mesh, const Tuple& edge)
         auto incident_edges = open_star(mesh, input_v).simplex_vector(PrimitiveType::Edge);
         for (const Simplex& _e : incident_edges) {
             if (mesh.is_boundary(_e.tuple(), PrimitiveType::Edge)) {
-                if (mesh.simplices_are_equal(Simplex(PrimitiveType::Vertex, _e.tuple()), input_v)) {
+                if (utils::SimplexComparisons::equal(
+                        mesh,
+                        Simplex(PrimitiveType::Vertex, _e.tuple()),
+                        input_v)) {
                     ret.push_back(mesh.switch_tuple(_e.tuple(), PrimitiveType::Vertex));
                 } else {
                     ret.push_back(_e.tuple());
@@ -69,7 +76,8 @@ bool link_condition(const TriMesh& mesh, const Tuple& edge)
         assert(boundary_neighbors_b.size() == 2); // if guarantee 2-manifold
         for (auto e_a : boundary_neighbors_a) {
             for (auto e_b : boundary_neighbors_b) {
-                if (mesh.simplices_are_equal(
+                if (utils::SimplexComparisons::equal(
+                        mesh,
                         Simplex(PrimitiveType::Vertex, e_a),
                         Simplex(PrimitiveType::Vertex, e_b))) {
                     // find common edge, link condition fails

--- a/src/wmtk/simplex/utils/CMakeLists.txt
+++ b/src/wmtk/simplex/utils/CMakeLists.txt
@@ -3,5 +3,7 @@ set(SRC_FILES
     tuple_vector_to_homogeneous_simplex_vector.cpp
     make_unique.cpp
     make_unique.hpp
+    SimplexComparisons.hpp
+    SimplexComparisons.cpp
     )
 target_sources(wildmeshing_toolkit PRIVATE ${SRC_FILES})

--- a/src/wmtk/simplex/utils/SimplexComparisons.cpp
+++ b/src/wmtk/simplex/utils/SimplexComparisons.cpp
@@ -1,0 +1,54 @@
+#include <wmtk/Mesh.hpp>
+#include "SimplexComparisons.hpp"
+
+namespace wmtk::simplex::utils {
+
+
+bool SimplexComparisons::equal(const Mesh& m, const Simplex& s0, const Simplex& s1)
+{
+    return equal(m, s0.tuple(), s0.primitive_type(), s1.tuple(), s1.primitive_type());
+}
+bool SimplexComparisons::equal(
+    const Mesh& m,
+    const Tuple& a,
+    PrimitiveType a_pt,
+    const Tuple& b,
+    PrimitiveType b_pt)
+{
+    return a_pt == b_pt && equal(m, a_pt, a, b);
+}
+bool SimplexComparisons::equal(
+    const Mesh& m,
+    PrimitiveType primitive_type,
+    const Tuple& a,
+    const Tuple& b)
+{
+    return m.id(a, primitive_type) == m.id(b, primitive_type);
+}
+
+bool SimplexComparisons::less(const Mesh& m, const Simplex& s0, const Simplex& s1)
+{
+    return less(m, s0.tuple(), s0.primitive_type(), s1.tuple(), s1.primitive_type());
+}
+bool SimplexComparisons::less(
+    const Mesh& m,
+    const Tuple& a,
+    PrimitiveType a_pt,
+    const Tuple& b,
+    PrimitiveType b_pt)
+{
+    if (a_pt == b_pt) {
+        return less(m, a_pt, a, b);
+    } else {
+        return a_pt < b_pt;
+    }
+}
+bool SimplexComparisons::less(
+    const Mesh& m,
+    PrimitiveType primitive_type,
+    const Tuple& a,
+    const Tuple& b)
+{
+    return m.id(a, primitive_type) < m.id(b, primitive_type);
+}
+} // namespace wmtk::simplex::internal

--- a/src/wmtk/simplex/utils/SimplexComparisons.hpp
+++ b/src/wmtk/simplex/utils/SimplexComparisons.hpp
@@ -1,0 +1,76 @@
+#pragma once
+
+#include <wmtk/Mesh.hpp>
+#include <wmtk/simplex/Simplex.hpp>
+namespace wmtk {
+class Mesh;
+}
+
+namespace wmtk::simplex::utils {
+struct SimplexComparisons
+{
+    /* @brief checks if simplex objects represent the same simplex
+     * @param m the mesh these simplices belong to
+     * @param s0 the first simplex compared
+     * @param s1 the second simplex compared
+     * @return true if two simplices are the same
+     * */
+    static bool equal(const Mesh& m, const Simplex& s0, const Simplex& s1);
+
+    /* @brief checks if simplex objects represent the same simplex
+     * @param m the mesh these simplices belong to
+     * @param a the first simplex compared's tuple
+     * @param a_pt the first simplex compared's primitive type
+     * @param b the second simplex compared's tuple
+     * @param b_pt the second simplex compared's primitive_type
+     * @return true if two simplices are the same
+     * */
+    static bool
+    equal(const Mesh& m, const Tuple& a, PrimitiveType a_pt, const Tuple& b, PrimitiveType b_pt);
+
+    /* @brief checks if simplex objects of the same dimension represent the same simplex
+     * @param m the mesh these simplices belong to
+     * @param primitive_type the primitive type of the two simplices
+     * @param a the first simplex compared's tuple
+     * @param b the second simplex compared's tuple
+     * @return true if two simplices are the same
+     * */
+    static bool equal(const Mesh& m, PrimitiveType primitive_type, const Tuple& a, const Tuple& b);
+
+
+    /* @brief checks if simplex objects are less than one another
+     *
+     * uses lexicgoraphic order of (primtiive type, id)
+     *
+     * @param m the mesh these simplices belong to
+     * @param s0 the first simplex compared
+     * @param s1 the second simplex compared
+     * @return true if two simplices are the same
+     * */
+    static bool less(const Mesh& m, const Simplex& s0, const Simplex& s1);
+    /* @brief checks if simplex objects are less than one another
+     *
+     * uses lexicgoraphic order of (primtiive type, id)
+     *
+     * @param m the mesh these simplices belong to
+     * @param a the first simplex compared's tuple
+     * @param a_pt the first simplex compared's primitive type
+     * @param b the second simplex compared's tuple
+     * @param b_pt the second simplex compared's primitive_type
+     * @return true if two simplices are the same
+     * */
+    static bool
+    less(const Mesh& m, const Tuple& a, PrimitiveType a_pt, const Tuple& b, PrimitiveType b_pt);
+    /* @brief checks if simplex objects are less than one another
+     *
+     * uses lexicgoraphic order of (primtiive type, id)
+     *
+     * @param m the mesh these simplices belong to
+     * @param primitive_type the primitive type of the two simplices
+     * @param a the first simplex compared's tuple
+     * @param b the second simplex compared's tuple
+     * @return true if two simplices are the same
+     * */
+    static bool less(const Mesh& m, PrimitiveType primitive_type, const Tuple& a, const Tuple& b);
+};
+} // namespace wmtk::simplex::internal

--- a/tests/test_invariants.cpp
+++ b/tests/test_invariants.cpp
@@ -1,5 +1,6 @@
 #include <catch2/catch_test_macros.hpp>
 
+#include <wmtk/simplex/utils/SimplexComparisons.hpp>
 #include "tools/DEBUG_TriMesh.hpp"
 #include "tools/TriMesh_examples.hpp"
 
@@ -30,7 +31,7 @@ TEST_CASE("MinIncidentValenceInvariant", "[invariants][2D]")
 
         for (const Tuple& t : m.get_all(PrimitiveType::Edge)) {
             const Simplex e = Simplex::edge(t);
-            if (m.simplices_are_equal(e, e_mid)) {
+            if (simplex::utils::SimplexComparisons::equal(m, e, e_mid)) {
                 CHECK(inv.before(t));
                 CHECK(inv.after(PrimitiveType::Edge, {t}));
             } else {

--- a/tests/test_io.cpp
+++ b/tests/test_io.cpp
@@ -15,6 +15,7 @@
 #include "tools/TriMesh_examples.hpp"
 
 #include <catch2/catch_test_macros.hpp>
+#include <wmtk/simplex/utils/SimplexComparisons.hpp>
 
 
 using namespace wmtk;
@@ -144,7 +145,7 @@ TEST_CASE("attribute_after_split", "[io]")
 
             // all edges hold 0 besides "edge"
             for (const Tuple& t : m.get_all(PE)) {
-                if (m.simplices_are_equal(Simplex::edge(edge), Simplex::edge(t))) {
+                if (simplex::utils::SimplexComparisons::equal(m,Simplex::edge(edge), Simplex::edge(t))) {
                     CHECK(acc_attribute.scalar_attribute(t) == 1);
                 } else {
                     CHECK(acc_attribute.scalar_attribute(t) == 0);

--- a/tests/test_simplex_collection.cpp
+++ b/tests/test_simplex_collection.cpp
@@ -18,6 +18,7 @@
 #include <wmtk/simplex/open_star_iterable.hpp>
 #include <wmtk/simplex/top_dimension_cofaces.hpp>
 #include <wmtk/simplex/top_dimension_cofaces_iterable.hpp>
+#include <wmtk/simplex/utils/SimplexComparisons.hpp>
 #include <wmtk/simplex/utils/tuple_vector_to_homogeneous_simplex_vector.hpp>
 #include "tools/DEBUG_EdgeMesh.hpp"
 #include "tools/DEBUG_TetMesh.hpp"
@@ -60,13 +61,13 @@ TEST_CASE("simplex_comparison", "[simplex_collection][2D]")
         for (const Tuple& t : vertices) {
             const simplex::Simplex s0(PV, t);
             const simplex::Simplex s1(PV, m.switch_tuple(t, PE));
-            CHECK(m.simplices_are_equal(s0, s1));
+            CHECK(simplex::utils::SimplexComparisons::equal(m, s0, s1));
             if (m.is_boundary_edge(t)) {
                 continue;
             }
             const simplex::Simplex s2(PV, m.switch_tuple(t, PF));
-            CHECK(m.simplices_are_equal(s0, s2));
-            CHECK(m.simplices_are_equal(s1, s2));
+            CHECK(simplex::utils::SimplexComparisons::equal(m, s0, s2));
+            CHECK(simplex::utils::SimplexComparisons::equal(m, s1, s2));
         }
     }
     SECTION("edges")
@@ -76,16 +77,16 @@ TEST_CASE("simplex_comparison", "[simplex_collection][2D]")
         for (const Tuple& t : edges) {
             const simplex::Simplex s0(PE, t);
             const simplex::Simplex s1(PE, m.switch_tuple(t, PV));
-            CHECK_FALSE(m.simplex_is_less(s0, s1));
-            CHECK_FALSE(m.simplex_is_less(s1, s0));
+            CHECK_FALSE(simplex::utils::SimplexComparisons::less(m, s0, s1));
+            CHECK_FALSE(simplex::utils::SimplexComparisons::less(m, s1, s0));
             if (m.is_boundary_edge(t)) {
                 continue;
             }
             const simplex::Simplex s2(PE, m.switch_tuple(t, PF));
-            CHECK_FALSE(m.simplex_is_less(s0, s2));
-            CHECK_FALSE(m.simplex_is_less(s2, s0));
-            CHECK_FALSE(m.simplex_is_less(s1, s2));
-            CHECK_FALSE(m.simplex_is_less(s2, s1));
+            CHECK_FALSE(simplex::utils::SimplexComparisons::less(m, s0, s2));
+            CHECK_FALSE(simplex::utils::SimplexComparisons::less(m, s2, s0));
+            CHECK_FALSE(simplex::utils::SimplexComparisons::less(m, s1, s2));
+            CHECK_FALSE(simplex::utils::SimplexComparisons::less(m, s2, s1));
         }
     }
     SECTION("faces")
@@ -95,13 +96,13 @@ TEST_CASE("simplex_comparison", "[simplex_collection][2D]")
         for (const Tuple& t : faces) {
             const simplex::Simplex s0(PF, t);
             const simplex::Simplex s1(PF, m.switch_tuple(t, PV));
-            CHECK_FALSE(m.simplex_is_less(s0, s1));
-            CHECK_FALSE(m.simplex_is_less(s1, s0));
+            CHECK_FALSE(simplex::utils::SimplexComparisons::less(m, s0, s1));
+            CHECK_FALSE(simplex::utils::SimplexComparisons::less(m, s1, s0));
             const simplex::Simplex s2(PF, m.switch_tuple(t, PE));
-            CHECK_FALSE(m.simplex_is_less(s0, s2));
-            CHECK_FALSE(m.simplex_is_less(s2, s0));
-            CHECK_FALSE(m.simplex_is_less(s1, s2));
-            CHECK_FALSE(m.simplex_is_less(s2, s1));
+            CHECK_FALSE(simplex::utils::SimplexComparisons::less(m, s0, s2));
+            CHECK_FALSE(simplex::utils::SimplexComparisons::less(m, s2, s0));
+            CHECK_FALSE(simplex::utils::SimplexComparisons::less(m, s1, s2));
+            CHECK_FALSE(simplex::utils::SimplexComparisons::less(m, s2, s1));
         }
     }
 }
@@ -183,7 +184,7 @@ TEST_CASE("simplex_faces", "[simplex_collection][2D]")
             expected_edges.simplex_vector(PrimitiveType::Edge);
         REQUIRE(e.size() <= 3);
         for (size_t i = 0; i < e.size(); ++i) {
-            CHECK(m.simplices_are_equal(e[i], expected_edge_simplices[i]));
+            CHECK(simplex::utils::SimplexComparisons::equal(m, e[i], expected_edge_simplices[i]));
         }
 
         CHECK(bd.simplex_vector(PrimitiveType::Face).size() == 0);
@@ -248,7 +249,10 @@ TEST_CASE("simplex_faces_iterable", "[simplex_collection][2D]")
     REQUIRE(itrb_collection.simplex_vector().size() == coll.simplex_vector().size());
 
     for (size_t i = 0; i < coll.simplex_vector().size(); ++i) {
-        CHECK(m.simplices_are_equal(itrb_collection.simplex_vector()[i], coll.simplex_vector()[i]));
+        CHECK(simplex::utils::SimplexComparisons::equal(
+            m,
+            itrb_collection.simplex_vector()[i],
+            coll.simplex_vector()[i]));
     }
 }
 
@@ -294,7 +298,7 @@ TEST_CASE("simplex_boundary", "[simplex_collection][2D]")
             expected_edges.simplex_vector(PrimitiveType::Edge);
         REQUIRE(e.size() <= 3);
         for (size_t i = 0; i < e.size(); ++i) {
-            CHECK(m.simplices_are_equal(e[i], expected_edge_simplices[i]));
+            CHECK(simplex::utils::SimplexComparisons::equal(m, e[i], expected_edge_simplices[i]));
         }
 
         CHECK(bd.simplex_vector(PrimitiveType::Face).size() == 0);
@@ -459,7 +463,7 @@ TEST_CASE("simplex_top_dimension_cofaces_iterable", "[simplex_collection][2D]")
 
         check_match_below_simplex_type(m, simplex, coll_s);
 
-        CHECK(m.simplices_are_equal(irtb_s, coll_s));
+        CHECK(simplex::utils::SimplexComparisons::equal(m, irtb_s, coll_s));
     }
 }
 
@@ -613,7 +617,10 @@ TEST_CASE("simplex_open_star_iterable", "[simplex_collection][2D]")
     REQUIRE(itrb_collection.simplex_vector().size() == coll.simplex_vector().size());
 
     for (size_t i = 0; i < coll.simplex_vector().size(); ++i) {
-        CHECK(m.simplices_are_equal(itrb_collection.simplex_vector()[i], coll.simplex_vector()[i]));
+        CHECK(simplex::utils::SimplexComparisons::equal(
+            m,
+            itrb_collection.simplex_vector()[i],
+            coll.simplex_vector()[i]));
     }
 }
 
@@ -645,7 +652,9 @@ TEST_CASE("simplex_closed_star", "[simplex_collection][2D]")
         for (size_t i = 7; i < 19; ++i) {
             const Simplex& e = simplices[i];
             const Tuple center = m.switch_vertex(m.next_edge(e.tuple()));
-            CHECK((faces(m, e).contains(v) || m.simplices_are_equal(v, Simplex::vertex(center))));
+            CHECK(
+                (faces(m, e).contains(v) ||
+                 simplex::utils::SimplexComparisons::equal(m, v, Simplex::vertex(center))));
         }
 
         CHECK(m.id(simplices[19]) == 0);
@@ -676,7 +685,9 @@ TEST_CASE("simplex_closed_star", "[simplex_collection][2D]")
         for (size_t i = 4; i < 9; ++i) {
             const Simplex& e = simplices[i];
             const Tuple center = m.switch_vertex(m.next_edge(e.tuple()));
-            CHECK((faces(m, e).contains(v) || m.simplices_are_equal(v, Simplex::vertex(center))));
+            CHECK(
+                (faces(m, e).contains(v) ||
+                 simplex::utils::SimplexComparisons::equal(m, v, Simplex::vertex(center))));
         }
 
         CHECK(m.id(simplices[9]) == 0);
@@ -707,7 +718,7 @@ TEST_CASE("simplex_closed_star", "[simplex_collection][2D]")
             SimplexCollection e_bd = faces(m, e);
             SimplexCollection bd_intersection = SimplexCollection::get_intersection(e_bd, t_bd);
             CHECK(
-                (m.simplices_are_equal(Simplex::edge(t), e) ||
+                (simplex::utils::SimplexComparisons::equal(m, Simplex::edge(t), e) ||
                  bd_intersection.simplex_vector().size() == 1));
         }
 
@@ -738,7 +749,7 @@ TEST_CASE("simplex_closed_star", "[simplex_collection][2D]")
             SimplexCollection e_bd = faces(m, e);
             SimplexCollection bd_intersection = SimplexCollection::get_intersection(e_bd, t_bd);
             CHECK(
-                (m.simplices_are_equal(Simplex::edge(t), e) ||
+                (simplex::utils::SimplexComparisons::equal(m, Simplex::edge(t), e) ||
                  bd_intersection.simplex_vector().size() == 1));
         }
 
@@ -763,7 +774,10 @@ TEST_CASE("simplex_closed_star", "[simplex_collection][2D]")
 
         for (size_t i = 3; i < 6; ++i) {
             const Simplex& e = simplices[i];
-            CHECK(m.simplices_are_equal(Simplex::face(t), Simplex::face(e.tuple())));
+            CHECK(simplex::utils::SimplexComparisons::equal(
+                m,
+                Simplex::face(t),
+                Simplex::face(e.tuple())));
         }
 
         CHECK(m.id(simplices[6]) == 2);
@@ -814,7 +828,10 @@ TEST_CASE("simplex_closed_star_iterable", "[simplex_collection][2D]")
     REQUIRE(itrb_collection.simplex_vector().size() == coll.simplex_vector().size());
 
     for (size_t i = 0; i < coll.simplex_vector().size(); ++i) {
-        CHECK(m.simplices_are_equal(itrb_collection.simplex_vector()[i], coll.simplex_vector()[i]));
+        CHECK(simplex::utils::SimplexComparisons::equal(
+            m,
+            itrb_collection.simplex_vector()[i],
+            coll.simplex_vector()[i]));
     }
 }
 
@@ -845,7 +862,7 @@ TEST_CASE("simplex_link", "[simplex_collection][2D]")
         for (size_t i = 6; i < 12; ++i) {
             const Simplex& e = simplices[i];
             const Tuple center = m.switch_vertex(m.next_edge(e.tuple()));
-            CHECK(m.simplices_are_equal(v, Simplex::vertex(center)));
+            CHECK(simplex::utils::SimplexComparisons::equal(m, v, Simplex::vertex(center)));
         }
     }
     SECTION("vertex_boundary")
@@ -868,7 +885,7 @@ TEST_CASE("simplex_link", "[simplex_collection][2D]")
         for (size_t i = 3; i < 5; ++i) {
             const Simplex& e = simplices[i];
             const Tuple center = m.switch_vertex(m.next_edge(e.tuple()));
-            CHECK(m.simplices_are_equal(v, Simplex::vertex(center)));
+            CHECK(simplex::utils::SimplexComparisons::equal(m, v, Simplex::vertex(center)));
         }
     }
     SECTION("edge_interior")
@@ -956,7 +973,10 @@ TEST_CASE("simplex_link_iterable", "[simplex_collection][2D]")
     REQUIRE(itrb_collection.simplex_vector().size() == coll.simplex_vector().size());
 
     for (size_t i = 0; i < coll.simplex_vector().size(); ++i) {
-        CHECK(m.simplices_are_equal(itrb_collection.simplex_vector()[i], coll.simplex_vector()[i]));
+        CHECK(simplex::utils::SimplexComparisons::equal(
+            m,
+            itrb_collection.simplex_vector()[i],
+            coll.simplex_vector()[i]));
     }
 }
 
@@ -1164,7 +1184,10 @@ TEST_CASE("simplex_compare_faces_with_faces_single_dimension", "[simplex_collect
 
                 REQUIRE(faces_single_dim.size() == bndry_single_dim.size());
                 for (size_t i = 0; i < faces_single_dim.size(); ++i) {
-                    CHECK(m.simplices_are_equal(bndry_single_dim[i], faces_single_dim[i]));
+                    CHECK(simplex::utils::SimplexComparisons::equal(
+                        m,
+                        bndry_single_dim[i],
+                        faces_single_dim[i]));
                 }
             }
         }

--- a/tests/test_simplicial_complex.cpp
+++ b/tests/test_simplicial_complex.cpp
@@ -6,6 +6,7 @@
 #include <wmtk/SimplicialComplex.hpp>
 #include <wmtk/TetMesh.hpp>
 #include <wmtk/TriMesh.hpp>
+#include <wmtk/simplex/utils/SimplexComparisons.hpp>
 #include "tools/DEBUG_EdgeMesh.hpp"
 #include "tools/DEBUG_TetMesh.hpp"
 #include "tools/DEBUG_TriMesh.hpp"
@@ -35,13 +36,13 @@ TEST_CASE("simplex_comparison", "[simplicial_complex][2D]")
         for (const Tuple& t : vertices) {
             const Simplex s0(PV, t);
             const Simplex s1(PV, m.switch_tuple(t, PE));
-            CHECK(m.simplices_are_equal(s0, s1));
+            CHECK(simplex::utils::SimplexComparisons::equal(m, s0, s1));
             if (m.is_boundary_edge(t)) {
                 continue;
             }
             const Simplex s2(PV, m.switch_tuple(t, PF));
-            CHECK(m.simplices_are_equal(s0, s2));
-            CHECK(m.simplices_are_equal(s1, s2));
+            CHECK(simplex::utils::SimplexComparisons::equal(m, s0, s2));
+            CHECK(simplex::utils::SimplexComparisons::equal(m, s1, s2));
         }
     }
     SECTION("edges")
@@ -51,16 +52,16 @@ TEST_CASE("simplex_comparison", "[simplicial_complex][2D]")
         for (const Tuple& t : edges) {
             const Simplex s0(PE, t);
             const Simplex s1(PE, m.switch_tuple(t, PV));
-            CHECK_FALSE(m.simplex_is_less(s0, s1));
-            CHECK_FALSE(m.simplex_is_less(s1, s0));
+            CHECK_FALSE(simplex::utils::SimplexComparisons::less(m, s0, s1));
+            CHECK_FALSE(simplex::utils::SimplexComparisons::less(m, s1, s0));
             if (m.is_boundary_edge(t)) {
                 continue;
             }
             const Simplex s2(PE, m.switch_tuple(t, PF));
-            CHECK_FALSE(m.simplex_is_less(s0, s2));
-            CHECK_FALSE(m.simplex_is_less(s2, s0));
-            CHECK_FALSE(m.simplex_is_less(s1, s2));
-            CHECK_FALSE(m.simplex_is_less(s2, s1));
+            CHECK_FALSE(simplex::utils::SimplexComparisons::less(m, s0, s2));
+            CHECK_FALSE(simplex::utils::SimplexComparisons::less(m, s2, s0));
+            CHECK_FALSE(simplex::utils::SimplexComparisons::less(m, s1, s2));
+            CHECK_FALSE(simplex::utils::SimplexComparisons::less(m, s2, s1));
         }
     }
     SECTION("faces")
@@ -70,13 +71,13 @@ TEST_CASE("simplex_comparison", "[simplicial_complex][2D]")
         for (const Tuple& t : faces) {
             const Simplex s0(PF, t);
             const Simplex s1(PF, m.switch_tuple(t, PV));
-            CHECK_FALSE(m.simplex_is_less(s0, s1));
-            CHECK_FALSE(m.simplex_is_less(s1, s0));
+            CHECK_FALSE(simplex::utils::SimplexComparisons::less(m, s0, s1));
+            CHECK_FALSE(simplex::utils::SimplexComparisons::less(m, s1, s0));
             const Simplex s2(PF, m.switch_tuple(t, PE));
-            CHECK_FALSE(m.simplex_is_less(s0, s2));
-            CHECK_FALSE(m.simplex_is_less(s2, s0));
-            CHECK_FALSE(m.simplex_is_less(s1, s2));
-            CHECK_FALSE(m.simplex_is_less(s2, s1));
+            CHECK_FALSE(simplex::utils::SimplexComparisons::less(m, s0, s2));
+            CHECK_FALSE(simplex::utils::SimplexComparisons::less(m, s2, s0));
+            CHECK_FALSE(simplex::utils::SimplexComparisons::less(m, s1, s2));
+            CHECK_FALSE(simplex::utils::SimplexComparisons::less(m, s2, s1));
         }
     }
 }
@@ -302,19 +303,28 @@ TEST_CASE("open_star", "[simplicial_complex][star][2D]")
     auto sc_v = SimplicialComplex::open_star(m, Simplex(PV, t)).get_simplex_vector();
     REQUIRE(sc_v.size() == 8);
     for (size_t i = 0; i < 8; i++) {
-        REQUIRE(m.simplices_are_equal(Simplex(PV, t), Simplex(PV, sc_v[i].tuple())));
+        REQUIRE(simplex::utils::SimplexComparisons::equal(
+            m,
+            Simplex(PV, t),
+            Simplex(PV, sc_v[i].tuple())));
     }
 
     auto sc_e = SimplicialComplex::open_star(m, Simplex(PE, t)).get_simplex_vector();
     REQUIRE(sc_e.size() == 3);
     for (size_t i = 0; i < 3; i++) {
-        REQUIRE(m.simplices_are_equal(Simplex(PE, t), Simplex(PE, sc_e[i].tuple())));
+        REQUIRE(simplex::utils::SimplexComparisons::equal(
+            m,
+            Simplex(PE, t),
+            Simplex(PE, sc_e[i].tuple())));
     }
 
     auto sc_f = SimplicialComplex::open_star(m, Simplex(PF, t)).get_simplex_vector();
     REQUIRE(sc_f.size() == 1);
     for (size_t i = 0; i < 1; i++) {
-        REQUIRE(m.simplices_are_equal(Simplex(PF, t), Simplex(PF, sc_f[i].tuple())));
+        REQUIRE(simplex::utils::SimplexComparisons::equal(
+            m,
+            Simplex(PF, t),
+            Simplex(PF, sc_f[i].tuple())));
     }
 }
 


### PR DESCRIPTION
In order to decompose simplex comparisons without constructing simplex objects it seemed convenient to move the comparisons from the Mesh class to a friended util class `wmtk::simplex::utils:::SimplexComparisons`. This PR implements this + refactors the code around this change