### PR TITLE
544 default cache and subcaching

### DIFF
--- a/src/wmtk/io/CMakeLists.txt
+++ b/src/wmtk/io/CMakeLists.txt
@@ -2,6 +2,12 @@
 set(SRC_FILES
     Cache.cpp
     Cache.hpp
+
+    CacheStack.hpp
+    CacheStack.cpp
+    SubCacheHandle.hpp
+    SubCacheHandle.cpp
+
     HDF5Reader.hpp
     HDF5Reader.cpp
     HDF5Writer.hpp

--- a/src/wmtk/io/Cache.hpp
+++ b/src/wmtk/io/Cache.hpp
@@ -2,6 +2,7 @@
 
 #include <filesystem>
 #include <map>
+#include <string_view>
 #include <wmtk/Mesh.hpp>
 
 namespace wmtk::io {
@@ -16,11 +17,19 @@ public:
      * cache name is a hex number representing a timestamp and another one representing the number
      * of tries that were necessary to create the cache folder.
      *
-     * The cache folder is automatically removed in the destructor of the class. If the contents of
-     * the cache should be stored, one can use `export_cache()`. Once a cache is exported, it can be
+     * The cache folder is automatically removed in the destructor of the class
+     * if delete_cache is set to be true. If the contents of the cache should
+     * be copied out, one can use `export_cache()`. Once a cache is exported, it
+     * can be
      * imported again using `import_cache()`.
      */
-    Cache(const std::string& prefix, const std::filesystem::path directory = "");
+    Cache(
+        const std::string& prefix,
+        const std::filesystem::path directory = "",
+        bool delete_cache = true);
+
+    Cache(Cache&&);
+    Cache& operator=(Cache&&);
 
     ~Cache();
 
@@ -120,6 +129,7 @@ public:
 private:
     std::filesystem::path m_cache_dir;
     std::map<std::string, std::filesystem::path> m_file_paths; // name --> file location
+    bool m_delete_cache = true;
 
     inline static const std::string m_cache_content_name =
         "cache_contents"; // name of the json file used for import/export

--- a/src/wmtk/io/CacheStack.cpp
+++ b/src/wmtk/io/CacheStack.cpp
@@ -1,0 +1,50 @@
+#include "CacheStack.hpp"
+
+
+namespace wmtk::io {
+namespace {
+CacheStack _default_stack;
+}
+CacheStack& CacheStack::default_stack()
+{
+    return _default_stack;
+}
+void CacheStack::set_default_stack(CacheStack&& stack)
+{
+    if (_default_stack.has_sub_caches()) {
+        throw std::runtime_error("Cannot change the default stack when it still has subcaches");
+    }
+    if (stack.has_sub_caches()) {
+        throw std::runtime_error("Cannot change the default stack to a stack with sub_caches");
+    }
+    if (!stack.has_sub_caches()) {
+        _default_stack = std::move(stack);
+    }
+}
+CacheStack::CacheStack()
+    : CacheStack(Cache("wmtk_cache", std::filesystem::temp_directory_path()))
+{}
+
+CacheStack::CacheStack(Cache&& cache)
+{
+    m_caches.push(std::move(cache));
+}
+
+const Cache& CacheStack::get_current_cache() const
+{
+    return m_caches.top();
+}
+
+const Cache& CacheStack::create_sub_cache(const std::string_view subcache_name)
+{
+    std::filesystem::path parent_path = get_current_cache().get_cache_path();
+
+    m_caches.push(Cache(std::string(subcache_name), parent_path, false));
+    return m_caches.top();
+}
+
+bool CacheStack::has_sub_caches() const
+{
+    return m_caches.size() == 1;
+}
+} // namespace wmtk::io

--- a/src/wmtk/io/CacheStack.hpp
+++ b/src/wmtk/io/CacheStack.hpp
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <stack>
+#include <string_view>
+#include "Cache.hpp"
+
+
+namespace wmtk::io {
+class SubCacheHandle;
+class CacheStack
+{
+public:
+    friend class SubCacheHandle;
+    // a small singleton stack that anyone can request at any time
+    static CacheStack& default_stack();
+    // reset the default cache stack to be something else.
+    static void set_default_stack(CacheStack&& stack);
+    // default creates a stack with the current folder as the cache
+    CacheStack();
+    CacheStack(Cache&& cache);
+    const Cache& get_current_cache() const;
+
+
+    bool has_sub_caches() const;
+
+private:
+    const Cache& create_sub_cache(const std::string_view subcache_name);
+    std::stack<Cache> m_caches;
+};
+} // namespace wmtk::io

--- a/src/wmtk/io/SubCacheHandle.cpp
+++ b/src/wmtk/io/SubCacheHandle.cpp
@@ -1,0 +1,34 @@
+#include "SubCacheHandle.hpp"
+#include "CacheStack.hpp"
+
+namespace wmtk::io {
+
+SubCacheHandle::SubCacheHandle(std::string_view cache_name)
+    : SubCacheHandle(cache_name, CacheStack::default_stack())
+{}
+SubCacheHandle::SubCacheHandle(std::string_view cache_name, CacheStack& stack)
+{
+    stack.create_sub_cache(cache_name);
+    m_stack = &stack;
+}
+
+SubCacheHandle::SubCacheHandle(SubCacheHandle&& o)
+    : m_stack(o.m_stack)
+{
+    o.m_stack = nullptr;
+}
+SubCacheHandle& SubCacheHandle::operator=(SubCacheHandle&& o)
+{
+    m_stack = o.m_stack;
+    o.m_stack = nullptr;
+    return *this;
+}
+
+
+SubCacheHandle::~SubCacheHandle()
+{
+    if (m_stack != nullptr) {
+        m_stack->m_caches.pop();
+    }
+}
+} // namespace wmtk::io

--- a/src/wmtk/io/SubCacheHandle.hpp
+++ b/src/wmtk/io/SubCacheHandle.hpp
@@ -1,0 +1,20 @@
+#pragma once
+
+
+#include <string_view>
+namespace wmtk::io {
+class CacheStack;
+class SubCacheHandle
+{
+public:
+    SubCacheHandle(std::string_view cache_name);
+    SubCacheHandle(std::string_view cache_name, CacheStack& stack);
+    SubCacheHandle(SubCacheHandle&&);
+    SubCacheHandle& operator=(SubCacheHandle&&);
+
+    ~SubCacheHandle();
+
+private:
+    CacheStack* m_stack = nullptr;
+};
+} // namespace wmtk::io

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -16,7 +16,6 @@ set(TEST_SOURCES
     test_tuple_1d.cpp
     test_tuple_2d.cpp
 	test_tuple_3d.cpp
-    test_io.cpp
     test_execution.cpp
     test_invariants.cpp
     test_simplex_collection.cpp
@@ -84,6 +83,7 @@ endfunction()
 add_subdirectory_with_source_group(components)
 add_subdirectory_with_source_group(function)
 add_subdirectory_with_source_group(simplex)
+add_subdirectory_with_source_group(io)
 
 
 

--- a/tests/io/CMakeLists.txt
+++ b/tests/io/CMakeLists.txt
@@ -1,0 +1,6 @@
+# Sources
+set(TEST_SOURCES
+    test_io.cpp
+    test_cache.cpp
+)
+target_sources(wmtk_tests PRIVATE ${TEST_SOURCES})

--- a/tests/io/test_cache.cpp
+++ b/tests/io/test_cache.cpp
@@ -1,0 +1,189 @@
+#include <wmtk/Mesh.hpp>
+#include <wmtk/TetMesh.hpp>
+#include <wmtk/TriMesh.hpp>
+#include <wmtk/io/Cache.hpp>
+#include <wmtk/io/CacheStack.hpp>
+#include <wmtk/io/SubCacheHandle.hpp>
+
+#include <wmtk/operations/OperationFactory.hpp>
+#include <wmtk/operations/tri_mesh/EdgeSplit.hpp>
+
+#include "../tools/DEBUG_TriMesh.hpp"
+#include "../tools/TriMesh_examples.hpp"
+
+#include <catch2/catch_test_macros.hpp>
+using namespace wmtk;
+using namespace wmtk::io;
+using namespace wmtk::tests;
+
+namespace fs = std::filesystem;
+
+TEST_CASE("cache_init", "[cache][io]")
+{
+    const fs::path dir = std::filesystem::current_path();
+    const std::string prefix = "wmtk_cache";
+
+    fs::path cache_dir;
+    {
+        io::Cache cache(prefix, dir);
+        cache_dir = cache.get_cache_path();
+
+        CHECK(fs::exists(cache_dir));
+
+        CHECK(dir == cache_dir.parent_path());
+        CHECK(cache_dir.stem().string().rfind(prefix, 0) == 0); // cache dir starts with prefix
+    }
+    CHECK_FALSE(fs::exists(cache_dir));
+}
+
+TEST_CASE("cache_move_assignment", "[cache][io]")
+{
+    const fs::path dir = std::filesystem::current_path();
+    const std::string prefix = "wmtk_cache";
+
+    std::optional<Cache> cache_opt;
+    fs::path cache_dir;
+    {
+        io::Cache cache(prefix, dir);
+        cache_dir = cache.get_cache_path();
+
+        CHECK(fs::exists(cache_dir));
+
+        CHECK(dir == cache_dir.parent_path());
+        CHECK(cache_dir.stem().string().rfind(prefix, 0) == 0); // cache dir starts with prefix
+        cache_opt = std::move(cache);
+        CHECK(fs::exists(cache_dir));
+    }
+    cache_opt.reset();
+    CHECK_FALSE(fs::exists(cache_dir));
+}
+TEST_CASE("cache_move_constructor", "[cache][io]")
+{
+    const fs::path dir = std::filesystem::current_path();
+    const std::string prefix = "wmtk_cache";
+
+    std::optional<Cache> cache_opt;
+    fs::path cache_dir;
+    {
+        io::Cache cache(prefix, dir);
+        cache_dir = cache.get_cache_path();
+
+        CHECK(fs::exists(cache_dir));
+
+        CHECK(dir == cache_dir.parent_path());
+        CHECK(cache_dir.stem().string().rfind(prefix, 0) == 0); // cache dir starts with prefix
+        cache_opt.emplace(std::move(cache));
+        CHECK(fs::exists(cache_dir));
+    }
+    cache_opt.reset();
+    CHECK_FALSE(fs::exists(cache_dir));
+}
+
+TEST_CASE("cache_stack_init", "[cache][io]")
+{
+    const fs::path dir = std::filesystem::current_path();
+    const std::string prefix = "wmtk_cache";
+
+    fs::path cache_dir;
+    {
+        io::Cache cache(prefix, dir);
+        cache_dir = cache.get_cache_path();
+
+        CHECK(fs::exists(cache_dir));
+
+        CHECK(dir == cache_dir.parent_path());
+        CHECK(cache_dir.stem().string().rfind(prefix, 0) == 0); // cache dir starts with prefix
+    }
+    CHECK_FALSE(fs::exists(cache_dir));
+}
+
+TEST_CASE("cache_files", "[cache][io]")
+{
+    fs::path filepath;
+    std::string file_name = "my_new_file";
+    {
+        io::Cache cache("wmtk_cache", fs::current_path());
+
+        filepath = cache.create_unique_file(file_name, ".txt");
+
+        CHECK(fs::exists(filepath));
+        CHECK(filepath.stem().string().rfind(file_name, 0) == 0);
+        CHECK(filepath.extension().string() == ".txt");
+
+        const fs::path filepath_from_cache = cache.get_file_path(file_name);
+
+        CHECK(filepath_from_cache == filepath);
+    }
+    CHECK_FALSE(fs::exists(filepath));
+}
+
+TEST_CASE("cache_read_write_mesh", "[cache][io]")
+{
+    io::Cache cache("wmtk_cache", fs::current_path());
+    TriMesh mesh = tests::single_triangle();
+
+    const std::string name = "cached_mesh";
+    cache.write_mesh(mesh, name);
+
+    auto mesh_from_cache = cache.read_mesh(name);
+
+    CHECK(*mesh_from_cache == mesh);
+    CHECK_THROWS(cache.read_mesh("some_file_that_does_not_exist"));
+}
+
+TEST_CASE("cache_export_import", "[cache][io]")
+{
+    const fs::path export_location =
+        io::Cache::create_unique_directory("wmtk_cache_export", fs::current_path());
+
+    const std::vector<std::string> file_names = {"a", "b", "c"};
+
+    // create cache
+    fs::path first_cache_path;
+    {
+        io::Cache cache("wmtk_cache", fs::current_path());
+        // generate some files
+        for (const std::string& name : file_names) {
+            const fs::path p = cache.create_unique_file(name, ".txt");
+            CHECK(fs::exists(p));
+            CHECK(p.stem().string().rfind(name, 0) == 0);
+            CHECK(p.extension().string() == ".txt");
+        }
+
+        first_cache_path = cache.get_cache_path();
+
+        // delete dummy directory
+        fs::remove_all(export_location);
+        REQUIRE_FALSE(fs::exists(export_location));
+        // export cache to dummy directory
+        REQUIRE(cache.export_cache(export_location));
+    }
+    CHECK_FALSE(fs::exists(first_cache_path));
+
+    // create new cache
+    {
+        io::Cache cache("wmtk_cache", fs::current_path());
+        // import the previously exported
+        CHECK(cache.import_cache(export_location));
+
+        // check if files are there
+        for (const std::string& name : file_names) {
+            const fs::path p = cache.get_file_path(name);
+            CHECK(fs::exists(p));
+            CHECK(p.stem().string().rfind(name, 0) == 0);
+            CHECK(p.extension().string() == ".txt");
+        }
+    }
+
+    // try to import even though the cache contains a file
+    {
+        io::Cache cache("wmtk_cache", fs::current_path());
+        cache.create_unique_file("some_file", "");
+        // import should not work if the cache already contains files
+        CHECK_FALSE(cache.import_cache(export_location));
+    }
+
+    // clean up export
+    fs::remove_all(export_location);
+}
+

--- a/tests/io/test_io.cpp
+++ b/tests/io/test_io.cpp
@@ -1,7 +1,6 @@
 #include <wmtk/Mesh.hpp>
 #include <wmtk/TetMesh.hpp>
 #include <wmtk/TriMesh.hpp>
-#include <wmtk/io/Cache.hpp>
 #include <wmtk/io/HDF5Writer.hpp>
 #include <wmtk/io/MeshReader.hpp>
 #include <wmtk/io/ParaviewWriter.hpp>
@@ -11,8 +10,8 @@
 #include <wmtk/operations/OperationFactory.hpp>
 #include <wmtk/operations/tri_mesh/EdgeSplit.hpp>
 
-#include "tools/DEBUG_TriMesh.hpp"
-#include "tools/TriMesh_examples.hpp"
+#include "../tools/DEBUG_TriMesh.hpp"
+#include "../tools/TriMesh_examples.hpp"
 
 #include <catch2/catch_test_macros.hpp>
 #include <wmtk/simplex/utils/SimplexComparisons.hpp>
@@ -145,7 +144,10 @@ TEST_CASE("attribute_after_split", "[io]")
 
             // all edges hold 0 besides "edge"
             for (const Tuple& t : m.get_all(PE)) {
-                if (simplex::utils::SimplexComparisons::equal(m,Simplex::edge(edge), Simplex::edge(t))) {
+                if (simplex::utils::SimplexComparisons::equal(
+                        m,
+                        Simplex::edge(edge),
+                        Simplex::edge(t))) {
                     CHECK(acc_attribute.scalar_attribute(t) == 1);
                 } else {
                     CHECK(acc_attribute.scalar_attribute(t) == 0);
@@ -181,110 +183,3 @@ TEST_CASE("attribute_after_split", "[io]")
     m.serialize(writer);
 }
 
-TEST_CASE("cache_init", "[cache][io]")
-{
-    const fs::path dir = std::filesystem::current_path();
-    const std::string prefix = "wmtk_cache";
-
-    fs::path cache_dir;
-    {
-        io::Cache cache(prefix, dir);
-        cache_dir = cache.get_cache_path();
-
-        CHECK(fs::exists(cache_dir));
-
-        CHECK(dir == cache_dir.parent_path());
-        CHECK(cache_dir.stem().string().rfind(prefix, 0) == 0); // cache dir starts with prefix
-    }
-    CHECK_FALSE(fs::exists(cache_dir));
-}
-
-TEST_CASE("cache_files", "[cache][io]")
-{
-    fs::path filepath;
-    std::string file_name = "my_new_file";
-    {
-        io::Cache cache("wmtk_cache", fs::current_path());
-
-        filepath = cache.create_unique_file(file_name, ".txt");
-
-        CHECK(fs::exists(filepath));
-        CHECK(filepath.stem().string().rfind(file_name, 0) == 0);
-        CHECK(filepath.extension().string() == ".txt");
-
-        const fs::path filepath_from_cache = cache.get_file_path(file_name);
-
-        CHECK(filepath_from_cache == filepath);
-    }
-    CHECK_FALSE(fs::exists(filepath));
-}
-
-TEST_CASE("cache_read_write_mesh", "[cache][io]")
-{
-    io::Cache cache("wmtk_cache", fs::current_path());
-    TriMesh mesh = tests::single_triangle();
-
-    const std::string name = "cached_mesh";
-    cache.write_mesh(mesh, name);
-
-    auto mesh_from_cache = cache.read_mesh(name);
-
-    CHECK(*mesh_from_cache == mesh);
-    CHECK_THROWS(cache.read_mesh("some_file_that_does_not_exist"));
-}
-
-TEST_CASE("cache_export_import", "[cache][io]")
-{
-    const fs::path export_location =
-        io::Cache::create_unique_directory("wmtk_cache_export", fs::current_path());
-
-    const std::vector<std::string> file_names = {"a", "b", "c"};
-
-    // create cache
-    fs::path first_cache_path;
-    {
-        io::Cache cache("wmtk_cache", fs::current_path());
-        // generate some files
-        for (const std::string& name : file_names) {
-            const fs::path p = cache.create_unique_file(name, ".txt");
-            CHECK(fs::exists(p));
-            CHECK(p.stem().string().rfind(name, 0) == 0);
-            CHECK(p.extension().string() == ".txt");
-        }
-
-        first_cache_path = cache.get_cache_path();
-
-        // delete dummy directory
-        fs::remove_all(export_location);
-        REQUIRE_FALSE(fs::exists(export_location));
-        // export cache to dummy directory
-        REQUIRE(cache.export_cache(export_location));
-    }
-    CHECK_FALSE(fs::exists(first_cache_path));
-
-    // create new cache
-    {
-        io::Cache cache("wmtk_cache", fs::current_path());
-        // import the previously exported
-        CHECK(cache.import_cache(export_location));
-
-        // check if files are there
-        for (const std::string& name : file_names) {
-            const fs::path p = cache.get_file_path(name);
-            CHECK(fs::exists(p));
-            CHECK(p.stem().string().rfind(name, 0) == 0);
-            CHECK(p.extension().string() == ".txt");
-        }
-    }
-
-    // try to import even though the cache contains a file
-    {
-        io::Cache cache("wmtk_cache", fs::current_path());
-        cache.create_unique_file("some_file", "");
-        // import should not work if the cache already contains files
-        CHECK_FALSE(cache.import_cache(export_location));
-    }
-
-    // clean up export
-    fs::remove_all(export_location);
-}


### PR DESCRIPTION
Thought is to enable a workflow like

```
CacheStack stack("opt",".",false);
for(int iter = 0; iter < 100; ++iter) {
   SubCacheHandle h(fmt::format("{:04}", iter), stack);
   Cache c = stack.get_current_stack();
  // all files created by c are put in the "path/0002_unique_stuff/..."
}
```