### PR TITLE
Mesh destructor cleans up child mesh references

### DIFF
--- a/src/wmtk/Mesh_construction.cpp
+++ b/src/wmtk/Mesh_construction.cpp
@@ -48,5 +48,8 @@ Mesh::Mesh(const int64_t& dimension, const int64_t& max_primitive_type_id, Primi
 }
 
 
-Mesh::~Mesh() = default;
+Mesh::~Mesh() {
+
+    m_multi_mesh_manager.detach_children();
+}
 } // namespace wmtk

--- a/src/wmtk/multimesh/MultiMeshManager.cpp
+++ b/src/wmtk/multimesh/MultiMeshManager.cpp
@@ -21,6 +21,19 @@ namespace wmtk::multimesh {
 
 namespace {} // namespace
 
+
+void MultiMeshManager::detach_children() {
+    for(auto& data: m_children) {
+
+        auto& m = *data.mesh;
+        m.m_multi_mesh_manager.m_parent = nullptr;
+        m.m_multi_mesh_manager.m_child_id = -1;
+        // TODO: delete attributes
+    }
+
+    m_children.clear();
+}
+
 Tuple MultiMeshManager::map_tuple_between_meshes(
     const Mesh& source_mesh,
     const Mesh& target_mesh,

--- a/src/wmtk/multimesh/MultiMeshManager.hpp
+++ b/src/wmtk/multimesh/MultiMeshManager.hpp
@@ -90,6 +90,9 @@ public:
     // attribute directly hashes its "children" components so it overrides "child_hashes"
     std::map<std::string, const wmtk::utils::Hashable*> child_hashables() const override;
     std::map<std::string, std::size_t> child_hashes() const override;
+    
+
+    void detach_children();
 
     //=========================================================
     // Storage of MultiMesh


### PR DESCRIPTION
When a mesh is destroyed its child meshes can be left in an invalid state.
This PR cleans up the parent pointers of children, but leaves child map attributes undisturbed. This is a TODO