### PR TITLE
Adding graceful disabling of integration tests without python

### DIFF
--- a/applications/CMakeLists.txt
+++ b/applications/CMakeLists.txt
@@ -56,15 +56,31 @@ wmtk_generate_test_config("${WMTK_TEST_CONFIG}")
 add_custom_target(wmtk_application_headers
     DEPENDS ${WMTK_APPLICATION_HEADER_TARGETS}
 )
+
 if(WILDMESHING_TOOLKIT_TOPLEVEL_PROJECT AND NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
-    enable_testing()
+    set(INTEGRATION_TESTING_ENABLED_DEFAULT  ON)
+else()
+    set(INTEGRATION_TESTING_ENABLED_DEFAULT  OFF)
+endif()
 
-    find_package(Python REQUIRED)
+find_package(Python)
+if(NOT Python_FOUND AND INTEGRATION_TESTING_ENABLED_DEFAULT)
 
-    add_test(
-        NAME wmtk_integration_test
-        COMMAND ${Python_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/integration_test.py
-        -c ${CMAKE_BINARY_DIR}/test_config.json
-        -b ${CMAKE_BINARY_DIR}/applications
-    )
+    set(INTEGRATION_TESTING_ENABLED_DEFAULT  OFF)
+    message(WARNING "Disabling Integration testing by default because python was not found, Install python and then enable WMTK_ENABLE_INTEGRATION_TESTING")
+endif()
+
+option(WMTK_ENABLE_INTEGRATION_TESTING "Whether integration testing is enabled, requires python" ${INTEGRATION_TESTING_ENABLED_DEFAULT})
+if(WMTK_ENABLE_INTEGRATION_TESTING)
+enable_testing()
+
+find_package(Python REQUIRED)
+
+
+add_test(
+    NAME wmtk_integration_test
+    COMMAND ${Python_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/integration_test.py
+    -c ${CMAKE_BINARY_DIR}/test_config.json
+    -b ${CMAKE_BINARY_DIR}/applications
+)
 endif()


### PR DESCRIPTION
If python doesn't exist this should gracefully work wit ha warning - and the user can sitll force integration tests even if in debug now