### PR TITLE
renaming multimeshvisitor and multimesheventvisitor to multimeshsimplex*

### DIFF
--- a/src/wmtk/Mesh.hpp
+++ b/src/wmtk/Mesh.hpp
@@ -50,9 +50,9 @@ class SimplexComparisons;
 
 namespace multimesh {
 template <long cell_dimension, typename NodeFunctor>
-class MultiMeshVisitor;
+class MultiMeshSimplexVisitor;
 template <typename Visitor>
-class MultiMeshVisitorExecutor;
+class MultiMeshSimplexVisitorExecutor;
 namespace utils::internal {
 class TupleTag;
 }
@@ -71,9 +71,9 @@ public:
     friend class HDF5Reader;
     friend class MultiMeshManager;
     template <long cell_dimension, typename NodeFunctor>
-    friend class multimesh::MultiMeshVisitor;
+    friend class multimesh::MultiMeshSimplexVisitor;
     template <typename Visitor>
-    friend class multimesh::MultiMeshVisitorExecutor;
+    friend class multimesh::MultiMeshSimplexVisitorExecutor;
     friend class multimesh::utils::internal::TupleTag;
     friend class operations::utils::UpdateEdgeOperationMultiMeshMapFunctor;
     friend class simplex::utils::SimplexComparisons;

--- a/src/wmtk/MultiMeshManager.hpp
+++ b/src/wmtk/MultiMeshManager.hpp
@@ -18,9 +18,9 @@ class UpdateEdgeOperationMultiMeshMapFunctor;
 }
 namespace multimesh {
 template <long cell_dimension, typename NodeFunctor>
-class MultiMeshVisitor;
+class MultiMeshSimplexVisitor;
 template <typename Visitor>
-class MultiMeshVisitorExecutor;
+class MultiMeshSimplexVisitorExecutor;
 } // namespace multimesh
 class Mesh;
 class SimplicialComplex;
@@ -38,9 +38,9 @@ public:
 
     // let the visitor object access the internal details
     template <long cell_dimension, typename NodeFunctor>
-    friend class multimesh::MultiMeshVisitor;
+    friend class multimesh::MultiMeshSimplexVisitor;
     template <typename Visitor>
-    friend class multimesh::MultiMeshVisitorExecutor;
+    friend class multimesh::MultiMeshSimplexVisitorExecutor;
     friend class operations::utils::UpdateEdgeOperationMultiMeshMapFunctor;
     friend void operations::utils::update_vertex_operation_multimesh_map_hash(
         Mesh& m,

--- a/src/wmtk/invariants/MultiMeshLinkConditionInvariant.cpp
+++ b/src/wmtk/invariants/MultiMeshLinkConditionInvariant.cpp
@@ -7,7 +7,7 @@
 #include <wmtk/SimplicialComplex.hpp>
 #include <wmtk/TetMesh.hpp>
 #include <wmtk/TriMesh.hpp>
-#include <wmtk/multimesh/MultiMeshVisitor.hpp>
+#include <wmtk/multimesh/MultiMeshSimplexVisitor.hpp>
 
 namespace wmtk {
 namespace {
@@ -38,7 +38,7 @@ MultiMeshLinkConditionInvariant::MultiMeshLinkConditionInvariant(const Mesh& m)
 {}
 bool MultiMeshLinkConditionInvariant::before(const Tuple& t) const
 {
-    multimesh::MultiMeshVisitor visitor(
+    multimesh::MultiMeshSimplexVisitor visitor(
         std::integral_constant<long, 1>{}, // specify that this runs on edges
         MultiMeshLinkConditionFunctor{});
     // TODO: fix visitor to work for const data

--- a/src/wmtk/invariants/MultiMeshMapValidInvariant.cpp
+++ b/src/wmtk/invariants/MultiMeshMapValidInvariant.cpp
@@ -7,7 +7,7 @@
 #include <wmtk/SimplicialComplex.hpp>
 #include <wmtk/TetMesh.hpp>
 #include <wmtk/TriMesh.hpp>
-#include <wmtk/multimesh/MultiMeshVisitor.hpp>
+#include <wmtk/multimesh/MultiMeshSimplexVisitor.hpp>
 #include <wmtk/simplex/top_dimension_cofaces.hpp>
 
 namespace wmtk {
@@ -103,7 +103,7 @@ MultiMeshMapValidInvariant::MultiMeshMapValidInvariant(const Mesh& m)
 {}
 bool MultiMeshMapValidInvariant::before(const Tuple& t) const
 {
-    multimesh::MultiMeshVisitor visitor(
+    multimesh::MultiMeshSimplexVisitor visitor(
         std::integral_constant<long, 1>{}, // specify that this runs on edges
         MultiMeshMapValidFunctor{});
     // TODO: fix visitor to work for const data

--- a/src/wmtk/invariants/MultiMeshTopologyInvariant.cpp
+++ b/src/wmtk/invariants/MultiMeshTopologyInvariant.cpp
@@ -7,7 +7,7 @@
 #include <wmtk/SimplicialComplex.hpp>
 #include <wmtk/TetMesh.hpp>
 #include <wmtk/TriMesh.hpp>
-#include <wmtk/multimesh/MultiMeshVisitor.hpp>
+#include <wmtk/multimesh/MultiMeshSimplexVisitor.hpp>
 #include <wmtk/simplex/Simplex.hpp>
 
 namespace wmtk {

--- a/src/wmtk/multimesh/CMakeLists.txt
+++ b/src/wmtk/multimesh/CMakeLists.txt
@@ -4,7 +4,7 @@ set(SRC_FILES
     same_simplex_dimension_surjection.cpp
     same_simplex_dimension_bijection.hpp
     same_simplex_dimension_bijection.cpp
-    MultiMeshVisitor.hpp
+    MultiMeshSimplexVisitor.hpp
     )
 target_sources(wildmeshing_toolkit PRIVATE ${SRC_FILES})
 

--- a/src/wmtk/multimesh/MultiMeshSimplexEventVisitor.hpp
+++ b/src/wmtk/multimesh/MultiMeshSimplexEventVisitor.hpp
@@ -1,14 +1,14 @@
 #pragma once
 
-#include "MultiMeshVisitor.hpp"
+#include "MultiMeshSimplexVisitor.hpp"
 
 namespace wmtk::multimesh {
 template <long cell_dimension, typename Functor>
-class MultiMeshEventVisitor
+class MultiMeshSimplexEventVisitor
 {
 public:
-    using VisitorType = MultiMeshVisitor<cell_dimension, Functor>;
-    MultiMeshEventVisitor(const MultiMeshVisitor<cell_dimension, Functor>& visitor)
+    using VisitorType = MultiMeshSimplexVisitor<cell_dimension, Functor>;
+    MultiMeshSimplexEventVisitor(const MultiMeshSimplexVisitor<cell_dimension, Functor>& visitor)
         : m_visitor(visitor)
     {}
     template <typename T>
@@ -32,12 +32,12 @@ private:
     const VisitorType& m_visitor;
 };
 template <long cell_dimension, typename Functor>
-MultiMeshEventVisitor(const MultiMeshVisitor<cell_dimension, Functor>& visitor)
-    -> MultiMeshEventVisitor<cell_dimension, Functor>;
+MultiMeshSimplexEventVisitor(const MultiMeshSimplexVisitor<cell_dimension, Functor>& visitor)
+    -> MultiMeshSimplexEventVisitor<cell_dimension, Functor>;
 
 template <long cell_dimension, typename Functor>
 template <typename EdgeFunctor>
-void MultiMeshEventVisitor<cell_dimension, Functor>::run_on_edges(EdgeFunctor&& edge_functor)
+void MultiMeshSimplexEventVisitor<cell_dimension, Functor>::run_on_edges(EdgeFunctor&& edge_functor)
 {
     // go through every edge event and run the edge functor on it
     for (const auto& pr : edge_events()) {
@@ -89,7 +89,7 @@ void MultiMeshEventVisitor<cell_dimension, Functor>::run_on_edges(EdgeFunctor&& 
 
 template <long cell_dimension, typename Functor>
 template <typename NodeFunctor>
-void MultiMeshEventVisitor<cell_dimension, Functor>::run_on_nodes(NodeFunctor&& node_functor)
+void MultiMeshSimplexEventVisitor<cell_dimension, Functor>::run_on_nodes(NodeFunctor&& node_functor)
 {
     // go through every edge event and run the edge functor on it
     for (const auto& event : node_events()) {

--- a/src/wmtk/multimesh/MultiMeshSimplexVisitor.hpp
+++ b/src/wmtk/multimesh/MultiMeshSimplexVisitor.hpp
@@ -22,10 +22,10 @@ namespace wmtk::multimesh {
 
 // if NodeFunctor returns a value then
 template <typename MMVisitor>
-class MultiMeshVisitorExecutor;
+class MultiMeshSimplexVisitorExecutor;
 
 template <long cell_dimension_, typename NodeFunctor_>
-class MultiMeshVisitor
+class MultiMeshSimplexVisitor
 {
 public:
     using MeshVariantTraits = wmtk::utils::metaprogramming::MeshVariantTraits;
@@ -60,7 +60,7 @@ public:
      *
      * @param f The functor that will be run on each mesh in the tree
      * */
-    MultiMeshVisitor(NodeFunctor&& f)
+    MultiMeshSimplexVisitor(NodeFunctor&& f)
         : m_node_functor(f)
     {}
 
@@ -68,14 +68,14 @@ public:
      * @param _ deduction hint that helps pick cell_dimension
      * @param f The functor that will be run on each mesh in the tree
      * */
-    MultiMeshVisitor(std::integral_constant<long, cell_dimension>, NodeFunctor&& f)
-        : MultiMeshVisitor(std::forward<NodeFunctor>(f))
+    MultiMeshSimplexVisitor(std::integral_constant<long, cell_dimension>, NodeFunctor&& f)
+        : MultiMeshSimplexVisitor(std::forward<NodeFunctor>(f))
     {}
 
 
     template <typename MMVisitor_>
-    friend class MultiMeshVisitorExecutor;
-    using Executor = MultiMeshVisitorExecutor<MultiMeshVisitor<cell_dimension, NodeFunctor>>;
+    friend class MultiMeshSimplexVisitorExecutor;
+    using Executor = MultiMeshSimplexVisitorExecutor<MultiMeshSimplexVisitor<cell_dimension, NodeFunctor>>;
 
     /* @brief executes the node functor (and potentially edge functor) from the subtree of the input
      * node
@@ -134,7 +134,7 @@ protected:
 
 // if NodeFunctor returns a value then
 template <typename MMVisitor>
-class MultiMeshVisitorExecutor
+class MultiMeshSimplexVisitorExecutor
 {
 public:
     constexpr static long cell_dimension = MMVisitor::cell_dimension;
@@ -149,7 +149,7 @@ public:
     constexpr static bool HasReturnCache =
         !wmtk::utils::metaprogramming::all_return_void_v<NodeFunctor, MeshVariantTraits, Simplex>;
 
-    MultiMeshVisitorExecutor(const MMVisitor& v)
+    MultiMeshSimplexVisitorExecutor(const MMVisitor& v)
         : visitor(v)
     {}
 
@@ -279,7 +279,7 @@ private:
                                 auto parent_id = m_return_data.get_id(current_mesh, simplex);
                                 auto child_id = m_return_data.get_id(child_mesh, child_simplex);
                                 // spdlog::info(
-                                //     "MultiMeshVisitor[{}=>{}] adding to edges edge simplex {}
+                                //     "MultiMeshSimplexVisitor[{}=>{}] adding to edges edge simplex {}
                                 //     " "child " "simplex{}",
                                 //     fmt::join(current_mesh.absolute_multi_mesh_id(), ","),
                                 //     fmt::join(child_mesh.absolute_multi_mesh_id(), ","),
@@ -309,11 +309,11 @@ private:
 
 
 template <long cell_dimension, typename NodeFunctor>
-MultiMeshVisitor(std::integral_constant<long, cell_dimension>, NodeFunctor&&)
-    -> MultiMeshVisitor<cell_dimension, NodeFunctor>;
+MultiMeshSimplexVisitor(std::integral_constant<long, cell_dimension>, NodeFunctor&&)
+    -> MultiMeshSimplexVisitor<cell_dimension, NodeFunctor>;
 
 template <typename NodeFunctor>
-MultiMeshVisitor(NodeFunctor&&) -> MultiMeshVisitor<0, NodeFunctor>;
+MultiMeshSimplexVisitor(NodeFunctor&&) -> MultiMeshSimplexVisitor<0, NodeFunctor>;
 
 
 } // namespace wmtk::multimesh

--- a/src/wmtk/operations/utils/multi_mesh_edge_collapse.cpp
+++ b/src/wmtk/operations/utils/multi_mesh_edge_collapse.cpp
@@ -1,7 +1,7 @@
 #include "multi_mesh_edge_collapse.hpp"
 #include <wmtk/invariants/InvariantCollection.hpp>
-#include <wmtk/multimesh/MultiMeshVisitor.hpp>
-#include <wmtk/multimesh/MultiMeshEventVisitor.hpp>
+#include <wmtk/multimesh/MultiMeshSimplexVisitor.hpp>
+#include <wmtk/multimesh/MultiMeshSimplexEventVisitor.hpp>
 #include <wmtk/operations/utils/MultiMeshEdgeCollapseFunctor.hpp>
 #include <wmtk/operations/utils/UpdateEdgeOperationMultiMeshMapFunctor.hpp>
 
@@ -18,12 +18,12 @@ std::shared_ptr<InvariantCollection> multimesh_edge_collapse_invariants(const Me
 
 CollapseReturnData multi_mesh_edge_collapse(Mesh& mesh, const Tuple& t)
 {
-    multimesh::MultiMeshVisitor visitor(
+    multimesh::MultiMeshSimplexVisitor visitor(
         std::integral_constant<long, 1>{}, // specify that this runs over edges
         MultiMeshEdgeCollapseFunctor{});
     visitor.execute_from_root(mesh, Simplex(PrimitiveType::Edge, t));
 
-    multimesh::MultiMeshEventVisitor event_visitor(visitor);
+    multimesh::MultiMeshSimplexEventVisitor event_visitor(visitor);
     event_visitor.run_on_nodes(UpdateEdgeOperationMultiMeshMapFunctor{});
 
     return visitor.cache();

--- a/src/wmtk/operations/utils/multi_mesh_edge_split.cpp
+++ b/src/wmtk/operations/utils/multi_mesh_edge_split.cpp
@@ -1,7 +1,7 @@
 #include "multi_mesh_edge_split.hpp"
 #include <wmtk/invariants/InvariantCollection.hpp>
-#include <wmtk/multimesh/MultiMeshEventVisitor.hpp>
-#include <wmtk/multimesh/MultiMeshVisitor.hpp>
+#include <wmtk/multimesh/MultiMeshSimplexEventVisitor.hpp>
+#include <wmtk/multimesh/MultiMeshSimplexVisitor.hpp>
 #include <wmtk/operations/utils/MultiMeshEdgeSplitFunctor.hpp>
 #include <wmtk/operations/utils/UpdateEdgeOperationMultiMeshMapFunctor.hpp>
 
@@ -18,11 +18,11 @@ std::shared_ptr<InvariantCollection> multimesh_edge_split_invariants(const Mesh&
 
 SplitReturnData multi_mesh_edge_split(Mesh& mesh, const Tuple& t)
 {
-    multimesh::MultiMeshVisitor visitor(
+    multimesh::MultiMeshSimplexVisitor visitor(
         std::integral_constant<long, 1>{}, // specify that this runs on edges
         MultiMeshEdgeSplitFunctor{});
     visitor.execute_from_root(mesh, Simplex(PrimitiveType::Edge, t));
-    multimesh::MultiMeshEventVisitor event_visitor(visitor);
+    multimesh::MultiMeshSimplexEventVisitor event_visitor(visitor);
     event_visitor.run_on_edges(UpdateEdgeOperationMultiMeshMapFunctor{});
     event_visitor.run_on_nodes(UpdateEdgeOperationMultiMeshMapFunctor{});
 

--- a/tests/multimesh/test_multi_mesh_visitor.cpp
+++ b/tests/multimesh/test_multi_mesh_visitor.cpp
@@ -5,8 +5,8 @@
 #include <wmtk/PointMesh.hpp>
 #include <wmtk/TetMesh.hpp>
 #include <wmtk/Types.hpp>
-#include <wmtk/multimesh/MultiMeshEventVisitor.hpp>
-#include <wmtk/multimesh/MultiMeshVisitor.hpp>
+#include <wmtk/multimesh/MultiMeshSimplexEventVisitor.hpp>
+#include <wmtk/multimesh/MultiMeshSimplexVisitor.hpp>
 #include <wmtk/multimesh/same_simplex_dimension_surjection.hpp>
 #include <wmtk/multimesh/utils/tuple_map_attribute_io.hpp>
 #include <wmtk/operations/tri_mesh/EdgeSplit.hpp>
@@ -89,7 +89,7 @@ TEST_CASE("test_multi_mesh_print_visitor", "[multimesh][2D]")
     parent.register_child_mesh(child2_ptr, child2_map);
 
 
-    multimesh::MultiMeshVisitor print_type_visitor(PrintTypeSizeFunctor{});
+    multimesh::MultiMeshSimplexVisitor print_type_visitor(PrintTypeSizeFunctor{});
 
     auto tups = parent.get_all(PrimitiveType::Face);
     for (const auto& t : tups) {
@@ -97,12 +97,12 @@ TEST_CASE("test_multi_mesh_print_visitor", "[multimesh][2D]")
     }
 
     spdlog::warn("edge visitor!");
-    multimesh::MultiMeshVisitor print_edge_visitor(GetTypeSizeFunctorWithReturn{});
+    multimesh::MultiMeshSimplexVisitor print_edge_visitor(GetTypeSizeFunctorWithReturn{});
 
 
     for (const auto& t : tups) {
         print_edge_visitor.execute_from_root(parent, Simplex(PF, t));
-        multimesh::MultiMeshEventVisitor print_edge_event_visitor(print_edge_visitor);
+        multimesh::MultiMeshSimplexEventVisitor print_edge_event_visitor(print_edge_visitor);
         print_edge_event_visitor.run_on_edges(PrintEdgeReturnsFunctor{});
     }
 }


### PR DESCRIPTION
the existing multimeshvisitor uses a simplex - i want to implement a multimeshvisitor that doesn't use the simplex (just browses the meshes), so i refactored the existing class name.
