### PR TITLE
Increase permissivity of Tuple::is_null

### DIFF
--- a/src/wmtk/CMakeLists.txt
+++ b/src/wmtk/CMakeLists.txt
@@ -26,7 +26,7 @@ set(SRC_FILES
     PrimitiveType.cpp
     Primitive.hpp
     Primitive.cpp
-    Tuple.cpp
+    Tuple.hxx
     Tuple.hpp
     Types.hpp
     Scheduler.hpp

--- a/src/wmtk/Tuple.hpp
+++ b/src/wmtk/Tuple.hpp
@@ -91,3 +91,4 @@ inline Tuple::Tuple(
     , m_hash(hash)
 {}
 } // namespace wmtk
+#include "Tuple.hxx"

--- a/src/wmtk/Tuple.hpp
+++ b/src/wmtk/Tuple.hpp
@@ -72,9 +72,10 @@ public:
     bool operator==(const Tuple& t) const;
     bool operator!=(const Tuple& t) const;
     bool operator<(const Tuple& t) const;
-    // equality comparison but skips the hash
+    /// Checks whether two tuples are equal, but ignores the hash
     bool same_ids(const Tuple& t) const;
 
+    /// Checks if a tuple is "null". This merely implies the global index is -1
     bool is_null() const;
     Tuple with_updated_hash(int64_t new_hash) const;
 };

--- a/src/wmtk/Tuple.hxx
+++ b/src/wmtk/Tuple.hxx
@@ -15,34 +15,33 @@ namespace wmtk {
 //         e2
 
 
-bool Tuple::operator!=(const wmtk::Tuple& t) const
+inline bool Tuple::operator!=(const wmtk::Tuple& t) const
 {
     return !(*this == t);
 }
-bool Tuple::operator==(const wmtk::Tuple& t) const
+inline bool Tuple::operator==(const wmtk::Tuple& t) const
 {
     return std::tie(m_local_vid, m_local_eid, m_local_fid, m_global_cid, m_hash) ==
            std::tie(t.m_local_vid, t.m_local_eid, t.m_local_fid, t.m_global_cid, t.m_hash);
 }
 
-bool Tuple::operator<(const wmtk::Tuple& t) const
+inline bool Tuple::operator<(const wmtk::Tuple& t) const
 {
     return std::tie(m_local_vid, m_local_eid, m_local_fid, m_global_cid, m_hash) <
            std::tie(t.m_local_vid, t.m_local_eid, t.m_local_fid, t.m_global_cid, t.m_hash);
 }
-bool Tuple::same_ids(const wmtk::Tuple& t) const
+inline bool Tuple::same_ids(const wmtk::Tuple& t) const
 {
     return std::tie(m_local_vid, m_local_eid, m_local_fid, m_global_cid) ==
            std::tie(t.m_local_vid, t.m_local_eid, t.m_local_fid, t.m_global_cid);
 }
 
-bool Tuple::is_null() const
+inline bool Tuple::is_null() const
 {
-    return m_local_vid == -1 && m_local_eid == -1 && m_local_fid == -1 && m_global_cid == -1 &&
-           m_hash == -1;
+    return m_global_cid == -1;
 }
 
-Tuple Tuple::with_updated_hash(int64_t new_hash) const
+inline Tuple Tuple::with_updated_hash(int64_t new_hash) const
 {
     return Tuple(m_local_vid, m_local_eid, m_local_fid, m_global_cid, new_hash);
 }

--- a/tests/test_tuple.cpp
+++ b/tests/test_tuple.cpp
@@ -6,6 +6,23 @@
 
 using namespace wmtk;
 
+TEST_CASE("tuple_is_null", "[tuple]")
+{
+    Tuple a(0, 0, 0, 0, 0);
+    CHECK(!a.is_null());
+
+    Tuple b(0, 0, 0, -1, 0);
+    CHECK(b.is_null());
+
+    Tuple c(-1, -1, -1, -1, -1);
+    CHECK(c.is_null());
+
+    Tuple d(-1, -1, -1, 0, -1);
+    CHECK(!d.is_null());
+
+    Tuple e(-1, -1, -1, -2, -1);
+    CHECK(!e.is_null());
+}
 TEST_CASE("tuple_comparison", "[tuple]")
 {
     { // check that equals are detected properly


### PR DESCRIPTION
the check now only confirms that the global id of the tuple is -1