### PR TITLE
Dzint/avoid memory allocations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -158,6 +158,8 @@ if(MSVC)
     target_compile_options(wildmeshing_toolkit PUBLIC $<$<CONFIG:RELWITHDEBINFO>:/GL>)
     target_compile_options(wildmeshing_toolkit PUBLIC $<$<CONFIG:RELWITHDEBINFO>:/Ob2>) # inline whenever suitable
     target_compile_options(wildmeshing_toolkit PUBLIC $<$<CONFIG:RELWITHDEBINFO>:/Ot>) # favor faster code over binary size
+    target_compile_options(wildmeshing_toolkit PUBLIC $<$<CONFIG:RELEASE>:/GL>)
+    target_compile_options(wildmeshing_toolkit PUBLIC $<$<CONFIG:RELEASE>:/Ot>)
     target_compile_definitions(wildmeshing_toolkit PUBLIC _SILENCE_ALL_MS_EXT_DEPRECATION_WARNINGS)
 endif()
 
@@ -224,6 +226,10 @@ if(WILDMESHING_TOOLKIT_TOPLEVEL_PROJECT)
         target_compile_options(wmtk_app PUBLIC $<$<CONFIG:RELWITHDEBINFO>:/Ot>) # favor faster code over binary size
         target_link_options(wmtk_app PRIVATE $<$<CONFIG:RELWITHDEBINFO>:/LTCG>)
         target_link_options(wmtk_app PRIVATE $<$<CONFIG:RELWITHDEBINFO>:/INCREMENTAL:NO>)
+        target_compile_options(wmtk_app PUBLIC $<$<CONFIG:RELEASE>:/GL>)
+        target_compile_options(wmtk_app PUBLIC $<$<CONFIG:RELEASE>:/Ot>)
+        target_link_options(wmtk_app PRIVATE $<$<CONFIG:RELEASE>:/LTCG>)
+        target_link_options(wmtk_app PRIVATE $<$<CONFIG:RELEASE>:/INCREMENTAL:NO>)
     endif()
 
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -156,6 +156,9 @@ target_link_libraries(wildmeshing_toolkit PUBLIC
 if(MSVC)
     target_compile_options(wildmeshing_toolkit PUBLIC /MP)
     target_compile_options(wildmeshing_toolkit PUBLIC $<$<CONFIG:RELWITHDEBINFO>:/GL>)
+    target_compile_options(wildmeshing_toolkit PUBLIC $<$<CONFIG:RELWITHDEBINFO>:/Ob2>) # inline whenever suitable
+    target_compile_options(wildmeshing_toolkit PUBLIC $<$<CONFIG:RELWITHDEBINFO>:/Ot>) # favor faster code over binary size
+    target_compile_definitions(wildmeshing_toolkit PUBLIC _SILENCE_ALL_MS_EXT_DEPRECATION_WARNINGS)
 endif()
 
 if(WILDMESHING_TOOLKIT_TOPLEVEL_PROJECT)
@@ -217,6 +220,8 @@ if(WILDMESHING_TOOLKIT_TOPLEVEL_PROJECT)
     if(MSVC)
         target_compile_options(wmtk_app PUBLIC /MP)
         target_compile_options(wmtk_app PUBLIC $<$<CONFIG:RELWITHDEBINFO>:/GL>)
+        target_compile_options(wmtk_app PUBLIC $<$<CONFIG:RELWITHDEBINFO>:/Ob2>) # inline whenever suitable
+        target_compile_options(wmtk_app PUBLIC $<$<CONFIG:RELWITHDEBINFO>:/Ot>) # favor faster code over binary size
         target_link_options(wmtk_app PRIVATE $<$<CONFIG:RELWITHDEBINFO>:/LTCG>)
         target_link_options(wmtk_app PRIVATE $<$<CONFIG:RELWITHDEBINFO>:/INCREMENTAL:NO>)
     endif()

--- a/main.cpp
+++ b/main.cpp
@@ -1,4 +1,5 @@
 #include <CLI/CLI.hpp>
+#include <chrono>
 #include <filesystem>
 #include <wmtk/components/run_components.hpp>
 #include <wmtk/utils/Logger.hpp>
@@ -36,7 +37,13 @@ int main(int argc, char** argv)
     }
     if (!spec_json.contains("root_path")) spec_json["root_path"] = json_input_file;
 
+    const auto start = std::chrono::high_resolution_clock::now();
+
     wmtk::components::run_components(spec_json, is_strict);
+
+    const auto stop = std::chrono::high_resolution_clock::now();
+    const auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(stop - start);
+    wmtk::logger().info("Wildmeshing runtime: {} ms", duration.count());
 
     return EXIT_SUCCESS;
 }

--- a/src/wmtk/TetMeshOperationExecutor.cpp
+++ b/src/wmtk/TetMeshOperationExecutor.cpp
@@ -3,6 +3,7 @@
 #include <wmtk/simplex/boundary.hpp>
 #include <wmtk/simplex/closed_star.hpp>
 #include <wmtk/simplex/faces.hpp>
+#include <wmtk/simplex/faces_single_dimension.hpp>
 #include <wmtk/simplex/link.hpp>
 #include <wmtk/simplex/open_star.hpp>
 #include <wmtk/simplex/top_dimension_cofaces.hpp>
@@ -114,8 +115,13 @@ TetMesh::TetMeshOperationExecutor::TetMeshOperationExecutor(
 
 
     // get the closed star of the edge
-    const simplex::SimplexCollection edge_link =
+    simplex::SimplexCollection edge_closed_star_vertices =
         simplex::link(m_mesh, simplex::Simplex::edge(operating_tuple));
+
+    simplex::faces_single_dimension(
+        edge_closed_star_vertices,
+        simplex::Simplex::edge(operating_tuple),
+        PrimitiveType::Vertex);
 
     // get all tets incident to the edge
     // TODO: having another implementation, remove this here
@@ -125,7 +131,8 @@ TetMesh::TetMeshOperationExecutor::TetMeshOperationExecutor(
 
     // update hash on all tets in the two-ring neighborhood
     simplex::SimplexCollection hash_update_region(m);
-    for (const simplex::Simplex& v : edge_link.simplex_vector(PrimitiveType::Vertex)) {
+    for (const simplex::Simplex& v :
+         edge_closed_star_vertices.simplex_vector(PrimitiveType::Vertex)) {
         simplex::top_dimension_cofaces(hash_update_region, v, false);
     }
     hash_update_region.sort_and_clean();

--- a/src/wmtk/TetMeshOperationExecutor.cpp
+++ b/src/wmtk/TetMeshOperationExecutor.cpp
@@ -3,6 +3,7 @@
 #include <wmtk/simplex/boundary.hpp>
 #include <wmtk/simplex/closed_star.hpp>
 #include <wmtk/simplex/faces.hpp>
+#include <wmtk/simplex/link.hpp>
 #include <wmtk/simplex/open_star.hpp>
 #include <wmtk/simplex/top_dimension_cofaces.hpp>
 #include <wmtk/utils/Logger.hpp>
@@ -113,8 +114,8 @@ TetMesh::TetMeshOperationExecutor::TetMeshOperationExecutor(
 
 
     // get the closed star of the edge
-    const simplex::SimplexCollection edge_closed_star =
-        simplex::closed_star(m_mesh, simplex::Simplex::edge(operating_tuple));
+    const simplex::SimplexCollection edge_link =
+        simplex::link(m_mesh, simplex::Simplex::edge(operating_tuple));
 
     // get all tets incident to the edge
     // TODO: having another implementation, remove this here
@@ -124,10 +125,8 @@ TetMesh::TetMeshOperationExecutor::TetMeshOperationExecutor(
 
     // update hash on all tets in the two-ring neighborhood
     simplex::SimplexCollection hash_update_region(m);
-    for (const simplex::Simplex& v : edge_closed_star.simplex_vector(PrimitiveType::Vertex)) {
-        const simplex::SimplexCollection v_closed_star =
-            simplex::top_dimension_cofaces(m_mesh, v, false);
-        hash_update_region.add(v_closed_star);
+    for (const simplex::Simplex& v : edge_link.simplex_vector(PrimitiveType::Vertex)) {
+        simplex::top_dimension_cofaces(hash_update_region, v, false);
     }
     hash_update_region.sort_and_clean();
 

--- a/src/wmtk/TetMeshOperationExecutor.cpp
+++ b/src/wmtk/TetMeshOperationExecutor.cpp
@@ -133,7 +133,7 @@ TetMesh::TetMeshOperationExecutor::TetMeshOperationExecutor(
     simplex::SimplexCollection hash_update_region(m);
     for (const simplex::Simplex& v :
          edge_closed_star_vertices.simplex_vector(PrimitiveType::Vertex)) {
-        simplex::top_dimension_cofaces(hash_update_region, v, false);
+        simplex::top_dimension_cofaces(v, hash_update_region, false);
     }
     hash_update_region.sort_and_clean();
 

--- a/src/wmtk/TetMeshOperationExecutor.cpp
+++ b/src/wmtk/TetMeshOperationExecutor.cpp
@@ -5,6 +5,7 @@
 #include <wmtk/simplex/faces.hpp>
 #include <wmtk/simplex/faces_single_dimension.hpp>
 #include <wmtk/simplex/link.hpp>
+#include <wmtk/simplex/link_single_dimension.hpp>
 #include <wmtk/simplex/open_star.hpp>
 #include <wmtk/simplex/top_dimension_cofaces.hpp>
 #include <wmtk/utils/Logger.hpp>
@@ -115,13 +116,19 @@ TetMesh::TetMeshOperationExecutor::TetMeshOperationExecutor(
 
 
     // get the closed star of the edge
-    simplex::SimplexCollection edge_closed_star_vertices =
-        simplex::link(m_mesh, simplex::Simplex::edge(operating_tuple));
+    simplex::SimplexCollection edge_closed_star_vertices = simplex::link_single_dimension(
+        m_mesh,
+        simplex::Simplex::edge(operating_tuple),
+        PrimitiveType::Vertex);
 
     simplex::faces_single_dimension(
         edge_closed_star_vertices,
         simplex::Simplex::edge(operating_tuple),
         PrimitiveType::Vertex);
+
+    assert(
+        edge_closed_star_vertices.simplex_vector().size() ==
+        edge_closed_star_vertices.simplex_vector(PrimitiveType::Vertex).size());
 
     // get all tets incident to the edge
     // TODO: having another implementation, remove this here
@@ -131,17 +138,16 @@ TetMesh::TetMeshOperationExecutor::TetMeshOperationExecutor(
 
     // update hash on all tets in the two-ring neighborhood
     simplex::SimplexCollection hash_update_region(m);
-    for (const simplex::Simplex& v :
-         edge_closed_star_vertices.simplex_vector(PrimitiveType::Vertex)) {
+    for (const simplex::Simplex& v : edge_closed_star_vertices.simplex_vector()) {
         simplex::top_dimension_cofaces(v, hash_update_region, false);
     }
     hash_update_region.sort_and_clean();
 
     global_simplex_ids_with_potentially_modified_hashes.resize(4);
     simplex::SimplexCollection faces(m_mesh);
+    faces.reserve(hash_update_region.simplex_vector().size() * 15);
 
-    for (const simplex::Simplex& t :
-         hash_update_region.simplex_vector(PrimitiveType::Tetrahedron)) {
+    for (const simplex::Simplex& t : hash_update_region.simplex_vector()) {
         cell_ids_to_update_hash.push_back(m_mesh.id(t));
 
         faces.add(wmtk::simplex::faces(m, t, false));

--- a/src/wmtk/operations/Operation.cpp
+++ b/src/wmtk/operations/Operation.cpp
@@ -59,17 +59,19 @@ void Operation::add_transfer_strategy(
 
 std::vector<simplex::Simplex> Operation::operator()(const simplex::Simplex& simplex)
 {
+    if (!before(simplex)) {
+        return {};
+    }
+
     auto scope = mesh().create_scope();
     assert(simplex.primitive_type() == primitive_type());
 
-    if (before(simplex)) {
-        auto unmods = unmodified_primitives(simplex);
-        auto mods = execute(simplex);
-        if (!mods.empty()) { // success should be marked here
-            apply_attribute_transfer(mods);
-            if (after(unmods, mods)) {
-                return mods; // scope destructor is called
-            }
+    auto unmods = unmodified_primitives(simplex);
+    auto mods = execute(simplex);
+    if (!mods.empty()) { // success should be marked here
+        apply_attribute_transfer(mods);
+        if (after(unmods, mods)) {
+            return mods; // scope destructor is called
         }
     }
     scope.mark_failed();

--- a/src/wmtk/simplex/CMakeLists.txt
+++ b/src/wmtk/simplex/CMakeLists.txt
@@ -19,6 +19,8 @@ set(SRC_FILES
     cofaces_single_dimension.cpp
     link.hpp
     link.cpp
+    link_single_dimension.hpp
+    link_single_dimension.cpp
     link_condition.hpp
     link_condition.cpp
     link_iterable.hpp

--- a/src/wmtk/simplex/SimplexCollection.cpp
+++ b/src/wmtk/simplex/SimplexCollection.cpp
@@ -51,13 +51,18 @@ void SimplexCollection::add(const SimplexCollection& simplex_collection)
     m_simplices.insert(m_simplices.end(), s.begin(), s.end());
 }
 
-void SimplexCollection::add(const PrimitiveType& ptype, const std::vector<Tuple>& tuple_vec)
+void SimplexCollection::add(const PrimitiveType ptype, const std::vector<Tuple>& tuple_vec)
 {
     m_simplices.reserve(m_simplices.size() + tuple_vec.size());
 
     for (const Tuple& t : tuple_vec) {
         m_simplices.emplace_back(Simplex(ptype, t));
     }
+}
+
+void SimplexCollection::add(const PrimitiveType ptype, const Tuple& tuple)
+{
+    m_simplices.emplace_back(Simplex(ptype, tuple));
 }
 
 void SimplexCollection::sort_and_clean()

--- a/src/wmtk/simplex/SimplexCollection.cpp
+++ b/src/wmtk/simplex/SimplexCollection.cpp
@@ -168,4 +168,9 @@ bool SimplexCollection::operator==(const SimplexCollection& other) const
     return are_simplex_collections_equal(*this, other);
 }
 
+void SimplexCollection::reserve(const size_t new_cap)
+{
+    m_simplices.reserve(new_cap);
+}
+
 } // namespace wmtk::simplex

--- a/src/wmtk/simplex/SimplexCollection.hpp
+++ b/src/wmtk/simplex/SimplexCollection.hpp
@@ -97,6 +97,8 @@ public:
 
     inline size_t size() const { return m_simplices.size(); }
 
+    void reserve(const size_t new_cap);
+
 
 protected:
     const Mesh& m_mesh;

--- a/src/wmtk/simplex/SimplexCollection.hpp
+++ b/src/wmtk/simplex/SimplexCollection.hpp
@@ -42,7 +42,9 @@ public:
 
     void add(const SimplexCollection& simplex_collection);
 
-    void add(const PrimitiveType& ptype, const std::vector<Tuple>& tuple_vec);
+    void add(const PrimitiveType ptype, const std::vector<Tuple>& tuple_vec);
+
+    void add(const PrimitiveType ptype, const Tuple& tuple);
     /**
      * @brief Sort simplex vector and remove duplicates.
      */

--- a/src/wmtk/simplex/closed_star.cpp
+++ b/src/wmtk/simplex/closed_star.cpp
@@ -2,6 +2,7 @@
 
 #include <wmtk/TetMesh.hpp>
 #include <wmtk/TriMesh.hpp>
+#include <wmtk/utils/Logger.hpp>
 
 #include "faces.hpp"
 #include "top_dimension_cofaces.hpp"
@@ -11,18 +12,25 @@ namespace wmtk::simplex {
 SimplexCollection closed_star(const Mesh& mesh, const Simplex& simplex, const bool sort_and_clean)
 {
     assert(mesh.is_valid_slow(simplex.tuple()));
-    SimplexCollection collection(mesh);
+    SimplexCollection collection = top_dimension_cofaces(mesh, simplex, false);
+
+    const size_t n_top_dimension_cofaces = collection.simplex_vector().size();
+
+    // reserve memory for all cells, their faces, and the input simplex
+    switch (mesh.top_simplex_type()) {
+    case PrimitiveType::Vertex: break;
+    case PrimitiveType::Edge: collection.reserve(n_top_dimension_cofaces * 3 + 1); break;
+    case PrimitiveType::Face: collection.reserve(n_top_dimension_cofaces * 7 + 1); break;
+    case PrimitiveType::Tetrahedron: collection.reserve(n_top_dimension_cofaces * 14 + 1); break;
+    case PrimitiveType::HalfEdge:
+    default: log_and_throw_error("unknown mesh type in top_dimension_cofaces_tuples");
+    }
+
+    for (size_t i = 0; i < n_top_dimension_cofaces; ++i) {
+        faces(collection, collection.simplex_vector()[i], false);
+    }
 
     collection.add(simplex);
-
-    const SimplexCollection top_dimension_cofaces_collection =
-        top_dimension_cofaces(mesh, simplex, false);
-
-    for (const Simplex& coface_cell : top_dimension_cofaces_collection.simplex_vector()) {
-        collection.add(coface_cell);
-        const SimplexCollection cell_boundary = faces(mesh, coface_cell, false);
-        collection.add(cell_boundary);
-    }
 
     if (sort_and_clean) {
         collection.sort_and_clean();

--- a/src/wmtk/simplex/closed_star.cpp
+++ b/src/wmtk/simplex/closed_star.cpp
@@ -17,16 +17,18 @@ SimplexCollection closed_star(const Mesh& mesh, const Simplex& simplex, const bo
     const size_t n_top_dimension_cofaces = collection.simplex_vector().size();
 
     // reserve memory for all cells, their faces, and the input simplex
+    // this is crucial to avoid reallocation!!
     switch (mesh.top_simplex_type()) {
     case PrimitiveType::Vertex: break;
     case PrimitiveType::Edge: collection.reserve(n_top_dimension_cofaces * 3 + 1); break;
     case PrimitiveType::Face: collection.reserve(n_top_dimension_cofaces * 7 + 1); break;
-    case PrimitiveType::Tetrahedron: collection.reserve(n_top_dimension_cofaces * 14 + 1); break;
+    case PrimitiveType::Tetrahedron: collection.reserve(n_top_dimension_cofaces * 15 + 1); break;
     case PrimitiveType::HalfEdge:
     default: log_and_throw_error("unknown mesh type in top_dimension_cofaces_tuples");
     }
 
     for (size_t i = 0; i < n_top_dimension_cofaces; ++i) {
+        // breaks if simplex vector needs to allocate memory due to reference!
         faces(collection, collection.simplex_vector()[i], false);
     }
 

--- a/src/wmtk/simplex/closed_star.hpp
+++ b/src/wmtk/simplex/closed_star.hpp
@@ -3,6 +3,14 @@
 #include "SimplexCollection.hpp"
 
 namespace wmtk::simplex {
+/**
+ * @brief The closed star contains the input simplex, all its top dimension cofaces, and their
+ * faces.
+ *
+ * @param mesh The mesh to which the simplex and its closed star belong.
+ * @param simplex The simplex of which the closed star is computed.
+ * @return A SimplexCollection with the closed star.
+ */
 SimplexCollection
 closed_star(const Mesh& mesh, const Simplex& simplex, const bool sort_and_clean = true);
-}
+} // namespace wmtk::simplex

--- a/src/wmtk/simplex/faces.cpp
+++ b/src/wmtk/simplex/faces.cpp
@@ -11,17 +11,22 @@ SimplexCollection faces(const Mesh& mesh, const Simplex& simplex, const bool sor
 {
     SimplexCollection collection(mesh);
 
+    faces(collection, simplex, sort_and_clean);
+
+    return collection;
+}
+
+void faces(SimplexCollection& simplex_collection, const Simplex& simplex, const bool sort_and_clean)
+{
     const auto primitive_range = wmtk::utils::primitive_below(simplex.primitive_type());
     for (size_t i = 1; i < primitive_range.size(); ++i) {
-        collection.add(faces_single_dimension(mesh, simplex, primitive_range[i]));
+        faces_single_dimension(simplex_collection, simplex, primitive_range[i]);
     }
 
 
     if (sort_and_clean) {
-        collection.sort_and_clean();
+        simplex_collection.sort_and_clean();
     }
-
-    return collection;
 }
 
 } // namespace wmtk::simplex

--- a/src/wmtk/simplex/faces.hpp
+++ b/src/wmtk/simplex/faces.hpp
@@ -21,4 +21,9 @@ namespace wmtk::simplex {
  * @return `SimplexCollection` holding the faces
  */
 SimplexCollection faces(const Mesh& mesh, const Simplex& simplex, const bool sort_and_clean = true);
+
+void faces(
+    SimplexCollection& simplex_collection,
+    const Simplex& simplex,
+    const bool sort_and_clean = true);
 } // namespace wmtk::simplex

--- a/src/wmtk/simplex/faces_single_dimension.cpp
+++ b/src/wmtk/simplex/faces_single_dimension.cpp
@@ -81,9 +81,19 @@ faces_single_dimension(const Mesh& mesh, const Simplex& simplex, const Primitive
 {
     SimplexCollection collection(mesh);
 
-    collection.add(face_type, faces_single_dimension_tuples(mesh, simplex, face_type));
+    faces_single_dimension(collection, simplex, face_type);
 
     return collection;
+}
+
+void faces_single_dimension(
+    SimplexCollection& simplex_collection,
+    const Simplex& simplex,
+    const PrimitiveType face_type)
+{
+    simplex_collection.add(
+        face_type,
+        faces_single_dimension_tuples(simplex_collection.mesh(), simplex, face_type));
 }
 
 std::vector<Tuple> faces_single_dimension_tuples(

--- a/src/wmtk/simplex/faces_single_dimension.hpp
+++ b/src/wmtk/simplex/faces_single_dimension.hpp
@@ -76,6 +76,11 @@ namespace wmtk::simplex {
 SimplexCollection
 faces_single_dimension(const Mesh& mesh, const Simplex& simplex, const PrimitiveType face_type);
 
+void faces_single_dimension(
+    SimplexCollection& simplex_collection,
+    const Simplex& simplex,
+    const PrimitiveType face_type);
+
 std::vector<Tuple> faces_single_dimension_tuples(
     const Mesh& mesh,
     const Simplex& simplex,

--- a/src/wmtk/simplex/link.cpp
+++ b/src/wmtk/simplex/link.cpp
@@ -55,7 +55,7 @@ link(const TriMesh& mesh, const simplex::Simplex& simplex, const bool sort_and_c
     case PrimitiveType::Face: break;
     case PrimitiveType::Tetrahedron:
     case PrimitiveType::HalfEdge:
-    default: log_and_throw_error("Unknown primitive type in open_star."); break;
+    default: log_and_throw_error("Unknown primitive type in link."); break;
     }
 
     SimplexCollection collection(mesh, std::move(all_cofaces));
@@ -117,7 +117,7 @@ link(const TetMesh& mesh, const simplex::Simplex& simplex, const bool sort_and_c
         break;
     case PrimitiveType::Tetrahedron: break;
     case PrimitiveType::HalfEdge:
-    default: log_and_throw_error("Unknown primitive type in open_star."); break;
+    default: log_and_throw_error("Unknown primitive type in link."); break;
     }
 
     SimplexCollection collection(mesh, std::move(all_cofaces));

--- a/src/wmtk/simplex/link_single_dimension.cpp
+++ b/src/wmtk/simplex/link_single_dimension.cpp
@@ -1,0 +1,207 @@
+#include "link_single_dimension.hpp"
+
+#include <wmtk/TetMesh.hpp>
+#include <wmtk/TriMesh.hpp>
+#include <wmtk/utils/Logger.hpp>
+
+#include "closed_star.hpp"
+#include "faces.hpp"
+#include "top_dimension_cofaces.hpp"
+
+namespace wmtk::simplex {
+
+SimplexCollection link_single_dimension(
+    const Mesh& mesh,
+    const simplex::Simplex& simplex,
+    const PrimitiveType link_type,
+    const bool sort_and_clean)
+{
+    switch (mesh.top_simplex_type()) {
+    case PrimitiveType::Face:
+        return link_single_dimension(
+            static_cast<const TriMesh&>(mesh),
+            simplex,
+            link_type,
+            sort_and_clean);
+    case PrimitiveType::Tetrahedron:
+        return link_single_dimension(
+            static_cast<const TetMesh&>(mesh),
+            simplex,
+            link_type,
+            sort_and_clean);
+    case PrimitiveType::Vertex:
+    case PrimitiveType::Edge:
+    case PrimitiveType::HalfEdge:
+    default: return link_single_dimension_slow(mesh, simplex, link_type, sort_and_clean); break;
+    }
+}
+
+SimplexCollection link_single_dimension(
+    const TriMesh& mesh,
+    const simplex::Simplex& simplex,
+    const PrimitiveType link_type,
+    const bool sort_and_clean)
+{
+    // make use of the fact that the top dimension coface tuples always contain the simplex itself
+    const std::vector<Tuple> cell_tuples = top_dimension_cofaces_tuples(mesh, simplex);
+
+    constexpr PrimitiveType PV = PrimitiveType::Vertex;
+    constexpr PrimitiveType PE = PrimitiveType::Edge;
+
+    std::vector<Simplex> all_cofaces;
+    switch (simplex.primitive_type()) {
+    case PrimitiveType::Vertex:
+        if (link_type == PrimitiveType::Vertex) {
+            all_cofaces.reserve(cell_tuples.size() * 2);
+            for (Tuple t : cell_tuples) {
+                t = mesh.switch_tuples(t, {PV, PE});
+                all_cofaces.emplace_back(Simplex::vertex(t));
+                t = mesh.switch_tuples(t, {PV});
+                all_cofaces.emplace_back(Simplex::vertex(t));
+            }
+        } else if (link_type == PrimitiveType::Edge) {
+            all_cofaces.reserve(cell_tuples.size());
+            for (Tuple t : cell_tuples) {
+                t = mesh.switch_tuples(t, {PV, PE});
+                all_cofaces.emplace_back(Simplex::edge(t));
+            }
+        }
+        break;
+    case PrimitiveType::Edge:
+        if (link_type == PrimitiveType::Vertex) {
+            all_cofaces.reserve(cell_tuples.size());
+            for (Tuple t : cell_tuples) {
+                t = mesh.switch_tuples(t, {PE, PV});
+                all_cofaces.emplace_back(Simplex::vertex(t));
+            }
+        }
+        break;
+    case PrimitiveType::Face: break;
+    case PrimitiveType::Tetrahedron:
+    case PrimitiveType::HalfEdge:
+    default: log_and_throw_error("Unknown primitive type in link_single_dimension."); break;
+    }
+
+    SimplexCollection collection(mesh, std::move(all_cofaces));
+
+    if (sort_and_clean) {
+        collection.sort_and_clean();
+    }
+
+    return collection;
+}
+
+SimplexCollection link_single_dimension(
+    const TetMesh& mesh,
+    const simplex::Simplex& simplex,
+    const PrimitiveType link_type,
+    const bool sort_and_clean)
+{
+    // make use of the fact that the top dimension coface tuples always contain the simplex itself
+    const std::vector<Tuple> cell_tuples = top_dimension_cofaces_tuples(mesh, simplex);
+
+    constexpr PrimitiveType PV = PrimitiveType::Vertex;
+    constexpr PrimitiveType PE = PrimitiveType::Edge;
+    constexpr PrimitiveType PF = PrimitiveType::Face;
+    constexpr PrimitiveType PT = PrimitiveType::Tetrahedron;
+
+    std::vector<Simplex> all_cofaces;
+    switch (simplex.primitive_type()) {
+    case PrimitiveType::Vertex:
+        if (link_type == PrimitiveType::Vertex) {
+            all_cofaces.reserve(cell_tuples.size() * 3);
+            for (Tuple t : cell_tuples) {
+                t = mesh.switch_tuples(t, {PV, PE, PF});
+                all_cofaces.emplace_back(Simplex::vertex(t));
+                t = mesh.switch_tuples(t, {PV, PE});
+                all_cofaces.emplace_back(Simplex::vertex(t));
+                t = mesh.switch_tuples(t, {PV, PE});
+                all_cofaces.emplace_back(Simplex::vertex(t));
+            }
+        } else if (link_type == PrimitiveType::Edge) {
+            all_cofaces.reserve(cell_tuples.size() * 3);
+            for (Tuple t : cell_tuples) {
+                t = mesh.switch_tuples(t, {PV, PE, PF});
+                all_cofaces.emplace_back(Simplex::edge(t));
+                t = mesh.switch_tuples(t, {PV, PE});
+                all_cofaces.emplace_back(Simplex::edge(t));
+                t = mesh.switch_tuples(t, {PV, PE});
+                all_cofaces.emplace_back(Simplex::edge(t));
+            }
+        }
+        if (link_type == PrimitiveType::Face) {
+            all_cofaces.reserve(cell_tuples.size());
+            for (Tuple t : cell_tuples) {
+                t = mesh.switch_tuples(t, {PV, PE, PF});
+                all_cofaces.emplace_back(Simplex::face(t));
+            }
+        }
+        break;
+    case PrimitiveType::Edge:
+        if (link_type == PrimitiveType::Vertex) {
+            all_cofaces.reserve(cell_tuples.size() * 2);
+            for (Tuple t : cell_tuples) {
+                t = mesh.switch_tuples(t, {PE, PV, PF, PE});
+                all_cofaces.emplace_back(Simplex::vertex(t));
+                all_cofaces.emplace_back(Simplex::vertex(mesh.switch_vertex(t)));
+            }
+        }
+        if (link_type == PrimitiveType::Edge) {
+            all_cofaces.reserve(cell_tuples.size());
+            for (Tuple t : cell_tuples) {
+                t = mesh.switch_tuples(t, {PE, PV, PF, PE});
+                all_cofaces.emplace_back(Simplex::edge(t));
+            }
+        }
+        break;
+    case PrimitiveType::Face:
+        if (link_type == PrimitiveType::Vertex) {
+            all_cofaces.reserve(cell_tuples.size());
+            for (Tuple t : cell_tuples) {
+                t = mesh.switch_tuples(t, {PE, PF, PE, PV});
+                all_cofaces.emplace_back(Simplex::vertex(t));
+            }
+        }
+        break;
+    case PrimitiveType::Tetrahedron: break;
+    case PrimitiveType::HalfEdge:
+    default: log_and_throw_error("Unknown primitive type in link_single_dimension."); break;
+    }
+
+    SimplexCollection collection(mesh, std::move(all_cofaces));
+
+    if (sort_and_clean) {
+        collection.sort_and_clean();
+    }
+
+    return collection;
+}
+
+SimplexCollection link_single_dimension_slow(
+    const Mesh& mesh,
+    const simplex::Simplex& simplex,
+    const PrimitiveType link_type,
+    const bool sort_and_clean)
+{
+    SimplexCollection collection(mesh);
+
+    SimplexCollection cs = closed_star(mesh, simplex, sort_and_clean);
+
+    SimplexCollection simplex_w_bd = faces(mesh, simplex, false);
+    simplex_w_bd.add(simplex);
+    simplex_w_bd.sort_and_clean();
+
+    for (const Simplex& s : cs.simplex_vector()) {
+        SimplexCollection bd = faces(mesh, s, false);
+        bd.add(s);
+        bd.sort_and_clean();
+        SimplexCollection intersection = SimplexCollection::get_intersection(simplex_w_bd, bd);
+        if (intersection.simplex_vector().empty()) {
+            collection.add(s);
+        }
+    }
+
+    return SimplexCollection(mesh, collection.simplex_vector(link_type));
+}
+
+} // namespace wmtk::simplex

--- a/src/wmtk/simplex/link_single_dimension.hpp
+++ b/src/wmtk/simplex/link_single_dimension.hpp
@@ -1,0 +1,29 @@
+#pragma once
+
+#include "SimplexCollection.hpp"
+
+namespace wmtk::simplex {
+SimplexCollection link_single_dimension(
+    const Mesh& mesh,
+    const simplex::Simplex& simplex,
+    const PrimitiveType link_type,
+    const bool sort_and_clean = true);
+
+SimplexCollection link_single_dimension(
+    const TriMesh& mesh,
+    const simplex::Simplex& simplex,
+    const PrimitiveType link_type,
+    const bool sort_and_clean = true);
+
+SimplexCollection link_single_dimension(
+    const TetMesh& mesh,
+    const simplex::Simplex& simplex,
+    const PrimitiveType link_type,
+    const bool sort_and_clean = true);
+
+SimplexCollection link_single_dimension_slow(
+    const Mesh& mesh,
+    const simplex::Simplex& simplex,
+    const PrimitiveType link_type,
+    const bool sort_and_clean = true);
+} // namespace wmtk::simplex

--- a/src/wmtk/simplex/open_star.cpp
+++ b/src/wmtk/simplex/open_star.cpp
@@ -28,30 +28,28 @@ SimplexCollection open_star(const TriMesh& mesh, const Simplex& simplex, const b
     // make use of the fact that the top dimension coface tuples always contain the simplex itself
     const std::vector<Tuple> cell_tuples = top_dimension_cofaces_tuples(mesh, simplex);
 
-    std::vector<Simplex> all_cofaces;
+    SimplexCollection collection(mesh);
     switch (simplex.primitive_type()) {
     case PrimitiveType::Vertex:
-        all_cofaces.reserve(cell_tuples.size() * 3 + 1);
+        collection.reserve(cell_tuples.size() * 3 + 1);
         for (const Tuple& t : cell_tuples) {
-            all_cofaces.emplace_back(Simplex::face(t));
-            all_cofaces.emplace_back(Simplex::edge(t));
-            all_cofaces.emplace_back(Simplex::edge(mesh.switch_edge(t)));
+            collection.add(Simplex::face(t));
+            collection.add(Simplex::edge(t));
+            collection.add(Simplex::edge(mesh.switch_edge(t)));
         }
         break;
     case PrimitiveType::Edge:
-        all_cofaces.reserve(cell_tuples.size() + 1);
+        collection.reserve(cell_tuples.size() + 1);
         for (const Tuple& t : cell_tuples) {
-            all_cofaces.emplace_back(Simplex::face(t));
+            collection.add(Simplex::face(t));
         }
         break;
-    case PrimitiveType::Face: all_cofaces.reserve(1); break;
+    case PrimitiveType::Face: collection.reserve(1); break;
     case PrimitiveType::Tetrahedron:
     case PrimitiveType::HalfEdge:
     default: break;
     }
-    all_cofaces.emplace_back(simplex);
-
-    SimplexCollection collection(mesh, std::move(all_cofaces));
+    collection.add(simplex);
 
 
     if (sort_and_clean) {
@@ -71,44 +69,42 @@ SimplexCollection open_star(const TetMesh& mesh, const Simplex& simplex, const b
     constexpr PrimitiveType PF = PrimitiveType::Face;
     constexpr PrimitiveType PT = PrimitiveType::Tetrahedron;
 
-    std::vector<Simplex> all_cofaces;
+    SimplexCollection collection(mesh);
     switch (simplex.primitive_type()) {
     case PrimitiveType::Vertex:
-        all_cofaces.reserve(cell_tuples.size() * 7 + 1);
+        collection.reserve(cell_tuples.size() * 7 + 1);
         for (Tuple t : cell_tuples) {
-            all_cofaces.emplace_back(Simplex::tetrahedron(t));
-            all_cofaces.emplace_back(Simplex::face(t));
-            all_cofaces.emplace_back(Simplex::edge(t));
+            collection.add(Simplex::tetrahedron(t));
+            collection.add(Simplex::face(t));
+            collection.add(Simplex::edge(t));
             t = mesh.switch_tuples(t, {PE, PF});
-            all_cofaces.emplace_back(Simplex::face(t));
-            all_cofaces.emplace_back(Simplex::edge(t));
+            collection.add(Simplex::face(t));
+            collection.add(Simplex::edge(t));
             t = mesh.switch_tuples(t, {PE, PF});
-            all_cofaces.emplace_back(Simplex::face(t));
-            all_cofaces.emplace_back(Simplex::edge(t));
+            collection.add(Simplex::face(t));
+            collection.add(Simplex::edge(t));
         }
         break;
     case PrimitiveType::Edge:
-        all_cofaces.reserve(cell_tuples.size() * 3 + 1);
+        collection.reserve(cell_tuples.size() * 3 + 1);
         for (const Tuple& t : cell_tuples) {
-            all_cofaces.emplace_back(Simplex::tetrahedron(t));
-            all_cofaces.emplace_back(Simplex::face(t));
-            all_cofaces.emplace_back(Simplex::face(mesh.switch_face(t)));
+            collection.add(Simplex::tetrahedron(t));
+            collection.add(Simplex::face(t));
+            collection.add(Simplex::face(mesh.switch_face(t)));
         }
         break;
     case PrimitiveType::Face:
-        all_cofaces.reserve(3);
+        collection.reserve(3);
         assert(cell_tuples.size() <= 2);
         for (const Tuple& t : cell_tuples) {
-            all_cofaces.emplace_back(Simplex::tetrahedron(t));
+            collection.add(Simplex::tetrahedron(t));
         }
         break;
-    case PrimitiveType::Tetrahedron: all_cofaces.reserve(1); break;
+    case PrimitiveType::Tetrahedron: collection.reserve(1); break;
     case PrimitiveType::HalfEdge:
     default: log_and_throw_error("Unknown primitive type in open_star."); break;
     }
-    all_cofaces.emplace_back(simplex);
-
-    SimplexCollection collection(mesh, std::move(all_cofaces));
+    collection.add(simplex);
 
 
     if (sort_and_clean) {

--- a/src/wmtk/simplex/top_dimension_cofaces.cpp
+++ b/src/wmtk/simplex/top_dimension_cofaces.cpp
@@ -347,8 +347,8 @@ void top_dimension_cofaces_tuples_tet(
 } // namespace
 
 void top_dimension_cofaces(
-    SimplexCollection& simplex_collection,
     const Simplex& simplex,
+    SimplexCollection& simplex_collection,
     const bool sort_and_clean)
 {
     const auto& m = simplex_collection.mesh();

--- a/src/wmtk/simplex/top_dimension_cofaces.cpp
+++ b/src/wmtk/simplex/top_dimension_cofaces.cpp
@@ -1,4 +1,5 @@
 #include "top_dimension_cofaces.hpp"
+#include <wmtk/utils/Logger.hpp>
 #include <wmtk/utils/TupleCellLessThanFunctor.hpp>
 #include "utils/tuple_vector_to_homogeneous_simplex_vector.hpp"
 
@@ -16,10 +17,11 @@ namespace wmtk::simplex {
 namespace {
 
 
-std::vector<Tuple> top_dimension_cofaces_tuples_vertex(const TriMesh& mesh, const Tuple& t_in)
+void top_dimension_cofaces_tuples_vertex(
+    const TriMesh& mesh,
+    const Tuple& t_in,
+    std::vector<Tuple>& collection)
 {
-    std::vector<Tuple> collection;
-
     assert(mesh.is_valid_slow(t_in));
     std::set<Tuple, wmtk::utils::TupleCellLessThan> touched_cells;
     std::queue<Tuple> q;
@@ -45,26 +47,30 @@ std::vector<Tuple> top_dimension_cofaces_tuples_vertex(const TriMesh& mesh, cons
             q.push(mesh.switch_face(t_other));
         }
     }
-    return collection;
 }
-std::vector<Tuple> top_dimension_cofaces_tuples_edge(const TriMesh& mesh, const Tuple& t)
+void top_dimension_cofaces_tuples_edge(
+    const TriMesh& mesh,
+    const Tuple& t,
+    std::vector<Tuple>& collection)
 {
-    std::vector<Tuple> collection;
     collection.emplace_back(t);
     if (!mesh.is_boundary_edge(t)) {
         collection.emplace_back(mesh.switch_face(t));
     }
-
-    return collection;
 }
-std::vector<Tuple> top_dimension_cofaces_tuples_face(const TriMesh& mesh, const Tuple& t)
+void top_dimension_cofaces_tuples_face(
+    const TriMesh& mesh,
+    const Tuple& t,
+    std::vector<Tuple>& collection)
 {
-    return {t};
+    collection.emplace_back(t);
 }
 
-std::vector<Tuple> top_dimension_cofaces_tuples_vertex(const TetMesh& mesh, const Tuple& input)
+void top_dimension_cofaces_tuples_vertex(
+    const TetMesh& mesh,
+    const Tuple& input,
+    std::vector<Tuple>& collection)
 {
-    std::vector<Tuple> collection;
     std::set<Tuple, wmtk::utils::TupleCellLessThan> touched_cells;
     std::queue<Tuple> q;
     q.push(input);
@@ -74,7 +80,7 @@ std::vector<Tuple> top_dimension_cofaces_tuples_vertex(const TetMesh& mesh, cons
 
         {
             // check if cell already exists
-            const auto [it, was_inserted] = touched_cells.insert(t);
+            const auto& [it, was_inserted] = touched_cells.insert(t);
             if (!was_inserted) {
                 continue;
             }
@@ -96,11 +102,12 @@ std::vector<Tuple> top_dimension_cofaces_tuples_vertex(const TetMesh& mesh, cons
             q.push(mesh.switch_tetrahedron(t3));
         }
     }
-    return collection;
 }
-std::vector<Tuple> top_dimension_cofaces_tuples_edge(const TetMesh& mesh, const Tuple& input)
+void top_dimension_cofaces_tuples_edge(
+    const TetMesh& mesh,
+    const Tuple& input,
+    std::vector<Tuple>& collection)
 {
-    std::vector<Tuple> collection;
     std::set<Tuple, wmtk::utils::TupleCellLessThan> touched_cells;
     std::queue<Tuple> q;
     q.push(input);
@@ -110,7 +117,7 @@ std::vector<Tuple> top_dimension_cofaces_tuples_edge(const TetMesh& mesh, const 
 
         {
             // check if cell already exists
-            const auto [it, was_inserted] = touched_cells.insert(t);
+            const auto& [it, was_inserted] = touched_cells.insert(t);
             if (!was_inserted) {
                 continue;
             }
@@ -128,30 +135,333 @@ std::vector<Tuple> top_dimension_cofaces_tuples_edge(const TetMesh& mesh, const 
             q.push(mesh.switch_tetrahedron(t2));
         }
     }
-    return collection;
 }
 
-std::vector<Tuple> top_dimension_cofaces_tuples_face(const TetMesh& mesh, const Tuple& input)
+void top_dimension_cofaces_tuples_face(
+    const TetMesh& mesh,
+    const Tuple& input,
+    std::vector<Tuple>& collection)
 {
-    std::vector<Tuple> collection = {input};
+    collection.emplace_back(input);
     if (!mesh.is_boundary_face(input)) {
         collection.emplace_back(mesh.switch_tetrahedron(input));
     }
+}
+void top_dimension_cofaces_tuples_tet(
+    const TetMesh& mesh,
+    const Tuple& t,
+    std::vector<Tuple>& collection)
+{
+    collection.emplace_back(t);
+}
+
+std::vector<Tuple> top_dimension_cofaces_tuples_vertex(const TriMesh& mesh, const Tuple& t)
+{
+    std::vector<Tuple> collection;
+    top_dimension_cofaces_tuples_vertex(mesh, t, collection);
+    return collection;
+}
+std::vector<Tuple> top_dimension_cofaces_tuples_edge(const TriMesh& mesh, const Tuple& t)
+{
+    std::vector<Tuple> collection;
+    top_dimension_cofaces_tuples_edge(mesh, t, collection);
+    return collection;
+}
+std::vector<Tuple> top_dimension_cofaces_tuples_face(const TriMesh& mesh, const Tuple& t)
+{
+    std::vector<Tuple> collection;
+    top_dimension_cofaces_tuples_face(mesh, t, collection);
+    return collection;
+}
+
+std::vector<Tuple> top_dimension_cofaces_tuples_vertex(const TetMesh& mesh, const Tuple& input)
+{
+    std::vector<Tuple> collection;
+    top_dimension_cofaces_tuples_vertex(mesh, input, collection);
+    return collection;
+}
+std::vector<Tuple> top_dimension_cofaces_tuples_edge(const TetMesh& mesh, const Tuple& input)
+{
+    std::vector<Tuple> collection;
+    top_dimension_cofaces_tuples_edge(mesh, input, collection);
+    return collection;
+}
+std::vector<Tuple> top_dimension_cofaces_tuples_face(const TetMesh& mesh, const Tuple& input)
+{
+    std::vector<Tuple> collection;
+    top_dimension_cofaces_tuples_face(mesh, input, collection);
     return collection;
 }
 std::vector<Tuple> top_dimension_cofaces_tuples_tet(const TetMesh& mesh, const Tuple& t)
 {
-    return {t};
+    std::vector<Tuple> collection;
+    top_dimension_cofaces_tuples_tet(mesh, t, collection);
+    return collection;
 }
 
 
 } // namespace
 
-std::vector<Tuple> top_dimension_cofaces_tuples(const EdgeMesh& mesh, const Simplex& simplex)
+namespace {
+
+
+void top_dimension_cofaces_tuples_vertex(
+    const TriMesh& mesh,
+    const Tuple& t_in,
+    SimplexCollection& collection)
 {
-    std::vector<Tuple> collection;
+    assert(mesh.is_valid_slow(t_in));
+    std::set<Tuple, wmtk::utils::TupleCellLessThan> touched_cells;
+    std::queue<Tuple> q;
+    q.push(t_in);
+    while (!q.empty()) {
+        const Tuple t = q.front();
+        q.pop();
+
+        {
+            // check if cell already exists
+            const auto [it, did_insert] = touched_cells.insert(t);
+            if (!did_insert) {
+                continue;
+            }
+        }
+        collection.add(PrimitiveType::Face, t);
+
+        if (!mesh.is_boundary_edge(t)) {
+            q.push(mesh.switch_tuples(t, {PrimitiveType::Face, PrimitiveType::Edge}));
+        }
+        const Tuple t_other = mesh.switch_edge(t);
+        if (!mesh.is_boundary_edge(t_other)) {
+            q.push(mesh.switch_face(t_other));
+        }
+    }
+}
+void top_dimension_cofaces_tuples_edge(
+    const TriMesh& mesh,
+    const Tuple& t,
+    SimplexCollection& collection)
+{
+    collection.add(PrimitiveType::Face, t);
+    if (!mesh.is_boundary_edge(t)) {
+        collection.add(PrimitiveType::Face, mesh.switch_face(t));
+    }
+}
+void top_dimension_cofaces_tuples_face(
+    const TriMesh& mesh,
+    const Tuple& t,
+    SimplexCollection& collection)
+{
+    collection.add(PrimitiveType::Face, t);
+}
+
+void top_dimension_cofaces_tuples_vertex(
+    const TetMesh& mesh,
+    const Tuple& input,
+    SimplexCollection& collection)
+{
+    std::set<Tuple, wmtk::utils::TupleCellLessThan> touched_cells;
+    std::queue<Tuple> q;
+    q.push(input);
+    while (!q.empty()) {
+        const Tuple t = q.front();
+        q.pop();
+
+        {
+            // check if cell already exists
+            const auto& [it, was_inserted] = touched_cells.insert(t);
+            if (!was_inserted) {
+                continue;
+            }
+        }
+
+        collection.add(PrimitiveType::Tetrahedron, t);
+
+        const Tuple& t1 = t;
+        const Tuple t2 = mesh.switch_face(t);
+        const Tuple t3 = mesh.switch_tuples(t, {PrimitiveType::Edge, PrimitiveType::Face});
+
+        if (!mesh.is_boundary_face(t1)) {
+            q.push(mesh.switch_tetrahedron(t1));
+        }
+        if (!mesh.is_boundary_face(t2)) {
+            q.push(mesh.switch_tetrahedron(t2));
+        }
+        if (!mesh.is_boundary_face(t3)) {
+            q.push(mesh.switch_tetrahedron(t3));
+        }
+    }
+}
+void top_dimension_cofaces_tuples_edge(
+    const TetMesh& mesh,
+    const Tuple& input,
+    SimplexCollection& collection)
+{
+    std::set<Tuple, wmtk::utils::TupleCellLessThan> touched_cells;
+    std::queue<Tuple> q;
+    q.push(input);
+    while (!q.empty()) {
+        const Tuple t = q.front();
+        q.pop();
+
+        {
+            // check if cell already exists
+            const auto& [it, was_inserted] = touched_cells.insert(t);
+            if (!was_inserted) {
+                continue;
+            }
+        }
+
+        collection.add(PrimitiveType::Tetrahedron, t);
+
+        const Tuple& t1 = t;
+        const Tuple t2 = mesh.switch_face(t);
+
+        if (!mesh.is_boundary_face(t1)) {
+            q.push(mesh.switch_tuples(t1, {PrimitiveType::Tetrahedron, PrimitiveType::Face}));
+        }
+        if (!mesh.is_boundary_face(t2)) {
+            q.push(mesh.switch_tetrahedron(t2));
+        }
+    }
+}
+
+void top_dimension_cofaces_tuples_face(
+    const TetMesh& mesh,
+    const Tuple& input,
+    SimplexCollection& collection)
+{
+    collection.add(PrimitiveType::Tetrahedron, input);
+    if (!mesh.is_boundary_face(input)) {
+        collection.add(PrimitiveType::Tetrahedron, mesh.switch_tetrahedron(input));
+    }
+}
+void top_dimension_cofaces_tuples_tet(
+    const TetMesh& mesh,
+    const Tuple& t,
+    SimplexCollection& collection)
+{
+    collection.add(PrimitiveType::Tetrahedron, t);
+}
 
 
+} // namespace
+
+void top_dimension_cofaces(
+    SimplexCollection& simplex_collection,
+    const Simplex& simplex,
+    const bool sort_and_clean)
+{
+    const auto& m = simplex_collection.mesh();
+    top_dimension_cofaces_tuples(m, simplex, simplex_collection);
+    if (sort_and_clean) {
+        simplex_collection.sort_and_clean();
+    }
+}
+
+void top_dimension_cofaces_tuples(
+    const EdgeMesh& mesh,
+    const Simplex& simplex,
+    SimplexCollection& collection)
+{
+    switch (simplex.primitive_type()) {
+    case PrimitiveType::Vertex: {
+        collection.add(simplex);
+        if (!mesh.is_boundary_vertex(simplex.tuple())) {
+            collection.add(simplex.primitive_type(), mesh.switch_edge(simplex.tuple()));
+        }
+        break;
+    }
+    case PrimitiveType::Edge: {
+        collection.add(simplex);
+        break;
+    }
+    case PrimitiveType::Face: {
+        log_and_throw_error("top_dimension_cofaces_tuples not implemented for Face in EdgeMesh");
+    }
+    case PrimitiveType::Tetrahedron:
+    case PrimitiveType::HalfEdge:
+    default: assert(false); break;
+    }
+}
+
+void top_dimension_cofaces_tuples(
+    const TriMesh& mesh,
+    const Simplex& simplex,
+    SimplexCollection& collection)
+{
+    switch (simplex.primitive_type()) {
+    case PrimitiveType::Vertex: {
+        top_dimension_cofaces_tuples_vertex(mesh, simplex.tuple(), collection);
+        break;
+    }
+    case PrimitiveType::Edge: {
+        top_dimension_cofaces_tuples_edge(mesh, simplex.tuple(), collection);
+        break;
+    }
+    case PrimitiveType::Face: {
+        top_dimension_cofaces_tuples_face(mesh, simplex.tuple(), collection);
+        break;
+    }
+    case PrimitiveType::Tetrahedron:
+    case PrimitiveType::HalfEdge:
+    default: assert(false); break;
+    }
+}
+
+void top_dimension_cofaces_tuples(
+    const TetMesh& mesh,
+    const Simplex& simplex,
+    SimplexCollection& collection)
+{
+    switch (simplex.primitive_type()) {
+    case PrimitiveType::Vertex: {
+        top_dimension_cofaces_tuples_vertex(mesh, simplex.tuple(), collection);
+        break;
+    }
+    case PrimitiveType::Edge: {
+        top_dimension_cofaces_tuples_edge(mesh, simplex.tuple(), collection);
+        break;
+    }
+    case PrimitiveType::Face: {
+        top_dimension_cofaces_tuples_face(mesh, simplex.tuple(), collection);
+        break;
+    }
+    case PrimitiveType::Tetrahedron: {
+        top_dimension_cofaces_tuples_tet(mesh, simplex.tuple(), collection);
+        break;
+    }
+    case PrimitiveType::HalfEdge:
+    default: assert(false); break;
+    }
+}
+
+void top_dimension_cofaces_tuples(
+    const Mesh& mesh,
+    const Simplex& simplex,
+    SimplexCollection& collection)
+{
+    switch (mesh.top_simplex_type()) {
+    case PrimitiveType::Face:
+        top_dimension_cofaces_tuples(static_cast<const TriMesh&>(mesh), simplex, collection);
+        break;
+    case PrimitiveType::Tetrahedron:
+        top_dimension_cofaces_tuples(static_cast<const TetMesh&>(mesh), simplex, collection);
+        break;
+    case PrimitiveType::Vertex:
+    case PrimitiveType::Edge:
+        top_dimension_cofaces_tuples(static_cast<const EdgeMesh&>(mesh), simplex, collection);
+        break;
+    case PrimitiveType::HalfEdge:
+    default: log_and_throw_error("unknown mesh type in top_dimension_cofaces_tuples");
+    }
+}
+
+
+void top_dimension_cofaces_tuples(
+    const EdgeMesh& mesh,
+    const Simplex& simplex,
+    std::vector<Tuple>& collection)
+{
     switch (simplex.primitive_type()) {
     case PrimitiveType::Vertex: {
         collection.emplace_back(simplex.tuple());
@@ -173,17 +483,13 @@ std::vector<Tuple> top_dimension_cofaces_tuples(const EdgeMesh& mesh, const Simp
     case PrimitiveType::HalfEdge:
     default: assert(false); break;
     }
-
-
-    return collection;
 }
 
-
-std::vector<Tuple> top_dimension_cofaces_tuples(const TriMesh& mesh, const Simplex& simplex)
+void top_dimension_cofaces_tuples(
+    const TriMesh& mesh,
+    const Simplex& simplex,
+    std::vector<Tuple>& collection)
 {
-    std::vector<Tuple> collection;
-
-
     switch (simplex.primitive_type()) {
     case PrimitiveType::Vertex: {
         collection = top_dimension_cofaces_tuples_vertex(mesh, simplex.tuple());
@@ -201,16 +507,13 @@ std::vector<Tuple> top_dimension_cofaces_tuples(const TriMesh& mesh, const Simpl
     case PrimitiveType::HalfEdge:
     default: assert(false); break;
     }
-
-
-    return collection;
 }
 
-std::vector<Tuple> top_dimension_cofaces_tuples(const TetMesh& mesh, const Simplex& simplex)
+void top_dimension_cofaces_tuples(
+    const TetMesh& mesh,
+    const Simplex& simplex,
+    std::vector<Tuple>& collection)
 {
-    std::vector<Tuple> collection;
-
-
     switch (simplex.primitive_type()) {
     case PrimitiveType::Vertex: {
         collection = top_dimension_cofaces_tuples_vertex(mesh, simplex.tuple());
@@ -231,26 +534,29 @@ std::vector<Tuple> top_dimension_cofaces_tuples(const TetMesh& mesh, const Simpl
     case PrimitiveType::HalfEdge:
     default: assert(false); break;
     }
-
-    return collection;
 }
 
-std::vector<Tuple> top_dimension_cofaces_tuples(const Mesh& mesh, const Simplex& simplex)
+void top_dimension_cofaces_tuples(
+    const Mesh& mesh,
+    const Simplex& simplex,
+    std::vector<Tuple>& tuples)
 {
     switch (mesh.top_simplex_type()) {
     case PrimitiveType::Face:
-        return top_dimension_cofaces_tuples(static_cast<const TriMesh&>(mesh), simplex);
+        top_dimension_cofaces_tuples(static_cast<const TriMesh&>(mesh), simplex, tuples);
+        break;
     case PrimitiveType::Tetrahedron:
-        return top_dimension_cofaces_tuples(static_cast<const TetMesh&>(mesh), simplex);
+        top_dimension_cofaces_tuples(static_cast<const TetMesh&>(mesh), simplex, tuples);
+        break;
     case PrimitiveType::Vertex:
     case PrimitiveType::Edge:
-        return top_dimension_cofaces_tuples(static_cast<const EdgeMesh&>(mesh), simplex);
+        top_dimension_cofaces_tuples(static_cast<const EdgeMesh&>(mesh), simplex, tuples);
+        break;
     case PrimitiveType::HalfEdge:
-    default:
-        assert(false);
-        throw std::runtime_error("unknown mesh type in top_dimension_cofaces_tuples");
+    default: log_and_throw_error("unknown mesh type in top_dimension_cofaces_tuples");
     }
 }
+
 
 SimplexCollection
 top_dimension_cofaces(const TriMesh& mesh, const Simplex& simplex, const bool sort_and_clean)
@@ -295,6 +601,45 @@ top_dimension_cofaces(const Mesh& mesh, const Simplex& simplex, const bool sort_
     }
 
     return collection;
+}
+
+
+std::vector<Tuple> top_dimension_cofaces_tuples(const EdgeMesh& mesh, const Simplex& simplex)
+{
+    std::vector<Tuple> collection;
+    top_dimension_cofaces_tuples(mesh, simplex, collection);
+    return collection;
+}
+
+std::vector<Tuple> top_dimension_cofaces_tuples(const TriMesh& mesh, const Simplex& simplex)
+{
+    std::vector<Tuple> collection;
+    top_dimension_cofaces_tuples(mesh, simplex, collection);
+    return collection;
+}
+
+std::vector<Tuple> top_dimension_cofaces_tuples(const TetMesh& mesh, const Simplex& simplex)
+{
+    std::vector<Tuple> collection;
+    top_dimension_cofaces_tuples(mesh, simplex, collection);
+    return collection;
+}
+
+std::vector<Tuple> top_dimension_cofaces_tuples(const Mesh& mesh, const Simplex& simplex)
+{
+    switch (mesh.top_simplex_type()) {
+    case PrimitiveType::Face:
+        return top_dimension_cofaces_tuples(static_cast<const TriMesh&>(mesh), simplex);
+    case PrimitiveType::Tetrahedron:
+        return top_dimension_cofaces_tuples(static_cast<const TetMesh&>(mesh), simplex);
+    case PrimitiveType::Vertex:
+    case PrimitiveType::Edge:
+        return top_dimension_cofaces_tuples(static_cast<const EdgeMesh&>(mesh), simplex);
+    case PrimitiveType::HalfEdge:
+    default:
+        assert(false);
+        throw std::runtime_error("unknown mesh type in top_dimension_cofaces_tuples");
+    }
 }
 
 } // namespace wmtk::simplex

--- a/src/wmtk/simplex/top_dimension_cofaces.hpp
+++ b/src/wmtk/simplex/top_dimension_cofaces.hpp
@@ -4,12 +4,37 @@
 
 namespace wmtk::simplex {
 
+/**
+ * @brief Get all top dimension cofaces of the given simplex.
+ *
+ * For example, the top dimension cofaces in a TetMesh are all tetrahedra incident to the given
+ * simplex.
+ *
+ * The tuple held by each Simplex is guaranteed to contain the child simplex (and all other lower
+ * order simplices of the tuple) In particular, for any simplex (t, k) for tuple t, dimension k,
+ * this function returns simplices (u,m) such that \forall i \leq k, id(t,i) = id(u,i).
+ *
+ * @param simplex The simplex of which the cofaces are computed.
+ * @param simplex_collection The top dimension cofaces are added to this SimplexCollection.
+ *
+ */
 void top_dimension_cofaces(
     const Simplex& simplex,
     SimplexCollection& simplex_collection,
     const bool sort_and_clean = true);
 
 
+/**
+ * @brief The same as top_dimension_cofaces but it appends to a vector of tuples.
+ *
+ * As all simplices returned by this function are of the same type, it is often more efficient to
+ * just return the vector of tuples instead of creating a SimplexCollection.
+ */
+void top_dimension_cofaces_tuples(
+    const Mesh& mesh,
+    const Simplex& simplex,
+    SimplexCollection& collection);
+
 void top_dimension_cofaces_tuples(
     const EdgeMesh& mesh,
     const Simplex& simplex,
@@ -25,11 +50,6 @@ void top_dimension_cofaces_tuples(
     const Simplex& simplex,
     SimplexCollection& collection);
 
-void top_dimension_cofaces_tuples(
-    const Mesh& mesh,
-    const Simplex& simplex,
-    SimplexCollection& collection);
-
 
 void top_dimension_cofaces_tuples(
     const EdgeMesh& mesh,
@@ -51,30 +71,47 @@ void top_dimension_cofaces_tuples(
     const Simplex& simplex,
     std::vector<Tuple>& collection);
 
-// Returns one simplex for every top level coface of the input simplex.
-// The tuple held by each Simplex is guaranteed to contain the child simplex (and all oother lower
-// order simplices of the tuple) In particular, for any simplex (t, k) for tuple t, dimension k,
-// this function returns simplices (u,m) such that \forall i \leq k, id(t,i) = id(u,i)
-SimplexCollection top_dimension_cofaces(
-    const TriMesh& mesh,
-    const Simplex& simplex,
-    const bool sort_and_clean = true);
-
-SimplexCollection top_dimension_cofaces(
-    const TetMesh& mesh,
-    const Simplex& simplex,
-    const bool sort_and_clean = true);
-
+/**
+ * @brief Get all top dimension cofaces of the given simplex.
+ *
+ * For example, the top dimension cofaces in a TetMesh are all tetrahedra incident to the given
+ * simplex.
+ *
+ * The tuple held by each Simplex is guaranteed to contain the child simplex (and all other lower
+ * order simplices of the tuple) In particular, for any simplex (t, k) for tuple t, dimension k,
+ * this function returns simplices (u,m) such that \forall i \leq k, id(t,i) = id(u,i).
+ *
+ * @param mesh The mesh to which the simplex and its cofaces belong.
+ * @param simplex The simplex of which the cofaces are computed.
+ * @return A SimplexCollection with all top dimension cofaces.
+ *
+ */
 SimplexCollection
 top_dimension_cofaces(const Mesh& mesh, const Simplex& simplex, const bool sort_and_clean = true);
+
+SimplexCollection top_dimension_cofaces(
+    const TriMesh& mesh,
+    const Simplex& simplex,
+    const bool sort_and_clean = true);
+
+SimplexCollection top_dimension_cofaces(
+    const TetMesh& mesh,
+    const Simplex& simplex,
+    const bool sort_and_clean = true);
+
+/**
+ * @brief The same as top_dimension_cofaces but it returns only a vector of tuples.
+ *
+ * As all simplices returned by this function are of the same type, it is often more efficient to
+ * just return the vector of tuples instead of creating a SimplexCollection.
+ */
+std::vector<Tuple> top_dimension_cofaces_tuples(const Mesh& mesh, const Simplex& simplex);
 
 std::vector<Tuple> top_dimension_cofaces_tuples(const EdgeMesh& mesh, const Simplex& simplex);
 
 std::vector<Tuple> top_dimension_cofaces_tuples(const TriMesh& mesh, const Simplex& simplex);
 
 std::vector<Tuple> top_dimension_cofaces_tuples(const TetMesh& mesh, const Simplex& simplex);
-
-std::vector<Tuple> top_dimension_cofaces_tuples(const Mesh& mesh, const Simplex& simplex);
 
 
 } // namespace wmtk::simplex

--- a/src/wmtk/simplex/top_dimension_cofaces.hpp
+++ b/src/wmtk/simplex/top_dimension_cofaces.hpp
@@ -5,8 +5,8 @@
 namespace wmtk::simplex {
 
 void top_dimension_cofaces(
-    SimplexCollection& simplex_collection,
     const Simplex& simplex,
+    SimplexCollection& simplex_collection,
     const bool sort_and_clean = true);
 
 

--- a/src/wmtk/simplex/top_dimension_cofaces.hpp
+++ b/src/wmtk/simplex/top_dimension_cofaces.hpp
@@ -4,27 +4,77 @@
 
 namespace wmtk::simplex {
 
+void top_dimension_cofaces(
+    SimplexCollection& simplex_collection,
+    const Simplex& simplex,
+    const bool sort_and_clean = true);
+
+
+void top_dimension_cofaces_tuples(
+    const EdgeMesh& mesh,
+    const Simplex& simplex,
+    SimplexCollection& collection);
+
+void top_dimension_cofaces_tuples(
+    const TriMesh& mesh,
+    const Simplex& simplex,
+    SimplexCollection& collection);
+
+void top_dimension_cofaces_tuples(
+    const TetMesh& mesh,
+    const Simplex& simplex,
+    SimplexCollection& collection);
+
+void top_dimension_cofaces_tuples(
+    const Mesh& mesh,
+    const Simplex& simplex,
+    SimplexCollection& collection);
+
+
+void top_dimension_cofaces_tuples(
+    const EdgeMesh& mesh,
+    const Simplex& simplex,
+    std::vector<Tuple>& collection);
+
+void top_dimension_cofaces_tuples(
+    const TriMesh& mesh,
+    const Simplex& simplex,
+    std::vector<Tuple>& collection);
+
+void top_dimension_cofaces_tuples(
+    const TetMesh& mesh,
+    const Simplex& simplex,
+    std::vector<Tuple>& collection);
+
+void top_dimension_cofaces_tuples(
+    const Mesh& mesh,
+    const Simplex& simplex,
+    std::vector<Tuple>& collection);
 
 // Returns one simplex for every top level coface of the input simplex.
 // The tuple held by each Simplex is guaranteed to contain the child simplex (and all oother lower
 // order simplices of the tuple) In particular, for any simplex (t, k) for tuple t, dimension k,
 // this function returns simplices (u,m) such that \forall i \leq k, id(t,i) = id(u,i)
-SimplexCollection
-top_dimension_cofaces(const TriMesh& mesh, const Simplex& simplex, const bool sort_and_clean = true);
+SimplexCollection top_dimension_cofaces(
+    const TriMesh& mesh,
+    const Simplex& simplex,
+    const bool sort_and_clean = true);
 
-SimplexCollection
-top_dimension_cofaces(const TetMesh& mesh, const Simplex& simplex, const bool sort_and_clean = true);
+SimplexCollection top_dimension_cofaces(
+    const TetMesh& mesh,
+    const Simplex& simplex,
+    const bool sort_and_clean = true);
 
 SimplexCollection
 top_dimension_cofaces(const Mesh& mesh, const Simplex& simplex, const bool sort_and_clean = true);
 
+std::vector<Tuple> top_dimension_cofaces_tuples(const EdgeMesh& mesh, const Simplex& simplex);
 
-// variants of top_dimension_cofaces that just use a std::vector<Tuple> because every return value has
-// the same simplex dimension
 std::vector<Tuple> top_dimension_cofaces_tuples(const TriMesh& mesh, const Simplex& simplex);
 
 std::vector<Tuple> top_dimension_cofaces_tuples(const TetMesh& mesh, const Simplex& simplex);
 
 std::vector<Tuple> top_dimension_cofaces_tuples(const Mesh& mesh, const Simplex& simplex);
+
 
 } // namespace wmtk::simplex

--- a/tests/test_performance.cpp
+++ b/tests/test_performance.cpp
@@ -2,6 +2,9 @@
 #include <nlohmann/json.hpp>
 #include <wmtk/TriMesh.hpp>
 #include <wmtk/io/MeshReader.hpp>
+#include <wmtk/utils/Logger.hpp>
+
+#include <polysolve/Utils.hpp>
 
 using json = nlohmann::json;
 
@@ -32,4 +35,62 @@ TEST_CASE("Read_only", "[performance][.]")
         }
     }
     std::cout << "sum = " << sum << std::endl;
+}
+
+TEST_CASE("accessor_performance", "[accessor][.]")
+{
+    const std::filesystem::path meshfile = data_dir / "armadillo.msh";
+
+    logger().set_level(spdlog::level::trace);
+
+    auto mesh_in = wmtk::read_mesh(meshfile);
+    Mesh& m = *mesh_in;
+
+    auto pos_handle = m.get_attribute_handle<double>("vertices", PrimitiveType::Vertex);
+    auto pos_acc = m.create_accessor<double>(pos_handle);
+
+    const size_t n_repetitions = 10000;
+
+
+    const auto vertices = m.get_all(PrimitiveType::Vertex);
+    {
+        POLYSOLVE_SCOPED_STOPWATCH("Accessors", logger());
+        double sum = 0;
+        for (size_t i = 0; i < n_repetitions; ++i) {
+            for (const Tuple& t : vertices) {
+                sum += pos_acc.const_vector_attribute(t)[0];
+            }
+            for (const Tuple& t : vertices) {
+                sum += pos_acc.const_vector_attribute(t)[1];
+            }
+            for (const Tuple& t : vertices) {
+                sum += pos_acc.const_vector_attribute(t)[2];
+            }
+        }
+        std::cout << "sum = " << sum << std::endl;
+    }
+
+    // create matrix of positions
+    Eigen::MatrixXd positions;
+    positions.resize(vertices.size(), 3);
+    for (size_t i = 0; i < vertices.size(); ++i) {
+        positions.row(i) = pos_acc.const_vector_attribute(vertices[i]);
+    }
+
+    {
+        POLYSOLVE_SCOPED_STOPWATCH("Direct", logger());
+        double sum = 0;
+        for (size_t i = 0; i < n_repetitions; ++i) {
+            for (size_t i = 0; i < vertices.size(); ++i) {
+                sum += positions(i, 0);
+            }
+            for (size_t i = 0; i < vertices.size(); ++i) {
+                sum += positions(i, 1);
+            }
+            for (size_t i = 0; i < vertices.size(); ++i) {
+                sum += positions(i, 2);
+            }
+        }
+        std::cout << "sum = " << sum << std::endl;
+    }
 }

--- a/tests/test_performance.cpp
+++ b/tests/test_performance.cpp
@@ -1,8 +1,10 @@
 #include <catch2/catch_test_macros.hpp>
 #include <nlohmann/json.hpp>
+#include <wmtk/PointMesh.hpp>
 #include <wmtk/TriMesh.hpp>
 #include <wmtk/io/MeshReader.hpp>
 #include <wmtk/utils/Logger.hpp>
+#include <wmtk/utils/mesh_utils.hpp>
 
 #include <polysolve/Utils.hpp>
 
@@ -49,26 +51,9 @@ TEST_CASE("accessor_performance", "[accessor][.]")
     auto pos_handle = m.get_attribute_handle<double>("vertices", PrimitiveType::Vertex);
     auto pos_acc = m.create_accessor<double>(pos_handle);
 
-    const size_t n_repetitions = 10000;
-
+    const size_t n_repetitions = 50000;
 
     const auto vertices = m.get_all(PrimitiveType::Vertex);
-    {
-        POLYSOLVE_SCOPED_STOPWATCH("Accessors", logger());
-        double sum = 0;
-        for (size_t i = 0; i < n_repetitions; ++i) {
-            for (const Tuple& t : vertices) {
-                sum += pos_acc.const_vector_attribute(t)[0];
-            }
-            for (const Tuple& t : vertices) {
-                sum += pos_acc.const_vector_attribute(t)[1];
-            }
-            for (const Tuple& t : vertices) {
-                sum += pos_acc.const_vector_attribute(t)[2];
-            }
-        }
-        std::cout << "sum = " << sum << std::endl;
-    }
 
     // create matrix of positions
     Eigen::MatrixXd positions;
@@ -93,4 +78,42 @@ TEST_CASE("accessor_performance", "[accessor][.]")
         }
         std::cout << "sum = " << sum << std::endl;
     }
+
+    PointMesh pm(vertices.size());
+    auto pph = mesh_utils::set_matrix_attribute(positions, "vertices", PrimitiveType::Vertex, pm);
+    auto pp_acc = pm.create_accessor<double>(pph);
+    {
+        const auto vv = pm.get_all(PrimitiveType::Vertex);
+        POLYSOLVE_SCOPED_STOPWATCH("PointMesh Accessors", logger());
+        double sum = 0;
+        for (size_t i = 0; i < n_repetitions; ++i) {
+            for (const Tuple& t : vv) {
+                sum += pp_acc.const_vector_attribute(t)[0];
+            }
+            for (const Tuple& t : vv) {
+                sum += pp_acc.const_vector_attribute(t)[1];
+            }
+            for (const Tuple& t : vv) {
+                sum += pp_acc.const_vector_attribute(t)[2];
+            }
+        }
+        std::cout << "sum = " << sum << std::endl;
+    }
+
+    //{
+    //    POLYSOLVE_SCOPED_STOPWATCH("TriMesh Accessors", logger());
+    //    double sum = 0;
+    //    for (size_t i = 0; i < n_repetitions; ++i) {
+    //        for (const Tuple& t : vertices) {
+    //            sum += pos_acc.const_vector_attribute(t)[0];
+    //        }
+    //        for (const Tuple& t : vertices) {
+    //            sum += pos_acc.const_vector_attribute(t)[1];
+    //        }
+    //        for (const Tuple& t : vertices) {
+    //            sum += pos_acc.const_vector_attribute(t)[2];
+    //        }
+    //    }
+    //    std::cout << "sum = " << sum << std::endl;
+    //}
 }

--- a/tests/test_simplex_collection.cpp
+++ b/tests/test_simplex_collection.cpp
@@ -361,6 +361,14 @@ TEST_CASE("simplex_top_dimension_cofaces_tri", "[simplex_collection]")
         cc2.sort_and_clean();
 
         CHECK(SimplexCollection::are_simplex_collections_equal(cc, cc2));
+
+        std::vector<Tuple> cc3_tuples;
+        top_dimension_cofaces_tuples(m, input, cc3_tuples);
+        SimplexCollection cc3(m);
+        cc3.add(PrimitiveType::Face, cc3_tuples);
+        cc3.sort_and_clean();
+
+        CHECK(SimplexCollection::are_simplex_collections_equal(cc, cc3));
     }
     SECTION("vertex_boundary")
     {
@@ -386,6 +394,14 @@ TEST_CASE("simplex_top_dimension_cofaces_tri", "[simplex_collection]")
         cc2.sort_and_clean();
 
         CHECK(SimplexCollection::are_simplex_collections_equal(cc, cc2));
+
+        std::vector<Tuple> cc3_tuples;
+        top_dimension_cofaces_tuples(m, input, cc3_tuples);
+        SimplexCollection cc3(m);
+        cc3.add(PrimitiveType::Face, cc3_tuples);
+        cc3.sort_and_clean();
+
+        CHECK(SimplexCollection::are_simplex_collections_equal(cc, cc3));
     }
     SECTION("edge_interior")
     {
@@ -412,6 +428,14 @@ TEST_CASE("simplex_top_dimension_cofaces_tri", "[simplex_collection]")
         cc2.sort_and_clean();
 
         CHECK(SimplexCollection::are_simplex_collections_equal(cc, cc2));
+
+        std::vector<Tuple> cc3_tuples;
+        top_dimension_cofaces_tuples(m, input, cc3_tuples);
+        SimplexCollection cc3(m);
+        cc3.add(PrimitiveType::Face, cc3_tuples);
+        cc3.sort_and_clean();
+
+        CHECK(SimplexCollection::are_simplex_collections_equal(cc, cc3));
     }
     SECTION("edge_boundary")
     {
@@ -437,6 +461,14 @@ TEST_CASE("simplex_top_dimension_cofaces_tri", "[simplex_collection]")
         cc2.sort_and_clean();
 
         CHECK(SimplexCollection::are_simplex_collections_equal(cc, cc2));
+
+        std::vector<Tuple> cc3_tuples;
+        top_dimension_cofaces_tuples(m, input, cc3_tuples);
+        SimplexCollection cc3(m);
+        cc3.add(PrimitiveType::Face, cc3_tuples);
+        cc3.sort_and_clean();
+
+        CHECK(SimplexCollection::are_simplex_collections_equal(cc, cc3));
     }
     SECTION("face")
     {
@@ -462,6 +494,14 @@ TEST_CASE("simplex_top_dimension_cofaces_tri", "[simplex_collection]")
         cc2.sort_and_clean();
 
         CHECK(SimplexCollection::are_simplex_collections_equal(cc, cc2));
+
+        std::vector<Tuple> cc3_tuples;
+        top_dimension_cofaces_tuples(m, input, cc3_tuples);
+        SimplexCollection cc3(m);
+        cc3.add(PrimitiveType::Face, cc3_tuples);
+        cc3.sort_and_clean();
+
+        CHECK(SimplexCollection::are_simplex_collections_equal(cc, cc3));
     }
 }
 
@@ -493,6 +533,14 @@ TEST_CASE("simplex_top_dimension_cofaces_tet", "[simplex_collection]")
         cc2.sort_and_clean();
 
         CHECK(SimplexCollection::are_simplex_collections_equal(cc, cc2));
+
+        std::vector<Tuple> cc3_tuples;
+        top_dimension_cofaces_tuples(m, input, cc3_tuples);
+        SimplexCollection cc3(m);
+        cc3.add(PrimitiveType::Tetrahedron, cc3_tuples);
+        cc3.sort_and_clean();
+
+        CHECK(SimplexCollection::are_simplex_collections_equal(cc, cc3));
     }
     SECTION("edge_interior")
     {
@@ -523,6 +571,14 @@ TEST_CASE("simplex_top_dimension_cofaces_tet", "[simplex_collection]")
         cc2.sort_and_clean();
 
         CHECK(SimplexCollection::are_simplex_collections_equal(cc, cc2));
+
+        std::vector<Tuple> cc3_tuples;
+        top_dimension_cofaces_tuples(m, input, cc3_tuples);
+        SimplexCollection cc3(m);
+        cc3.add(PrimitiveType::Tetrahedron, cc3_tuples);
+        cc3.sort_and_clean();
+
+        CHECK(SimplexCollection::are_simplex_collections_equal(cc, cc3));
     }
     SECTION("edge_boundary")
     {
@@ -549,6 +605,14 @@ TEST_CASE("simplex_top_dimension_cofaces_tet", "[simplex_collection]")
         cc2.sort_and_clean();
 
         CHECK(SimplexCollection::are_simplex_collections_equal(cc, cc2));
+
+        std::vector<Tuple> cc3_tuples;
+        top_dimension_cofaces_tuples(m, input, cc3_tuples);
+        SimplexCollection cc3(m);
+        cc3.add(PrimitiveType::Tetrahedron, cc3_tuples);
+        cc3.sort_and_clean();
+
+        CHECK(SimplexCollection::are_simplex_collections_equal(cc, cc3));
     }
     SECTION("face_interior")
     {
@@ -575,6 +639,14 @@ TEST_CASE("simplex_top_dimension_cofaces_tet", "[simplex_collection]")
         cc2.sort_and_clean();
 
         CHECK(SimplexCollection::are_simplex_collections_equal(cc, cc2));
+
+        std::vector<Tuple> cc3_tuples;
+        top_dimension_cofaces_tuples(m, input, cc3_tuples);
+        SimplexCollection cc3(m);
+        cc3.add(PrimitiveType::Tetrahedron, cc3_tuples);
+        cc3.sort_and_clean();
+
+        CHECK(SimplexCollection::are_simplex_collections_equal(cc, cc3));
     }
     SECTION("face_boundary")
     {
@@ -600,6 +672,14 @@ TEST_CASE("simplex_top_dimension_cofaces_tet", "[simplex_collection]")
         cc2.sort_and_clean();
 
         CHECK(SimplexCollection::are_simplex_collections_equal(cc, cc2));
+
+        std::vector<Tuple> cc3_tuples;
+        top_dimension_cofaces_tuples(m, input, cc3_tuples);
+        SimplexCollection cc3(m);
+        cc3.add(PrimitiveType::Tetrahedron, cc3_tuples);
+        cc3.sort_and_clean();
+
+        CHECK(SimplexCollection::are_simplex_collections_equal(cc, cc3));
     }
 }
 

--- a/tests/test_simplex_collection.cpp
+++ b/tests/test_simplex_collection.cpp
@@ -327,7 +327,7 @@ TEST_CASE("simplex_boundary", "[simplex_collection][2D]")
     }
 }
 
-TEST_CASE("simplex_top_dimension_cofaces", "[simplex_collection][2D]")
+TEST_CASE("simplex_top_dimension_cofaces_tri", "[simplex_collection]")
 {
     tests::DEBUG_TriMesh m = tests::hex_plus_two();
 
@@ -351,6 +351,15 @@ TEST_CASE("simplex_top_dimension_cofaces", "[simplex_collection][2D]")
         for (const Simplex& s : cells) {
             check_match_below_simplex_type(m, input, s);
         }
+
+        SimplexCollection cc2(
+            m,
+            simplex::utils::tuple_vector_to_homogeneous_simplex_vector(
+                top_dimension_cofaces_tuples(m, input),
+                PrimitiveType::Face));
+        cc2.sort_and_clean();
+
+        CHECK(SimplexCollection::are_simplex_collections_equal(cc, cc2));
     }
     SECTION("vertex_boundary")
     {
@@ -367,6 +376,15 @@ TEST_CASE("simplex_top_dimension_cofaces", "[simplex_collection][2D]")
         for (const Simplex& s : cells) {
             check_match_below_simplex_type(m, input, s);
         }
+
+        SimplexCollection cc2(
+            m,
+            simplex::utils::tuple_vector_to_homogeneous_simplex_vector(
+                top_dimension_cofaces_tuples(m, input),
+                PrimitiveType::Face));
+        cc2.sort_and_clean();
+
+        CHECK(SimplexCollection::are_simplex_collections_equal(cc, cc2));
     }
     SECTION("edge_interior")
     {
@@ -384,6 +402,15 @@ TEST_CASE("simplex_top_dimension_cofaces", "[simplex_collection][2D]")
         for (const Simplex& s : cells) {
             check_match_below_simplex_type(m, input, s);
         }
+
+        SimplexCollection cc2(
+            m,
+            simplex::utils::tuple_vector_to_homogeneous_simplex_vector(
+                top_dimension_cofaces_tuples(m, input),
+                PrimitiveType::Face));
+        cc2.sort_and_clean();
+
+        CHECK(SimplexCollection::are_simplex_collections_equal(cc, cc2));
     }
     SECTION("edge_boundary")
     {
@@ -400,6 +427,15 @@ TEST_CASE("simplex_top_dimension_cofaces", "[simplex_collection][2D]")
         for (const Simplex& s : cells) {
             check_match_below_simplex_type(m, input, s);
         }
+
+        SimplexCollection cc2(
+            m,
+            simplex::utils::tuple_vector_to_homogeneous_simplex_vector(
+                top_dimension_cofaces_tuples(m, input),
+                PrimitiveType::Face));
+        cc2.sort_and_clean();
+
+        CHECK(SimplexCollection::are_simplex_collections_equal(cc, cc2));
     }
     SECTION("face")
     {
@@ -416,6 +452,153 @@ TEST_CASE("simplex_top_dimension_cofaces", "[simplex_collection][2D]")
         for (const Simplex& s : cells) {
             check_match_below_simplex_type(m, input, s);
         }
+
+        SimplexCollection cc2(
+            m,
+            simplex::utils::tuple_vector_to_homogeneous_simplex_vector(
+                top_dimension_cofaces_tuples(m, input),
+                PrimitiveType::Face));
+        cc2.sort_and_clean();
+
+        CHECK(SimplexCollection::are_simplex_collections_equal(cc, cc2));
+    }
+}
+
+TEST_CASE("simplex_top_dimension_cofaces_tet", "[simplex_collection]")
+{
+    tests_3d::DEBUG_TetMesh m = tests_3d::six_cycle_tets();
+
+    SECTION("vertex_boundary")
+    {
+        const Tuple t = m.edge_tuple_between_v1_v2(0, 1, 0);
+        Simplex input = simplex::Simplex::vertex(t);
+        SimplexCollection cc = top_dimension_cofaces(m, input);
+
+        REQUIRE(cc.simplex_vector().size() == 2);
+        REQUIRE(cc.simplex_vector(PrimitiveType::Tetrahedron).size() == 2);
+
+        const auto& cells = cc.simplex_vector();
+        CHECK(m.id(cells[0]) == 0);
+        CHECK(m.id(cells[1]) == 1);
+        for (const Simplex& s : cells) {
+            check_match_below_simplex_type(m, input, s);
+        }
+
+        SimplexCollection cc2(
+            m,
+            simplex::utils::tuple_vector_to_homogeneous_simplex_vector(
+                top_dimension_cofaces_tuples(m, input),
+                PrimitiveType::Tetrahedron));
+        cc2.sort_and_clean();
+
+        CHECK(SimplexCollection::are_simplex_collections_equal(cc, cc2));
+    }
+    SECTION("edge_interior")
+    {
+        const Tuple t = m.edge_tuple_between_v1_v2(2, 3, 0);
+
+        Simplex input = simplex::Simplex::edge(t);
+        SimplexCollection cc = top_dimension_cofaces(m, input);
+
+        REQUIRE(cc.simplex_vector().size() == 6);
+        REQUIRE(cc.simplex_vector(PrimitiveType::Tetrahedron).size() == 6);
+
+        const auto& cells = cc.simplex_vector();
+        CHECK(m.id(cells[0]) == 0);
+        CHECK(m.id(cells[1]) == 1);
+        CHECK(m.id(cells[2]) == 2);
+        CHECK(m.id(cells[3]) == 3);
+        CHECK(m.id(cells[4]) == 4);
+        CHECK(m.id(cells[5]) == 5);
+        for (const Simplex& s : cells) {
+            check_match_below_simplex_type(m, input, s);
+        }
+
+        SimplexCollection cc2(
+            m,
+            simplex::utils::tuple_vector_to_homogeneous_simplex_vector(
+                top_dimension_cofaces_tuples(m, input),
+                PrimitiveType::Tetrahedron));
+        cc2.sort_and_clean();
+
+        CHECK(SimplexCollection::are_simplex_collections_equal(cc, cc2));
+    }
+    SECTION("edge_boundary")
+    {
+        const Tuple t = m.edge_tuple_between_v1_v2(0, 2, 0);
+
+        Simplex input = simplex::Simplex::edge(t);
+        SimplexCollection cc = top_dimension_cofaces(m, input);
+
+        REQUIRE(cc.simplex_vector().size() == 2);
+        REQUIRE(cc.simplex_vector(PrimitiveType::Tetrahedron).size() == 2);
+
+        const auto& cells = cc.simplex_vector();
+        CHECK(m.id(cells[0]) == 0);
+        CHECK(m.id(cells[1]) == 1);
+        for (const Simplex& s : cells) {
+            check_match_below_simplex_type(m, input, s);
+        }
+
+        SimplexCollection cc2(
+            m,
+            simplex::utils::tuple_vector_to_homogeneous_simplex_vector(
+                top_dimension_cofaces_tuples(m, input),
+                PrimitiveType::Tetrahedron));
+        cc2.sort_and_clean();
+
+        CHECK(SimplexCollection::are_simplex_collections_equal(cc, cc2));
+    }
+    SECTION("face_interior")
+    {
+        const Tuple t = m.face_tuple_from_vids(0, 2, 3);
+
+        Simplex input = simplex::Simplex::face(t);
+        SimplexCollection cc = top_dimension_cofaces(m, input);
+
+        REQUIRE(cc.simplex_vector().size() == 2);
+        REQUIRE(cc.simplex_vector(PrimitiveType::Tetrahedron).size() == 2);
+
+        const auto& cells = cc.simplex_vector();
+        CHECK(m.id(cells[0]) == 0);
+        CHECK(m.id(cells[1]) == 1);
+        for (const Simplex& s : cells) {
+            check_match_below_simplex_type(m, input, s);
+        }
+
+        SimplexCollection cc2(
+            m,
+            simplex::utils::tuple_vector_to_homogeneous_simplex_vector(
+                top_dimension_cofaces_tuples(m, input),
+                PrimitiveType::Tetrahedron));
+        cc2.sort_and_clean();
+
+        CHECK(SimplexCollection::are_simplex_collections_equal(cc, cc2));
+    }
+    SECTION("face_boundary")
+    {
+        const Tuple t = m.face_tuple_from_vids(0, 1, 2);
+
+        Simplex input = simplex::Simplex::face(t);
+        SimplexCollection cc = top_dimension_cofaces(m, input);
+
+        REQUIRE(cc.simplex_vector().size() == 1);
+        REQUIRE(cc.simplex_vector(PrimitiveType::Tetrahedron).size() == 1);
+
+        const auto& cells = cc.simplex_vector();
+        CHECK(m.id(cells[0]) == 0);
+        for (const Simplex& s : cells) {
+            check_match_below_simplex_type(m, input, s);
+        }
+
+        SimplexCollection cc2(
+            m,
+            simplex::utils::tuple_vector_to_homogeneous_simplex_vector(
+                top_dimension_cofaces_tuples(m, input),
+                PrimitiveType::Tetrahedron));
+        cc2.sort_and_clean();
+
+        CHECK(SimplexCollection::are_simplex_collections_equal(cc, cc2));
     }
 }
 

--- a/tests/test_simplex_collection.cpp
+++ b/tests/test_simplex_collection.cpp
@@ -17,6 +17,7 @@
 #include <wmtk/simplex/link.hpp>
 #include <wmtk/simplex/link_condition.hpp>
 #include <wmtk/simplex/link_iterable.hpp>
+#include <wmtk/simplex/link_single_dimension.hpp>
 #include <wmtk/simplex/open_star.hpp>
 #include <wmtk/simplex/open_star_iterable.hpp>
 #include <wmtk/simplex/top_dimension_cofaces.hpp>
@@ -1255,16 +1256,35 @@ TEST_CASE("simplex_link_trimesh", "[simplex_collection]")
         SimplexCollection os_tri = link(m, simplex::Simplex::vertex(t));
         SimplexCollection os_m = link_slow(m, simplex::Simplex::vertex(t));
         CHECK(SimplexCollection::are_simplex_collections_equal(os_m, os_tri));
+
+        for (const PrimitiveType pt : wmtk::utils::primitive_below(m.top_simplex_type())) {
+            SimplexCollection single_dim =
+                link_single_dimension(m, simplex::Simplex::vertex(t), pt);
+            SimplexCollection single_dim_comp(m, os_m.simplex_vector(pt));
+            CHECK(SimplexCollection::are_simplex_collections_equal(single_dim, single_dim_comp));
+        }
     }
     for (const Tuple& t : m.get_all(PrimitiveType::Edge)) {
         SimplexCollection os_tri = link(m, simplex::Simplex::edge(t));
         SimplexCollection os_m = link_slow(m, simplex::Simplex::edge(t));
         CHECK(SimplexCollection::are_simplex_collections_equal(os_m, os_tri));
+
+        for (const PrimitiveType pt : wmtk::utils::primitive_below(m.top_simplex_type())) {
+            SimplexCollection single_dim = link_single_dimension(m, simplex::Simplex::edge(t), pt);
+            SimplexCollection single_dim_comp(m, os_m.simplex_vector(pt));
+            CHECK(SimplexCollection::are_simplex_collections_equal(single_dim, single_dim_comp));
+        }
     }
     for (const Tuple& t : m.get_all(PrimitiveType::Face)) {
         SimplexCollection os_tri = link(m, simplex::Simplex::face(t));
         SimplexCollection os_m = link_slow(m, simplex::Simplex::face(t));
         CHECK(SimplexCollection::are_simplex_collections_equal(os_m, os_tri));
+
+        for (const PrimitiveType pt : wmtk::utils::primitive_below(m.top_simplex_type())) {
+            SimplexCollection single_dim = link_single_dimension(m, simplex::Simplex::face(t), pt);
+            SimplexCollection single_dim_comp(m, os_m.simplex_vector(pt));
+            CHECK(SimplexCollection::are_simplex_collections_equal(single_dim, single_dim_comp));
+        }
     }
 }
 
@@ -1277,21 +1297,47 @@ TEST_CASE("simplex_link_tetmesh", "[simplex_collection]")
         SimplexCollection os_tri = link(m, simplex::Simplex::vertex(t));
         SimplexCollection os_m = link_slow(m, simplex::Simplex::vertex(t));
         CHECK(SimplexCollection::are_simplex_collections_equal(os_m, os_tri));
+
+        for (const PrimitiveType pt : wmtk::utils::primitive_below(m.top_simplex_type())) {
+            SimplexCollection single_dim =
+                link_single_dimension(m, simplex::Simplex::vertex(t), pt);
+            SimplexCollection single_dim_comp(m, os_m.simplex_vector(pt));
+            CHECK(SimplexCollection::are_simplex_collections_equal(single_dim, single_dim_comp));
+        }
     }
     for (const Tuple& t : m.get_all(PrimitiveType::Edge)) {
         SimplexCollection os_tri = link(m, simplex::Simplex::edge(t));
         SimplexCollection os_m = link_slow(m, simplex::Simplex::edge(t));
         CHECK(SimplexCollection::are_simplex_collections_equal(os_m, os_tri));
+
+        for (const PrimitiveType pt : wmtk::utils::primitive_below(m.top_simplex_type())) {
+            SimplexCollection single_dim = link_single_dimension(m, simplex::Simplex::edge(t), pt);
+            SimplexCollection single_dim_comp(m, os_m.simplex_vector(pt));
+            CHECK(SimplexCollection::are_simplex_collections_equal(single_dim, single_dim_comp));
+        }
     }
     for (const Tuple& t : m.get_all(PrimitiveType::Face)) {
         SimplexCollection os_tri = link(m, simplex::Simplex::face(t));
         SimplexCollection os_m = link_slow(m, simplex::Simplex::face(t));
         CHECK(SimplexCollection::are_simplex_collections_equal(os_m, os_tri));
+
+        for (const PrimitiveType pt : wmtk::utils::primitive_below(m.top_simplex_type())) {
+            SimplexCollection single_dim = link_single_dimension(m, simplex::Simplex::face(t), pt);
+            SimplexCollection single_dim_comp(m, os_m.simplex_vector(pt));
+            CHECK(SimplexCollection::are_simplex_collections_equal(single_dim, single_dim_comp));
+        }
     }
     for (const Tuple& t : m.get_all(PrimitiveType::Tetrahedron)) {
         SimplexCollection os_tri = link(m, simplex::Simplex::tetrahedron(t));
         SimplexCollection os_m = link_slow(m, simplex::Simplex::tetrahedron(t));
         CHECK(SimplexCollection::are_simplex_collections_equal(os_m, os_tri));
+
+        for (const PrimitiveType pt : wmtk::utils::primitive_below(m.top_simplex_type())) {
+            SimplexCollection single_dim =
+                link_single_dimension(m, simplex::Simplex::tetrahedron(t), pt);
+            SimplexCollection single_dim_comp(m, os_m.simplex_vector(pt));
+            CHECK(SimplexCollection::are_simplex_collections_equal(single_dim, single_dim_comp));
+        }
     }
 }
 


### PR DESCRIPTION
Remove small memory allocations by passing `SimplexCollection`s as references.