### PR TITLE
Adding CLI11 dep explicitly

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,6 +89,7 @@ include(fast_envelope)
 include(bvh)
 include(volume_mesher)
 include(onetbb)
+include(CLI11)
 
 # Core library
 add_library(wildmeshing_toolkit)

--- a/cmake/recipes/CLI11.cmake
+++ b/cmake/recipes/CLI11.cmake
@@ -1,0 +1,9 @@
+if (TARGET CLI11::CLI11)
+    return()
+endif()
+
+message(STATUS "Third-party (external): creating target 'CLI11::CLI11'")
+
+include(CPM)
+CPMAddPackage("gh:CLIUtils/CLI11@2.4.2")
+

--- a/cmake/recipes/fast_envelope.cmake
+++ b/cmake/recipes/fast_envelope.cmake
@@ -8,6 +8,8 @@ endif()
 set(FAST_ENVELOPE_WITH_UNIT_TESTS OFF)
 set(FAST_ENVELOPE_ENABLE_TBB OFF)
 
+include(CLI11)
+
 # HACK because there is a linker error on Windows otherwise
 if(WIN32)
     set(FAST_ENVELOPE_WITH_GEOGRAM_PREDICATES ON)


### PR DESCRIPTION
Previously CLI11 was imported through fast_envelope. This resulted in us using an ancient version. Adding the dep to our own dep list / fixing fast_envelope recipe to use our version of the dep.