### PR TITLE
future proofing `primitive_type_name`

### DIFF
--- a/src/wmtk/Primitive.cpp
+++ b/src/wmtk/Primitive.cpp
@@ -40,11 +40,11 @@ PrimitiveType get_primitive_type_from_id(long id)
 std::string_view primitive_type_name(PrimitiveType t)
 {
     long id = get_primitive_type_id(t);
-    long num_ids = 5;
-    if (id >= 0 && id <= num_ids) {
-        return names[id];
+    constexpr size_t valid_ids = sizeof(names) / sizeof(std::string) - 1;
+    if (id >= 0 && id <= valid_ids) {
+        return std::string_view(names[id]);
     } else {
-        return names[num_ids];
+        return std::string_view(names[valid_ids]);
     }
 }
 } // namespace wmtk

--- a/src/wmtk/Primitive.cpp
+++ b/src/wmtk/Primitive.cpp
@@ -4,6 +4,8 @@
 
 namespace wmtk {
 namespace {
+    // NOTE: The order of these entries must be aligned with the order of enum values in PrimitiveType.
+    // Invalid must be the last string here for primitive_type_name to work
 const static std::string names[] = {
     "Vertex",
     "Edge",


### PR DESCRIPTION
Added some specifications on how `primitive_type_name operates to make sure that we only pass in valid arguments even if the number of primitives change.

The main motivation for this was that gcc 13 on my personal laptop was unhappy with the degree in which we were constraining accesses into the local `names` array so I added some extra specification to make sure that it would build.