### PR TITLE
adding opt-in optimization for invariants that dont use before or after

### DIFF
--- a/src/wmtk/invariants/EdgeValenceInvariant.cpp
+++ b/src/wmtk/invariants/EdgeValenceInvariant.cpp
@@ -4,7 +4,7 @@
 
 namespace wmtk::invariants {
 EdgeValenceInvariant::EdgeValenceInvariant(const Mesh& m, int64_t valence)
-    : Invariant(m)
+    : Invariant(m,true,false,false)
     , m_valence(valence)
 {}
 

--- a/src/wmtk/invariants/EdgeValenceInvariant.hpp
+++ b/src/wmtk/invariants/EdgeValenceInvariant.hpp
@@ -13,7 +13,6 @@ class EdgeValenceInvariant : public Invariant
 {
 public:
     EdgeValenceInvariant(const Mesh& m, int64_t valence);
-    using Invariant::Invariant;
 
     bool before(const simplex::Simplex& t) const override;
 

--- a/src/wmtk/invariants/FunctionInvariant.cpp
+++ b/src/wmtk/invariants/FunctionInvariant.cpp
@@ -8,7 +8,7 @@ namespace wmtk::invariants {
 FunctionInvariant::FunctionInvariant(
     const PrimitiveType type,
     const std::shared_ptr<function::PerSimplexFunction>& func)
-    : Invariant(func->mesh())
+    : Invariant(func->mesh(), false, true, true)
     , m_func(func)
     , m_type(type)
 {}
@@ -17,18 +17,16 @@ bool FunctionInvariant::after(
     const std::vector<Tuple>& top_dimension_tuples_before,
     const std::vector<Tuple>& top_dimension_tuples_after) const
 {
-    const double before = mesh().parent_scope([&]() {
+    auto sum = [&](const std::vector<Tuple>& tuples) {
         double _before = 0;
-        for (const auto& t : top_dimension_tuples_before)
-            _before += m_func->get_value(simplex::Simplex(m_type, t));
+        for (const auto& t : tuples) _before += m_func->get_value(simplex::Simplex(m_type, t));
 
         return _before;
-    });
+    };
 
 
-    double after = 0;
-    for (const auto& t : top_dimension_tuples_after)
-        after += m_func->get_value(simplex::Simplex(m_type, t));
+    const double before = mesh().parent_scope(sum, top_dimension_tuples_before);
+    const double after = sum(top_dimension_tuples_after);
 
     return after < before;
 }

--- a/src/wmtk/invariants/InteriorSimplexInvariant.cpp
+++ b/src/wmtk/invariants/InteriorSimplexInvariant.cpp
@@ -1,10 +1,10 @@
 #include "InteriorSimplexInvariant.hpp"
-#include <wmtk/simplex/Simplex.hpp>
 #include <wmtk/Mesh.hpp>
+#include <wmtk/simplex/Simplex.hpp>
 
 namespace wmtk::invariants {
 InteriorSimplexInvariant::InteriorSimplexInvariant(const Mesh& m, PrimitiveType pt)
-    : Invariant(m)
+    : Invariant(m, true, false, false)
     , m_primitive_type(pt)
 {}
 bool InteriorSimplexInvariant::before(const simplex::Simplex& t) const

--- a/src/wmtk/invariants/Invariant.hpp
+++ b/src/wmtk/invariants/Invariant.hpp
@@ -18,7 +18,14 @@ public:
     virtual bool after(
         const std::vector<Tuple>& top_dimension_tuples_before,
         const std::vector<Tuple>& top_dimension_tuples_after) const;
+
+    // have an invariant that sets all three by default
     Invariant(const Mesh& m);
+    Invariant(
+        const Mesh& m,
+        bool use_before,
+        bool use_old_state_in_after,
+        bool use_new_state_in_after);
     virtual ~Invariant();
 
     const Mesh& mesh() const;
@@ -28,8 +35,17 @@ public:
         const std::vector<simplex::Simplex>& simplices_before,
         const std::vector<simplex::Simplex>& simplices_after) const;
 
+
+    bool use_before() const;
+    bool use_after() const;
+    bool use_old_state_in_after() const;
+    bool use_new_state_in_after() const;
+
 private:
     const Mesh& m_mesh;
+    const bool m_use_before = true;
+    const bool m_use_old_state_in_after = true;
+    const bool m_use_new_state_in_after = true;
 
     const std::vector<Tuple> get_top_dimension_cofaces(
         const std::vector<simplex::Simplex>& simplices) const;

--- a/src/wmtk/invariants/InvariantCollection.cpp
+++ b/src/wmtk/invariants/InvariantCollection.cpp
@@ -6,7 +6,7 @@
 namespace wmtk {
 
 InvariantCollection::InvariantCollection(const Mesh& m)
-    : Invariant(m)
+    : Invariant(m, true, true, true)
 {}
 InvariantCollection::~InvariantCollection() = default;
 InvariantCollection::InvariantCollection(const InvariantCollection&) = default;
@@ -51,16 +51,22 @@ bool InvariantCollection::after(
 {
     for (const auto& invariant : m_invariants) {
         if (&mesh() != &invariant->mesh()) {
-            auto mapped_tuples_after = mesh().map_tuples(
-                invariant->mesh(),
-                mesh().top_simplex_type(),
-                top_dimension_tuples_after);
-            auto mapped_tuples_before = mesh().parent_scope([&]() {
+            const bool invariant_uses_old_state = invariant->use_old_state_in_after();
+            const bool invariant_uses_new_state = invariant->use_new_state_in_after();
+            if (!(invariant_uses_old_state || invariant_uses_new_state)) {
+                continue;
+            }
+            auto map = [&](const auto& tuples) {
                 return mesh().map_tuples(
                     invariant->mesh(),
                     mesh().top_simplex_type(),
-                    top_dimension_tuples_before);
-            });
+                    top_dimension_tuples_after);
+            };
+            const std::vector<Tuple> mapped_tuples_after =
+                invariant_uses_new_state ? map(top_dimension_tuples_after) : std::vector<Tuple>{};
+            const std::vector<Tuple> mapped_tuples_before =
+                invariant_uses_old_state ? mesh().parent_scope(map, top_dimension_tuples_before)
+                                         : std::vector<Tuple>{};
             if (!invariant->after(mapped_tuples_before, mapped_tuples_after)) {
                 return false;
             }

--- a/src/wmtk/invariants/MaxEdgeLengthInvariant.cpp
+++ b/src/wmtk/invariants/MaxEdgeLengthInvariant.cpp
@@ -7,7 +7,7 @@ MaxEdgeLengthInvariant::MaxEdgeLengthInvariant(
     const Mesh& m,
     const TypedAttributeHandle<double>& coordinate,
     double threshold_squared)
-    : Invariant(m)
+    : Invariant(m, true, false, false)
     , m_coordinate_handle(coordinate)
     , m_threshold_squared(threshold_squared)
 {}

--- a/src/wmtk/invariants/MaxEdgeLengthInvariant.hpp
+++ b/src/wmtk/invariants/MaxEdgeLengthInvariant.hpp
@@ -12,7 +12,6 @@ public:
         const Mesh& m,
         const TypedAttributeHandle<double>& coordinate,
         double threshold_squared);
-    using Invariant::Invariant;
     bool before(const simplex::Simplex& t) const override;
 
 private:

--- a/src/wmtk/invariants/MaxFunctionInvariant.cpp
+++ b/src/wmtk/invariants/MaxFunctionInvariant.cpp
@@ -17,18 +17,18 @@ bool MaxFunctionInvariant::after(
     const std::vector<Tuple>& top_dimension_tuples_before,
     const std::vector<Tuple>& top_dimension_tuples_after) const
 {
-    const double before = mesh().parent_scope([&]() {
-        double _before = std::numeric_limits<double>::lowest();
-        for (const auto& t : top_dimension_tuples_before)
-            _before = std::max(_before, m_func->get_value(simplex::Simplex(m_type, t)));
 
-        return _before;
-    });
+    auto max = [&](const std::vector<Tuple>& tuples) {
+        double value = std::numeric_limits<double>::lowest();
+        for (const auto& t : tuples)
+            value = std::max(value, m_func->get_value(simplex::Simplex(m_type, t)));
+
+        return value;
+    };
+    const double before = mesh().parent_scope(max, top_dimension_tuples_before);
 
 
-    double after = std::numeric_limits<double>::lowest();
-    for (const auto& t : top_dimension_tuples_after)
-        after = std::max(after, m_func->get_value(simplex::Simplex(m_type, t)));
+    const double after = max(top_dimension_tuples_after);
 
     return after < before;
 }

--- a/src/wmtk/invariants/MinEdgeLengthInvariant.cpp
+++ b/src/wmtk/invariants/MinEdgeLengthInvariant.cpp
@@ -7,7 +7,7 @@ MinEdgeLengthInvariant::MinEdgeLengthInvariant(
     const Mesh& m,
     const TypedAttributeHandle<double>& coordinate,
     double threshold_squared)
-    : Invariant(m)
+    : Invariant(m, true, false, false)
     , m_coordinate_handle(coordinate)
     , m_threshold_squared(threshold_squared)
 {}

--- a/src/wmtk/invariants/MinEdgeLengthInvariant.hpp
+++ b/src/wmtk/invariants/MinEdgeLengthInvariant.hpp
@@ -14,7 +14,6 @@ public:
         const Mesh& m,
         const TypedAttributeHandle<double>& coordinate,
         double threshold_squared);
-    using Invariant::Invariant;
     bool before(const simplex::Simplex& t) const override;
 
 private:

--- a/src/wmtk/invariants/MinIncidentValenceInvariant.cpp
+++ b/src/wmtk/invariants/MinIncidentValenceInvariant.cpp
@@ -8,7 +8,7 @@ namespace wmtk::invariants {
 
 
 MinIncidentValenceInvariant::MinIncidentValenceInvariant(const Mesh& m, int64_t min_valence)
-    : Invariant(m)
+    : Invariant(m, true, false, false)
     , m_min_valence(min_valence)
 {}
 

--- a/src/wmtk/invariants/MinIncidentValenceInvariant.hpp
+++ b/src/wmtk/invariants/MinIncidentValenceInvariant.hpp
@@ -11,7 +11,6 @@ class MinIncidentValenceInvariant : public Invariant
 {
 public:
     MinIncidentValenceInvariant(const Mesh& m, int64_t min_valence);
-    using Invariant::Invariant;
     bool before(const simplex::Simplex& t) const override;
     bool after(
         const std::vector<Tuple>& top_dimension_tuples_before,

--- a/src/wmtk/invariants/MultiMeshLinkConditionInvariant.cpp
+++ b/src/wmtk/invariants/MultiMeshLinkConditionInvariant.cpp
@@ -34,7 +34,7 @@ struct MultiMeshLinkConditionFunctor
 } // namespace
 
 MultiMeshLinkConditionInvariant::MultiMeshLinkConditionInvariant(const Mesh& m)
-    : Invariant(m)
+    : Invariant(m, true, false, false)
 {}
 bool MultiMeshLinkConditionInvariant::before(const simplex::Simplex& t) const
 {

--- a/src/wmtk/invariants/MultiMeshMapValidInvariant.cpp
+++ b/src/wmtk/invariants/MultiMeshMapValidInvariant.cpp
@@ -98,7 +98,7 @@ struct MultiMeshMapValidFunctor
 } // namespace
 
 MultiMeshMapValidInvariant::MultiMeshMapValidInvariant(const Mesh& m)
-    : Invariant(m)
+    : Invariant(m, true, false, false)
 {}
 bool MultiMeshMapValidInvariant::before(const simplex::Simplex& t) const
 {

--- a/src/wmtk/invariants/MultiMeshTopologyInvariant.cpp
+++ b/src/wmtk/invariants/MultiMeshTopologyInvariant.cpp
@@ -13,7 +13,7 @@ namespace wmtk {
 MultiMeshEdgeTopologyInvariant::MultiMeshEdgeTopologyInvariant(
     const Mesh& parent,
     const EdgeMesh& child)
-    : Invariant(parent)
+    : Invariant(parent, true, false, false)
     , m_child_mesh(child)
 {}
 

--- a/src/wmtk/invariants/NoBoundaryCollapseToInteriorInvariant.cpp
+++ b/src/wmtk/invariants/NoBoundaryCollapseToInteriorInvariant.cpp
@@ -4,7 +4,7 @@
 
 namespace wmtk::invariants {
 NoBoundaryCollapseToInteriorInvariant::NoBoundaryCollapseToInteriorInvariant(const Mesh& m)
-    : Invariant(m)
+    : Invariant(m, true, false, false)
 {}
 
 bool NoBoundaryCollapseToInteriorInvariant::before(const simplex::Simplex& t) const

--- a/src/wmtk/invariants/SimplexInversionInvariant.cpp
+++ b/src/wmtk/invariants/SimplexInversionInvariant.cpp
@@ -8,12 +8,12 @@ namespace wmtk {
 SimplexInversionInvariant::SimplexInversionInvariant(
     const Mesh& m,
     const TypedAttributeHandle<double>& coordinate)
-    : Invariant(m)
+    : Invariant(m, true, false, true)
     , m_coordinate_handle(coordinate)
 {}
 
 bool SimplexInversionInvariant::after(
-    const std::vector<Tuple>& top_dimension_tuples_before,
+    const std::vector<Tuple>&,
     const std::vector<Tuple>& top_dimension_tuples_after) const
 {
     ConstAccessor<double> accessor = mesh().create_accessor(m_coordinate_handle);

--- a/src/wmtk/invariants/SimplexInversionInvariant.hpp
+++ b/src/wmtk/invariants/SimplexInversionInvariant.hpp
@@ -14,9 +14,8 @@ public:
      *  we assume with local vid order (v0,v1,v2,v3) has positive volume (orient3d(v0,v1,v2,v3)>0)
      a CLOCKWISE input tuple will have the same orientation as the local vid order
      */
-    bool after(
-        const std::vector<Tuple>& top_dimension_tuples_before,
-        const std::vector<Tuple>& top_dimension_tuples_after) const override;
+    bool after(const std::vector<Tuple>&, const std::vector<Tuple>& top_dimension_tuples_after)
+        const override;
 
 private:
     const TypedAttributeHandle<double> m_coordinate_handle;

--- a/src/wmtk/invariants/TetMeshSubstructureTopologyPreservingInvariant.cpp
+++ b/src/wmtk/invariants/TetMeshSubstructureTopologyPreservingInvariant.cpp
@@ -13,7 +13,7 @@ TetMeshSubstructureTopologyPreservingInvariant::TetMeshSubstructureTopologyPrese
     const TypedAttributeHandle<int64_t>& substructure_face_tag_handle,
     const TypedAttributeHandle<int64_t>& substructure_edge_tag_handle,
     const int64_t substructure_tag_value)
-    : Invariant(m)
+    : Invariant(m, true, false, false)
     , m_substructure_face_tag_handle(substructure_face_tag_handle)
     , m_substructure_edge_tag_handle(substructure_edge_tag_handle)
     , m_substructure_tag_value(substructure_tag_value)

--- a/src/wmtk/invariants/TodoInvariant.cpp
+++ b/src/wmtk/invariants/TodoInvariant.cpp
@@ -6,7 +6,7 @@ TodoInvariant::TodoInvariant(
     const Mesh& m,
     const TypedAttributeHandle<int64_t>& todo_handle,
     const int64_t val)
-    : Invariant(m)
+    : Invariant(m, true, false, false)
     , m_todo_handle(todo_handle)
     , m_val(val)
 {}
@@ -22,7 +22,7 @@ TodoLargerInvariant::TodoLargerInvariant(
     const Mesh& m,
     const TypedAttributeHandle<double>& todo_handle,
     const double val)
-    : Invariant(m)
+    : Invariant(m, true, false, false)
     , m_todo_handle(todo_handle)
     , m_val(val)
 {}
@@ -38,7 +38,7 @@ TodoSmallerInvariant::TodoSmallerInvariant(
     const Mesh& m,
     const TypedAttributeHandle<double>& todo_handle,
     const double val)
-    : Invariant(m)
+    : Invariant(m, true, false, false)
     , m_todo_handle(todo_handle)
     , m_val(val)
 {}

--- a/src/wmtk/invariants/TriMeshSubstructureTopologyPreservingInvariant.cpp
+++ b/src/wmtk/invariants/TriMeshSubstructureTopologyPreservingInvariant.cpp
@@ -12,7 +12,7 @@ TriMeshSubstructureTopologyPreservingInvariant::TriMeshSubstructureTopologyPrese
     const Mesh& m,
     const TypedAttributeHandle<int64_t>& substructure_edge_tag_handle,
     const int64_t substructure_tag_value)
-    : Invariant(m)
+    : Invariant(m, true, false, false)
     , m_substructure_edge_tag_handle(substructure_edge_tag_handle)
     , m_substructure_tag_value(substructure_tag_value)
 {}

--- a/src/wmtk/invariants/ValenceImprovementInvariant.cpp
+++ b/src/wmtk/invariants/ValenceImprovementInvariant.cpp
@@ -6,7 +6,7 @@
 
 namespace wmtk::invariants {
 ValenceImprovementInvariant::ValenceImprovementInvariant(const Mesh& m)
-    : Invariant(m)
+    : Invariant(m, true, false, false)
 {}
 bool ValenceImprovementInvariant::before(const simplex::Simplex& simplex) const
 {


### PR DESCRIPTION
invariant constructor can now take in 3 bools to identify whether it implements the before or whether it uses the "old state" in the after or the "new state" in the after. I don't foresee any invariant not using the "new state" in the after, but this specification leaves a clean semantic for "if we don't use the old state or the new state then there is no need to run the after".

also refactored some before+after invariants to just use a lambda instead of copy pasting implementations