### PR TITLE
Making attribute cache use a static max size (of 6)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,6 +110,9 @@ target_compile_definitions(wildmeshing_toolkit PUBLIC NOMINMAX)
 target_compile_features(wildmeshing_toolkit PUBLIC cxx_std_17)
 
 #target_compile_options(wildmeshing_toolkit PUBLIC  -fconcepts)
+set(WMTK_MAX_ATTRIBUTE_DIMENSION -1 CACHE STRING "Set the largest size a vector can be in an attribute")
+target_compile_definitions(wildmeshing_toolkit PUBLIC WMTK_MAX_ATTRIBUTE_DIMENSION=${WMTK_MAX_ATTRIBUTE_DIMENSION})
+
 
 
 target_link_libraries(wildmeshing_toolkit PRIVATE wmtk::warnings)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,7 +110,9 @@ target_compile_definitions(wildmeshing_toolkit PUBLIC NOMINMAX)
 target_compile_features(wildmeshing_toolkit PUBLIC cxx_std_17)
 
 #target_compile_options(wildmeshing_toolkit PUBLIC  -fconcepts)
-set(WMTK_MAX_ATTRIBUTE_DIMENSION -1 CACHE STRING "Set the largest size a vector can be in an attribute")
+
+# the max dimension an attribute can be - default is to be any size (a dynamic size), but this can be set to a number like 6
+set(WMTK_MAX_ATTRIBUTE_DIMENSION Eigen::Dynamic CACHE STRING "Set the largest size a vector can be in an attribute")
 target_compile_definitions(wildmeshing_toolkit PUBLIC WMTK_MAX_ATTRIBUTE_DIMENSION=${WMTK_MAX_ATTRIBUTE_DIMENSION})
 
 

--- a/src/wmtk/attribute/AccessorBase.hpp
+++ b/src/wmtk/attribute/AccessorBase.hpp
@@ -28,8 +28,8 @@ public:
     using MeshAttributesType = MeshAttributes<T>;
     using AttributeType = Attribute<T>;
 
-    using MapResult = typename VectorX<T>::MapType;
-    using ConstMapResult = typename VectorX<T>::ConstMapType;
+    using MapResult = typename Attribute<T>::MapResult;
+    using ConstMapResult = typename Attribute<T>::ConstMapResult;
 
 
 public:

--- a/src/wmtk/attribute/Attribute.hpp
+++ b/src/wmtk/attribute/Attribute.hpp
@@ -29,7 +29,8 @@ template <typename T>
 class Attribute : public wmtk::utils::Hashable
 {
 public:
-    constexpr static int MAX_ATTR_SIZE = 6;
+    // this value is set by CMake
+    constexpr static int MAX_ATTR_SIZE = WMTK_MAX_ATTRIBUTE_DIMENSION;
     template <int R>
     using MapResultD =
         Eigen::Map<Eigen::Matrix<T, R, 1, 0, (R == Eigen::Dynamic ? MAX_ATTR_SIZE : R), 1>>;

--- a/src/wmtk/attribute/Attribute.hpp
+++ b/src/wmtk/attribute/Attribute.hpp
@@ -29,10 +29,13 @@ template <typename T>
 class Attribute : public wmtk::utils::Hashable
 {
 public:
+    constexpr static int MAX_ATTR_SIZE = 6;
     template <int R>
-    using MapResultD = Eigen::Map<Eigen::Matrix<T, R, 1>>;
+    using MapResultD =
+        Eigen::Map<Eigen::Matrix<T, R, 1, 0, (R == Eigen::Dynamic ? MAX_ATTR_SIZE : R), 1>>;
     template <int R>
-    using ConstMapResultD = Eigen::Map<const Eigen::Matrix<T, R, 1>>;
+    using ConstMapResultD =
+        Eigen::Map<const Eigen::Matrix<T, R, 1, 0, (R == Eigen::Dynamic ? MAX_ATTR_SIZE : R), 1>>;
 
     using MapResult = MapResultD<Eigen::Dynamic>;
     using ConstMapResult = ConstMapResultD<Eigen::Dynamic>;
@@ -140,6 +143,7 @@ private:
     std::unique_ptr<PerThreadAttributeScopeStacks<T>> m_scope_stacks;
     int64_t m_dimension = -1;
     T m_default_value = T(0);
+
 public:
     std::string m_name;
 };

--- a/src/wmtk/attribute/AttributeCacheData.hpp
+++ b/src/wmtk/attribute/AttributeCacheData.hpp
@@ -6,7 +6,7 @@ template <typename T>
 class AttributeCacheData
 {
 public:
-    using Vector = Eigen::Matrix<T, Eigen::Dynamic, 1>;
+    using Vector = Eigen::Matrix<T, Eigen::Dynamic, 1, 0, 6, 1>;
     template <typename Derived>
     AttributeCacheData(const Eigen::MatrixBase<Derived>& a, bool d = false)
         : data(a)

--- a/src/wmtk/attribute/AttributeCacheData.hpp
+++ b/src/wmtk/attribute/AttributeCacheData.hpp
@@ -6,7 +6,7 @@ template <typename T>
 class AttributeCacheData
 {
 public:
-    using Vector = Eigen::Matrix<T, Eigen::Dynamic, 1, 0, 6, 1>;
+    using Vector = Eigen::Matrix<T, Eigen::Dynamic, 1, 0, WMTK_MAX_ATTRIBUTE_DIMENSION, 1>;
     template <typename Derived>
     AttributeCacheData(const Eigen::MatrixBase<Derived>& a, bool d = false)
         : data(a)


### PR DESCRIPTION
to reduce a double allocation of each map node allocation + a vectorXd's heap allocation i set a max size. this max size should be set as a compiler argument in the future, this is an experiment for now

making attributes use at most size 6 for attributes for now as a side effect