### PR TITLE
Remove index usage in AttributeManager::get_all_attributes

### DIFF
--- a/src/wmtk/attribute/AttributeManager.cpp
+++ b/src/wmtk/attribute/AttributeManager.cpp
@@ -280,13 +280,15 @@ std::vector<MeshAttributeHandle::HandleVariant> AttributeManager::get_all_attrib
 
         const std::vector<MeshAttributes<T>>& mesh_attributes = get<T>();
         for (size_t pt_index = 0; pt_index < mesh_attributes.size(); ++pt_index) {
+                const PrimitiveType pt = get_primitive_type_from_id(pt_index);
+
+            auto handle_converter = [pt](const AttributeHandle& h)  -> TypedAttributeHandle<T> {
+                return {h, pt};
+                return TypedAttributeHandle<T>{h,pt};
+            };
             size_t count = mesh_attributes[pt_index].attribute_count();
-            for (int64_t index = 0; index < count; ++index) {
-                TypedAttributeHandle<T> t;
-                t.m_base_handle.index = index;
-                t.m_primitive_type = get_primitive_type_from_id(pt_index);
-                handles.emplace_back(t);
-            }
+            const auto active_handles = mesh_attributes[pt_index].active_attributes();
+            std::transform(active_handles.begin(), active_handles.end(), std::back_inserter(handles), handle_converter);
         }
     };
     run(double{});

--- a/src/wmtk/attribute/MeshAttributes.cpp
+++ b/src/wmtk/attribute/MeshAttributes.cpp
@@ -200,7 +200,21 @@ int64_t MeshAttributes<T>::reserved_size() const
 template <typename T>
 size_t MeshAttributes<T>::attribute_count() const
 {
-    return m_attributes.size();
+    return active_attributes().size();
+}
+template <typename T>
+auto MeshAttributes<T>::active_attributes() const -> std::vector<AttributeHandle>
+{
+    std::vector<AttributeHandle> handles;
+    handles.reserve(m_attributes.size());
+    for(size_t j = 0; j < m_attributes.size(); ++j) {
+        if(bool(m_attributes[j])) {
+            handles.emplace_back(j);
+        }
+    }
+
+    return handles;
+
 }
 
 template <typename T>

--- a/src/wmtk/attribute/MeshAttributes.hpp
+++ b/src/wmtk/attribute/MeshAttributes.hpp
@@ -95,8 +95,13 @@ public:
 
     bool has_attribute(const std::string& name) const;
 
-    // the number of attributes held in this object
+    // the number of active attributes held in this object
+    // Note that the set of active attribute indices is not defined by the integers between 0, attribute_count. To get a list of valid handles use active_attributes
+    // This function is not that fast
     size_t attribute_count() const;
+
+    // Returns a vector of handles to the set of active attributes
+    std::vector<AttributeHandle> active_attributes() const;
     void assert_capacity_valid(int64_t cap) const;
 
 protected:


### PR DESCRIPTION
#790 forgot to change how the set of all attributes was computed in `AttributeManager::get_all_attributes`. In particular, it used a loop over indices to generate handles for every attribute in a `MeshAttributes` - but now `MeshAttributes` can contain dead attributes within the index range 0...`attribute_count()`. This PR therefore moves responsibility of creating the set of valid `AttributeHandle` objects to the `MeshAttributes` class, which the `AttributeManager` invokes (via a call to `MeshAttributes::active_attributes()`.