### PR TITLE
Dzint/fixing integration tests

### DIFF
--- a/components/tests/integration_guide.md
+++ b/components/tests/integration_guide.md
@@ -1,10 +1,9 @@
 # Guide for Using Integration Test
 
-When you want to start a new integration test, then you need to have following a few steps to set up the test.
+1. Write a JSON file under the folder `/data/unit_test/`, you can refer to those existing JSON files to learn how to write it.
+2. Put the mesh for your test under the folder `/data/unit_test/meshes`.
+3. Add the JSON file's name to `/components/tests/integration_test.cpp`, i.e. add the line `WMTK_INTEGRATION("YOUR TEST NAME", false);`.
+4. The first time you run your integration test, set the `DO_VALIDATION` parameter `false`, i.e. `WMTK_INTEGRATION("YOUR TEST NAME", false);`. The integration test will then add the test output (number of simplices) to your JSON. Afterward, set the parameter to `true`. Now, the integration test will compare the result with your original output and fail if the two do not match.
+5. Push the JSON and meshes to the [wmtk data repo](https://github.com/wildmeshing/data).
 
-- First, write a JSON file under the folder `/data/unit_test/`, you can refer to those existing JSON files to learn how to write it.
-- Second, you need the model to run your integration test. Put your model under the folder `/data/unit_test/meshes`.(you may have to update the wmtkdata)
-- Third, after you have done the steps above, you should add the JSON file's name to `/components/tests/integration_test.cpp`. Such as `WMTK_INTEGRATION("YOUR TEST NAME", false);`
-- Fourth, for the first time you run your integration test, you should set `DO_VALIDATION` parameter `true` in `WMTK_INTEGRATION`. Then `integraion_test.cpp` will generate the original performance of your code. After that, you should set the parameter as `false`. In the later integration test, `integraion_test.cpp` will compare the result with your original performance to make sure your new version code's performance always consistent with the original one.
-
-NOTE: you can have a look at the `integrations_test.cpp` to get more details if you want.
+Look at `integrations_test.cpp` for more details.

--- a/components/tests/integration_guide.md
+++ b/components/tests/integration_guide.md
@@ -1,7 +1,7 @@
 # Guide for Using Integration Test
 
 1. Write a JSON file under the folder `/data/unit_test/`, you can refer to those existing JSON files to learn how to write it.
-2. Put the mesh for your test under the folder `/data/unit_test/meshes`.
+2. Put the mesh for your test under the folder `/data/unit_test/meshes`. Please check first, if one of the existing meshes is suitable for your integration test.
 3. Add the JSON file's name to `/components/tests/integration_test.cpp`, i.e. add the line `WMTK_INTEGRATION("YOUR TEST NAME", false);`.
 4. The first time you run your integration test, set the `DO_VALIDATION` parameter `false`, i.e. `WMTK_INTEGRATION("YOUR TEST NAME", false);`. The integration test will then add the test output (number of simplices) to your JSON. Afterward, set the parameter to `true`. Now, the integration test will compare the result with your original output and fail if the two do not match.
 5. Push the JSON and meshes to the [wmtk data repo](https://github.com/wildmeshing/data).

--- a/components/tests/integration_test.cpp
+++ b/components/tests/integration_test.cpp
@@ -51,7 +51,7 @@ int authenticate_json(const std::string& json_file, const bool compute_validatio
 {
     json in_args;
     if (!load_json(json_file, in_args)) {
-        spdlog::error("unable to open {} file", json_file);
+        wmtk::logger().error("unable to open {} file", json_file);
         return 1;
     }
 
@@ -68,18 +68,18 @@ int authenticate_json(const std::string& json_file, const bool compute_validatio
 
     if (!compute_validation) {
         if (missing_tests_data(in_args)) {
-            spdlog::error("JSON file missing \"tests\" or meshes key.");
+            wmtk::logger().error("JSON file missing \"tests\" or meshes key.");
             return 1;
         }
 
         REQUIRE(contains_results(in_args));
 
-        spdlog::info("Authenticating...");
+        wmtk::logger().info("Authenticating...");
 
         const std::vector<std::string> meshes = in_args["tests"]["meshes"];
 
         if (in_args["tests"].contains("skip_check") && in_args["tests"]["skip_check"]) {
-            spdlog::warn("Skpping checks for {}", json_file);
+            wmtk::logger().warn("Skpping checks for {}", json_file);
             return 0;
         }
 
@@ -89,7 +89,7 @@ int authenticate_json(const std::string& json_file, const bool compute_validatio
         const auto tetrahedra = in_args["tests"]["tetrahedra"];
         if (meshes.size() != vertices.size() || meshes.size() != edges.size() ||
             meshes.size() != faces.size() || meshes.size() != tetrahedra.size()) {
-            spdlog::error(
+            wmtk::logger().error(
                 "JSON size missmatch between meshes and vertices, edges, faces, or tetrahedra.");
             return 2;
         }
@@ -108,7 +108,7 @@ int authenticate_json(const std::string& json_file, const bool compute_validatio
             const int64_t n_tetrahedra = mesh->get_all(PrimitiveType::Tetrahedron).size();
 
             if (n_vertices != expected_vertices) {
-                spdlog::error(
+                wmtk::logger().error(
                     "Violating Authenticate in mesh `{}` for vertices {} != {}",
                     meshes[i],
                     n_vertices,
@@ -116,7 +116,7 @@ int authenticate_json(const std::string& json_file, const bool compute_validatio
                 return 2;
             }
             if (n_edges != expected_edges) {
-                spdlog::error(
+                wmtk::logger().error(
                     "Violating Authenticate in mesh `{}` for edges {} != {}",
                     meshes[i],
                     n_edges,
@@ -124,7 +124,7 @@ int authenticate_json(const std::string& json_file, const bool compute_validatio
                 return 2;
             }
             if (n_faces != expected_faces) {
-                spdlog::error(
+                wmtk::logger().error(
                     "Violating Authenticate in mesh `{}` for faces {} != {}",
                     meshes[i],
                     n_faces,
@@ -132,7 +132,7 @@ int authenticate_json(const std::string& json_file, const bool compute_validatio
                 return 2;
             }
             if (n_tetrahedra != expected_tetrahedra) {
-                spdlog::error(
+                wmtk::logger().error(
                     "Violating Authenticate in mesh `{}` for tetrahedra {} != {}",
                     meshes[i],
                     n_tetrahedra,
@@ -141,17 +141,17 @@ int authenticate_json(const std::string& json_file, const bool compute_validatio
             }
         }
 
-        spdlog::info("Authenticated ✅");
+        wmtk::logger().info("Authenticated ✅");
     } else {
         if (contains_results(in_args)) {
-            spdlog::error(
+            wmtk::logger().error(
                 "JSON file contains results even though the test was run in `computation "
                 "mode`. Set DO_VALIDATION to false to compare with saved results or remove "
                 "results from JSON to re-compute them.");
             return 2;
         }
 
-        spdlog::warn("Appending JSON...");
+        wmtk::logger().warn("Appending JSON...");
 
         const std::vector<std::string> meshes = cache.mesh_names();
         in_args["tests"]["meshes"] = meshes;
@@ -200,7 +200,7 @@ std::string tagsrun = "[.][integration]";
     {                                                                                \
         std::string path = std::string("unit_test/") + NAME + ".json";               \
         bool compute_validation = DO_VALIDATION;                                     \
-        spdlog::info("Processing {}", NAME);                                         \
+        wmtk::logger().info("Processing {}", NAME);                                  \
         auto flag = authenticate_json(WMTK_DATA_DIR "/" + path, compute_validation); \
         REQUIRE(flag == 0);                                                          \
     }

--- a/components/tests/integration_test.cpp
+++ b/components/tests/integration_test.cpp
@@ -220,4 +220,4 @@ WMTK_INTEGRATION("disk_fan_mm", false);
 // WMTK_INTEGRATION("grid",false);
 // WMTK_INTEGRATION("wildmeshing_2d", false);
 // WMTK_INTEGRATION("wildmeshing_3d", false);
-WMTK_INTEGRATION("marching", true);
+WMTK_INTEGRATION("marching", false);

--- a/components/wmtk_components/main/wmtk/components/run_components.cpp
+++ b/components/wmtk_components/main/wmtk/components/run_components.cpp
@@ -2,6 +2,7 @@
 
 #include <jse/jse.h>
 #include <wmtk/utils/Logger.hpp>
+#include <wmtk/utils/Stopwatch.hpp>
 
 
 #include <wmtk/components/base/Paths.hpp>
@@ -81,6 +82,7 @@ wmtk::io::Cache run_components(const nlohmann::json& json_input_file, bool stric
     for (const nlohmann::json& component_json : spec_json["components"]) {
         for (auto& el : component_json.items()) {
             wmtk::logger().info("Component {}", el.key());
+            wmtk::utils::StopWatch sw(el.key());
             components[el.key()](paths, el.value(), cache);
             cache.flush_multimeshes();
         }

--- a/src/wmtk/io/Cache.cpp
+++ b/src/wmtk/io/Cache.cpp
@@ -180,6 +180,16 @@ void Cache::flush_multimeshes()
     }
 }
 
+std::vector<std::string> Cache::mesh_names()
+{
+    std::vector<std::string> names;
+    for (const auto& fp : m_file_paths) {
+        names.emplace_back(fp.first);
+    }
+
+    return names;
+}
+
 void Cache::write_mesh(
     const Mesh& m,
     const std::string& name,

--- a/src/wmtk/io/Cache.hpp
+++ b/src/wmtk/io/Cache.hpp
@@ -147,6 +147,11 @@ public:
     /// Unsets the mesh held by each cached mm - useful for debugging whether cache loading works
     void flush_multimeshes();
 
+    /**
+     * @brief Get all names of the meshes stored in cache.
+     */
+    std::vector<std::string> mesh_names();
+
 private:
     std::filesystem::path m_cache_dir;
     std::map<std::string, std::filesystem::path> m_file_paths; // name --> file location

--- a/src/wmtk/utils/CMakeLists.txt
+++ b/src/wmtk/utils/CMakeLists.txt
@@ -61,6 +61,9 @@ set(SRC_FILES
 
     EigenMatrixWriter.hpp
     EigenMatrixWriter.cpp
+
+    Stopwatch.hpp
+    Stopwatch.cpp
 )
 target_sources(wildmeshing_toolkit PRIVATE ${SRC_FILES})
 

--- a/src/wmtk/utils/Stopwatch.cpp
+++ b/src/wmtk/utils/Stopwatch.cpp
@@ -1,0 +1,60 @@
+#include "Stopwatch.hpp"
+
+
+#include <spdlog/common.h>
+
+namespace wmtk::utils {
+
+
+StopWatch::StopWatch(const std::string& name)
+    : StopWatch(name, spdlog::level::info)
+{}
+
+StopWatch::StopWatch(const std::string& name, const spdlog::level::level_enum log_level)
+    : m_name(name)
+    , m_log_level(log_level)
+{
+    start();
+}
+
+StopWatch::~StopWatch()
+{
+    if (m_is_running) {
+        stop();
+        log_msg();
+    }
+}
+
+void StopWatch::start()
+{
+    m_is_running = true;
+    m_start = std::chrono::high_resolution_clock::now();
+}
+
+void StopWatch::stop()
+{
+    if (!m_is_running) {
+        return;
+    }
+    m_is_running = false;
+    m_stop = std::chrono::high_resolution_clock::now();
+}
+
+inline void StopWatch::log_msg()
+{
+    int64_t h = getElapsedTime<std::chrono::hours>();
+    int64_t m = getElapsedTime<std::chrono::minutes>() % 60;
+    int64_t s = getElapsedTime<std::chrono::seconds>() % 60;
+    int64_t ms = getElapsedTime<std::chrono::milliseconds>() % 1000;
+
+    logger().log(
+        m_log_level,
+        "[runtime h:m:s.ms] {}: {:02d}:{:02d}:{:02d}.{:03d}",
+        m_name,
+        h,
+        m,
+        s,
+        ms);
+}
+
+} // namespace wmtk::utils

--- a/src/wmtk/utils/Stopwatch.hpp
+++ b/src/wmtk/utils/Stopwatch.hpp
@@ -1,0 +1,43 @@
+#pragma once
+
+#include <spdlog/common.h>
+#include <chrono>
+#include <type_traits>
+#include <wmtk/utils/Logger.hpp>
+
+namespace wmtk::utils {
+
+class StopWatch
+{
+public:
+    StopWatch(const std::string& name);
+    StopWatch(const std::string& name, const spdlog::level::level_enum log_level);
+
+    virtual ~StopWatch();
+
+    void start();
+    void stop();
+
+    template <typename T = std::chrono::seconds>
+    int64_t getElapsedTime();
+
+    void log_msg();
+
+
+private:
+    std::string m_name;
+    spdlog::level::level_enum m_log_level = spdlog::level::info;
+    std::chrono::high_resolution_clock::time_point m_start;
+    std::chrono::high_resolution_clock::time_point m_stop;
+
+    bool m_is_running = false;
+};
+
+template <typename T>
+inline int64_t StopWatch::getElapsedTime()
+{
+    auto duration = std::chrono::duration_cast<T>(m_stop - m_start);
+    return duration.count();
+}
+
+} // namespace wmtk::utils


### PR DESCRIPTION
Creating a new integration test is now simpler. The "tests" object in the JSON is automatically created.