### PR TITLE
Delete `tuple_vector` from `SimplexCollection`

### DIFF
--- a/src/wmtk/simplex/SimplexCollection.cpp
+++ b/src/wmtk/simplex/SimplexCollection.cpp
@@ -31,18 +31,6 @@ void SimplexCollection::add(const SimplexCollection& simplex_collection)
     m_simplices.insert(m_simplices.end(), s.begin(), s.end());
 }
 
-std::vector<Tuple> SimplexCollection::tuple_vector() const
-{
-    std::vector<Tuple> tuples;
-    tuples.reserve(m_simplices.size()); // giving the vector some (hopefully) resonable size
-
-    // add simplices to the vector
-    for (const Simplex& s : m_simplices) {
-        tuples.emplace_back(s.tuple());
-    }
-
-    return tuples;
-}
 
 void SimplexCollection::sort_and_clean()
 {

--- a/src/wmtk/simplex/SimplexCollection.hpp
+++ b/src/wmtk/simplex/SimplexCollection.hpp
@@ -35,12 +35,6 @@ public:
 
     void add(const SimplexCollection& simplex_collection);
     /**
-     * @brief return the vector of tuples of the simplex collection.
-     *
-     * @return std::vector<Tuple>
-     */
-    std::vector<Tuple> tuple_vector() const;
-    /**
      * @brief Sort simplex vector and remove duplicates.
      */
     void sort_and_clean();


### PR DESCRIPTION
This function returns tuples from a heterogeneous collection of simplices, which does not have a clear semantic and therefore should not exist.
If a function needs a collection of Tuple objects then it should simply return a `vector<Tuple>`.