### PR TITLE
Monotonic allocator for attribute caches

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,6 +112,11 @@ target_compile_features(wildmeshing_toolkit PUBLIC cxx_std_17)
 #target_compile_options(wildmeshing_toolkit PUBLIC  -fconcepts)
 
 
+option(WMTK_USE_MONOTONIC_ATTRIBUTE_CACHE "Use monotonic allocator to store the cache buffer" OFF)
+if(WMTK_USE_MONOTONIC_ATTRIBUTE_CACHE)
+    target_compile_definitions(wildmeshing_toolkit PRIVATE WMTK_USE_MONOTONIC_ATTRIBUTE_CACHE)
+endif()
+
 target_link_libraries(wildmeshing_toolkit PRIVATE wmtk::warnings)
 target_link_libraries(wildmeshing_toolkit PUBLIC
     spdlog::spdlog

--- a/src/wmtk/attribute/AttributeCache.cpp
+++ b/src/wmtk/attribute/AttributeCache.cpp
@@ -6,9 +6,11 @@ namespace wmtk::attribute {
 
 template <typename T>
 AttributeCache<T>::AttributeCache()
+#if defined(WMTK_USE_MONOTONIC_ATTRIBUTE_CACHE)
     : m_buffer(32 * sizeof(typename DataStorage::value_type))
     , m_resource(m_buffer.data(), m_buffer.size())
     , m_data(std::pmr::polymorphic_allocator<std::pair<const int64_t, Data>>{&m_resource})
+#endif
 {} //: m_data({m_resource}) {}
 template <typename T>
 AttributeCache<T>::~AttributeCache() = default;

--- a/src/wmtk/attribute/AttributeCache.cpp
+++ b/src/wmtk/attribute/AttributeCache.cpp
@@ -5,7 +5,11 @@ namespace wmtk::attribute {
 
 
 template <typename T>
-AttributeCache<T>::AttributeCache() = default;
+AttributeCache<T>::AttributeCache()
+    : m_buffer(32 * sizeof(typename DataStorage::value_type))
+    , m_resource(m_buffer.data(), m_buffer.size())
+    , m_data(std::pmr::polymorphic_allocator<std::pair<const int64_t, Data>>{&m_resource})
+{} //: m_data({m_resource}) {}
 template <typename T>
 AttributeCache<T>::~AttributeCache() = default;
 template <typename T>

--- a/src/wmtk/attribute/AttributeCache.hpp
+++ b/src/wmtk/attribute/AttributeCache.hpp
@@ -4,7 +4,10 @@
 #include <memory>
 #include "AccessorBase.hpp"
 #include "AttributeCacheData.hpp"
+
+#if defined(WMTK_USE_MONOTONIC_ATTRIBUTE_CACHE)
 #include <memory_resource>
+#endif
 
 
 namespace wmtk::attribute {
@@ -13,7 +16,11 @@ class AttributeCache
 {
 public:
     using Data = AttributeCacheData<T>;
-    using DataStorage = std::map<int64_t, Data, std::less<int64_t>, std::pmr::polymorphic_allocator<std::pair<const int64_t, Data>>>;
+    using DataStorage = std::map<int64_t, Data, std::less<int64_t>
+#if defined(WMTK_USE_MONOTONIC_ATTRIBUTE_CACHE)
+        , std::pmr::polymorphic_allocator<std::pair<const int64_t, Data>>
+#endif
+        >;
 
     using MapResult = typename AccessorBase<T>::MapResult;
     using ConstMapResult = typename AccessorBase<T>::ConstMapResult;
@@ -37,8 +44,10 @@ public:
 
 
 protected:
+#if defined(WMTK_USE_MONOTONIC_ATTRIBUTE_CACHE)
     mutable std::vector<std::int8_t> m_buffer;
     mutable std::pmr::monotonic_buffer_resource m_resource;
+#endif
     mutable DataStorage m_data;
 };
 } // namespace wmtk::attribute

--- a/src/wmtk/attribute/AttributeCache.hpp
+++ b/src/wmtk/attribute/AttributeCache.hpp
@@ -4,6 +4,7 @@
 #include <memory>
 #include "AccessorBase.hpp"
 #include "AttributeCacheData.hpp"
+#include <memory_resource>
 
 
 namespace wmtk::attribute {
@@ -12,7 +13,7 @@ class AttributeCache
 {
 public:
     using Data = AttributeCacheData<T>;
-    using DataStorage = std::map<int64_t, Data>;
+    using DataStorage = std::map<int64_t, Data, std::less<int64_t>, std::pmr::polymorphic_allocator<std::pair<const int64_t, Data>>>;
 
     using MapResult = typename AccessorBase<T>::MapResult;
     using ConstMapResult = typename AccessorBase<T>::ConstMapResult;
@@ -36,6 +37,8 @@ public:
 
 
 protected:
+    mutable std::vector<std::int8_t> m_buffer;
+    mutable std::pmr::monotonic_buffer_resource m_resource;
     mutable DataStorage m_data;
 };
 } // namespace wmtk::attribute


### PR DESCRIPTION
made the map used for caching store data use a monotonic allocator / a static size buffer to start

(lol i mispressed setting base to be gh-pages and now that one is locked?)