### PR TITLE
removing need for explicit template parameters in parent_scope

### DIFF
--- a/src/wmtk/Mesh.hpp
+++ b/src/wmtk/Mesh.hpp
@@ -180,6 +180,8 @@ public:
      */
     template <typename T>
     T parent_scope(std::function<T()> f);
+    template <typename Functor, typename... Args>
+    decltype(auto) parent_scope_invoke(Functor&& f, Args&&... args);
 
 
     ConstAccessor<char> get_flag_accessor(PrimitiveType type) const;
@@ -710,12 +712,20 @@ long Mesh::get_attribute_dimension(const MeshAttributeHandle<T>& handle) const
 template <typename T>
 inline T Mesh::parent_scope(std::function<T()> f)
 {
-    return m_attribute_manager.parent_scope<T>(f);
+    return m_attribute_manager.parent_scope(f);
 }
 template <>
 inline void Mesh::parent_scope(std::function<void()> f)
 {
-    m_attribute_manager.parent_scope<void>(f);
+    m_attribute_manager.parent_scope(f);
+}
+
+template <typename Functor, typename... Args>
+decltype(auto) Mesh::parent_scope_invoke(Functor&& f, Args&&... args)
+{
+    return m_attribute_manager.parent_scope(
+        std::forward<Functor>(f),
+        std::forward<Args>(args)...);
 }
 
 inline Tuple Mesh::switch_vertex(const Tuple& tuple) const

--- a/src/wmtk/Mesh.hpp
+++ b/src/wmtk/Mesh.hpp
@@ -174,14 +174,12 @@ public:
      * @brief Evaluate the passed in function inside the parent scope.
      * The parent_scope function can be nested to reach deeper levels in the scope stack.
      *
-     * @tparam return type of f
      * @param f The function that is evaluated within the parent scope.
+     * @param args... The other arguments to this function
      * @returns The return value of f.
      */
-    template <typename T>
-    T parent_scope(std::function<T()> f);
     template <typename Functor, typename... Args>
-    decltype(auto) parent_scope_invoke(Functor&& f, Args&&... args);
+    decltype(auto) parent_scope(Functor&& f, Args&&... args);
 
 
     ConstAccessor<char> get_flag_accessor(PrimitiveType type) const;
@@ -709,23 +707,11 @@ long Mesh::get_attribute_dimension(const MeshAttributeHandle<T>& handle) const
     return m_attribute_manager.get_attribute_dimension(handle);
 }
 
-template <typename T>
-inline T Mesh::parent_scope(std::function<T()> f)
-{
-    return m_attribute_manager.parent_scope(f);
-}
-template <>
-inline void Mesh::parent_scope(std::function<void()> f)
-{
-    m_attribute_manager.parent_scope(f);
-}
 
 template <typename Functor, typename... Args>
-decltype(auto) Mesh::parent_scope_invoke(Functor&& f, Args&&... args)
+decltype(auto) Mesh::parent_scope(Functor&& f, Args&&... args)
 {
-    return m_attribute_manager.parent_scope(
-        std::forward<Functor>(f),
-        std::forward<Args>(args)...);
+    return m_attribute_manager.parent_scope(std::forward<Functor>(f), std::forward<Args>(args)...);
 }
 
 inline Tuple Mesh::switch_vertex(const Tuple& tuple) const

--- a/src/wmtk/attribute/AttributeManager.hpp
+++ b/src/wmtk/attribute/AttributeManager.hpp
@@ -4,6 +4,7 @@
 #include <wmtk/utils/Rational.hpp>
 #include "AttributeScopeHandle.hpp"
 #include "MeshAttributes.hpp"
+#include "internal/CheckpointScope.hpp"
 
 namespace wmtk {
 class Mesh;
@@ -14,6 +15,7 @@ template <typename T>
 class MeshAttributes;
 struct AttributeManager
 {
+    friend class internal::CheckpointScope;
     AttributeManager(long size);
     ~AttributeManager();
     AttributeManager(const AttributeManager& o);
@@ -71,8 +73,8 @@ struct AttributeManager
 
     void change_to_parent_scope();
     void change_to_leaf_scope();
-    template <typename T>
-    T parent_scope(std::function<T()> f);
+    template <typename Functor, typename... Args>
+    decltype(auto) parent_scope(Functor&& f, Args&&... args);
 
     template <typename T>
     long get_attribute_dimension(const MeshAttributeHandle<T>& handle) const;
@@ -141,20 +143,12 @@ MeshAttributeHandle<T> AttributeManager::register_attribute(
     r.m_primitive_type = ptype;
     return r;
 }
-template <typename T>
-inline T AttributeManager::parent_scope(std::function<T()> f)
+
+template <typename Functor, typename... Args>
+decltype(auto) AttributeManager::parent_scope(Functor&& f, Args&&... args)
 {
-    change_to_parent_scope();
-    T return_value = f();
-    change_to_leaf_scope();
-    return return_value;
-}
-template <>
-inline void AttributeManager::parent_scope(std::function<void()> f)
-{
-    change_to_parent_scope();
-    f();
-    change_to_leaf_scope();
+    internal::CheckpointScope scope(*this);
+    return std::invoke(std::forward<Functor>(f), std::forward<Args>(args)...);
 }
 template <typename T>
 long AttributeManager::get_attribute_dimension(const MeshAttributeHandle<T>& handle) const

--- a/src/wmtk/attribute/CMakeLists.txt
+++ b/src/wmtk/attribute/CMakeLists.txt
@@ -20,6 +20,10 @@ set(SRC_FILES
     AttributeScopeHandle.hpp
     AttributeScopeHandle.cpp
 
+
+    internal/CheckpointScope.hpp
+    internal/CheckpointScope.cpp
+
     AccessorBase.cpp
     AccessorBase.hpp
 

--- a/src/wmtk/attribute/internal/CheckpointScope.cpp
+++ b/src/wmtk/attribute/internal/CheckpointScope.cpp
@@ -1,0 +1,14 @@
+#include "CheckpointScope.hpp"
+
+#include <wmtk/attribute/AttributeManager.hpp>
+namespace wmtk::attribute::internal {
+CheckpointScope::CheckpointScope(wmtk::attribute::AttributeManager& manager)
+    : m_manager(manager)
+{
+    m_manager.change_to_parent_scope();
+}
+CheckpointScope::~CheckpointScope()
+{
+    m_manager.change_to_leaf_scope();
+}
+} // namespace wmtk::attribute::internal

--- a/src/wmtk/attribute/internal/CheckpointScope.hpp
+++ b/src/wmtk/attribute/internal/CheckpointScope.hpp
@@ -1,0 +1,15 @@
+#pragma once
+namespace wmtk::attribute {
+class AttributeManager;
+}
+namespace wmtk::attribute::internal {
+class CheckpointScope
+{
+public:
+    CheckpointScope(wmtk::attribute::AttributeManager& manager);
+    ~CheckpointScope();
+
+private:
+    wmtk::attribute::AttributeManager& m_manager;
+};
+} // namespace wmtk::attribute::internal

--- a/tests/test_accessor.cpp
+++ b/tests/test_accessor.cpp
@@ -342,7 +342,7 @@ TEST_CASE("accessor_parent_scope_access", "[accessor]")
             long_acc.scalar_attribute(t) = 1;
         }
 
-        m.parent_scope<void>([&]() {
+        m.parent_scope([&]() {
             for (const Tuple& t : m.get_all(PrimitiveType::Vertex)) {
                 CHECK(long_acc.scalar_attribute(t) == 0);
             }
@@ -350,7 +350,7 @@ TEST_CASE("accessor_parent_scope_access", "[accessor]")
 
         // return a value from the parent scope
         {
-            long parent_value = m.parent_scope<long>([&]() {
+            long parent_value = m.parent_scope([&]() {
                 for (const Tuple& t : m.get_all(PrimitiveType::Vertex)) {
                     return long_acc.scalar_attribute(t);
                 }
@@ -371,12 +371,12 @@ TEST_CASE("accessor_parent_scope_access", "[accessor]")
                 CHECK(long_acc.scalar_attribute(t) == 2);
             }
 
-            m.parent_scope<void>([&]() {
+            m.parent_scope([&]() {
                 for (const Tuple& t : m.get_all(PrimitiveType::Vertex)) {
                     CHECK(long_acc.scalar_attribute(t) == 1);
                 }
                 // parent of parent
-                m.parent_scope<void>([&]() {
+                m.parent_scope([&]() {
                     for (const Tuple& t : m.get_all(PrimitiveType::Vertex)) {
                         CHECK(long_acc.scalar_attribute(t) == 0);
                     }


### PR DESCRIPTION
removed teh use of std::function / explicitly requiring the explicit declaration of a template parameter. Adding a little RAII to handle checkpoint closing removed the need of temporarily storing the result of `std::invoke`.