### PR TITLE
Delete single attribute

### DIFF
--- a/components/wmtk_components/winding_number/wmtk/components/winding_number/internal/winding_number.cpp
+++ b/components/wmtk_components/winding_number/wmtk/components/winding_number/internal/winding_number.cpp
@@ -5,8 +5,15 @@
 #include <wmtk/utils/EigenMatrixWriter.hpp>
 
 #include <igl/bfs_orient.h>
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Warray-bounds"
+#endif
 #include <igl/fast_winding_number.h>
 #include <igl/winding_number.h>
+#if defined(__GNUG__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
 #include <wmtk/utils/Rational.hpp>
 
 namespace wmtk::components::internal {

--- a/src/wmtk/Mesh.hpp
+++ b/src/wmtk/Mesh.hpp
@@ -254,6 +254,8 @@ public:
         const std::vector<attribute::MeshAttributeHandle::HandleVariant>& keep_attributes);
     void clear_attributes();
     void clear_attributes(const std::vector<attribute::MeshAttributeHandle>& keep_attributes);
+    void delete_attribute(const attribute::MeshAttributeHandle& to_delete);
+    void delete_attribute(const attribute::MeshAttributeHandle::HandleVariant& to_delete);
 
 
     // creates a scope as int64_t as the AttributeScopeHandle exists

--- a/src/wmtk/Mesh_attributes.cpp
+++ b/src/wmtk/Mesh_attributes.cpp
@@ -184,7 +184,19 @@ void Mesh::clear_attributes(const std::vector<attribute::MeshAttributeHandle>& k
         mptr->clear_attributes(handles);
     }
 }
+void Mesh::delete_attribute(const attribute::MeshAttributeHandle& to_delete)
+{
+    assert(this == &to_delete.mesh());
 
+    delete_attribute(to_delete.handle());
+
+}
+
+void Mesh::delete_attribute(const attribute::MeshAttributeHandle::HandleVariant& to_delete)
+{
+    m_attribute_manager.delete_attribute(to_delete);
+
+}
 multimesh::attribute::AttributeScopeHandle Mesh::create_scope()
 {
     return multimesh::attribute::AttributeScopeHandle(*this);

--- a/src/wmtk/attribute/AttributeManager.cpp
+++ b/src/wmtk/attribute/AttributeManager.cpp
@@ -334,6 +334,8 @@ void AttributeManager::clear_attributes(
                     using T = typename HandleType::Type;
                     customs.get<T>()[get_primitive_type_id(val.primitive_type())].emplace_back(
                         val.base_handle());
+                } else {
+                assert(false); // this code doesn't work with hybrid rational types
                 }
             },
             attr);
@@ -343,8 +345,9 @@ void AttributeManager::clear_attributes(
     auto run = [&](auto t) {
         using T = typename std::decay_t<decltype(t)>;
         auto& mycustoms = customs.get<T>();
+        const auto& attributes = get<T>();
 
-        for (size_t ptype_id = 0; ptype_id < m_char_attributes.size(); ++ptype_id) {
+        for (size_t ptype_id = 0; ptype_id < attributes.size(); ++ptype_id) {
             const PrimitiveType primitive_type = get_primitive_type_from_id(ptype_id);
 
 

--- a/src/wmtk/attribute/AttributeManager.cpp
+++ b/src/wmtk/attribute/AttributeManager.cpp
@@ -357,5 +357,19 @@ void AttributeManager::clear_attributes(
     run(char{});
     run(Rational{});
 }
+void AttributeManager::delete_attribute(
+    const attribute::MeshAttributeHandle::HandleVariant& to_delete)
+{
+    std::visit(
+        [&](auto&& val) noexcept {
+            using HandleType = typename std::decay_t<decltype(val)>;
+            if constexpr (attribute::MeshAttributeHandle::template handle_type_is_basic<
+                              HandleType>()) {
+                using T = typename HandleType::Type;
+                get<T>(val).remove_attribute(val.base_handle());
+            }
+        },
+        to_delete);
+}
 
 } // namespace wmtk::attribute

--- a/src/wmtk/attribute/AttributeManager.hpp
+++ b/src/wmtk/attribute/AttributeManager.hpp
@@ -122,6 +122,8 @@ public:
      */
     void clear_attributes(
         const std::vector<attribute::MeshAttributeHandle::HandleVariant>& custom_attributes);
+    void delete_attribute(
+        const attribute::MeshAttributeHandle::HandleVariant& to_delete);
 };
 
 template <typename T>

--- a/src/wmtk/attribute/MeshAttributes.cpp
+++ b/src/wmtk/attribute/MeshAttributes.cpp
@@ -230,7 +230,7 @@ void MeshAttributes<T>::guarantee_at_least(const int64_t size)
 }
 
 template <typename T>
-void MeshAttributes<T>::remove_attributes(const std::vector<AttributeHandle>& attributes)
+void MeshAttributes<T>::remove_attributes(const std::vector<AttributeHandle>& attributes, bool invalidate_handles)
 {
     if (attributes.empty()) {
         return;
@@ -252,7 +252,9 @@ void MeshAttributes<T>::remove_attributes(const std::vector<AttributeHandle>& at
     }
 
 
+    if(invalidate_handles) {
     clear_dead_attributes();
+    }
 }
 
 

--- a/src/wmtk/attribute/MeshAttributes.cpp
+++ b/src/wmtk/attribute/MeshAttributes.cpp
@@ -177,14 +177,18 @@ template <typename T>
 void MeshAttributes<T>::set(const AttributeHandle& handle, std::vector<T> val)
 {
     // TODO: should we validate the size of val compared to the internally held data?
-    auto& attr = *m_attributes[handle.index];
+    auto& attr_ptr = m_attributes[handle.index];
+    assert(bool(attr_ptr));
+    auto& attr = *attr_ptr;
     attr.set(std::move(val));
 }
 
 template <typename T>
 size_t MeshAttributes<T>::attribute_size(const AttributeHandle& handle) const
 {
-    return m_attributes[handle.index]->reserved_size();
+    auto& attr_ptr = m_attributes[handle.index];
+    assert(bool(attr_ptr));
+    return attr_ptr->reserved_size();
 }
 
 template <typename T>
@@ -204,7 +208,9 @@ void MeshAttributes<T>::reserve(const int64_t size)
 {
     m_reserved_size = size;
     for (auto& attr_ptr : m_attributes) {
-        attr_ptr->reserve(size);
+        if (bool(attr_ptr)) {
+            attr_ptr->reserve(size);
+        }
     }
 }
 
@@ -302,6 +308,7 @@ void MeshAttributes<T>::set_name(const AttributeHandle& handle, const std::strin
     }
 
     auto& attr = m_attributes[handle.index];
+    assert(bool(attr));
     assert(attr->m_name == old_name);
 
     assert(m_handles.count(name) == 0); // name should not exist already

--- a/src/wmtk/attribute/MeshAttributes.cpp
+++ b/src/wmtk/attribute/MeshAttributes.cpp
@@ -135,7 +135,8 @@ AttributeHandle MeshAttributes<T>::attribute_handle(const std::string& name) con
 template <typename T>
 bool MeshAttributes<T>::has_attribute(const std::string& name) const
 {
-    return m_handles.find(name) != m_handles.end();
+    auto it = m_handles.find(name);
+    return it != m_handles.end() && bool(m_attributes[it->second.index]);
 }
 
 template <typename T>
@@ -248,6 +249,22 @@ void MeshAttributes<T>::remove_attributes(const std::vector<AttributeHandle>& at
 }
 
 
+template <typename T>
+void MeshAttributes<T>::remove_attribute(const AttributeHandle& attribute)
+{
+    m_attributes[attribute.index].reset();
+}
+
+template <typename T>
+void MeshAttributes<T>::clear_dead_attribute_names() {
+    for (auto it = m_handles.begin(); it != m_handles.end(); /* no increment */) {
+        if (!bool(m_attributes[it->second.index])) {
+            it = m_handles.erase(it);
+        } else {
+        ++it;
+        }
+    }
+}
 template <typename T>
 std::string MeshAttributes<T>::get_name(const AttributeHandle& handle) const
 {

--- a/src/wmtk/attribute/MeshAttributes.hpp
+++ b/src/wmtk/attribute/MeshAttributes.hpp
@@ -69,6 +69,8 @@ public:
      * @param attributes Vector of attributes that should be removed.
      */
     void remove_attributes(const std::vector<AttributeHandle>& attributes);
+    void remove_attribute(const AttributeHandle& attributes);
+    void clear_dead_attribute_names();
 
     bool operator==(const MeshAttributes<T>& other) const;
     void push_scope();

--- a/src/wmtk/attribute/MeshAttributes.hpp
+++ b/src/wmtk/attribute/MeshAttributes.hpp
@@ -70,7 +70,7 @@ public:
      */
     void remove_attributes(const std::vector<AttributeHandle>& attributes);
     void remove_attribute(const AttributeHandle& attributes);
-    void clear_dead_attribute_names();
+    void clear_dead_attributes();
 
     bool operator==(const MeshAttributes<T>& other) const;
     void push_scope();

--- a/src/wmtk/attribute/MeshAttributes.hpp
+++ b/src/wmtk/attribute/MeshAttributes.hpp
@@ -69,8 +69,13 @@ public:
      * @param attributes Vector of attributes that should be removed.
      */
     void remove_attributes(const std::vector<AttributeHandle>& attributes);
-    void remove_attribute(const AttributeHandle& attributes);
-    void clear_dead_attributes();
+    /**
+     * @brief Remove a single attribute
+     *
+     * @param attribute the attribute being deleted
+     */
+    void remove_attribute(const AttributeHandle& attribute);
+
 
     bool operator==(const MeshAttributes<T>& other) const;
     void push_scope();
@@ -94,6 +99,9 @@ public:
     void assert_capacity_valid(int64_t cap) const;
 
 protected:
+    /// Clears and compactifies the attribute list. This invalidates all existing handles
+    void clear_dead_attributes();
+
     AttributeHandle attribute_handle(const std::string& name) const;
 
 

--- a/src/wmtk/attribute/MeshAttributes.hpp
+++ b/src/wmtk/attribute/MeshAttributes.hpp
@@ -67,8 +67,9 @@ public:
      * @brief Remove all passed in attributes.
      *
      * @param attributes Vector of attributes that should be removed.
+     * @param invalidate_handles invalidates all handles. If true this garbage collects old handles
      */
-    void remove_attributes(const std::vector<AttributeHandle>& attributes);
+    void remove_attributes(const std::vector<AttributeHandle>& attributes, bool invalidate_handles = true);
     /**
      * @brief Remove a single attribute
      *


### PR DESCRIPTION
Deleting a single attribute is a pain right now, so changed the semantic for deleting an attribute to be that the attribute's unique_ptr is deleted / empty. As such we can delete attributes without invalidating every handle.

Accessors to a deleted attribute will result in UB.