### PR TITLE
moved some =default to the header to optimize

### DIFF
--- a/src/wmtk/Tuple.cpp
+++ b/src/wmtk/Tuple.cpp
@@ -7,18 +7,6 @@
 #include <tuple>
 
 namespace wmtk {
-Tuple::Tuple(
-    int8_t local_vid,
-    int8_t local_eid,
-    int8_t local_fid,
-    int64_t global_cid,
-    int8_t hash)
-    : m_local_vid(local_vid)
-    , m_local_eid(local_eid)
-    , m_local_fid(local_fid)
-    , m_hash(hash)
-    , m_global_cid(global_cid)
-{}
 
 //         v2
 //       /    \ .
@@ -26,11 +14,6 @@ Tuple::Tuple(
 //     v0 - - - v1
 //         e2
 
-Tuple::Tuple() = default;
-Tuple::Tuple(const Tuple& other) = default;
-Tuple::Tuple(Tuple&& other) = default;
-Tuple& Tuple::operator=(const Tuple& other) = default;
-Tuple& Tuple::operator=(Tuple&& other) = default;
 
 bool Tuple::operator!=(const wmtk::Tuple& t) const
 {

--- a/src/wmtk/Tuple.hpp
+++ b/src/wmtk/Tuple.hpp
@@ -33,11 +33,11 @@ class Tuple
 private:
     // if Tuple is in 2d mesh m_global_cid is the global triangle id, and local_fid is -1
     // if Tuple is in 3d mesh m_global_cid is the global tetrahedron id
+    int64_t m_global_cid = -1;
     int8_t m_local_vid = -1;
     int8_t m_local_eid = -1;
     int8_t m_local_fid = -1;
     int8_t m_hash = -1;
-    int64_t m_global_cid = -1;
 
 public:
     friend class Mesh;
@@ -63,11 +63,11 @@ public:
     //     v0 - - - v1
     //         e2
 
-    Tuple();
-    Tuple(const Tuple& other);
-    Tuple(Tuple&& other);
-    Tuple& operator=(const Tuple& other);
-    Tuple& operator=(Tuple&& other);
+    Tuple() = default;
+    Tuple(const Tuple& other) = default;
+    Tuple(Tuple&& other) = default;
+    Tuple& operator=(const Tuple& other) = default;
+    Tuple& operator=(Tuple&& other) = default;
 
     bool operator==(const Tuple& t) const;
     bool operator!=(const Tuple& t) const;
@@ -78,4 +78,16 @@ public:
     bool is_null() const;
     Tuple with_updated_hash(int64_t new_hash) const;
 };
+inline Tuple::Tuple(
+    int8_t local_vid,
+    int8_t local_eid,
+    int8_t local_fid,
+    int64_t global_cid,
+    int8_t hash)
+    : m_global_cid(global_cid)
+    , m_local_vid(local_vid)
+    , m_local_eid(local_eid)
+    , m_local_fid(local_fid)
+    , m_hash(hash)
+{}
 } // namespace wmtk

--- a/src/wmtk/attribute/MeshAttributeHandle.cpp
+++ b/src/wmtk/attribute/MeshAttributeHandle.cpp
@@ -8,11 +8,6 @@ MeshAttributeHandle::MeshAttributeHandle(Mesh& m, const HandleVariant& h)
     : m_mesh(&m)
     , m_handle(h)
 {}
-MeshAttributeHandle::MeshAttributeHandle() = default;
-MeshAttributeHandle::MeshAttributeHandle(const MeshAttributeHandle& o) = default;
-MeshAttributeHandle::MeshAttributeHandle(MeshAttributeHandle&& o) = default;
-MeshAttributeHandle& MeshAttributeHandle::operator=(const MeshAttributeHandle& o) = default;
-MeshAttributeHandle& MeshAttributeHandle::operator=(MeshAttributeHandle&& o) = default;
 
 bool MeshAttributeHandle::is_same_mesh(const Mesh& m) const
 {

--- a/src/wmtk/attribute/MeshAttributeHandle.hpp
+++ b/src/wmtk/attribute/MeshAttributeHandle.hpp
@@ -39,12 +39,12 @@ public:
 
     friend class wmtk::Mesh;
     friend class wmtk::hash<MeshAttributeHandle>;
-    MeshAttributeHandle();
+    MeshAttributeHandle() = default;
     MeshAttributeHandle(Mesh& m, const HandleVariant& h);
-    MeshAttributeHandle(const MeshAttributeHandle& o);
-    MeshAttributeHandle(MeshAttributeHandle&& o);
-    MeshAttributeHandle& operator=(const MeshAttributeHandle& o);
-    MeshAttributeHandle& operator=(MeshAttributeHandle&& o);
+    MeshAttributeHandle(const MeshAttributeHandle& o) = default;
+    MeshAttributeHandle(MeshAttributeHandle&& o) = default;
+    MeshAttributeHandle& operator=(const MeshAttributeHandle& o) = default;
+    MeshAttributeHandle& operator=(MeshAttributeHandle&& o) = default;
 
     bool operator==(const MeshAttributeHandle& o) const
     {

--- a/src/wmtk/multimesh/MappableContainer.cpp
+++ b/src/wmtk/multimesh/MappableContainer.cpp
@@ -8,9 +8,6 @@ namespace wmtk {
 MappableContainer::MappableContainer(const Mesh& m)
     : Mappable(m)
 {}
-MappableContainer::~MappableContainer() = default;
-MappableContainer::MappableContainer(const MappableContainer&) = default;
-MappableContainer::MappableContainer(MappableContainer&&) = default;
 MappableContainer& MappableContainer::operator=(const MappableContainer& o)
 {
     assert(o.mesh() == mesh());

--- a/src/wmtk/multimesh/MappableContainer.hpp
+++ b/src/wmtk/multimesh/MappableContainer.hpp
@@ -6,11 +6,11 @@ class MappableContainer : public Mappable
 {
 public:
     MappableContainer(const Mesh& m);
-    MappableContainer(const MappableContainer&);
-    MappableContainer(MappableContainer&&);
+    MappableContainer(const MappableContainer&) = default;
+    MappableContainer(MappableContainer&&) = default;
     MappableContainer& operator=(const MappableContainer&);
     MappableContainer& operator=(MappableContainer&&);
-    ~MappableContainer();
+    ~MappableContainer() = default;
 
 
     virtual std::vector<std::shared_ptr<Mappable>> mappables() = 0;

--- a/src/wmtk/multimesh/attribute/AttributeScopeHandle.cpp
+++ b/src/wmtk/multimesh/attribute/AttributeScopeHandle.cpp
@@ -19,7 +19,6 @@ AttributeScopeHandle::AttributeScopeHandle(Mesh& m)
     MultiMeshVisitor(get_handles).execute_from_root(m);
 }
 
-AttributeScopeHandle::~AttributeScopeHandle() = default;
 
 void AttributeScopeHandle::mark_failed()
 {

--- a/src/wmtk/multimesh/attribute/AttributeScopeHandle.hpp
+++ b/src/wmtk/multimesh/attribute/AttributeScopeHandle.hpp
@@ -13,7 +13,7 @@ class AttributeScopeHandle
 public:
     using single_handle_type = wmtk::attribute::AttributeScopeHandle;
     AttributeScopeHandle(Mesh& m);
-    ~AttributeScopeHandle();
+    ~AttributeScopeHandle() = default;
 
     void mark_failed();
 

--- a/src/wmtk/multimesh/operations/extract_operation_tuples.cpp
+++ b/src/wmtk/multimesh/operations/extract_operation_tuples.cpp
@@ -19,15 +19,18 @@ public:
     //     return std::array<Tuple, 2>{};
     // }
 
-    std::array<Tuple, 2> operator()(const wmtk::operations::edge_mesh::EdgeOperationData& t) const
+    std::array<Tuple, 2> operator()(
+        const wmtk::operations::edge_mesh::EdgeOperationData& t) const noexcept
     {
         return std::array<Tuple, 2>{{t.m_operating_tuple, t.m_output_tuple}};
     }
-    std::array<Tuple, 2> operator()(const wmtk::operations::tri_mesh::EdgeOperationData& t) const
+    std::array<Tuple, 2> operator()(
+        const wmtk::operations::tri_mesh::EdgeOperationData& t) const noexcept
     {
         return std::array<Tuple, 2>{{t.m_operating_tuple, t.m_output_tuple}};
     }
-    std::array<Tuple, 2> operator()(const wmtk::operations::tet_mesh::EdgeOperationData& t) const
+    std::array<Tuple, 2> operator()(
+        const wmtk::operations::tet_mesh::EdgeOperationData& t) const noexcept
     {
         return std::array<Tuple, 2>{{t.m_operating_tuple, t.m_output_tuple}};
     }

--- a/tests/multimesh/consolidate.cpp
+++ b/tests/multimesh/consolidate.cpp
@@ -154,7 +154,7 @@ TEST_CASE("consolidate_multimesh_splits", "[mesh][consolidate_multimesh]")
 
     for (int j = 0; j < 5; ++j) {
         for (const auto& tup : dptr->get_all(wmtk::PrimitiveType::Edge)) {
-            split_op(simplex::Simplex::edge(tup)).empty();
+            split_op(simplex::Simplex::edge(tup));//.empty();
         }
     }
     DEBUG_TriMesh& debug_d = reinterpret_cast<DEBUG_TriMesh&>(*dptr);


### PR DESCRIPTION
making some default constructors inline / making sure things satisfy trivialy copyable