### PR TITLE
operation preallocation

### DIFF
--- a/src/wmtk/EdgeMeshOperationExecutor.cpp
+++ b/src/wmtk/EdgeMeshOperationExecutor.cpp
@@ -235,7 +235,7 @@ std::vector<int64_t> EdgeMesh::EdgeMeshOperationExecutor::request_simplex_indice
     const PrimitiveType type,
     int64_t count)
 {
-    m_mesh.reserve_attributes(type, m_mesh.capacity(type) + count);
+    m_mesh.guarantee_more_attributes(type, count);
     return m_mesh.request_simplex_indices(type, count);
 }
 

--- a/src/wmtk/Mesh.hpp
+++ b/src/wmtk/Mesh.hpp
@@ -348,10 +348,6 @@ protected: // member functions
      */
     Tuple resurrect_tuple_slow(const Tuple& tuple);
 
-    // provides new simplices - should ONLY be called in our atomic topological operations
-    // all returned simplices are active (i.e their flags say they exist)
-    [[nodiscard]] std::vector<int64_t> request_simplex_indices(PrimitiveType type, int64_t count);
-
 
 protected:
     /**
@@ -373,6 +369,28 @@ protected:
     void reserve_attributes(PrimitiveType type, int64_t size);
     void reserve_attributes(int64_t dimension, int64_t size);
 
+
+    // specifies the number of simplices of each type and resizes attributes appropritely
+    void set_capacities(std::vector<int64_t> capacities);
+
+    // reserves extra attributes than necessary right now
+    void reserve_more_attributes(PrimitiveType type, int64_t size);
+    // reserves extra attributes than necessary right now, does not pay attention
+    void reserve_more_attributes(const std::vector<int64_t>& sizes);
+
+    // makes sure that there are at least `size` simples of type `type` avialable
+    void guarantee_more_attributes(PrimitiveType type, int64_t size);
+    // makes sure that there are at least `size` simplices avialable at every dimension
+    void guarantee_more_attributes(const std::vector<int64_t>& sizes);
+
+    // makes sure that there are at least `size` simples of type `type` avialable
+    void guarantee_at_least_attributes(PrimitiveType type, int64_t size);
+    // makes sure that there are at least `size` simplices avialable at every dimension
+    void guarantee_at_least_attributes(const std::vector<int64_t>& sizes);
+
+    // provides new simplices - should ONLY be called in our atomic topological operations
+    // all returned simplices are active (i.e their flags say they exist)
+    [[nodiscard]] std::vector<int64_t> request_simplex_indices(PrimitiveType type, int64_t count);
 
 public:
     /**
@@ -783,13 +801,6 @@ protected:
         return attr.index_access();
     }
 
-    // specifies the number of simplices of each type and resizes attributes appropritely
-    void set_capacities(std::vector<int64_t> capacities);
-
-    // reserves extra attributes than necessary right now
-    void reserve_more_attributes(PrimitiveType type, int64_t size);
-    // reserves extra attributes than necessary right now
-    void reserve_more_attributes(const std::vector<int64_t>& sizes);
 
     // std::shared_ptr<AccessorCache> request_accesor_cache();
     //[[nodiscard]] AccessorScopeHandle push_accesor_scope();

--- a/src/wmtk/Mesh_attributes.cpp
+++ b/src/wmtk/Mesh_attributes.cpp
@@ -112,6 +112,28 @@ void Mesh::reserve_more_attributes(const std::vector<int64_t>& sizes)
         m_attribute_manager.reserve_more_attributes(j, sizes[j]);
     }
 }
+void Mesh::guarantee_at_least_attributes(PrimitiveType type, int64_t size)
+{
+    m_attribute_manager.guarantee_at_least_attributes(get_primitive_type_id(type), size);
+}
+void Mesh::guarantee_at_least_attributes(const std::vector<int64_t>& sizes)
+{
+    assert(top_cell_dimension() + 1 == sizes.size());
+    for (int64_t j = 0; j < sizes.size(); ++j) {
+        m_attribute_manager.guarantee_at_least_attributes(j, sizes[j]);
+    }
+}
+void Mesh::guarantee_more_attributes(PrimitiveType type, int64_t size)
+{
+    m_attribute_manager.guarantee_more_attributes(get_primitive_type_id(type), size);
+}
+void Mesh::guarantee_more_attributes(const std::vector<int64_t>& sizes)
+{
+    assert(top_cell_dimension() + 1 == sizes.size());
+    for (int64_t j = 0; j < sizes.size(); ++j) {
+        m_attribute_manager.guarantee_more_attributes(j, sizes[j]);
+    }
+}
 
 namespace {
 std::vector<attribute::TypedAttributeHandleVariant> variant_diff(
@@ -153,11 +175,11 @@ void Mesh::clear_attributes(
 }
 void Mesh::clear_attributes(const std::vector<attribute::MeshAttributeHandle>& keep_attributes)
 {
-    std::map<Mesh*,std::vector<attribute::TypedAttributeHandleVariant>> keeps_t;
-    for(const auto& attr: keep_attributes) {
+    std::map<Mesh*, std::vector<attribute::TypedAttributeHandleVariant>> keeps_t;
+    for (const auto& attr : keep_attributes) {
         keeps_t[const_cast<Mesh*>(&attr.mesh())].emplace_back(attr.handle());
     }
-    for(auto&[ mptr, handles]: keeps_t) {
+    for (auto& [mptr, handles] : keeps_t) {
         mptr->clear_attributes(handles);
     }
 }

--- a/src/wmtk/Scheduler.cpp
+++ b/src/wmtk/Scheduler.cpp
@@ -20,6 +20,7 @@ SchedulerStats Scheduler::run_operation_on_all(operations::Operation& op)
 {
     SchedulerStats res;
     std::vector<simplex::Simplex> simplices;
+    op.reserve_enough_simplices();
 
     const auto type = op.primitive_type();
     {

--- a/src/wmtk/TetMeshOperationExecutor.cpp
+++ b/src/wmtk/TetMeshOperationExecutor.cpp
@@ -1057,7 +1057,7 @@ std::vector<int64_t> TetMesh::TetMeshOperationExecutor::request_simplex_indices(
     const PrimitiveType type,
     int64_t count)
 {
-    m_mesh.reserve_attributes(type, m_mesh.capacity(type) + count);
+    m_mesh.guarantee_more_attributes(type, count);
 
     return m_mesh.request_simplex_indices(type, count);
 }

--- a/src/wmtk/TriMeshOperationExecutor.cpp
+++ b/src/wmtk/TriMeshOperationExecutor.cpp
@@ -550,7 +550,7 @@ std::vector<int64_t> TriMesh::TriMeshOperationExecutor::request_simplex_indices(
     const PrimitiveType type,
     int64_t count)
 {
-    m_mesh.reserve_attributes(type, m_mesh.capacity(type) + count);
+    m_mesh.guarantee_more_attributes(type, count);
 
     return m_mesh.request_simplex_indices(type, count);
 }

--- a/src/wmtk/attribute/AttributeManager.cpp
+++ b/src/wmtk/attribute/AttributeManager.cpp
@@ -97,11 +97,62 @@ void AttributeManager::reserve_more_attributes(const std::vector<int64_t>& more_
         reserve_more_attributes(dim, more_capacities[dim]);
     }
 }
+void AttributeManager::guarantee_at_least_attributes(int64_t dimension, int64_t size)
+{
+    assert(dimension < this->size());
+
+
+    m_char_attributes[dimension].guarantee_at_least(size);
+    m_long_attributes[dimension].guarantee_at_least(size);
+    m_double_attributes[dimension].guarantee_at_least(size);
+    m_rational_attributes[dimension].guarantee_at_least(size);
+}
+
+void AttributeManager::guarantee_at_least_attributes(const std::vector<int64_t>& at_least_capacities)
+{
+    assert(at_least_capacities.size() == size());
+    for (int64_t dim = 0; dim < size(); ++dim) {
+        guarantee_at_least_attributes(dim, at_least_capacities[dim]);
+    }
+}
+void AttributeManager::guarantee_more_attributes(int64_t dimension, int64_t size)
+{
+    const int64_t current_capacity = m_capacities[dimension];
+    const int64_t target_capacity = current_capacity + size;
+    guarantee_at_least_attributes(dimension,target_capacity);
+}
+void AttributeManager::guarantee_more_attributes(const std::vector<int64_t>& more_capacities)
+{
+    assert(more_capacities.size() == size());
+    for (int64_t dim = 0; dim < size(); ++dim) {
+        guarantee_more_attributes(dim, more_capacities[dim]);
+    }
+}
 void AttributeManager::set_capacities(std::vector<int64_t> capacities)
 {
     assert(capacities.size() == m_capacities.size());
     m_capacities = std::move(capacities);
     reserve_attributes_to_fit();
+}
+void AttributeManager::assert_capacity_valid() const
+{
+    assert(m_char_attributes.size() == m_capacities.size());
+    assert(m_long_attributes.size() == m_capacities.size());
+    assert(m_double_attributes.size() == m_capacities.size());
+    assert(m_rational_attributes.size() == m_capacities.size());
+
+    for (size_t i = 0; i < m_capacities.size(); ++i) {
+        assert(m_capacities[i] > 0);
+        assert(m_char_attributes[i].reserved_size() >= m_capacities[i]);
+        assert(m_long_attributes[i].reserved_size() >= m_capacities[i]);
+        assert(m_double_attributes[i].reserved_size() >= m_capacities[i]);
+        assert(m_rational_attributes[i].reserved_size() >= m_capacities[i]);
+
+        m_char_attributes[i].assert_capacity_valid(m_capacities[i]);
+        m_long_attributes[i].assert_capacity_valid(m_capacities[i]);
+        m_double_attributes[i].assert_capacity_valid(m_capacities[i]);
+        m_rational_attributes[i].assert_capacity_valid(m_capacities[i]);
+    }
 }
 
 void AttributeManager::reserve_attributes_to_fit()

--- a/src/wmtk/attribute/AttributeManager.hpp
+++ b/src/wmtk/attribute/AttributeManager.hpp
@@ -55,28 +55,13 @@ public:
     void set_capacities(std::vector<int64_t> capacities);
     void reserve_more_attributes(int64_t dimension, int64_t size);
     void reserve_more_attributes(const std::vector<int64_t>& more_capacities);
+    void guarantee_more_attributes(int64_t dimension, int64_t size);
+    void guarantee_more_attributes(const std::vector<int64_t>& more_capacities);
+    void guarantee_at_least_attributes(int64_t dimension, int64_t size);
+    void guarantee_at_least_attributes(const std::vector<int64_t>& at_least_capacities);
     bool operator==(const AttributeManager& other) const;
 
-    inline void assert_capacity_valid() const
-    {
-        assert(m_char_attributes.size() == m_capacities.size());
-        assert(m_long_attributes.size() == m_capacities.size());
-        assert(m_double_attributes.size() == m_capacities.size());
-        assert(m_rational_attributes.size() == m_capacities.size());
-
-        for (size_t i = 0; i < m_capacities.size(); ++i) {
-            assert(m_capacities[i] > 0);
-            assert(m_char_attributes[i].reserved_size() >= m_capacities[i]);
-            assert(m_long_attributes[i].reserved_size() >= m_capacities[i]);
-            assert(m_double_attributes[i].reserved_size() >= m_capacities[i]);
-            assert(m_rational_attributes[i].reserved_size() >= m_capacities[i]);
-
-            m_char_attributes[i].assert_capacity_valid(m_capacities[i]);
-            m_long_attributes[i].assert_capacity_valid(m_capacities[i]);
-            m_double_attributes[i].assert_capacity_valid(m_capacities[i]);
-            m_rational_attributes[i].assert_capacity_valid(m_capacities[i]);
-        }
-    }
+    void assert_capacity_valid() const;
 
     template <typename T>
     TypedAttributeHandle<T> register_attribute(

--- a/src/wmtk/attribute/MeshAttributes.cpp
+++ b/src/wmtk/attribute/MeshAttributes.cpp
@@ -209,6 +209,16 @@ void MeshAttributes<T>::reserve_more(const int64_t size)
 {
     reserve(m_reserved_size + size);
 }
+
+template <typename T>
+void MeshAttributes<T>::guarantee_at_least(const int64_t size)
+{
+    if (size > m_reserved_size) {
+        logger().warn("Pre-reserve enough simplices before your operation.");
+        reserve(size);
+    }
+}
+
 template <typename T>
 void MeshAttributes<T>::remove_attributes(const std::vector<AttributeHandle>& attributes)
 {

--- a/src/wmtk/attribute/MeshAttributes.hpp
+++ b/src/wmtk/attribute/MeshAttributes.hpp
@@ -55,7 +55,10 @@ public:
     int64_t reserved_size() const;
     void reserve(const int64_t size);
 
+    // adds size more simplices to teh existing reservation
     void reserve_more(int64_t size);
+    // makes sure we have at least size simplices reserved
+    void guarantee_at_least(int64_t size);
 
     /**
      * @brief Remove all passed in attributes.

--- a/src/wmtk/operations/Operation.hpp
+++ b/src/wmtk/operations/Operation.hpp
@@ -63,6 +63,8 @@ public:
         const attribute::MeshAttributeHandle& attribute,
         const std::shared_ptr<operations::AttributeTransferStrategyBase>& other);
 
+    virtual void reserve_enough_simplices();
+
 protected:
     /**
      * @brief returns an empty vector in case of failure


### PR DESCRIPTION
operations now get the chance to declare how many of each type of simplex they would like in each attribute.
The default is to make 3 * capacity available, which is overkill for every existing op except swap (which only will cause issues in artificial circumstasnces)