### PR TITLE
Tuple Accessor

### DIFF
--- a/src/wmtk/attribute/Accessor.hpp
+++ b/src/wmtk/attribute/Accessor.hpp
@@ -65,10 +65,13 @@ public:
 
     using BaseType::attribute; // access to Attribute object being used here
     using BaseType::handle;
-    using BaseType::mesh;
+    using BaseType::typed_handle;
     using CachingBaseType::has_stack;
     using CachingBaseType::mesh;
     using CachingBaseType::stack_depth;
+
+    MeshType& mesh() { return static_cast<MeshType&>(BaseType::mesh()); }
+    const MeshType& mesh() const { return static_cast<const MeshType&>(BaseType::mesh()); }
 
 protected:
     int64_t index(const Tuple& t) const;

--- a/src/wmtk/attribute/TupleAccessor.hpp
+++ b/src/wmtk/attribute/TupleAccessor.hpp
@@ -1,0 +1,48 @@
+#pragma once
+
+#include "Accessor.hpp"
+
+
+namespace wmtk::attribute {
+
+
+template <typename MeshType>
+class TupleAccessor
+{
+public:
+    TupleAccessor(MeshType& m, const TypedAttributeHandle<int64_t>& handle);
+    TupleAccessor(const MeshType& m, const TypedAttributeHandle<int64_t>& handle);
+    TupleAccessor(const Accessor<int64_t, MeshType>& accessor);
+
+    // Eigen::Map<VectorX<T>>
+    template <int D = Eigen::Dynamic>
+    using MapResult = internal::MapResult<Tuple, D>;
+    // Eigen::Map<const VectorX<T>>
+    template <int D = Eigen::Dynamic>
+    using ConstMapResult = internal::ConstMapResult<Tuple, D>;
+
+
+    const Tuple& const_scalar_attribute(const Tuple& t) const;
+    Tuple& scalar_attribute(const Tuple& t);
+
+    template <int D = Eigen::Dynamic>
+    ConstMapResult<D> const_vector_attribute(const Tuple& t) const;
+    template <int D = Eigen::Dynamic>
+    MapResult<D> vector_attribute(const Tuple& t);
+
+    Eigen::Index dimension() const { return m_dimension; }
+
+private:
+    Accessor<int64_t, MeshType> m_base_accessor;
+    Eigen::Index m_dimension;
+};
+
+
+template <typename MeshType>
+TupleAccessor(MeshType& m, const TypedAttributeHandle<int64_t>& handle) -> TupleAccessor<MeshType>;
+template <typename MeshType>
+TupleAccessor(const MeshType& m, const TypedAttributeHandle<int64_t>& handle)
+    -> TupleAccessor<MeshType>;
+
+} // namespace wmtk::attribute
+#include "TupleAccessor.hxx"

--- a/src/wmtk/attribute/TupleAccessor.hxx
+++ b/src/wmtk/attribute/TupleAccessor.hxx
@@ -46,7 +46,7 @@ auto TupleAccessor<MeshType>::vector_attribute(const Tuple& t) -> MapResult<D>
 template <typename MeshType>
 auto TupleAccessor<MeshType>::scalar_attribute(const Tuple& t) -> Tuple&
 {
-    auto base_map = m_base_accessor.template vector_attribute(t);
+    auto base_map = m_base_accessor.template vector_attribute<2>(t);
 
     assert(m_dimension == 1);
     return *reinterpret_cast<Tuple*>(base_map.data());
@@ -56,7 +56,7 @@ template <typename MeshType>
 auto TupleAccessor<MeshType>::const_scalar_attribute(const Tuple& t) const -> const Tuple&
 {
     assert(m_dimension == 1);
-    auto base_map = m_base_accessor.template const_vector_attribute(t);
+    auto base_map = m_base_accessor.template const_vector_attribute<2>(t);
     return *reinterpret_cast<const Tuple*>(base_map.data());
 }
 

--- a/src/wmtk/attribute/TupleAccessor.hxx
+++ b/src/wmtk/attribute/TupleAccessor.hxx
@@ -1,0 +1,64 @@
+
+#pragma once
+#include <wmtk/utils/Rational.hpp>
+#include "TupleAccessor.hpp"
+
+namespace wmtk::attribute {
+
+
+template <typename MeshType>
+TupleAccessor<MeshType>::TupleAccessor(MeshType& m, const TypedAttributeHandle<int64_t>& handle)
+    : m_base_accessor(m, handle)
+    , m_dimension(m_base_accessor.dimension() / (sizeof(Tuple) / sizeof(int64_t)))
+{}
+template <typename MeshType>
+TupleAccessor<MeshType>::TupleAccessor(
+    const MeshType& m,
+    const TypedAttributeHandle<int64_t>& handle)
+    : TupleAccessor(const_cast<MeshType&>(m), handle)
+{}
+template <typename MeshType>
+TupleAccessor<MeshType>::TupleAccessor(const Accessor<int64_t, MeshType>& accessor)
+    : TupleAccessor(accessor.mesh(), accessor.typed_handle())
+{}
+
+template <typename MeshType>
+template <int D>
+auto TupleAccessor<MeshType>::const_vector_attribute(const Tuple& t) const -> ConstMapResult<D>
+{
+    auto base_map = m_base_accessor.template const_vector_attribute<D>(t);
+
+    const int64_t* int_data = base_map.data();
+    const Tuple* data = reinterpret_cast<const Tuple*>(int_data);
+    return ConstMapResult<D>(data, dimension());
+}
+
+template <typename MeshType>
+template <int D>
+auto TupleAccessor<MeshType>::vector_attribute(const Tuple& t) -> MapResult<D>
+{
+    auto base_map = m_base_accessor.template vector_attribute<D>(t);
+    int64_t* int_data = base_map.data();
+    Tuple* data = reinterpret_cast<Tuple*>(int_data);
+    return MapResult<D>(data, dimension());
+}
+
+template <typename MeshType>
+auto TupleAccessor<MeshType>::scalar_attribute(const Tuple& t) -> Tuple&
+{
+    auto base_map = m_base_accessor.template vector_attribute(t);
+
+    assert(m_dimension == 1);
+    return *reinterpret_cast<Tuple*>(base_map.data());
+}
+
+template <typename MeshType>
+auto TupleAccessor<MeshType>::const_scalar_attribute(const Tuple& t) const -> const Tuple&
+{
+    assert(m_dimension == 1);
+    auto base_map = m_base_accessor.template const_vector_attribute(t);
+    return *reinterpret_cast<const Tuple*>(base_map.data());
+}
+
+
+} // namespace wmtk::attribute

--- a/src/wmtk/multimesh/MultiMeshManager.cpp
+++ b/src/wmtk/multimesh/MultiMeshManager.cpp
@@ -721,6 +721,7 @@ void MultiMeshManager::update_map_tuple_hashes(
             //  read off the original map's data
             auto parent_to_child_data = Mesh::get_index_access(parent_to_child_accessor)
                                             .const_vector_attribute(original_parent_gid);
+            // wmtk::attribute::TupleAccessor<wmtk::Mesh> tuple_accessor(m, int64_t_handle);
 
             // read off the data in the Tuple format
             Tuple parent_tuple, child_tuple;
@@ -949,8 +950,11 @@ int64_t MultiMeshManager::parent_local_fid(
     return Mesh::get_index_access(child_to_parent)
         .vector_attribute(child_gid)(wmtk::multimesh::utils::TUPLE_SIZE + 2);
 #else
-    const int64_t v = Mesh::get_index_access(child_to_parent)
-                          .vector_attribute(child_gid)(wmtk::multimesh::utils::TUPLE_SIZE);
+    // pick hte index that isn't teh global id index
+    const int64_t v =
+        Mesh::get_index_access(child_to_parent)
+            .vector_attribute(child_gid)(
+                wmtk::multimesh::utils::TUPLE_SIZE + (1 - wmtk::multimesh::utils::GLOBAL_ID_INDEX));
     auto vptr = reinterpret_cast<const int8_t*>(&v);
     return vptr[2];
 #endif

--- a/src/wmtk/multimesh/utils/tuple_map_attribute_io.cpp
+++ b/src/wmtk/multimesh/utils/tuple_map_attribute_io.cpp
@@ -1,9 +1,10 @@
 #include "tuple_map_attribute_io.hpp"
+#include <wmtk/attribute/TupleAccessor.hpp>
 
 #include <wmtk/EdgeMesh.hpp>
-#include <wmtk/TriMesh.hpp>
-#include <wmtk/TetMesh.hpp>
 #include <wmtk/Mesh.hpp>
+#include <wmtk/TetMesh.hpp>
+#include <wmtk/TriMesh.hpp>
 #include <wmtk/Types.hpp>
 #include <wmtk/utils/TupleInspector.hpp>
 
@@ -17,26 +18,14 @@ using Vec84 = Vector<int8_t, 4>;
 }
 Vector<int64_t, 2> tuple_to_vector2(const Tuple& t)
 {
-    Vector<int64_t, 2> v;
-    Vec84* v_p = reinterpret_cast<Vec84*>(&v.coeffRef(0));
-    Vec84& v_ = *v_p;
-    // Vec84 v_;
-    v_[0] = wmtk::utils::TupleInspector::local_vid(t);
-    v_[1] = wmtk::utils::TupleInspector::local_eid(t);
-    v_[2] = wmtk::utils::TupleInspector::local_fid(t);
-    v_[3] = wmtk::utils::TupleInspector::hash(t);
-
-    // v(0) = static_cast<int64_t>(v_);
-    v(1) = wmtk::utils::TupleInspector::global_cid(t);
+    Vector<int64_t, 2> v = Vector<int64_t, 2>::ConstMapType(reinterpret_cast<const int64_t*>(&t));
     return v;
 }
 
 Tuple vector2_to_tuple(const Eigen::Ref<const Vector2l>& v)
 {
-    const Vec84* v_p = reinterpret_cast<const Vec84*>(&v.coeffRef(0));
-    const Vec84& v_ = *v_p;
-
-    return Tuple(v_[0], v_[1], v_[2], v(1), v_[3]);
+    const Tuple* data = reinterpret_cast<const Tuple*>(v.data());
+    return *data;
 }
 Vector<int64_t, 5> tuple_to_vector5(const Tuple& t)
 {
@@ -86,33 +75,36 @@ TwoTupleVector tuples_to_vectors(const Tuple& a, const Tuple& b)
 }
 
 
-
-
 template <typename MeshType>
 std::tuple<Tuple, Tuple> read_tuple_map_attribute(
     const wmtk::attribute::Accessor<int64_t, MeshType>& accessor,
     const Tuple& source_tuple)
 {
-    auto map = accessor.const_vector_attribute(source_tuple);
+#if !defined(NDEBUG)
+    // check t hat the global ids are either -1 or positive
+    auto v = accessor.const_vector_attribute(source_tuple);
+    assert(v(0) >= -1);
+    assert(v(2) >= -1);
+#endif
+    assert(accessor.dimension() == 4);
 
-    return vectors_to_tuples(map);
+    const wmtk::attribute::TupleAccessor<MeshType> acc(accessor);
+    assert(acc.dimension() == 2);
+    auto map = acc.const_vector_attribute(source_tuple);
+    return std::tie(map(0), map(1));
 }
 
 
-template 
-std::tuple<Tuple, Tuple> read_tuple_map_attribute(
+template std::tuple<Tuple, Tuple> read_tuple_map_attribute(
     const wmtk::attribute::Accessor<int64_t, wmtk::Mesh>& accessor,
     const Tuple& source_tuple);
-template 
-std::tuple<Tuple, Tuple> read_tuple_map_attribute(
+template std::tuple<Tuple, Tuple> read_tuple_map_attribute(
     const wmtk::attribute::Accessor<int64_t, wmtk::EdgeMesh>& accessor,
     const Tuple& source_tuple);
-template 
-std::tuple<Tuple, Tuple> read_tuple_map_attribute(
+template std::tuple<Tuple, Tuple> read_tuple_map_attribute(
     const wmtk::attribute::Accessor<int64_t, wmtk::TriMesh>& accessor,
     const Tuple& source_tuple);
-template 
-std::tuple<Tuple, Tuple> read_tuple_map_attribute(
+template std::tuple<Tuple, Tuple> read_tuple_map_attribute(
     const wmtk::attribute::Accessor<int64_t, wmtk::TetMesh>& accessor,
     const Tuple& source_tuple);
 
@@ -123,34 +115,36 @@ void write_tuple_map_attribute(
     const Tuple& source_tuple,
     const Tuple& target_tuple)
 {
-    auto map = map_accessor.vector_attribute(source_tuple);
-
-    assert(map.size() == TWO_TUPLE_SIZE);
-    map = tuples_to_vectors(source_tuple, target_tuple);
+    assert(map_accessor.dimension() == 4);
+    wmtk::attribute::TupleAccessor<MeshType> acc(map_accessor);
+    assert(acc.dimension() == 2);
+    auto map = acc.vector_attribute(source_tuple);
+    map(0) = source_tuple;
+    map(1) = target_tuple;
+#if !defined(NDEBUG)
+    // check t hat the global ids are either -1 or positive
+    auto v = map_accessor.const_vector_attribute(source_tuple);
+    assert(v(0) >= -1);
+    assert(v(2) >= -1);
+#endif
 }
 
-template 
-void write_tuple_map_attribute(
+template void write_tuple_map_attribute(
     wmtk::attribute::Accessor<int64_t, wmtk::Mesh>& map_accessor,
     const Tuple& source_tuple,
     const Tuple& target_tuple);
-template 
-void write_tuple_map_attribute(
+template void write_tuple_map_attribute(
     wmtk::attribute::Accessor<int64_t, wmtk::EdgeMesh>& map_accessor,
     const Tuple& source_tuple,
     const Tuple& target_tuple);
-template 
-void write_tuple_map_attribute(
+template void write_tuple_map_attribute(
     wmtk::attribute::Accessor<int64_t, wmtk::TriMesh>& map_accessor,
     const Tuple& source_tuple,
     const Tuple& target_tuple);
-template 
-void write_tuple_map_attribute(
+template void write_tuple_map_attribute(
     wmtk::attribute::Accessor<int64_t, wmtk::TetMesh>& map_accessor,
     const Tuple& source_tuple,
     const Tuple& target_tuple);
-
-
 
 
 void write_tuple_map_attribute_slow(

--- a/src/wmtk/multimesh/utils/tuple_map_attribute_io.hpp
+++ b/src/wmtk/multimesh/utils/tuple_map_attribute_io.hpp
@@ -1,5 +1,5 @@
-#include <wmtk/attribute/Accessor.hpp>
 #include <wmtk/Types.hpp>
+#include <wmtk/attribute/Accessor.hpp>
 
 // #define WMTK_DISABLE_COMPRESSED_MULTIMESH_TUPLE
 namespace wmtk::multimesh::utils {
@@ -8,7 +8,7 @@ constexpr static int64_t TUPLE_SIZE = 5; // in terms of int64_t
 constexpr static int64_t GLOBAL_ID_INDEX = 3;
 #else
 constexpr static int64_t TUPLE_SIZE = 2; // in terms of int64_t
-constexpr static int64_t GLOBAL_ID_INDEX = 1;
+constexpr static int64_t GLOBAL_ID_INDEX = 0;
 #endif
 constexpr static int64_t DEFAULT_TUPLES_VALUES = -1;
 constexpr static int64_t TWO_TUPLE_SIZE = TUPLE_SIZE * 2; // in terms of int64_t

--- a/tests/attributes/CMakeLists.txt
+++ b/tests/attributes/CMakeLists.txt
@@ -1,5 +1,6 @@
 # Sources
 set(TEST_SOURCES
     test_accessor.cpp
+    tuple_accessor.cpp
 )
 target_sources(wmtk_tests PRIVATE ${TEST_SOURCES})

--- a/tests/attributes/test_accessor.cpp
+++ b/tests/attributes/test_accessor.cpp
@@ -224,9 +224,10 @@ TEST_CASE("test_accessor_caching", "[accessor]")
 
         for (const wmtk::Tuple& tup : vertices) {
             auto check_id = [&](const auto& va, int id) {
+                using T = typename std::decay_t<decltype(va)>::T;
                 auto v = va.const_vector_attribute(id);
                 auto x = v.eval();
-                std::iota(x.begin(), x.end(), va.dimension() * id);
+                std::iota(x.begin(), x.end(), T(va.dimension() * id));
                 CHECK(v == x);
                 bool is_scalar = va.dimension() == 1;
                 if (is_scalar) {

--- a/tests/attributes/test_accessor.cpp
+++ b/tests/attributes/test_accessor.cpp
@@ -25,7 +25,7 @@ void populate(DEBUG_PointMesh& m, VectorAcc& va, bool for_zeros = false)
         if (for_zeros) {
             v.setZero();
         } else {
-            std::iota(v.begin(), v.end(), dimension * id);
+            std::iota(v.begin(), v.end(), (typename VectorAcc::Scalar)(dimension * id));
         }
     }
 }
@@ -46,7 +46,7 @@ void check(DEBUG_PointMesh& m, VectorAcc& va, bool for_zeros = false)
             }
         } else {
             auto v = va.vector_attribute(tup);
-            std::iota(x.begin(), x.end(), dimension * id);
+            std::iota(x.begin(), x.end(), (typename VectorAcc::Scalar)(dimension * id));
             CHECK(v == x);
             if (is_scalar) {
                 CHECK(va.const_scalar_attribute(tup) == id);

--- a/tests/attributes/tuple_accessor.cpp
+++ b/tests/attributes/tuple_accessor.cpp
@@ -33,7 +33,6 @@ TEST_CASE("tuple_to_int64_t_storage", "[accessor]")
         CHECK(idat(0) == iptr[0]);
         CHECK(idat(1) == iptr[1]);
     }
-    // }
 }
 
 TEST_CASE("test_single_tuple_accessor", "[accessor]")

--- a/tests/attributes/tuple_accessor.cpp
+++ b/tests/attributes/tuple_accessor.cpp
@@ -1,0 +1,111 @@
+#include <numeric>
+
+#include <catch2/catch_test_macros.hpp>
+#include <wmtk/attribute/Attribute.hpp>
+#include <wmtk/attribute/AttributeScopeStack.hpp>
+#include <wmtk/attribute/TupleAccessor.hpp>
+#include <wmtk/utils/Logger.hpp>
+#include <wmtk/utils/TupleInspector.hpp>
+#include "../tools/DEBUG_PointMesh.hpp"
+
+
+using namespace wmtk::tests;
+namespace {} // namespace
+
+TEST_CASE("test_single_tuple_accessor", "[accessor]")
+{
+    int64_t size = 20;
+    DEBUG_PointMesh m(size);
+    REQUIRE(size == m.capacity(wmtk::PrimitiveType::Vertex));
+    auto int64_t_handle =
+        m.register_attribute_typed<int64_t>("int64_t", wmtk::PrimitiveType::Vertex, 2, false, -1);
+    REQUIRE(m.get_attribute_dimension(int64_t_handle) == 2);
+    auto int64_t_acc = m.create_accessor(int64_t_handle);
+
+    auto vertices = m.get_all(wmtk::PrimitiveType::Vertex);
+
+    wmtk::attribute::TupleAccessor<wmtk::PointMesh> tuple_accessor(m, int64_t_handle);
+
+    REQUIRE(int64_t_acc.reserved_size() == size);
+    REQUIRE(tuple_accessor.dimension() == 1);
+
+    // test default initialization to 0
+    for (const wmtk::Tuple& tup : vertices) {
+        int64_t gid = m.id(tup);
+        auto v = int64_t_acc.const_vector_attribute(tup);
+        CHECK(v.x() == -1);
+        CHECK(v.y() == -1);
+        const wmtk::Tuple& t = tuple_accessor.const_scalar_attribute(tup);
+        wmtk::Tuple& t_ref = tuple_accessor.scalar_attribute(tup);
+        CHECK(t == t_ref);
+        CHECK(t.is_null());
+        t_ref = wmtk::Tuple(gid, gid + 1, gid + 2, gid + 3, gid + 4);
+        {
+            const wmtk::Tuple t2 = tuple_accessor.const_scalar_attribute(tup);
+            CHECK(wmtk::utils::TupleInspector::local_vid(t2) == gid);
+            CHECK(wmtk::utils::TupleInspector::local_eid(t2) == gid + 1);
+            CHECK(wmtk::utils::TupleInspector::local_fid(t2) == gid + 2);
+            CHECK(wmtk::utils::TupleInspector::global_cid(t2) == gid + 3);
+            CHECK(wmtk::utils::TupleInspector::hash(t2) == gid + 4);
+        }
+    }
+    for (const wmtk::Tuple& tup : vertices) {
+        int64_t gid = m.id(tup);
+        auto v = int64_t_acc.const_vector_attribute(tup);
+        const wmtk::Tuple t = tuple_accessor.const_scalar_attribute(tup);
+        CHECK(!t.is_null());
+        CHECK(wmtk::utils::TupleInspector::local_vid(t) == gid);
+        CHECK(wmtk::utils::TupleInspector::local_eid(t) == gid + 1);
+        CHECK(wmtk::utils::TupleInspector::local_fid(t) == gid + 2);
+        CHECK(wmtk::utils::TupleInspector::global_cid(t) == gid + 3);
+        CHECK(wmtk::utils::TupleInspector::hash(t) == gid + 4);
+    }
+}
+
+TEST_CASE("test_multi_tuple_accessor", "[accessor]")
+{
+    int64_t size = 20;
+    DEBUG_PointMesh m(size);
+    REQUIRE(size == m.capacity(wmtk::PrimitiveType::Vertex));
+    auto int64_t_handle =
+        m.register_attribute_typed<int64_t>("int64_t", wmtk::PrimitiveType::Vertex, 4, false, -1);
+    REQUIRE(m.get_attribute_dimension(int64_t_handle) == 4);
+    auto int64_t_acc = m.create_accessor(int64_t_handle);
+
+    auto vertices = m.get_all(wmtk::PrimitiveType::Vertex);
+
+    wmtk::attribute::TupleAccessor<wmtk::PointMesh> tuple_accessor(m, int64_t_handle);
+
+    REQUIRE(int64_t_acc.reserved_size() == size);
+    REQUIRE(tuple_accessor.dimension() == 2);
+
+    // test default initialization to 0
+    for (const wmtk::Tuple& tup : vertices) {
+        auto v = int64_t_acc.const_vector_attribute(tup);
+        CHECK(v.x() == -1);
+        CHECK(v.y() == -1);
+        auto t = tuple_accessor.vector_attribute(tup);
+        REQUIRE(t.size() == 2);
+        REQUIRE(t.rows() == 2);
+        REQUIRE(t.cols() == 1);
+        // CHECK(t == t_ref);
+        CHECK(t(0).is_null());
+        CHECK(t(1).is_null());
+        int64_t gid = m.id(tup);
+        t(0) = wmtk::Tuple(gid, gid + 1, gid + 2, gid + 3, gid + 4);
+        t(1) = wmtk::Tuple(gid, gid + 5, gid + 6, gid + 7, gid + 8);
+    }
+    for (const wmtk::Tuple& tup : vertices) {
+        auto v = int64_t_acc.const_vector_attribute(tup);
+        const auto t = tuple_accessor.const_vector_attribute(tup);
+        REQUIRE(t.size() == 2);
+        REQUIRE(t.rows() == 2);
+        REQUIRE(t.cols() == 1);
+        // CHECK(t == t_ref);
+        CHECK(!t(0).is_null());
+        CHECK(!t(1).is_null());
+        int64_t gid = m.id(tup);
+        CHECK(t(0) == wmtk::Tuple(gid, gid + 1, gid + 2, gid + 3, gid + 4));
+        CHECK(t(1) == wmtk::Tuple(gid, gid + 5, gid + 6, gid + 7, gid + 8));
+    }
+}

--- a/tests/attributes/tuple_accessor.cpp
+++ b/tests/attributes/tuple_accessor.cpp
@@ -4,6 +4,7 @@
 #include <wmtk/attribute/Attribute.hpp>
 #include <wmtk/attribute/AttributeScopeStack.hpp>
 #include <wmtk/attribute/TupleAccessor.hpp>
+#include <wmtk/multimesh/utils/tuple_map_attribute_io.hpp>
 #include <wmtk/utils/Logger.hpp>
 #include <wmtk/utils/TupleInspector.hpp>
 #include "../tools/DEBUG_PointMesh.hpp"
@@ -11,6 +12,29 @@
 
 using namespace wmtk::tests;
 namespace {} // namespace
+
+TEST_CASE("tuple_to_int64_t_storage", "[accessor]")
+{
+    std::array basic_data = {
+        wmtk::Tuple(0, 0, 0, 0, 0),
+        wmtk::Tuple(1, 0, 0, 0, 0),
+        wmtk::Tuple(0, 1, 0, 0, 0),
+        wmtk::Tuple(0, 0, 1, 0, 0),
+        wmtk::Tuple(0, 0, 0, 1, 0),
+        wmtk::Tuple(0, 0, 0, 0, 1),
+        wmtk::Tuple(-1, -1, -1, -1, -1),
+        wmtk::Tuple(0, 0, 0, 0, 0),
+        wmtk::Tuple(0, 20, 30, 40, 50),
+        wmtk::Tuple(-20, 0, -3, 16, -4)};
+    for (const auto& t : basic_data) {
+        wmtk::Vector<int64_t, 2> idat = wmtk::multimesh::utils::tuple_to_vector(t);
+        const int64_t* iptr = reinterpret_cast<const int64_t*>(&t);
+        std::cout << idat.transpose() << " === " << iptr[0] << " " << iptr[1] << std::endl;
+        CHECK(idat(0) == iptr[0]);
+        CHECK(idat(1) == iptr[1]);
+    }
+    // }
+}
 
 TEST_CASE("test_single_tuple_accessor", "[accessor]")
 {
@@ -107,5 +131,43 @@ TEST_CASE("test_multi_tuple_accessor", "[accessor]")
         int64_t gid = m.id(tup);
         CHECK(t(0) == wmtk::Tuple(gid, gid + 1, gid + 2, gid + 3, gid + 4));
         CHECK(t(1) == wmtk::Tuple(gid, gid + 5, gid + 6, gid + 7, gid + 8));
+    }
+}
+TEST_CASE("test_multi_tuple_accessor_gid", "[accessor]")
+{
+    int64_t size = 20;
+    DEBUG_PointMesh m(size);
+    REQUIRE(size == m.capacity(wmtk::PrimitiveType::Vertex));
+    auto int64_t_handle =
+        m.register_attribute_typed<int64_t>("int64_t", wmtk::PrimitiveType::Vertex, 4, false, -1);
+    REQUIRE(m.get_attribute_dimension(int64_t_handle) == 4);
+    auto int64_t_acc = m.create_accessor(int64_t_handle);
+
+    auto vertices = m.get_all(wmtk::PrimitiveType::Vertex);
+
+    wmtk::attribute::TupleAccessor<wmtk::PointMesh> tuple_accessor(m, int64_t_handle);
+
+    REQUIRE(int64_t_acc.reserved_size() == size);
+    REQUIRE(tuple_accessor.dimension() == 2);
+
+    // test default initialization to 0
+    for (const wmtk::Tuple& tup : vertices) {
+        auto v = int64_t_acc.vector_attribute(tup);
+        CHECK((v.array() == -1).all());
+        auto t = tuple_accessor.vector_attribute(tup);
+        REQUIRE(t.size() == 2);
+        REQUIRE(t.rows() == 2);
+        REQUIRE(t.cols() == 1);
+        // CHECK(t == t_ref);
+        CHECK(t(0).is_null());
+        CHECK(t(1).is_null());
+        int64_t gid = m.id(tup);
+
+
+        for (int j = 0; j < tuple_accessor.dimension(); ++j) {
+            int64_t value = gid + 2 * j;
+            v(2 * j) = value;
+            CHECK(wmtk::utils::TupleInspector::global_cid(t(j)) == value);
+        }
     }
 }


### PR DESCRIPTION
Slight changae to multimesh map encoding to try using a TupleAccessor object that cleans up the access of tuples held within int64_t objects