### PR TITLE
Fixing null paths in input component

### DIFF
--- a/components/input/src/wmtk/components/input/MeshCollection.cpp
+++ b/components/input/src/wmtk/components/input/MeshCollection.cpp
@@ -23,7 +23,7 @@ NamedMultiMesh& MeshCollection::add_mesh(const InputOptions& opts)
 const NamedMultiMesh& MeshCollection::get_named_multimesh(const std::string_view& path) const
 {
     using namespace std;
-    const std::string_view nmm_name = *internal::split_path(path).begin();
+    const auto nmm_name = *internal::split_path(path).begin();
     if(nmm_name.empty() && m_meshes.size() == 1) {
         wmtk::logger().debug("MeshCollection accessed with an empty name, but has only 1 mesh so assuming that is the right mesh");
         return m_meshes.begin()->second;

--- a/components/input/src/wmtk/components/input/internal/split_path.hpp
+++ b/components/input/src/wmtk/components/input/internal/split_path.hpp
@@ -15,9 +15,13 @@ inline auto split_path(const std::string_view& view)
            });
 
 #else
+    std::vector<std::string> tokens;
+    if(view.empty()) {
+        tokens.emplace_back("");
+    
+    } else {
     std::string v = std::string(view);
     std::istringstream iss(v);
-    std::vector<std::string> tokens;
     std::string token;
     if(v.size() > 0 && v[0] == '.') {
         tokens.emplace_back("");
@@ -25,6 +29,7 @@ inline auto split_path(const std::string_view& view)
     while (std::getline(iss, token, '.')) {
         if (!token.empty())
             tokens.push_back(token);
+    }
     }
     return tokens;
 #endif


### PR DESCRIPTION
input component implementation of path splitting behaves differently between cpp20 and cpp17 due to types returned and for null paths the path was empty rather than singular. PR fixes that by allowing for static polymorphic type for first entry instead