### PR TITLE
495 least upper bound multi mesh mapping

### DIFF
--- a/src/wmtk/Mesh.cpp
+++ b/src/wmtk/Mesh.cpp
@@ -25,41 +25,31 @@ std::vector<Tuple> Mesh::get_all(PrimitiveType type) const
     return get_all(type, false);
 }
 
-std::tuple<
-std::vector<std::vector<long>>,
-std::vector<std::vector<long>>
-> 
-Mesh::consolidate()
+std::tuple<std::vector<std::vector<long>>, std::vector<std::vector<long>>> Mesh::consolidate()
 {
     // Number of dimensions
     long tcp = top_cell_dimension() + 1;
-    
+
     // Store the map from new indices to old. First index is dimensions, second simplex id
     std::vector<std::vector<long>> new2old(tcp);
     // Store the map from old indices to new. First index is dimensions, second simplex id
     std::vector<std::vector<long>> old2new(tcp);
 
     // Initialize both maps
-    for (long d = 0; d < tcp; d++) 
-    {
+    for (long d = 0; d < tcp; d++) {
         Accessor<char> flag_accessor = get_flag_accessor(wmtk::get_primitive_type_from_id(d));
-        for (long i = 0; i < capacity(wmtk::get_primitive_type_from_id(d)); ++i) 
-        {
-            if (flag_accessor.index_access().scalar_attribute(i) & 1)
-            {
+        for (long i = 0; i < capacity(wmtk::get_primitive_type_from_id(d)); ++i) {
+            if (flag_accessor.index_access().scalar_attribute(i) & 1) {
                 old2new[d].push_back(new2old[d].size());
-                new2old[d].push_back(old2new[d].size()-1); // -1 since we just pushed into it
-            }
-            else 
-            {
+                new2old[d].push_back(old2new[d].size() - 1); // -1 since we just pushed into it
+            } else {
                 old2new[d].push_back(-1);
             }
         }
     }
 
     // Use new2oldmap to compact all attributes
-    for (long d = 0; d < tcp; d++) 
-    {
+    for (long d = 0; d < tcp; d++) {
         attribute::MeshAttributes<char>& attributesc = m_attribute_manager.m_char_attributes[d];
         for (auto h = attributesc.m_attributes.begin(); h != attributesc.m_attributes.end(); h++)
             h->consolidate(new2old[d]);
@@ -72,28 +62,26 @@ Mesh::consolidate()
         for (auto h = attributesd.m_attributes.begin(); h != attributesd.m_attributes.end(); h++)
             h->consolidate(new2old[d]);
 
-        attribute::MeshAttributes<Rational>& attributesr = m_attribute_manager.m_rational_attributes[d];
+        attribute::MeshAttributes<Rational>& attributesr =
+            m_attribute_manager.m_rational_attributes[d];
         for (auto h = attributesr.m_attributes.begin(); h != attributesr.m_attributes.end(); h++)
             h->consolidate(new2old[d]);
     }
 
     // Update the attribute size in the manager
-    for (long d = 0; d < tcp; d++) 
-        m_attribute_manager.m_capacities[d] = new2old[d].size();
+    for (long d = 0; d < tcp; d++) m_attribute_manager.m_capacities[d] = new2old[d].size();
 
-    // Apply old2new to attributes containing indices 
+    // Apply old2new to attributes containing indices
     std::vector<std::vector<TypedAttributeHandle<long>>> handle_indices = connectivity_attributes();
 
-    for (long d = 0; d < tcp; d++)
-    {
-        for (long i = 0; i < handle_indices[d].size(); ++i)
-        {
+    for (long d = 0; d < tcp; d++) {
+        for (long i = 0; i < handle_indices[d].size(); ++i) {
             Accessor<long> accessor = create_accessor<long>(handle_indices[d][i]);
             accessor.attribute().index_remap(old2new[d]);
         }
     }
     // Return both maps for custom attribute remapping
-    return {new2old,old2new};
+    return {new2old, old2new};
 }
 
 std::vector<Tuple> Mesh::get_all(PrimitiveType type, const bool include_deleted) const
@@ -328,7 +316,8 @@ std::vector<Simplex> Mesh::lub_map(const Mesh& other_mesh, const Simplex& my_sim
     return m_multi_mesh_manager.lub_map(*this, other_mesh, my_simplex);
 }
 
-std::vector<Simplex> Mesh::lub_map(const Mesh& other_mesh, const std::vector<Simplex>& simplices) const
+std::vector<Simplex> Mesh::lub_map(const Mesh& other_mesh, const std::vector<Simplex>& simplices)
+    const
 {
     std::vector<Simplex> ret;
     ret.reserve(simplices.size());
@@ -383,6 +372,30 @@ Mesh::map_tuples(const Mesh& other_mesh, PrimitiveType pt, const std::vector<Tup
 
     return ret;
 }
+std::vector<Tuple> Mesh::lub_map_tuples(const Mesh& other_mesh, const Simplex& my_simplex) const
+{
+    if (!is_from_same_multi_mesh_structure(other_mesh)) {
+        throw std::runtime_error(
+            "Attempted to map between two simplices in different multi-mesh structures");
+    }
+    return m_multi_mesh_manager.lub_map_tuples(*this, other_mesh, my_simplex);
+}
+
+std::vector<Tuple> Mesh::lub_map_tuples(
+    const Mesh& other_mesh,
+    PrimitiveType pt,
+    const std::vector<Tuple>& tuples) const
+{
+    std::vector<Tuple> ret;
+    ret.reserve(tuples.size());
+    for (const auto& t : tuples) {
+        auto v = lub_map_tuples(other_mesh, Simplex(pt, t));
+        ret.insert(ret.end(), v.begin(), v.end());
+    }
+
+    return ret;
+}
+
 Tuple Mesh::map_to_parent_tuple(const Simplex& my_simplex) const
 {
     if (is_multi_mesh_root()) {

--- a/src/wmtk/Mesh.cpp
+++ b/src/wmtk/Mesh.cpp
@@ -319,6 +319,27 @@ std::vector<Simplex> Mesh::map(const Mesh& other_mesh, const std::vector<Simplex
     return ret;
 }
 
+std::vector<Simplex> Mesh::lub_map(const Mesh& other_mesh, const Simplex& my_simplex) const
+{
+    if (!is_from_same_multi_mesh_structure(other_mesh)) {
+        throw std::runtime_error(
+            "Attempted to map between two simplices in different multi-mesh structures");
+    }
+    return m_multi_mesh_manager.lub_map(*this, other_mesh, my_simplex);
+}
+
+std::vector<Simplex> Mesh::lub_map(const Mesh& other_mesh, const std::vector<Simplex>& simplices) const
+{
+    std::vector<Simplex> ret;
+    ret.reserve(simplices.size());
+    for (const auto& s : simplices) {
+        auto v = lub_map(other_mesh, s);
+        ret.insert(ret.end(), v.begin(), v.end());
+    }
+
+    return ret;
+}
+
 
 Simplex Mesh::map_to_parent(const Simplex& my_simplex) const
 {

--- a/src/wmtk/Mesh.hpp
+++ b/src/wmtk/Mesh.hpp
@@ -624,6 +624,34 @@ public:
         const std::vector<Tuple>& my_simplices) const;
 
     /**
+     * @brief maps a simplex from this mesh to any other mesh using LUB mesh as root
+     *
+     *
+     * Satisfies the same properties of standard map_tuples, but uses a the LUB as the root
+     *
+     *
+     * @param mesh the mesh a simplex should be mapped to
+     * @param simplex the simplex being mapped to the child mesh
+     * @returns every simplex that corresponds to this simplex
+     * */
+    std::vector<Tuple> lub_map_tuples(const Mesh& other_mesh, const Simplex& my_simplex) const;
+
+
+    /*
+     * @brief maps a collection of simplices from this mesh to any other mesh using LUB mesh as root
+     *
+     * Satisfies the same properties of standard map_tuples, but uses a the LUB as the root
+     *
+     * @param mesh the mesh the simplices should be mapped to
+     * @param simplices the simplices being mapped to the child mesh
+     * @returns every simplex that corresponds to the passed simplices
+     * */
+    std::vector<Tuple> lub_map_tuples(
+        const Mesh& other_mesh,
+        PrimitiveType pt,
+        const std::vector<Tuple>& my_simplices) const;
+
+    /**
      * @brief optimized map from a simplex from this mesh to its direct parent
      *
      *

--- a/src/wmtk/Mesh.hpp
+++ b/src/wmtk/Mesh.hpp
@@ -530,6 +530,32 @@ public:
         const;
 
     /**
+     * @brief maps a simplex from this mesh to any other mesh using LUB mesh as root
+     *
+     *
+     * Satisfies the same properties of standard map, but uses a the LUB as the root
+     *
+     *
+     * @param mesh the mesh a simplex should be mapped to
+     * @param simplex the simplex being mapped to the child mesh
+     * @returns every simplex that corresponds to this simplex
+     * */
+    std::vector<Simplex> lub_map(const Mesh& other_mesh, const Simplex& my_simplex) const;
+
+
+    /*
+     * @brief maps a collection of simplices from this mesh to any other mesh using LUB mesh as root
+     *
+     * Satisfies the same properties of standard map, but uses a the LUB as the root
+     *
+     * @param mesh the mesh the simplices should be mapped to
+     * @param simplices the simplices being mapped to the child mesh
+     * @returns every simplex that corresponds to the passed simplices
+     * */
+    std::vector<Simplex> lub_map(const Mesh& other_mesh, const std::vector<Simplex>& my_simplices)
+        const;
+
+    /**
      * @brief optimized map from a simplex from this mesh to its direct parent
      *
      *

--- a/src/wmtk/MultiMeshManager.cpp
+++ b/src/wmtk/MultiMeshManager.cpp
@@ -1104,7 +1104,7 @@ std::vector<long> MultiMeshManager::relative_id(
     const std::vector<long>& parent,
     const std::vector<long>& child)
 {
-    assert(parent.size() < child.size());
+    assert(parent.size() <= child.size());
 #if !defined(NDEBUG)
     for (size_t j = 0; j < parent.size(); ++j) {
         assert(parent[j] == child[j]);

--- a/src/wmtk/MultiMeshManager.cpp
+++ b/src/wmtk/MultiMeshManager.cpp
@@ -249,36 +249,52 @@ MultiMeshManager::map(const Mesh& my_mesh, const Mesh& other_mesh, const Simplex
         ret_tups,
         my_simplex.primitive_type());
 }
-std::vector<Tuple> MultiMeshManager::map_tuples(
+std::vector<Simplex> MultiMeshManager::lub_map(
     const Mesh& my_mesh,
     const Mesh& other_mesh,
     const Simplex& my_simplex) const
 {
-    const PrimitiveType pt = my_simplex.primitive_type();
+    const auto ret_tups = lub_map_tuples(my_mesh, other_mesh, my_simplex);
+    return simplex::utils::tuple_vector_to_homogeneous_simplex_vector(
+        ret_tups,
+        my_simplex.primitive_type());
+}
+
+std::pair<const Mesh&, Tuple>
+MultiMeshManager::map_up_to_tuples(const Mesh& my_mesh, const Simplex& my_simplex, long depth) const
+{
     assert((&my_mesh.m_multi_mesh_manager) == this);
-    std::vector<Tuple> equivalent_tuples =
-        simplex::top_dimension_cofaces_tuples(my_mesh, my_simplex);
-    // MultiMeshMapVisitor visitor(my_mesh, other_mesh);
-    // const auto my_id = absolute_id(); someday could be used to map down
-    const auto other_id = other_mesh.absolute_multi_mesh_id();
+    const PrimitiveType pt = my_simplex.primitive_type();
 
     // get a root tuple by converting the tuple up parent meshes until root is found
     Tuple cur_tuple = my_simplex.tuple();
     const Mesh* cur_mesh = &my_mesh;
-    while (!cur_mesh->m_multi_mesh_manager
-                .is_root()) { // cur_mesh == nullptr if we just walked past the root node so we stop
+    for (long d = 0; d < depth; ++d) {
         cur_tuple = cur_mesh->m_multi_mesh_manager.map_tuple_to_parent_tuple(*cur_mesh, cur_tuple);
         cur_mesh = cur_mesh->m_multi_mesh_manager.m_parent;
+        assert(cur_mesh != nullptr);
     }
+    assert(cur_mesh->m_multi_mesh_manager
+               .is_root()); // cur_mesh == nullptr if we just walked past the root node so we stop
 
     // bieng lazy about how i set cur_mesh to nullptr above - could simplify the loop to optimize
+    return std::pair<const Mesh&, Tuple>(*cur_mesh, cur_tuple);
+}
 
+std::vector<Tuple> MultiMeshManager::map_down_relative_tuples(
+    const Mesh& my_mesh,
+    const Simplex& my_simplex,
+    const std::vector<long>& relative_id) const
+{
+    assert((&my_mesh.m_multi_mesh_manager) == this);
 
+    const PrimitiveType pt = my_simplex.primitive_type();
     // note that (cur_mesh, tuples) always match (i.e tuples are tuples from cur_mesh)
     std::vector<Tuple> tuples;
-    tuples.emplace_back(cur_tuple);
+    tuples.emplace_back(my_simplex.tuple());
+    const Mesh* cur_mesh = &my_mesh;
 
-    for (auto it = other_id.cbegin(); it != other_id.cend(); ++it) {
+    for (auto it = relative_id.cbegin(); it != relative_id.cend(); ++it) {
         // get the select ID from the child map
         long child_index = *it;
         const ChildData& cd = cur_mesh->m_multi_mesh_manager.m_children.at(child_index);
@@ -303,6 +319,44 @@ std::vector<Tuple> MultiMeshManager::map_tuples(
     // visitor.map(equivalent_tuples, my_simplex.primitive_type());
 
     return tuples;
+}
+
+std::vector<Tuple> MultiMeshManager::map_tuples(
+    const Mesh& my_mesh,
+    const Mesh& other_mesh,
+    const Simplex& my_simplex) const
+{
+    const auto my_id = absolute_id();
+    const auto other_id = other_mesh.absolute_multi_mesh_id();
+
+    long depth = my_id.size();
+
+    auto [root_ref, tuple] = map_up_to_tuples(my_mesh, my_simplex, depth);
+    const Simplex simplex(my_simplex.primitive_type(), tuple);
+
+    return root_ref.m_multi_mesh_manager.map_down_relative_tuples(root_ref, simplex, other_id);
+}
+
+std::vector<Tuple> MultiMeshManager::lub_map_tuples(
+    const Mesh& my_mesh,
+    const Mesh& other_mesh,
+    const Simplex& my_simplex) const
+{
+    const auto my_id = absolute_id();
+    const auto other_id = other_mesh.absolute_multi_mesh_id();
+    const auto lub_id = least_upper_bound_id(my_id, other_id);
+
+    long depth = my_id.size() - lub_id.size();
+
+    auto [local_root_ref, tuple] = map_up_to_tuples(my_mesh, my_simplex, depth);
+
+    const Simplex simplex(my_simplex.primitive_type(), tuple);
+
+    auto other_relative_id = relative_id(lub_id, other_id);
+    return local_root_ref.m_multi_mesh_manager.map_down_relative_tuples(
+        local_root_ref,
+        simplex,
+        other_relative_id);
 }
 
 Simplex MultiMeshManager::map_to_root(const Mesh& my_mesh, const Simplex& my_simplex) const
@@ -1030,5 +1084,36 @@ void MultiMeshManager::check_child_map_valid(const Mesh& my_mesh, const ChildDat
     }
 }
 
+
+std::vector<long> MultiMeshManager::least_upper_bound_id(
+    const std::vector<long>& a,
+    const std::vector<long>& b)
+{
+    std::vector<long> ret;
+    size_t size = std::min(a.size(), b.size());
+    for (size_t j = 0; j < size; ++j) {
+        if (a[j] == b[j]) {
+            ret.emplace_back(a[j]);
+        } else {
+            break;
+        }
+    }
+    return ret;
+}
+std::vector<long> MultiMeshManager::relative_id(
+    const std::vector<long>& parent,
+    const std::vector<long>& child)
+{
+    assert(parent.size() < child.size());
+#if !defined(NDEBUG)
+    for (size_t j = 0; j < parent.size(); ++j) {
+        assert(parent[j] == child[j]);
+    }
+
+#endif
+    std::vector<long> ret;
+    std::copy(child.begin() + parent.size(), child.end(), std::back_inserter(ret));
+    return ret;
+}
 
 } // namespace wmtk

--- a/src/wmtk/MultiMeshManager.hpp
+++ b/src/wmtk/MultiMeshManager.hpp
@@ -149,6 +149,34 @@ public:
     std::vector<Simplex> map(const Mesh& my_mesh, const Mesh& other_mesh, const Simplex& my_simplex)
         const;
     /**
+     * @brief maps a simplex from this mesh to any other mesh using the LUB as the root
+     *
+     *
+     * Satisfies the same properties of standard map, but uses a the LUB as the root
+     *
+     *
+     * @param my_mesh the mesh that this structure is owned by
+     * @param the mesh a simplex should be mapped to
+     * @param the simplex being mapped to the child mesh
+     * @returns every simplex that could correspond to this simplex, without the dimension encoded
+     * */
+    std::vector<Tuple>
+    lub_map_tuples(const Mesh& my_mesh, const Mesh& other_mesh, const Simplex& my_simplex) const;
+
+
+    /**
+     * @brief maps a simplex from this mesh to any other mesh using the LUB as the root
+     *
+     * Satisfies the same properties of standard map, but uses a the LUB as the root
+     *
+     * @param my_mesh the mesh that this structure is owned by
+     * @param the mesh a simplex should be mapped to
+     * @param the simplex being mapped to the child mesh
+     * @returns every simplex that could correspond to this simplex, without the dimension encoded
+     * */
+    std::vector<Simplex>
+    lub_map(const Mesh& my_mesh, const Mesh& other_mesh, const Simplex& my_simplex) const;
+    /**
      * @brief maps a simplex from this mesh to any other mesh
      *
      *
@@ -168,7 +196,6 @@ public:
      * */
     std::vector<Tuple>
     map_tuples(const Mesh& my_mesh, const Mesh& other_mesh, const Simplex& my_simplex) const;
-
 
     /**
      * @brief optimized map from a simplex from this mesh to its direct parent
@@ -389,6 +416,25 @@ protected: // protected to enable unit testing
     static long parent_global_cid(
         const attribute::ConstAccessor<long>& child_to_parent,
         long child_gid);
+
+
+    // internal function for mapping up a multimesh tree by a certain number of edges
+    //
+    // @return the mesh found at the top and the tuple that was found
+    std::pair<const Mesh&, Tuple>
+    map_up_to_tuples(const Mesh& my_mesh, const Simplex& simplex, long depth) const;
+
+    // internal function for mapping down a multimesh tree by following a sequence of ids
+    //
+    // @return the mesh found at the top and the tuple that was found
+    std::vector<Tuple> map_down_relative_tuples(
+        const Mesh& my_mesh,
+        const Simplex& my_simplex,
+        const std::vector<long>& local_id_path) const;
+
+
+    static std::vector<long> least_upper_bound_id(const std::vector<long>& a, const std::vector<long>& b);
+    static std::vector<long> relative_id(const std::vector<long>& parent, const std::vector<long>& child);
 
 private:
     // this is defined internally but is preferablly invoked through the multimesh free function

--- a/tests/multimesh/test_multi_mesh.cpp
+++ b/tests/multimesh/test_multi_mesh.cpp
@@ -225,6 +225,9 @@ TEST_CASE("test_register_child_mesh", "[multimesh][2D]")
                     auto c0tuples = parent.map_to_child_tuples(child0, psimplex);
                     REQUIRE(c0tuples.size() == 1);
                     CHECK(c0tuples[0] == c0_expected);
+
+                    auto c0tuples_lub = parent.lub_map_tuples(child0, psimplex);
+                    CHECK(c0tuples == c0tuples_lub);
                 }
 
                 Tuple c1_expected = p_to_c1_map[parent_index];
@@ -232,6 +235,9 @@ TEST_CASE("test_register_child_mesh", "[multimesh][2D]")
                     auto c1tuples = parent.map_to_child_tuples(child1, psimplex);
                     REQUIRE(c1tuples.size() == 1);
                     CHECK(c1tuples[0] == c1_expected);
+
+                    auto c1tuples_lub = parent.lub_map_tuples(child1, psimplex);
+                    CHECK(c1tuples == c1tuples_lub);
                 }
             }
             for (size_t child0_index = 0; child0_index < c0_to_p_map.size(); ++child0_index) {
@@ -239,12 +245,21 @@ TEST_CASE("test_register_child_mesh", "[multimesh][2D]")
                 Simplex csimplex = Simplex(PF, tuple);
                 auto ptuple = child0.map_to_parent_tuple(csimplex);
                 CHECK(ptuple == c0_to_p_map[child0_index]);
+
+                auto parents_lub = child0.lub_map_tuples(parent, csimplex);
+                REQUIRE(parents_lub.size() == 1);
+
+                CHECK(parents_lub[0] == ptuple);
             }
             for (size_t child1_index = 0; child1_index < c1_to_p_map.size(); ++child1_index) {
                 auto tuple = child1.tuple_from_id(PF, child1_index);
                 Simplex csimplex = Simplex(PF, tuple);
                 auto ptuple = child1.map_to_parent_tuple(csimplex);
                 CHECK(ptuple == c1_to_p_map[child1_index]);
+
+                auto parents_lub = child1.lub_map_tuples(parent,csimplex);
+                REQUIRE(parents_lub.size() == 1);
+                CHECK(parents_lub[0] == ptuple);
             }
         }
     }


### PR DESCRIPTION
when we have multimeshes whose trees have depth > 1 we don't always want to go to through the root node. For instance, say we have

unseamed position mesh -> seamed uv mesh - > {boundary edg emeshes}_{j=1..n}

then a tuple for a map( tuple from boundary_edge  -> uv mesh)  will usually return two edges rather than one. this is because the standard map goes all hte way up to the position mesh to find all copies of an edge - and so both sides of a seam will be caught.

least-upper-bound mapping (`lub_map`) identifies that `lub(uv,boundary edge) == uv` so the `uv` mesh is used as the "root" of the mapping operation. 

Note that `lub_map` is a strict generalization of `map_to_child` and `map_to_parent` - it always returns the same values as those two operations (albeit in teh latter a vector of size 1).

this iwll be useful in attribute transfer - consider the case where we want to update the uv  value on a uv mesh by transforming values from  a boundary edge mesh - we do not want each edgemesh vertex to update both sides of the seam. The immediate approach for this would be to use `map_to_parent`, which guarantees uniqueness / not to catch the other side of a seam - but this is not sustainable in a generic API without making attribute transfer classes for different relative multimesh structures. Therefore `lub_map` - which generalizes `map_to_child` and `map_to_parent` is useful here.