### PR TITLE
Update Operation.cpp

### DIFF
--- a/src/wmtk/operations/Operation.cpp
+++ b/src/wmtk/operations/Operation.cpp
@@ -95,10 +95,7 @@ bool Operation::before(const simplex::Simplex& simplex) const
     //     return false;
     // }
 
-    if (!mesh().is_valid(simplex)) {
-        return false;
-    }
-    if (mesh().is_removed(simplex.tuple())) {
+    if (mesh().is_removed(simplex.tuple()) || !mesh().is_valid(simplex)) {
         return false;
     }
 


### PR DESCRIPTION
The `is_valid(simplex)` check must be performed after the `is_removed` check, because `is_valid` has an assert that checks for `is_removed`.