### PR TITLE
Refactor shortestedge_collapse API.

### DIFF
--- a/applications/cdt_sec/cdt_sec_main.cpp
+++ b/applications/cdt_sec/cdt_sec_main.cpp
@@ -98,22 +98,22 @@ int main(int argc, char* argv[])
     auto child_mesh_position_handle =
         child_mesh->get_attribute_handle<double>("vertices", PrimitiveType::Vertex);
 
-    std::optional<attribute::MeshAttributeHandle> parent_mesh_position_handle =
+    attribute::MeshAttributeHandle parent_mesh_position_handle =
         parent_mesh->get_attribute_handle<double>("vertices", PrimitiveType::Vertex);
 
+    {
+        components::ShortestEdgeCollapseOptions options;
+        options.position_handle = child_mesh_position_handle;
+        options.length_rel = j["length_rel"];
+        options.envelope_size = j["envelope_size"];
+        options.inversion_position_handle = parent_mesh_position_handle;
+        options.pass_through_attributes = pass_through;
 
-    auto mesh_after_sec = wmtk::components::shortestedge_collapse(
-        static_cast<TriMesh&>(*child_mesh),
-        child_mesh_position_handle,
-        parent_mesh_position_handle,
-        false,
-        j["length_rel"],
-        false,
-        j["envelope_size"],
-        pass_through);
+        components::shortestedge_collapse(static_cast<TriMesh&>(*child_mesh), options);
+    }
 
     wmtk::components::output(*parent_mesh, output_file, "vertices");
-    wmtk::components::output(*mesh_after_sec, output_file + "_surface", "vertices");
+    wmtk::components::output(*child_mesh, output_file + "_surface", "vertices");
 
     const std::string report = j["report"];
     if (!report.empty()) {

--- a/components/shortestedge_collapse/wmtk/components/shortestedge_collapse/CMakeLists.txt
+++ b/components/shortestedge_collapse/wmtk/components/shortestedge_collapse/CMakeLists.txt
@@ -7,6 +7,7 @@ endif()
 set(SRC_FILES
     shortestedge_collapse.hpp
     shortestedge_collapse.cpp
+    ShortestEdgeCollapseOptions.hpp
     )
 
 

--- a/components/shortestedge_collapse/wmtk/components/shortestedge_collapse/ShortestEdgeCollapseOptions.hpp
+++ b/components/shortestedge_collapse/wmtk/components/shortestedge_collapse/ShortestEdgeCollapseOptions.hpp
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <wmtk/TriMesh.hpp>
+
+namespace wmtk::components {
+
+struct ShortestEdgeCollapseOptions
+{
+    /**
+     * vertex positions (double)
+     */
+    attribute::MeshAttributeHandle position_handle;
+    /**
+     * The desired edge length relative to the AABB.
+     */
+    double length_rel;
+    /**
+     * Are boundary vertices allowed to be collapsed?
+     */
+    bool lock_boundary = false;
+    /**
+     * The envelope size relative to the AABB.
+     */
+    std::optional<double> envelope_size;
+    /**
+     * If this attribute is specified, it is used to check for inversions. The mesh must be of top
+     * dimension, e.g., a TriMesh in 2D or a TetMesh in 3D.
+     */
+    attribute::MeshAttributeHandle inversion_position_handle;
+    /**
+     * Any other attribute goes here. They are handled with the default attribute behavior.
+     */
+    std::vector<attribute::MeshAttributeHandle> pass_through_attributes;
+};
+
+} // namespace wmtk::components

--- a/components/shortestedge_collapse/wmtk/components/shortestedge_collapse/shortestedge_collapse.hpp
+++ b/components/shortestedge_collapse/wmtk/components/shortestedge_collapse/shortestedge_collapse.hpp
@@ -2,16 +2,36 @@
 #include <wmtk/Mesh.hpp>
 #include <wmtk/TriMesh.hpp>
 
+#include "ShortestEdgeCollapseOptions.hpp"
+
 namespace wmtk::components {
 
-std::shared_ptr<Mesh> shortestedge_collapse(
+/**
+ * @brief Perform shortest-edge collapse on a triangular surface mesh.
+ *
+ * This function generates new attributes that are not removed automatically.
+ *
+ * @param mesh The triangular surface mesh.
+ * @param options All options required for performing the shortest-edge collapse.
+ */
+void shortestedge_collapse(TriMesh& mesh, const ShortestEdgeCollapseOptions& options);
+
+/**
+ * @brief Perform shortest-edge collapse on a triangular surface mesh.
+ *
+ * This function generates new attributes that are not removed automatically.
+ *
+ * This function wraps the behavior of `shortestedge_collapse` with options. For details on the
+ * default values of the options, look at ShortestEdgeCollapseOptions.
+ *
+ */
+void shortestedge_collapse(
     TriMesh& mesh,
     const attribute::MeshAttributeHandle& position_handle,
-    std::optional<attribute::MeshAttributeHandle>& inversion_position_handle,
-    bool update_other_position,
     const double length_rel,
-    bool lock_boundary,
-    double envelope_size,
-    const std::vector<attribute::MeshAttributeHandle>& pass_through);
+    std::optional<bool> lock_boundary = {},
+    std::optional<double> envelope_size = {},
+    std::optional<attribute::MeshAttributeHandle> inversion_position_handle = {},
+    const std::vector<attribute::MeshAttributeHandle>& pass_through = {});
 
 } // namespace wmtk::components

--- a/components/tetwild_simplification/wmtk/components/tetwild_simplification/tetwild_simplification.cpp
+++ b/components/tetwild_simplification/wmtk/components/tetwild_simplification/tetwild_simplification.cpp
@@ -911,7 +911,7 @@ nlohmann::json simplify(
 std::tuple<std::shared_ptr<TriMesh>, nlohmann::json> tetwild_simplification(
     const TriMesh& mesh,
     const std::string& postion_attr_name,
-    double main_esp,
+    double main_eps,
     bool relative,
     double duplicate_tol,
     bool use_sampling)
@@ -945,13 +945,13 @@ std::tuple<std::shared_ptr<TriMesh>, nlohmann::json> tetwild_simplification(
 
     const double bbdiag = (bmax - bmin).norm();
 
-    if (relative) main_esp *= bbdiag;
+    if (relative) main_eps *= bbdiag;
 
     if (duplicate_tol < 0) duplicate_tol = SCALAR_ZERO;
     if (relative) duplicate_tol *= bbdiag;
 
-    const double envelope_size = 2 * main_esp * (9 - 2 * sqrt(3)) / 25.0;
-    const double sampling_dist = (8.0 / 15.0) * main_esp;
+    const double envelope_size = 2 * main_eps * (9 - 2 * sqrt(3)) / 25.0;
+    const double sampling_dist = (8.0 / 15.0) * main_eps;
 
     AABBWrapper tree(vertices, faces, envelope_size, sampling_dist, use_sampling);
 

--- a/components/tetwild_simplification/wmtk/components/tetwild_simplification/tetwild_simplification.hpp
+++ b/components/tetwild_simplification/wmtk/components/tetwild_simplification/tetwild_simplification.hpp
@@ -7,11 +7,24 @@
 
 namespace wmtk::components {
 
+/**
+ * @brief Perform the simplification from the original tetwild.
+ *
+ * This code does not use WMTK for anything besides in the API.
+ *
+ * @param mesh The mesh that should be simplified.
+ * @param postion_attr_name The name of the position attribute.
+ * @param main_eps Specifies the amount of simplification.
+ * @param relative The `main_eps` and `duplicate_tol` are relative to the bbox diagonal.
+ * @param duplicate_tol The radius in which vertices are considered duplicates. Also, faces that
+ * have an area below this value are removed.
+ * @param use_sampling Use sampling for the envelope.
+ */
 std::tuple<std::shared_ptr<TriMesh>, nlohmann::json> tetwild_simplification(
     const TriMesh& mesh,
     const std::string& postion_attr_name,
-    double main_esp,
-    bool realitive = true,
+    double main_eps,
+    bool relative = true,
     double duplicate_tol = -1,
     bool use_sampling = true);
 


### PR DESCRIPTION
Refactor shortestedge_collapse API.

Additionally, I fixed the computation of the bbox. It was only checking for x and y coordinates, indipendently of the dimension of the position attribute.