### PR TITLE
Operations Undo Exceptions

### DIFF
--- a/src/wmtk/Mesh.hpp
+++ b/src/wmtk/Mesh.hpp
@@ -38,6 +38,14 @@
 
 
 namespace wmtk {
+    namespace tests {
+        class DEBUG_Mesh;
+namespace tools {
+
+class TestTools;
+
+}
+}
 // thread management tool that we will PImpl
 namespace attribute {
 class AttributeManager;
@@ -50,6 +58,9 @@ class Operation;
 class EdgeCollapse;
 class EdgeSplit;
 class EdgeOperationData;
+namespace internal {
+class CollapseAlternateFacetData;
+}
 namespace utils {
 class UpdateEdgeOperationMultiMeshMapFunctor;
 }
@@ -91,6 +102,8 @@ class TupleTag;
 class Mesh : public std::enable_shared_from_this<Mesh>, public wmtk::utils::MerkleTreeInteriorNode
 {
 public:
+    friend class tests::tools::TestTools;
+    friend class tests::DEBUG_Mesh;
     template <typename T, int Dim>
     friend class attribute::AccessorBase;
     template <typename T, typename MeshType, int Dim>
@@ -121,7 +134,7 @@ public:
     friend class operations::EdgeCollapse;
     friend class operations::EdgeSplit;
     friend class operations::EdgeOperationData;
-
+    friend class operations::internal::CollapseAlternateFacetData;
 
 
     int64_t top_cell_dimension() const;

--- a/src/wmtk/attribute/TypedAttributeHandle.hpp
+++ b/src/wmtk/attribute/TypedAttributeHandle.hpp
@@ -46,7 +46,7 @@ private:
     template <int D>
     friend class utils::HybridRationalAttribute;
     wmtk::attribute::AttributeHandle m_base_handle;
-    wmtk::PrimitiveType m_primitive_type;
+    wmtk::PrimitiveType m_primitive_type = wmtk::PrimitiveType::Vertex;
 
     TypedAttributeHandle(AttributeHandle ah, PrimitiveType pt)
         : m_base_handle(ah)

--- a/src/wmtk/attribute/internal/hash.cpp
+++ b/src/wmtk/attribute/internal/hash.cpp
@@ -15,7 +15,8 @@ size_t wmtk::hash<wmtk::attribute::MeshAttributeHandle>::operator()(
     data.emplace_back(handle_hash(handle));
     data.emplace_back(mesh_hash(handle));
     data.emplace_back(size_t(handle.held_type()));
-    return wmtk::utils::vector_hash(data);
+    const size_t r = wmtk::utils::vector_hash(data);
+    return r;
 }
 size_t wmtk::hash<wmtk::attribute::MeshAttributeHandle>::handle_hash(
     const wmtk::attribute::MeshAttributeHandle& handle) const noexcept

--- a/src/wmtk/attribute/internal/hash.hpp
+++ b/src/wmtk/attribute/internal/hash.hpp
@@ -28,7 +28,8 @@ public:
         std::vector<size_t> data;
         data.emplace_back(handle_hash(handle));
         data.emplace_back(primitive_hash(handle));
-        return wmtk::utils::vector_hash(data);
+        const size_t r = wmtk::utils::vector_hash(data);
+        return r;
     }
     size_t handle_hash(const wmtk::attribute::TypedAttributeHandle<T>& handle) const noexcept
     {

--- a/src/wmtk/multimesh/MultiMeshManager.cpp
+++ b/src/wmtk/multimesh/MultiMeshManager.cpp
@@ -22,9 +22,9 @@ namespace wmtk::multimesh {
 namespace {} // namespace
 
 
-void MultiMeshManager::detach_children() {
-    for(auto& data: m_children) {
-
+void MultiMeshManager::detach_children()
+{
+    for (auto& data : m_children) {
         auto& m = *data.mesh;
         m.m_multi_mesh_manager.m_parent = nullptr;
         m.m_multi_mesh_manager.m_child_id = -1;
@@ -862,7 +862,7 @@ void MultiMeshManager::update_map_tuple_hashes(
                 split_cell_maps);
 
             if (!new_parent_shared_opt.has_value()) {
-                //std::cout << "get skipped, someting is wrong?" << std::endl;
+                // std::cout << "get skipped, someting is wrong?" << std::endl;
                 continue;
             }
             // assert(new_parent_shared_opt.has_value());
@@ -1038,8 +1038,6 @@ int64_t MultiMeshManager::parent_local_fid(
     return vptr[2];
 #endif
 }
-
-
 
 
 // remove after bug fix

--- a/src/wmtk/simplex/top_dimension_cofaces.cpp
+++ b/src/wmtk/simplex/top_dimension_cofaces.cpp
@@ -8,6 +8,7 @@
 #include <set>
 
 #include <wmtk/EdgeMesh.hpp>
+#include <wmtk/PointMesh.hpp>
 #include <wmtk/TetMesh.hpp>
 #include <wmtk/TriMesh.hpp>
 
@@ -437,6 +438,30 @@ void top_dimension_cofaces(
 }
 
 void top_dimension_cofaces_tuples(
+    const PointMesh& mesh,
+    const Simplex& simplex,
+    SimplexCollection& collection)
+{
+    switch (simplex.primitive_type()) {
+    case PrimitiveType::Vertex: {
+        collection.add(simplex);
+        break;
+    }
+    case PrimitiveType::Edge: {
+        log_and_throw_error("top_dimension_cofaces_tuples not implemented for Edge in PointMesh");
+        break;
+    }
+    case PrimitiveType::Triangle: {
+        log_and_throw_error("top_dimension_cofaces_tuples not implemented for Face in PointMesh");
+    }
+    case PrimitiveType::Tetrahedron:
+        log_and_throw_error(
+            "top_dimension_cofaces_tuples not implemented for Tetrahedron in PointMesh");
+    default: assert(false); break;
+    }
+}
+
+void top_dimension_cofaces_tuples(
     const EdgeMesh& mesh,
     const Simplex& simplex,
     SimplexCollection& collection)
@@ -522,15 +547,40 @@ void top_dimension_cofaces_tuples(
     case PrimitiveType::Tetrahedron:
         top_dimension_cofaces_tuples(static_cast<const TetMesh&>(mesh), simplex, collection);
         break;
-    case PrimitiveType::Vertex:
     case PrimitiveType::Edge:
         top_dimension_cofaces_tuples(static_cast<const EdgeMesh&>(mesh), simplex, collection);
+        break;
+    case PrimitiveType::Vertex:
+        top_dimension_cofaces_tuples(static_cast<const PointMesh&>(mesh), simplex, collection);
         break;
     default: log_and_throw_error("unknown mesh type in top_dimension_cofaces_tuples");
     }
 }
 
 
+void top_dimension_cofaces_tuples(
+    const PointMesh& mesh,
+    const Simplex& simplex,
+    std::vector<Tuple>& collection)
+{
+    switch (simplex.primitive_type()) {
+    case PrimitiveType::Vertex: {
+        collection.emplace_back(simplex.tuple());
+        break;
+    }
+    case PrimitiveType::Edge: {
+        log_and_throw_error("top_dimension_cofaces_tuples not implemented for Edge in PointMesh");
+        break;
+    }
+    case PrimitiveType::Triangle: {
+        log_and_throw_error("top_dimension_cofaces_tuples not implemented for Face in PointMesh");
+    }
+    case PrimitiveType::Tetrahedron:
+        log_and_throw_error(
+            "top_dimension_cofaces_tuples not implemented for Tetrahedron in PointMesh");
+    default: assert(false); break;
+    }
+}
 void top_dimension_cofaces_tuples(
     const EdgeMesh& mesh,
     const Simplex& simplex,
@@ -619,9 +669,11 @@ void top_dimension_cofaces_tuples(
     case PrimitiveType::Tetrahedron:
         top_dimension_cofaces_tuples(static_cast<const TetMesh&>(mesh), simplex, tuples);
         break;
-    case PrimitiveType::Vertex:
     case PrimitiveType::Edge:
         top_dimension_cofaces_tuples(static_cast<const EdgeMesh&>(mesh), simplex, tuples);
+        break;
+    case PrimitiveType::Vertex:
+        top_dimension_cofaces_tuples(static_cast<const PointMesh&>(mesh), simplex, tuples);
         break;
     default: assert(false); //"unknown mesh type in top_dimension_cofaces_tuples"
     }
@@ -676,6 +728,13 @@ top_dimension_cofaces(const Mesh& mesh, const Simplex& simplex, const bool sort_
     return collection;
 }
 
+std::vector<Tuple> top_dimension_cofaces_tuples(const PointMesh& mesh, const Simplex& simplex)
+{
+    std::vector<Tuple> collection;
+    top_dimension_cofaces_tuples(mesh, simplex, collection);
+    return collection;
+}
+
 
 std::vector<Tuple> top_dimension_cofaces_tuples(const EdgeMesh& mesh, const Simplex& simplex)
 {
@@ -705,9 +764,10 @@ std::vector<Tuple> top_dimension_cofaces_tuples(const Mesh& mesh, const Simplex&
         return top_dimension_cofaces_tuples(static_cast<const TriMesh&>(mesh), simplex);
     case PrimitiveType::Tetrahedron:
         return top_dimension_cofaces_tuples(static_cast<const TetMesh&>(mesh), simplex);
-    case PrimitiveType::Vertex:
     case PrimitiveType::Edge:
         return top_dimension_cofaces_tuples(static_cast<const EdgeMesh&>(mesh), simplex);
+    case PrimitiveType::Vertex:
+        return top_dimension_cofaces_tuples(static_cast<const PointMesh&>(mesh), simplex);
     default:
         assert(false);
         throw std::runtime_error("unknown mesh type in top_dimension_cofaces_tuples");

--- a/src/wmtk/simplex/top_dimension_cofaces.hpp
+++ b/src/wmtk/simplex/top_dimension_cofaces.hpp
@@ -36,6 +36,11 @@ void top_dimension_cofaces_tuples(
     SimplexCollection& collection);
 
 void top_dimension_cofaces_tuples(
+    const PointMesh& mesh,
+    const Simplex& simplex,
+    SimplexCollection& collection);
+
+void top_dimension_cofaces_tuples(
     const EdgeMesh& mesh,
     const Simplex& simplex,
     SimplexCollection& collection);
@@ -50,6 +55,11 @@ void top_dimension_cofaces_tuples(
     const Simplex& simplex,
     SimplexCollection& collection);
 
+
+void top_dimension_cofaces_tuples(
+    const PointMesh& mesh,
+    const Simplex& simplex,
+    std::vector<Tuple>& collection);
 
 void top_dimension_cofaces_tuples(
     const EdgeMesh& mesh,
@@ -106,6 +116,8 @@ SimplexCollection top_dimension_cofaces(
  * just return the vector of tuples instead of creating a SimplexCollection.
  */
 std::vector<Tuple> top_dimension_cofaces_tuples(const Mesh& mesh, const Simplex& simplex);
+
+std::vector<Tuple> top_dimension_cofaces_tuples(const PointMesh& mesh, const Simplex& simplex);
 
 std::vector<Tuple> top_dimension_cofaces_tuples(const EdgeMesh& mesh, const Simplex& simplex);
 

--- a/tests/tools/DEBUG_Mesh.hpp
+++ b/tests/tools/DEBUG_Mesh.hpp
@@ -5,7 +5,7 @@
 #include "DEBUG_MultiMeshManager.hpp"
 
 namespace wmtk::tests {
-class DEBUG_Mesh : public virtual Mesh
+class DEBUG_Mesh : public Mesh
 {
 public:
     using Mesh::Mesh;
@@ -14,17 +14,30 @@ public:
 
     // uses spdlog to print out a variety of information about the mesh
     void print_state() const;
+    static DEBUG_MultiMeshManager& multi_mesh_manager(Mesh& m) {
+        return reinterpret_cast<DEBUG_MultiMeshManager&>(m.m_multi_mesh_manager);
+    }
+    static const DEBUG_MultiMeshManager& multi_mesh_manager(const Mesh& m) {
+        return reinterpret_cast<const DEBUG_MultiMeshManager&>(m.m_multi_mesh_manager);
+    }
+    static wmtk::attribute::AttributeManager& attribute_manager(Mesh& m) {
+        return m.m_attribute_manager;
+    }
+    static const wmtk::attribute::AttributeManager& attribute_manager(const Mesh& m) {
+        return m.m_attribute_manager;
+    }
     DEBUG_MultiMeshManager& multi_mesh_manager()
     {
-        return reinterpret_cast<DEBUG_MultiMeshManager&>(m_multi_mesh_manager);
+        return multi_mesh_manager(*this);
     }
     const DEBUG_MultiMeshManager& multi_mesh_manager() const
     {
-        return reinterpret_cast<const DEBUG_MultiMeshManager&>(m_multi_mesh_manager);
+        return multi_mesh_manager(*this);
     }
 
     template <typename T>
-    attribute::AccessorBase<T> create_base_accessor(const attribute::TypedAttributeHandle<T>& handle)
+    attribute::AccessorBase<T> create_base_accessor(
+        const attribute::TypedAttributeHandle<T>& handle)
     {
         return attribute::AccessorBase<T>(*this, handle);
     }
@@ -36,7 +49,8 @@ public:
         return attribute::AccessorBase<T>(const_cast<DEBUG_Mesh&>(*this), handle);
     }
     template <typename T>
-    attribute::AccessorBase<T> create_base_accessor(const attribute::TypedAttributeHandle<T>& handle) const
+    attribute::AccessorBase<T> create_base_accessor(
+        const attribute::TypedAttributeHandle<T>& handle) const
     {
         return create_const_base_accessor(handle);
     }
@@ -44,11 +58,10 @@ public:
     void reserve_attributes(PrimitiveType type, int64_t size);
 
 
+    using Mesh::id;
     using Mesh::tuple_from_id;
 
-#if defined(WMTK_ENABLE_HASH_UPDATE) 
-    attribute::Accessor<int64_t> get_cell_hash_accessor();
-#endif
+
 };
 
 } // namespace wmtk::tests


### PR DESCRIPTION
Previously if an exception were thrown in an operation the operation would not undo properly.
Operations now catch and rethrow exceptions to mark operations as failed if an exception occurs.