### PR TITLE
updating github actions checkout to 4.1.1

### DIFF
--- a/.github/workflows/continuous.yml
+++ b/.github/workflows/continuous.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: Prepare ccache
         run: |
-          ccache --max-size=20.0G
+          ccache --max-size=10.0G
           ccache -V && ccache --show-stats && ccache --zero-stats
 
       - name: Configure
@@ -104,7 +104,7 @@ jobs:
 
       - name: Prepare ccache
         run: |
-          ccache --max-size=20.0G
+          ccache --max-size=10.0G
           ccache -V && ccache --show-stats && ccache --zero-stats
 
       - name: Configure

--- a/.github/workflows/continuous.yml
+++ b/.github/workflows/continuous.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Cache Build
         id: cache-build
-        uses: actions/cache@v3
+        uses: actions/cache@v2
         with:
           path: ${{ env.CACHE_PATH }}
           key: ${{ runner.os }}-${{ matrix.config }}-cache-${{ github.sha }}
@@ -94,13 +94,13 @@ jobs:
         run: |
           echo 'CACHE_PATH=~/Library/Caches/ccache' >> "$GITHUB_ENV"
 
-      - name: Cache Build
-        id: cache-build
-        uses: actions/cache@v3
-        with:
-          path: ${{ env.CACHE_PATH }}
-          key: ${{ runner.os }}-${{ matrix.config }}-${{ matrix.arch }}-cache-${{ github.sha }}
-          restore-keys: ${{ runner.os }}-${{ matrix.config }}-${{ matrix.arch }}-cache
+          #- name: Cache Build
+          #  id: cache-build
+          #  uses: actions/cache@v2
+          #  with:
+          #    path: ${{ env.CACHE_PATH }}
+          #    key: ${{ runner.os }}-${{ matrix.config }}-${{ matrix.arch }}-cache-${{ github.sha }}
+          #    restore-keys: ${{ runner.os }}-${{ matrix.config }}-${{ matrix.arch }}-cache
 
       - name: Prepare ccache
         run: |

--- a/.github/workflows/continuous.yml
+++ b/.github/workflows/continuous.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Cache Build
         id: cache-build
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ env.CACHE_PATH }}
           key: ${{ runner.os }}-${{ matrix.config }}-cache-${{ github.sha }}
@@ -96,7 +96,7 @@ jobs:
 
       - name: Cache Build
         id: cache-build
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ env.CACHE_PATH }}
           key: ${{ runner.os }}-${{ matrix.config }}-${{ matrix.arch }}-cache-${{ github.sha }}

--- a/.github/workflows/continuous.yml
+++ b/.github/workflows/continuous.yml
@@ -31,7 +31,7 @@ jobs:
             name: Linux
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4.1.1
         with:
           fetch-depth: 10
 
@@ -86,7 +86,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4.1.1
         with:
           fetch-depth: 10
 
@@ -141,7 +141,7 @@ jobs:
         config: [Debug, Release]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4.1.1
         with:
           fetch-depth: 10
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -25,7 +25,7 @@ jobs:
             name: Linux
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4.1.1
         with:
           fetch-depth: 10
 

--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v2.5.0
+        uses: actions/checkout@v4.1.1
 
       - name: Update APT
         run: |


### PR DESCRIPTION
it's causing warnings in the CI, checkout behavior shouldn't be that complex so i don't foresee issues