### PR TITLE
541 fixing and testing multimap with bijections

### DIFF
--- a/src/wmtk/MultiMeshManager.cpp
+++ b/src/wmtk/MultiMeshManager.cpp
@@ -74,7 +74,7 @@ bool MultiMeshManager::is_root() const
 
 long MultiMeshManager::child_id() const
 {
-    if(is_root()) {
+    if (is_root()) {
         throw std::runtime_error("Tried to access the child id of a mesh that is in fact a root");
     }
     return m_child_id;
@@ -371,7 +371,12 @@ std::vector<std::array<Tuple, 2>> MultiMeshManager::same_simplex_dimension_surje
     const std::vector<long>& parent_simplices)
 {
     PrimitiveType primitive_type = parent.top_simplex_type();
-    assert(primitive_type == child.top_simplex_type());
+#if !defined(NDEBUG)
+    if (primitive_type != child.top_simplex_type()) {
+        throw std::runtime_error(
+            "Cannot use same_simplex_dimension_bijection on meshes with simplex dimensions");
+    }
+#endif
 
     long size = child.capacity(primitive_type);
     assert(size == long(parent_simplices.size()));

--- a/src/wmtk/multimesh/CMakeLists.txt
+++ b/src/wmtk/multimesh/CMakeLists.txt
@@ -2,6 +2,8 @@
 set(SRC_FILES
     same_simplex_dimension_surjection.hpp
     same_simplex_dimension_surjection.cpp
+    same_simplex_dimension_bijection.hpp
+    same_simplex_dimension_bijection.cpp
     MultiMeshVisitor.hpp
     )
 target_sources(wildmeshing_toolkit PRIVATE ${SRC_FILES})

--- a/src/wmtk/multimesh/same_simplex_dimension_bijection.cpp
+++ b/src/wmtk/multimesh/same_simplex_dimension_bijection.cpp
@@ -1,6 +1,8 @@
-#include "same_simplex_dimension_surjection.hpp"
+
+#include "same_simplex_dimension_bijection.hpp"
 #include <numeric>
 #include <wmtk/Mesh.hpp>
+#include "same_simplex_dimension_surjection.hpp"
 
 
 namespace wmtk::multimesh {
@@ -9,10 +11,9 @@ std::vector<std::array<Tuple, 2>> same_simplex_dimension_bijection(
     const Mesh& child)
 {
     PrimitiveType primitive_type = parent.top_simplex_type();
+    assert(primitive_type == child.top_simplex_type());
     long size = parent.capacity(primitive_type);
 #if !defined(NDEBUG)
-    // the MultimEshManager::surjection checks this as well - but we need to check it here to do the
-    // capacity check
     if (primitive_type != child.top_simplex_type()) {
         throw std::runtime_error(
             "Cannot use same_simplex_dimension_bijection on meshes with simplex dimensions");
@@ -29,11 +30,4 @@ std::vector<std::array<Tuple, 2>> same_simplex_dimension_bijection(
     return same_simplex_dimension_surjection(parent, child, ps);
 }
 
-std::vector<std::array<Tuple, 2>> same_simplex_dimension_surjection(
-    const Mesh& parent,
-    const Mesh& child,
-    const std::vector<long>& parent_simplices)
-{
-    return MultiMeshManager::same_simplex_dimension_surjection(parent, child, parent_simplices);
-}
 } // namespace wmtk::multimesh

--- a/src/wmtk/multimesh/same_simplex_dimension_bijection.hpp
+++ b/src/wmtk/multimesh/same_simplex_dimension_bijection.hpp
@@ -1,0 +1,21 @@
+
+#pragma once
+#include <array>
+#include <vector>
+#include <wmtk/Tuple.hpp>
+
+namespace wmtk {
+class Mesh;
+}
+
+namespace wmtk::multimesh {
+
+// Handles the "trivial " mapping case as we see in OBJ files
+// parent and child are assumed to be homogeneous meshes of the same dimension and the same number
+// of top level simplices It is assumed that for each index between [0,num_top_level_simplices) it
+// is assumed that the tuple parent.tuple_from_id(pt,index) should be mapped to
+// child.tuple_from_id(pt,index)
+std::vector<std::array<Tuple, 2>> same_simplex_dimension_bijection(
+    const Mesh& parent,
+    const Mesh& child);
+} // namespace wmtk::multimesh

--- a/src/wmtk/multimesh/same_simplex_dimension_surjection.cpp
+++ b/src/wmtk/multimesh/same_simplex_dimension_surjection.cpp
@@ -12,8 +12,7 @@ std::vector<std::array<Tuple, 2>> same_simplex_dimension_surjection(
     assert(primitive_type == child.top_simplex_type());
     long size = parent.capacity(primitive_type);
     assert(size == child.capacity(primitive_type));
-    std::vector<long> ps;
-    ps.reserve(size);
+    std::vector<long> ps(size);
     std::iota(ps.begin(), ps.end(), 0);
     return same_simplex_dimension_surjection(parent, child, ps);
 }

--- a/src/wmtk/multimesh/same_simplex_dimension_surjection.hpp
+++ b/src/wmtk/multimesh/same_simplex_dimension_surjection.hpp
@@ -10,14 +10,8 @@ class Mesh;
 namespace wmtk::multimesh {
 
 // Handles the "trivial " mapping case as we see in OBJ files
-// parent and child are assumed to be homogeneous meshes of the same dimension and the same number
-// of top level simplices It is assumed that for each index between [0,num_top_level_simplices) it
-// is assumed that the tuple parent.tuple_from_id(pt,index) should be mapped to
-// child.tuple_from_id(pt,index)
-std::vector<std::array<Tuple, 2>> same_simplex_dimension_surjection(
-    const Mesh& parent,
-    const Mesh& child);
-// same as above except  the mapping selects a subset of parent_simplices
+// parent and child are assumed to be homogeneous meshes of the same dimension.
+// the mapping selects a subset of parent_simplices
 // the tuple parent.tuple_from_id(pt,parent_simplices[index]) should be mapped to
 // child.tuple_from_id(pt,index)
 std::vector<std::array<Tuple, 2>> same_simplex_dimension_surjection(

--- a/tests/multimesh/test_multi_mesh.cpp
+++ b/tests/multimesh/test_multi_mesh.cpp
@@ -1,5 +1,6 @@
 #include <catch2/catch_test_macros.hpp>
 #include <wmtk/Types.hpp>
+#include <wmtk/multimesh/same_simplex_dimension_bijection.hpp>
 #include <wmtk/multimesh/same_simplex_dimension_surjection.hpp>
 #include <wmtk/multimesh/utils/tuple_map_attribute_io.hpp>
 #include <wmtk/operations/tri_mesh/EdgeCollapse.hpp>
@@ -50,6 +51,36 @@ void print_tuple_map(const DEBUG_TriMesh& parent, const DEBUG_MultiMeshManager& 
     }
 }
 
+TEST_CASE("test_register_child_mesh_bijection", "[multimesh][2D]")
+{
+    DEBUG_TriMesh parent = two_neighbors();
+    std::shared_ptr<DEBUG_TriMesh> child0_ptr = std::make_shared<DEBUG_TriMesh>(two_neighbors());
+    std::shared_ptr<DEBUG_TriMesh> child1_ptr = std::make_shared<DEBUG_TriMesh>(two_neighbors());
+
+
+    auto& child0 = *child0_ptr;
+    auto& child1 = *child1_ptr;
+
+    // check that bijection ~ surjection with the same number of elements
+    auto child0_map = multimesh::same_simplex_dimension_surjection(parent, child0, {0, 1, 2});
+    auto child1_map = multimesh::same_simplex_dimension_bijection(parent, child1);
+
+    // the maps should be the same
+    REQUIRE(child0_map == child1_map);
+
+
+    // some debug mode only checks
+#if !defined(NDEBUG)
+    // chekc that it fails when the # simplices is wrong
+    std::shared_ptr<DEBUG_TriMesh> child2_ptr = std::make_shared<DEBUG_TriMesh>(one_ear());
+    CHECK_THROWS(multimesh::same_simplex_dimension_bijection(parent, *child2_ptr));
+
+    // check that it fails when mesh dimensions are wrong
+    std::shared_ptr<DEBUG_EdgeMesh> child3_ptr = std::make_shared<DEBUG_EdgeMesh>(single_line());
+    CHECK_THROWS(multimesh::same_simplex_dimension_bijection(parent, *child3_ptr));
+#endif
+}
+
 TEST_CASE("test_register_child_mesh", "[multimesh][2D]")
 {
     DEBUG_TriMesh parent = two_neighbors();
@@ -62,6 +93,17 @@ TEST_CASE("test_register_child_mesh", "[multimesh][2D]")
 
     auto child0_map = multimesh::same_simplex_dimension_surjection(parent, child0, {2});
     auto child1_map = multimesh::same_simplex_dimension_surjection(parent, child1, {0, 1});
+
+    // some debug mode only checks
+#if !defined(NDEBUG)
+    {
+        // check for a dimension failure
+        std::shared_ptr<DEBUG_EdgeMesh> child3_ptr =
+            std::make_shared<DEBUG_EdgeMesh>(single_line());
+        auto& child3 = *child3_ptr;
+        CHECK_THROWS(multimesh::same_simplex_dimension_bijection(parent, child3));
+    }
+#endif
 
     parent.register_child_mesh(child0_ptr, child0_map);
     parent.register_child_mesh(child1_ptr, child1_map);


### PR DESCRIPTION
the default map when two meshes are bijective in a trivial way was not tested / used. Fixed an issue where reserve was used but resizing never happened in the vector. also changed the name from surjection to bijection, changed asserts to throw so catch2 can check that the exceptions do the desired things.