### PR TITLE
Added primitive class and refactored cell class

### DIFF
--- a/src/wmtk/CMakeLists.txt
+++ b/src/wmtk/CMakeLists.txt
@@ -19,6 +19,8 @@ set(SRC_FILES
     TriMeshOperationExecutor.cpp
     TetMeshOperationExecutor.hpp
     TetMeshOperationExecutor.cpp
+    PrimitiveType.hpp
+    PrimitiveType.cpp
     Primitive.hpp
     Primitive.cpp
     Tuple.cpp

--- a/src/wmtk/Cell.cpp
+++ b/src/wmtk/Cell.cpp
@@ -2,6 +2,44 @@
 #include <tuple>
 
 namespace wmtk {
+
+Cell::Cell(const long& dimension, const Tuple& t)
+    : m_dimension{dimension}
+    , m_tuple{t}
+{}
+
+Cell::Cell(const Simplex& simplex)
+    : m_dimension{simplex.dimension()}
+    , m_tuple{simplex.tuple()}
+{}
+
+
+long Cell::dimension() const
+{
+    return m_dimension;
+}
+const Tuple& Cell::tuple() const
+{
+    return m_tuple;
+}
+
+Cell Cell::vertex(const Tuple& t)
+{
+    return Cell(0, t);
+}
+Cell Cell::edge(const Tuple& t)
+{
+    return Cell(1, t);
+}
+Cell Cell::face(const Tuple& t)
+{
+    return Cell(2, t);
+}
+Cell Cell::tetrahedron(const Tuple& t)
+{
+    return Cell(3, t);
+}
+
 bool Cell::operator==(const Cell& o) const
 {
     return m_dimension == o.m_dimension && m_tuple == o.m_tuple;

--- a/src/wmtk/Cell.hpp
+++ b/src/wmtk/Cell.hpp
@@ -11,23 +11,17 @@ class Cell
     Tuple m_tuple;
 
 public:
-    Cell(const long& dimension, const Tuple& t)
-        : m_dimension{dimension}
-        , m_tuple{t}
-    {}
-    Cell(const Simplex& simplex)
-        : m_dimension{simplex.dimension()}
-        , m_tuple{simplex.tuple()}
-    {}
+    Cell(const long& dimension, const Tuple& t);
+    Cell(const Simplex& simplex);
 
 
-    long dimension() const { return m_dimension; }
-    const Tuple& tuple() const { return m_tuple; }
+    long dimension() const;
+    const Tuple& tuple() const;
 
-    static Cell vertex(const Tuple& t) { return Cell(0, t); }
-    static Cell edge(const Tuple& t) { return Cell(1, t); }
-    static Cell face(const Tuple& t) { return Cell(2, t); }
-    static Cell tetrahedron(const Tuple& t) { return Cell(3, t); }
+    static Cell vertex(const Tuple& t);
+    static Cell edge(const Tuple& t);
+    static Cell face(const Tuple& t);
+    static Cell tetrahedron(const Tuple& t);
 
     bool operator==(const Cell& o) const;
     bool operator<(const Cell& o) const;

--- a/src/wmtk/Primitive.cpp
+++ b/src/wmtk/Primitive.cpp
@@ -1,50 +1,58 @@
 #include "Primitive.hpp"
-#include <string>
 
 
 namespace wmtk {
-namespace {
-const static std::string names[] = {
-    "Vertex",
-    "Edge",
-    "Face",
-    "Tetrahedron",
-    "HalfEdge"
-    "Invalid"};
+
+Primitive::Primitive(const PrimitiveType& primitive_type, const Tuple& t)
+    : m_primitive_type{primitive_type}
+    , m_tuple{t}
+{}
+Primitive::Primitive(const Simplex& simplex)
+    : m_primitive_type{simplex.primitive_type()}
+    , m_tuple{simplex.tuple()}
+{}
+Primitive::Primitive(const Cell& cell)
+    : m_primitive_type{get_primitive_type_from_id(cell.dimension())}
+    , m_tuple{cell.tuple()}
+{}
+
+PrimitiveType Primitive::primitive_type() const
+{
+    return m_primitive_type;
+}
+const Tuple& Primitive::tuple() const
+{
+    return m_tuple;
 }
 
-long get_max_primitive_type_id(const std::vector<PrimitiveType>& primitive_types)
+Primitive Primitive::vertex(const Tuple& t)
 {
-    long max_id = -1;
-    for (const auto& t : primitive_types) {
-        max_id = std::max(max_id, get_primitive_type_id(t));
-    }
-
-    return max_id;
+    return Primitive(PrimitiveType::Vertex, t);
+}
+Primitive Primitive::edge(const Tuple& t)
+{
+    return Primitive(PrimitiveType::Edge, t);
+}
+Primitive Primitive::face(const Tuple& t)
+{
+    return Primitive(PrimitiveType::Face, t);
+}
+Primitive Primitive::tetrahedron(const Tuple& t)
+{
+    return Primitive(PrimitiveType::Tetrahedron, t);
+}
+Primitive Primitive::halfedge(const Tuple& t)
+{
+    return Primitive(PrimitiveType::HalfEdge, t);
 }
 
-PrimitiveType get_primitive_type_from_id(long id)
+bool Primitive::operator==(const Primitive& o) const
 {
-    switch (id) {
-    case 0: return PrimitiveType::Vertex;
-    case 1: return PrimitiveType::Edge;
-    case 2: return PrimitiveType::Face;
-    case 3: return PrimitiveType::Tetrahedron;
-    case 4: return PrimitiveType::HalfEdge;
-    default: break; // just return at the end because compilers can be finicky
-    }
-
-    return PrimitiveType::Vertex;
+    return m_primitive_type == o.m_primitive_type && m_tuple == o.m_tuple;
 }
 
-std::string_view primitive_type_name(PrimitiveType t)
+bool Primitive::operator<(const Primitive& o) const
 {
-    long id = get_primitive_type_id(t);
-    long num_ids = 5;
-    if (id >= 0 && id <= num_ids) {
-        return names[id];
-    } else {
-        return names[num_ids];
-    }
+    return std::tie(m_primitive_type, m_tuple) < std::tie(o.m_primitive_type, o.m_tuple);
 }
 } // namespace wmtk

--- a/src/wmtk/Primitive.hpp
+++ b/src/wmtk/Primitive.hpp
@@ -1,90 +1,32 @@
 #pragma once
 
-#include <stdexcept>
-#include <string_view>
-#include <vector>
+#include "Cell.hpp"
+#include "PrimitiveType.hpp"
+#include "Simplex.hpp"
+#include "Tuple.hpp"
 
 namespace wmtk {
 
-enum class PrimitiveType { Vertex, Edge, Face, Tetrahedron, HalfEdge };
-
-// TODO Remove due to outdated semantics
-[[deprecated("use get_primitve_type_id instead")]] constexpr long get_simplex_dimension(
-    PrimitiveType t)
+class Primitive
 {
-    switch (t) {
-    case PrimitiveType::Vertex: return 0;
-    case PrimitiveType::Edge: return 1;
-    case PrimitiveType::Face: return 2;
-    case PrimitiveType::Tetrahedron: return 3;
-    case PrimitiveType::HalfEdge: {
-        throw std::runtime_error("halfedge is not a simplex");
-        break;
-    }
-    default: break; // just return at the end because compilers can be finicky
-    }
+    PrimitiveType m_primitive_type;
+    Tuple m_tuple;
 
-    return -2;
-}
+public:
+    Primitive(const PrimitiveType& primitive_type, const Tuple& t);
+    Primitive(const Simplex& simplex);
+    Primitive(const Cell& cell);
 
-/**
- * @brief Get a unique integer id corresponding to each primitive type
- *
- * Ordering of primitive types by dimension allows to exploit the fact that all m<n dimensional
- * primitives exist in an n dimensional manifold
- */
-constexpr long get_primitive_type_id(PrimitiveType t)
-{
-    switch (t) {
-    case PrimitiveType::Vertex: return 0;
-    case PrimitiveType::Edge: return 1;
-    case PrimitiveType::Face: return 2;
-    case PrimitiveType::Tetrahedron: return 3;
-    case PrimitiveType::HalfEdge: return 4;
-    default: break; // just return at the end because compilers can be finicky
-    }
+    PrimitiveType primitive_type() const;
+    const Tuple& tuple() const;
 
-    return -2;
-}
+    static Primitive vertex(const Tuple& t);
+    static Primitive edge(const Tuple& t);
+    static Primitive face(const Tuple& t);
+    static Primitive tetrahedron(const Tuple& t);
+    static Primitive halfedge(const Tuple& t);
 
-constexpr bool operator==(PrimitiveType a, PrimitiveType b)
-{
-    return get_primitive_type_id(a) == get_primitive_type_id(b);
-}
-constexpr bool operator!=(PrimitiveType a, PrimitiveType b)
-{
-    return get_primitive_type_id(a) != get_primitive_type_id(b);
-}
-constexpr bool operator<(PrimitiveType a, PrimitiveType b)
-{
-    return get_primitive_type_id(a) < get_primitive_type_id(b);
-}
-constexpr bool operator>(PrimitiveType a, PrimitiveType b)
-{
-    return get_primitive_type_id(a) > get_primitive_type_id(b);
-}
-constexpr bool operator<=(PrimitiveType a, PrimitiveType b)
-{
-    return get_primitive_type_id(a) <= get_primitive_type_id(b);
-}
-constexpr bool operator>=(PrimitiveType a, PrimitiveType b)
-{
-    return get_primitive_type_id(a) >= get_primitive_type_id(b);
-}
-
-
-/**
- * @brief Get the primitive type corresponding to its unique integer id
- */
-PrimitiveType get_primitive_type_from_id(long id);
-
-/**
- * @brief Get the maximum id for a list of primitive types
- *
- * @param primitive_types: list of primitive types
- * @return maximum primitive type id among the list
- */
-long get_max_primitive_type_id(const std::vector<PrimitiveType>& primitive_types);
-
-std::string_view primitive_type_name(PrimitiveType t);
+    bool operator==(const Primitive& o) const;
+    bool operator<(const Primitive& o) const;
+};
 } // namespace wmtk

--- a/src/wmtk/PrimitiveType.cpp
+++ b/src/wmtk/PrimitiveType.cpp
@@ -1,0 +1,51 @@
+#include "PrimitiveType.hpp"
+#include <string>
+
+
+namespace wmtk {
+namespace {
+const static std::string names[] = {
+    "Vertex",
+    "Edge",
+    "Face",
+    "Tetrahedron",
+    "HalfEdge"
+    "Invalid"};
+}
+
+long get_max_primitive_type_id(const std::vector<PrimitiveType>& primitive_types)
+{
+    long max_id = -1;
+    for (const auto& t : primitive_types) {
+        max_id = std::max(max_id, get_primitive_type_id(t));
+    }
+
+    return max_id;
+}
+
+PrimitiveType get_primitive_type_from_id(long id)
+{
+    switch (id) {
+    case 0: return PrimitiveType::Vertex;
+    case 1: return PrimitiveType::Edge;
+    case 2: return PrimitiveType::Face;
+    case 3: return PrimitiveType::Tetrahedron;
+    case 4: return PrimitiveType::HalfEdge;
+    default: break; // just return at the end because compilers can be finicky
+    }
+
+    return PrimitiveType::Vertex;
+}
+
+std::string_view primitive_type_name(PrimitiveType t)
+{
+    long id = get_primitive_type_id(t);
+    long num_ids = 5;
+    if (id >= 0 && id <= num_ids) {
+        return names[id];
+    } else {
+        return names[num_ids];
+    }
+}
+
+} // namespace wmtk

--- a/src/wmtk/PrimitiveType.hpp
+++ b/src/wmtk/PrimitiveType.hpp
@@ -1,0 +1,91 @@
+#pragma once
+
+#include <stdexcept>
+#include <string_view>
+#include <vector>
+
+namespace wmtk {
+
+enum class PrimitiveType { Vertex, Edge, Face, Tetrahedron, HalfEdge };
+
+// TODO Remove due to outdated semantics
+[[deprecated("use get_primitve_type_id instead")]] constexpr long get_simplex_dimension(
+    PrimitiveType t)
+{
+    switch (t) {
+    case PrimitiveType::Vertex: return 0;
+    case PrimitiveType::Edge: return 1;
+    case PrimitiveType::Face: return 2;
+    case PrimitiveType::Tetrahedron: return 3;
+    case PrimitiveType::HalfEdge: {
+        throw std::runtime_error("halfedge is not a simplex");
+        break;
+    }
+    default: break; // just return at the end because compilers can be finicky
+    }
+
+    return -2;
+}
+
+/**
+ * @brief Get a unique integer id corresponding to each primitive type
+ *
+ * Ordering of primitive types by dimension allows to exploit the fact that all m<n dimensional
+ * primitives exist in an n dimensional manifold
+ */
+constexpr long get_primitive_type_id(PrimitiveType t)
+{
+    switch (t) {
+    case PrimitiveType::Vertex: return 0;
+    case PrimitiveType::Edge: return 1;
+    case PrimitiveType::Face: return 2;
+    case PrimitiveType::Tetrahedron: return 3;
+    case PrimitiveType::HalfEdge: return 4;
+    default: break; // just return at the end because compilers can be finicky
+    }
+
+    return -2;
+}
+
+constexpr bool operator==(PrimitiveType a, PrimitiveType b)
+{
+    return get_primitive_type_id(a) == get_primitive_type_id(b);
+}
+constexpr bool operator!=(PrimitiveType a, PrimitiveType b)
+{
+    return get_primitive_type_id(a) != get_primitive_type_id(b);
+}
+constexpr bool operator<(PrimitiveType a, PrimitiveType b)
+{
+    return get_primitive_type_id(a) < get_primitive_type_id(b);
+}
+constexpr bool operator>(PrimitiveType a, PrimitiveType b)
+{
+    return get_primitive_type_id(a) > get_primitive_type_id(b);
+}
+constexpr bool operator<=(PrimitiveType a, PrimitiveType b)
+{
+    return get_primitive_type_id(a) <= get_primitive_type_id(b);
+}
+constexpr bool operator>=(PrimitiveType a, PrimitiveType b)
+{
+    return get_primitive_type_id(a) >= get_primitive_type_id(b);
+}
+
+
+/**
+ * @brief Get the primitive type corresponding to its unique integer id
+ */
+PrimitiveType get_primitive_type_from_id(long id);
+
+/**
+ * @brief Get the maximum id for a list of primitive types
+ *
+ * @param primitive_types: list of primitive types
+ * @return maximum primitive type id among the list
+ */
+long get_max_primitive_type_id(const std::vector<PrimitiveType>& primitive_types);
+
+std::string_view primitive_type_name(PrimitiveType t);
+
+} // namespace wmtk

--- a/src/wmtk/Simplex.hpp
+++ b/src/wmtk/Simplex.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <wmtk/simplex/Simplex.hpp>
-#include "Primitive.hpp"
+#include "PrimitiveType.hpp"
 #include "Tuple.hpp"
 
 namespace wmtk {

--- a/src/wmtk/Tuple.hpp
+++ b/src/wmtk/Tuple.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "Primitive.hpp"
+#include "PrimitiveType.hpp"
 
 
 namespace wmtk {

--- a/src/wmtk/simplex/Simplex.hpp
+++ b/src/wmtk/simplex/Simplex.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <wmtk/Primitive.hpp>
+#include <wmtk/PrimitiveType.hpp>
 #include <wmtk/Tuple.hpp>
 
 namespace wmtk::simplex {
@@ -16,7 +16,7 @@ public:
         , m_tuple{t}
     {}
 
-  
+
     PrimitiveType primitive_type() const { return m_primitive_type; }
     long dimension() const { return get_primitive_type_id(m_primitive_type); }
     const Tuple& tuple() const { return m_tuple; }


### PR DESCRIPTION
I've added a `Primitive` class to act as a direct replacement for `Simplex`, with the addition of HalfEdge, for primitive comparisons and enumerations. It supports implicit conversion from `Simplex` (for deprecation purposes) and `Cell`.

I am uncertain to what extent we really want to allow arbitrary conversion between these classes. `Simplex` -> `Cell` and `Simplex` -> `Primitive` makes sense to me for deprecation reasons, but I am not sure if we want to allow the reverse conversions.

Also, I think the conversions `Primitive`<->`Cell` may not make sense; not every `Primitive` is a `Cell`, and if every `Cell` is a `Primitive` (e.g., we don't want to allow cells of dimension higher than 4) it might make more sense to just derive the `Cell` class from the `Primitive` class.
