### PR TITLE
656 refactor optimization smooth

### DIFF
--- a/components/wmtk_components/wildmeshing/wmtk/components/wildmeshing/wildmeshing.cpp
+++ b/components/wmtk_components/wildmeshing/wmtk/components/wildmeshing/wildmeshing.cpp
@@ -354,7 +354,7 @@ void wildmeshing(const base::Paths& paths, const nlohmann::json& j, io::Cache& c
     // 4) Smoothing
     auto energy =
         std::make_shared<function::LocalNeighborsSumFunction>(*mesh, pt_attribute, *amips);
-    ops.emplace_back(std::make_shared<OptimizationSmoothing>(energy));
+    ops.emplace_back(std::make_shared<OptimizationSmoothing>(*mesh, energy));
     ops.back()->add_invariant(
         std::make_shared<SimplexInversionInvariant>(*mesh, pt_attribute.as<double>()));
     ops.back()->add_invariant(std::make_shared<InteriorVertexInvariant>(*mesh));

--- a/src/wmtk/invariants/InvariantCollection.cpp
+++ b/src/wmtk/invariants/InvariantCollection.cpp
@@ -33,7 +33,7 @@ bool InvariantCollection::before(const simplex::Simplex& t) const
     for (const auto& invariant : m_invariants) {
         if (&mesh() != &invariant->mesh()) {
             for (const Tuple& ct : mesh().map_tuples(invariant->mesh(), t)) {
-                if (!invariant->before(t)) {
+                if (!invariant->before(simplex::Simplex(t.primitive_type(), ct))) {
                     return false;
                 }
             }

--- a/src/wmtk/operations/OptimizationSmoothing.cpp
+++ b/src/wmtk/operations/OptimizationSmoothing.cpp
@@ -104,11 +104,23 @@ bool OptimizationSmoothing::WMTKProblem::is_step_valid(const TVector& x0, const 
     auto domain = m_energy.domain(m_simplex);
     std::vector<Tuple> dom_tmp;
     dom_tmp.reserve(domain.size());
-    std::transform(
-        domain.begin(),
-        domain.end(),
-        std::back_inserter(dom_tmp),
-        [](const simplex::Simplex& s) { return s.tuple(); });
+
+    if (&m_energy.mesh() == &m_invariants.mesh()) {
+        std::transform(
+            domain.begin(),
+            domain.end(),
+            std::back_inserter(dom_tmp),
+            [](const simplex::Simplex& s) { return s.tuple(); });
+    } else {
+        std::transform(
+            domain.begin(),
+            domain.end(),
+            std::back_inserter(dom_tmp),
+            [&](const simplex::Simplex& s) {
+                return m_energy.mesh().map_tuples(m_invariants.mesh(), s).front();
+            });
+    }
+    // need to map the domain to the invariant mesh
 
     bool res = m_invariants.after({}, dom_tmp);
 

--- a/src/wmtk/operations/OptimizationSmoothing.hpp
+++ b/src/wmtk/operations/OptimizationSmoothing.hpp
@@ -21,7 +21,7 @@ private:
     class WMTKProblem;
 
 public:
-    OptimizationSmoothing(std::shared_ptr<wmtk::function::Function> energy);
+    OptimizationSmoothing(Mesh& m, std::shared_ptr<wmtk::function::Function> energy);
 
     std::vector<simplex::Simplex> execute(const simplex::Simplex& simplex) override;
 


### PR DESCRIPTION
Refactor optimizationSmooth.*pp so that it can smooth the energy defined(registered) on a child mesh.