### PR TITLE
switching gcc false positive bug with atomic_store in tbb to be a war…

### DIFF
--- a/cmake/recipes/onetbb.cmake
+++ b/cmake/recipes/onetbb.cmake
@@ -18,8 +18,8 @@ message(STATUS "Third-party (external): creating targets 'TBB::tbb'")
 include(FetchContent)
 FetchContent_Declare(
     tbb
-    URL https://github.com/oneapi-src/oneTBB/archive/refs/tags/v2021.6.0-rc1.zip
-    URL_HASH MD5=88f1dd24a1e393e66d7a851de6e8dc0c
+    URL https://github.com/oneapi-src/oneTBB/archive/refs/tags/v2021.12.0.zip
+    URL_HASH MD5=0919a8eda74333e1aafa8d602bb9cc90
 )
 
 option(TBB_TEST "Enable testing" OFF)
@@ -55,5 +55,12 @@ foreach(name IN ITEMS tbb tbbmalloc tbbmalloc_proxy)
         # Without this macro, TBB will explicitly link against "tbb12_debug.lib" in Debug configs.
         # This is undesirable, since our pre-compiled version of MKL is linked against "tbb12.dll".
         target_compile_definitions(${name} PUBLIC -D__TBB_NO_IMPLICIT_LINKAGE=1)
+
+        # following https://github.com/Oneflow-Inc/oneflow/pull/10236 because the current fix in 
+        # https://github.com/oneapi-src/oneTBB/issues/843 seems to not be fully solved
+        if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 12)
+            target_compile_options(${name} PRIVATE "-Wno-error=stringop-overflow")
+        endif()
+
     endif()
 endforeach()


### PR DESCRIPTION
[This bug](https://github.com/oneapi-src/oneTBB/issues/843) seems to still present itself in our toolkit on my personal machines so I'm converting it to a warning to match 
https://github.com/Oneflow-Inc/oneflow/pull/10236

I'm running 
```
❯ gcc --version
gcc (Gentoo 13.2.1_p20240210 p14) 13.2.1 20240210
```

```
In file included from /usr/lib/gcc/x86_64-pc-linux-gnu/13/include/g++-v13/atomic:41,
                 from _deps/tbb-src/include/oneapi/tbb/detail/_utils.h:22,
                 from _deps/tbb-src/src/tbb/address_waiter.cpp:17:
In member function ‘void std::__atomic_base<_IntTp>::store(__int_type, std::memory_order) [with _ITp = bool]’,
    inlined from ‘void std::atomic<bool>::store(bool, std::memory_order)’ at /usr/lib/gcc/x86_64-pc-linux-gnu/13/include/g++-v13/atomic:104:20,
    inlined from ‘void tbb::detail::r1::concurrent_monitor_base<Context>::abort_all_relaxed() [with Context = tbb::detail::r1::address_context]’ at _deps/tbb-src/src/tbb/concurrent_monitor.h:440:53,
    inlined from ‘void tbb::detail::r1::concurrent_monitor_base<Context>::abort_all() [with Context = tbb::detail::r1::address_context]’ at _deps/tbb-src/src/tbb/concurrent_monitor.h:423:26,
    inlined from ‘void tbb::detail::r1::concurrent_monitor_base<Context>::destroy() [with Context = tbb::detail::r1::address_context]’ at _deps/tbb-src/src/tbb/concurrent_monitor.h:456:24,
    inlined from ‘void tbb::detail::r1::clear_address_waiter_table()’ at _deps/tbb-src/src/tbb/address_waiter.cpp:60:40:
/usr/lib/gcc/x86_64-pc-linux-gnu/13/include/g++-v13/bits/atomic_base.h:481:25: error: ‘void __atomic_store_1(volatile void*, unsigned char, int)’ writing 1 byte into a region of size 0 overflows the destination [-Werror=stringop-overflow=]
  481 |         __atomic_store_n(&_M_i, __i, int(__m));
      |         ~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~
```