### PR TITLE
cleaning up the autodiff interface for more generic functions

### DIFF
--- a/src/wmtk/function/AMIPS.cpp
+++ b/src/wmtk/function/AMIPS.cpp
@@ -1,4 +1,3 @@
-#pragma once
 #include "AMIPS.hpp"
 #include <wmtk/TriMesh.hpp>
 #include <wmtk/function/utils/AutoDiffRAII.hpp>
@@ -13,7 +12,11 @@ AMIPS::~AMIPS() = default;
 using DScalar = typename AutodiffFunction::DScalar;
 using DSVec2 = Eigen::Vector2<DScalar>;
 using DSVec3 = Eigen::Vector3<DScalar>;
-DScalar AMIPS::eval(DSVec& coordinate0, DSVec& coordinate1, DSVec& coordinate2) const
+DScalar AMIPS::eval(
+    const simplex::Simplex& domain_simplex,
+    DSVec& coordinate0,
+    DSVec& coordinate1,
+    DSVec& coordinate2) const
 {
     switch (embedded_dimension()) {
     case 2: {

--- a/src/wmtk/function/AMIPS.hpp
+++ b/src/wmtk/function/AMIPS.hpp
@@ -15,7 +15,11 @@ public:
     ~AMIPS();
 
 protected:
-    DScalar eval(DSVec& coordinate0, DSVec& coordinate1, DSVec& coordinate2) const override;
+    DScalar eval(
+        const Simplex& domain_simplex,
+        DSVec& coordinate0,
+        DSVec& coordinate1,
+        DSVec& coordinate2) const override;
 };
 
 } // namespace wmtk::function

--- a/src/wmtk/function/AutodiffFunction.cpp
+++ b/src/wmtk/function/AutodiffFunction.cpp
@@ -1,5 +1,6 @@
 #include "AutodiffFunction.hpp"
 #include <wmtk/function/utils/AutoDiffRAII.hpp>
+#include <wmtk/simplex/faces_single_dimension.hpp>
 #include <wmtk/simplex/internal/SimplexEqualFunctor.hpp>
 namespace wmtk::function {
 
@@ -11,5 +12,57 @@ AutodiffFunction::AutodiffFunction(
 {}
 
 AutodiffFunction::~AutodiffFunction() = default;
+
+auto AutodiffFunction::get_coordinates(
+    const Tuple& domain_tuple,
+    const std::optional<Tuple>& variable_tuple_opt) const -> std::vector<DSVec>
+{
+    const PrimitiveType primitive_type = get_coordinate_attribute_primitive_type();
+    const std::vector<Tuple> faces = wmtk::simplex::faces_single_dimension(
+        mesh(),
+        as_domain_simplex(domain_tuple),
+        primitive_type);
+
+    ConstAccessor<double> pos = mesh().create_const_accessor(get_coordinate_attribute_handle());
+
+    std::vector<DSVec> ret;
+    ret.reserve(faces.size());
+
+    std::transform(
+        faces.begin(),
+        faces.end(),
+        std::back_inserter(ret),
+        [&](const Tuple& face_tuple) -> DSVec {
+            auto value = pos.const_vector_attribute(face_tuple).eval();
+            // if we have a variable simplex and are trying to differentiate it then fill its
+            // gradient
+            if (variable_tuple_opt.has_value()) {
+                const auto& variable_tuple = variable_tuple_opt.value();
+                if (wmtk::simplex::utils::SimplexComparisons::equal(
+                        mesh(),
+                        primitive_type,
+                        face_tuple,
+                        variable_tuple)) {
+                    return utils::as_DScalar<DScalar>(value);
+                }
+            }
+            return value.cast<DScalar>();
+        });
+    return ret;
+}
+auto AutodiffFunction::get_coordinates(
+    const Simplex& domain_simplex,
+    const std::optional<Simplex>& variable_simplex_opt) const -> std::vector<DSVec>
+{
+    assert(domain_simplex.primitive_type() == domain_simplex_type());
+    if (variable_simplex_opt.has_value()) {
+        assert(
+            variable_simplex_opt.value().primitive_type() ==
+            get_coordinate_attribute_primitive_type());
+        return get_coordinates(domain_simplex.tuple(), variable_simplex_opt.value().tuple());
+    } else {
+        return get_coordinates(domain_simplex.tuple());
+    }
+}
 
 } // namespace wmtk::function

--- a/src/wmtk/function/AutodiffFunction.cpp
+++ b/src/wmtk/function/AutodiffFunction.cpp
@@ -54,7 +54,7 @@ auto AutodiffFunction::get_coordinates(
     const Simplex& domain_simplex,
     const std::optional<Simplex>& variable_simplex_opt) const -> std::vector<DSVec>
 {
-    assert(domain_simplex.primitive_type() == domain_simplex_type());
+    assert(domain_simplex.primitive_type() == get_domain_simplex_type());
     if (variable_simplex_opt.has_value()) {
         assert(
             variable_simplex_opt.value().primitive_type() ==

--- a/src/wmtk/function/AutodiffFunction.hpp
+++ b/src/wmtk/function/AutodiffFunction.hpp
@@ -3,8 +3,8 @@
 #include <optional>
 #include <wmtk/function/utils/AutoDiffRAII.hpp>
 #include <wmtk/function/utils/AutoDiffUtils.hpp>
-#include "PerSimplexDifferentiableFunction.hpp"
 #include <wmtk/simplex/utils/SimplexComparisons.hpp>
+#include "PerSimplexDifferentiableFunction.hpp"
 namespace wmtk::function {
 /**
  * @brief This is an extension of the PerSimplexDifferentiableFunction class that uses autodiff
@@ -28,20 +28,6 @@ public:
 
 protected:
     /**
-     * @brief This function defines a function f(x) where f is defined over a triangle domain and
-     * the variables for f are the three vertices coordinates of the triangle.
-     *
-     * The input three coordinates are obtained through the get_variable_coordinates function. Theya
-     * re encoded in autodiff type so that the function can be differentiated through autodiff.
-     *
-     * @param coordinate0
-     * @param coordinate1
-     * @param coordinate2
-     * @return DScalar
-     */
-    virtual DScalar eval(DSVec& coordinate0, DSVec& coordinate1, DSVec& coordinate2) const = 0;
-
-    /**
      * @brief This is a helper function that obtains the coordinates of the variables for the
      * function f(x) where f is defined over a domain consists of the input argument domain_tuples.
      *
@@ -58,34 +44,45 @@ protected:
      * @return std::array<DSVec, N> The coordinates of the variables for the function f(x) that are
      * in autodiff type
      */
+    std::vector<DSVec> get_coordinates(
+        const Tuple& domain_tuple,
+        const std::optional<Tuple>& variable_tuple_opt = {}) const;
+
+    std::vector<DSVec> get_coordinates(
+        const Simplex& domain_simplex,
+        const std::optional<Simplex>& variable_simplex_opt = {}) const;
+
     template <int N>
-    std::array<DSVec, N> get_variable_coordinates(
-        const std::vector<Tuple>& domain_tuples,
-        const std::optional<Simplex>& variable_simplex_opt) const;
+    std::array<DSVec, N> get_coordinates_T(
+        const Tuple& domain_tuple,
+        const std::optional<Tuple>& variable_tuple_opt = {}) const;
+
+    template <int N>
+    std::array<DSVec, N> get_coordinates_T(
+        const Simplex& domain_simplex,
+        const std::optional<Simplex>& variable_simplex_opt = {}) const;
 };
 
 template <int N>
-std::array<AutodiffFunction::DSVec, N> AutodiffFunction::get_variable_coordinates(
-    const std::vector<Tuple>& domain_tuples,
-    const std::optional<Simplex>& variable_simplex_opt) const
+auto AutodiffFunction::get_coordinates_T(
+    const Tuple& domain_tuple,
+    const std::optional<Tuple>& variable_tuple_opt) const -> std::array<DSVec, N>
 {
-    ConstAccessor<double> pos = mesh().create_const_accessor(get_coordinate_attribute_handle());
-
-    std::array<DSVec, N> coordinates;
-    assert(N == domain_tuples.size());
-    for (size_t i = 0; i < domain_tuples.size(); i++) {
-        Tuple domain_tuple = domain_tuples[i];
-        Simplex domain_simplex(get_coordinate_attribute_primitive_type(), domain_tuple);
-        if (variable_simplex_opt.has_value() &&
-            wmtk::simplex::utils::SimplexComparisons::equal(mesh(),domain_simplex, variable_simplex_opt.value())) {
-            Simplex variable_simplex = variable_simplex_opt.value();
-            coordinates[i] =
-                utils::as_DScalar<DScalar>(pos.const_vector_attribute(variable_simplex.tuple()));
-        } else {
-            Eigen::VectorXd temp_coord = pos.const_vector_attribute(domain_tuple);
-            coordinates[i] = temp_coord.cast<DScalar>();
-        }
-    }
-    return coordinates;
+    auto vec = get_coordinates(domain_tuple, variable_tuple_opt);
+    assert(vec.size() == N);
+    std::array<DSVec, N> r;
+    std::copy(vec.begin(), vec.end(), r.begin());
+    return r;
+}
+template <int N>
+auto AutodiffFunction::get_coordinates_T(
+    const Simplex& domain_simplex,
+    const std::optional<Simplex>& variable_simplex_opt) const -> std::array<DSVec, N>
+{
+    auto vec = get_coordinates(domain_simplex, variable_simplex_opt);
+    assert(vec.size() == N);
+    std::array<DSVec, N> r;
+    std::copy(vec.begin(), vec.end(), r.begin());
+    return r;
 }
 } // namespace wmtk::function

--- a/src/wmtk/function/PerSimplexDifferentiableFunction.cpp
+++ b/src/wmtk/function/PerSimplexDifferentiableFunction.cpp
@@ -27,7 +27,9 @@ Eigen::VectorXd PerSimplexDifferentiableFunction::get_gradient_sum(
     const Simplex& variable_simplex) const
 {
     Eigen::VectorXd g = Eigen::VectorXd::Zero(embedded_dimension());
+    assert(variable_simplex.primitive_type() == get_coordinate_attribute_primitive_type());
     for (const Simplex& cell : domain_simplices) {
+        assert(cell.primitive_type() == get_domain_simplex_type());
         g += get_gradient(cell, variable_simplex);
     }
     return g;
@@ -36,9 +38,34 @@ Eigen::MatrixXd PerSimplexDifferentiableFunction::get_hessian_sum(
     const std::vector<Simplex>& domain_simplices,
     const Simplex& variable_simplex) const
 {
+    assert(variable_simplex.primitive_type() == get_coordinate_attribute_primitive_type());
     Eigen::MatrixXd h = Eigen::MatrixXd::Zero(embedded_dimension(), embedded_dimension());
     for (const Simplex& cell : domain_simplices) {
+        assert(cell.primitive_type() == get_domain_simplex_type());
         h += get_hessian(cell, variable_simplex);
+    }
+    return h;
+}
+
+Eigen::VectorXd PerSimplexDifferentiableFunction::get_gradient_sum(
+    const std::vector<Tuple>& domain_simplices,
+    const Tuple& variable_tuple) const
+{
+    const Simplex variable_simplex = as_coordinate_attribute_simplex(variable_tuple);
+    Eigen::VectorXd g = Eigen::VectorXd::Zero(embedded_dimension());
+    for (const Tuple& cell : domain_simplices) {
+        g += get_gradient(as_domain_simplex(cell), variable_simplex);
+    }
+    return g;
+}
+Eigen::MatrixXd PerSimplexDifferentiableFunction::get_hessian_sum(
+    const std::vector<Tuple>& domain_simplices,
+    const Tuple& variable_tuple) const
+{
+    Eigen::MatrixXd h = Eigen::MatrixXd::Zero(embedded_dimension(), embedded_dimension());
+    const Simplex variable_simplex = as_coordinate_attribute_simplex(variable_tuple);
+    for (const Tuple& cell : domain_simplices) {
+        h += get_hessian(as_domain_simplex(cell), variable_simplex);
     }
     return h;
 }
@@ -47,4 +74,10 @@ long PerSimplexDifferentiableFunction::embedded_dimension() const
 {
     return mesh().get_attribute_dimension(get_coordinate_attribute_handle());
 }
+
+Simplex PerSimplexDifferentiableFunction::as_coordinate_attribute_simplex(const Tuple& t) const
+{
+    return Simplex(get_coordinate_attribute_primitive_type(), t);
+}
+
 } // namespace wmtk::function

--- a/src/wmtk/function/PerSimplexDifferentiableFunction.hpp
+++ b/src/wmtk/function/PerSimplexDifferentiableFunction.hpp
@@ -46,6 +46,16 @@ public:
         const std::vector<Simplex>& simplices,
         const Simplex& variable_simplex) const;
 
+    Eigen::VectorXd get_gradient_sum(
+        const std::vector<Tuple>& simplices,
+        const Tuple& variable_simplex) const;
+    Eigen::MatrixXd get_hessian_sum(
+        const std::vector<Tuple>& simplices,
+        const Tuple& variable_simplex) const;
+
+protected:
+    Simplex as_coordinate_attribute_simplex(const Tuple& t) const;
+
 private:
     const MeshAttributeHandle<double> m_coordinate_attribute_handle;
 };

--- a/src/wmtk/function/PerSimplexFunction.cpp
+++ b/src/wmtk/function/PerSimplexFunction.cpp
@@ -28,4 +28,18 @@ double PerSimplexFunction::get_value_sum(const std::vector<Simplex>& simplices) 
     return v;
 }
 
+double PerSimplexFunction::get_value_sum(const std::vector<Tuple>& simplices) const
+{
+    double v = 0;
+    for (const Tuple& cell : simplices) {
+        v += get_value(as_domain_simplex(cell));
+    }
+    return v;
+}
+
+Simplex PerSimplexFunction::as_domain_simplex(const Tuple& t) const
+{
+    return Simplex(get_domain_simplex_type(), t);
+}
+
 } // namespace wmtk::function

--- a/src/wmtk/function/PerSimplexFunction.hpp
+++ b/src/wmtk/function/PerSimplexFunction.hpp
@@ -22,12 +22,18 @@ public:
      * @return double The numerical value of the function at the input domain.
      */
     virtual double get_value(const simplex::Simplex& domain_simplex) const = 0;
+
     // helper because in many cases we want to compute the value of multiple simplices at once
     double get_value_sum(const std::vector<Simplex>& domain_simplices) const;
+
+    // helper because in many cases we want to compute the value of multiple simplices at once
+    double get_value_sum(const std::vector<Tuple>& domain_simplices) const;
 
     // get domain simplex_type
     PrimitiveType get_domain_simplex_type() const;
 
+protected:
+    Simplex as_domain_simplex(const Tuple& t) const;
 private:
     const Mesh& m_mesh;
     const PrimitiveType m_domain_simplex_type;

--- a/src/wmtk/function/TriangleAutodiffFunction.cpp
+++ b/src/wmtk/function/TriangleAutodiffFunction.cpp
@@ -8,39 +8,31 @@ TriangleAutodiffFunction::TriangleAutodiffFunction(
     const TriMesh& mesh,
     const MeshAttributeHandle<double>& coordinate_attribute_handle)
     : AutodiffFunction(mesh, PrimitiveType::Face, coordinate_attribute_handle)
-{}
+{
+    const PrimitiveType pt = get_coordinate_attribute_primitive_type();
+    if (pt == PrimitiveType::Face) {
+        throw std::runtime_error(
+            "TriangleAutodiffFunction does not work on functions defined on faces");
+    }
+}
 
 TriangleAutodiffFunction::~TriangleAutodiffFunction() = default;
 
-std::array<TriangleAutodiffFunction::DSVec, 3> TriangleAutodiffFunction::get_variable_coordinates(
+std::array<TriangleAutodiffFunction::DSVec, 3> TriangleAutodiffFunction::get_coordinates(
     const simplex::Simplex& domain_simplex,
     const std::optional<simplex::Simplex>& variable_simplex_opt) const
 {
-    std::vector<Tuple> domain_tuples;
-    Tuple domain_tuple = domain_simplex.tuple();
-    if (mesh().is_ccw(domain_simplex.tuple())) {
-        domain_tuple = mesh().switch_vertex(domain_tuple);
-    }
-    Tuple starting_tuple = domain_tuple;
-    // assume the ccw oriented trinagles vertices has positive signed energy
-
-    do {
-        domain_tuples.emplace_back(domain_tuple);
-        domain_tuple = mesh().switch_vertex(mesh().switch_edge(domain_tuple));
-    } while (domain_tuple != starting_tuple);
-    assert(domain_tuples.size() == 3);
-
-    return AutodiffFunction::get_variable_coordinates<3>(domain_tuples, variable_simplex_opt);
+    return AutodiffFunction::get_coordinates_T<3>(domain_simplex, variable_simplex_opt);
 }
 
 double TriangleAutodiffFunction::get_value(const simplex::Simplex& domain_simplex) const
 {
     auto scope = utils::AutoDiffRAII(embedded_dimension());
     // get the pos coordinates of the triangle
-    std::array<DSVec, 3> coordinates = get_variable_coordinates(domain_simplex, std::nullopt);
+    std::array<DSVec, 3> coordinates = get_coordinates(domain_simplex);
 
     // return the energy
-    return eval(coordinates[0], coordinates[1], coordinates[2]).getValue();
+    return eval(domain_simplex, coordinates[0], coordinates[1], coordinates[2]).getValue();
 }
 
 Eigen::VectorXd TriangleAutodiffFunction::get_gradient(
@@ -49,11 +41,10 @@ Eigen::VectorXd TriangleAutodiffFunction::get_gradient(
 {
     auto scope = utils::AutoDiffRAII(embedded_dimension());
     // get the pos coordinates of the triangle
-    std::array<DSVec, 3> coordinates =
-        get_variable_coordinates(domain_simplex, std::make_optional<Simplex>(variable_simplex));
+    std::array<DSVec, 3> coordinates = get_coordinates(domain_simplex, variable_simplex);
 
     // return the gradient
-    return eval(coordinates[0], coordinates[1], coordinates[2]).getGradient();
+    return eval(domain_simplex, coordinates[0], coordinates[1], coordinates[2]).getGradient();
 }
 
 Eigen::MatrixXd TriangleAutodiffFunction::get_hessian(
@@ -62,11 +53,10 @@ Eigen::MatrixXd TriangleAutodiffFunction::get_hessian(
 {
     auto scope = utils::AutoDiffRAII(embedded_dimension());
     // get the pos coordinates of the triangle
-    std::array<DSVec, 3> coordinates =
-        get_variable_coordinates(domain_simplex, std::make_optional<Simplex>(variable_simplex));
+    std::array<DSVec, 3> coordinates = get_coordinates(domain_simplex, variable_simplex);
 
     // return the hessian
-    return eval(coordinates[0], coordinates[1], coordinates[2]).getHessian();
+    return eval(domain_simplex, coordinates[0], coordinates[1], coordinates[2]).getHessian();
 }
 
 

--- a/src/wmtk/function/TriangleAutodiffFunction.hpp
+++ b/src/wmtk/function/TriangleAutodiffFunction.hpp
@@ -28,8 +28,26 @@ public:
         const simplex::Simplex& variable_simplex) const override;
 
 protected:
-    std::array<DSVec, 3> get_variable_coordinates(
+    std::array<DSVec, 3> get_coordinates(
         const simplex::Simplex& domain_simplex,
-        const std::optional<simplex::Simplex>& variable_simplex_opt) const;
+        const std::optional<simplex::Simplex>& variable_simplex_opt = {}) const;
+
+    /**
+     * @brief This function defines a function f(x) where f is defined over a triangle domain and
+     * the variables for f are the three vertices coordinates of the triangle.
+     *
+     * The input three coordinates are obtained through the get_coordinates function. Theya
+     * re encoded in autodiff type so that the function can be differentiated through autodiff.
+     *
+     * @param coordinate0
+     * @param coordinate1
+     * @param coordinate2
+     * @return DScalar
+     */
+    virtual DScalar eval(
+        const simplex::Simplex& domain_simplex,
+        DSVec& coordinate0,
+        DSVec& coordinate1,
+        DSVec& coordinate2) const = 0;
 };
 } // namespace wmtk::function


### PR DESCRIPTION
shoved the `eval(dvec,dvec,dvec)` function to be the responsibility of the `TriangleAutodiffFunction` and made sure it's clear that this class doesn't work for per-face attributes.

moved `get_variable_coordinate` to `get_coordinate` and made the interface use `faces` rather than manual iteration to specify a generic ordering for which hwo simplices are ordered by the function.

