### PR TITLE
IdSimplex ID use with derived meshes + Accessors

### DIFF
--- a/src/wmtk/Mesh.cpp
+++ b/src/wmtk/Mesh.cpp
@@ -20,6 +20,11 @@ std::vector<Tuple> Mesh::get_all(PrimitiveType type) const
     return get_all(type, false);
 }
 
+std::vector<simplex::IdSimplex> Mesh::get_all_id_simplex(PrimitiveType type) const
+{
+    return get_all_id_simplex(type, false);
+}
+
 simplex::IdSimplex Mesh::get_id_simplex(const Tuple& tuple, PrimitiveType pt) const
 {
     return simplex::IdSimplex(pt, id(tuple, pt));
@@ -29,6 +34,26 @@ simplex::Simplex Mesh::get_simplex(const simplex::IdSimplex& s) const
 {
     const Tuple& t = tuple_from_id(s.primitive_type(), s.index());
     return simplex::Simplex(*this, s.primitive_type(), t);
+}
+
+std::vector<simplex::IdSimplex> Mesh::get_all_id_simplex(PrimitiveType type, const bool include_deleted) const
+{
+    std::vector<simplex::IdSimplex> ret;
+
+    if (static_cast<int8_t>(type) > top_cell_dimension()) return ret;
+
+    const int64_t cap = capacity(type);
+
+    const attribute::Accessor<char> flag_accessor = get_flag_accessor(type);
+    const attribute::CachingAccessor<char>& flag_accessor_indices = flag_accessor.index_access();
+    ret.reserve(cap);
+    for (size_t index = 0; index < cap; ++index) {
+        if (flag_accessor_indices.const_scalar_attribute(index) & 1)
+            ret.emplace_back(simplex::IdSimplex(type, index));
+        else if (include_deleted)
+            ret.emplace_back();
+    }
+    return ret;
 }
 
 

--- a/src/wmtk/Mesh.hpp
+++ b/src/wmtk/Mesh.hpp
@@ -168,6 +168,7 @@ public:
      */
     std::vector<Tuple> get_all(PrimitiveType type) const;
 
+    std::vector<simplex::IdSimplex> get_all_id_simplex(PrimitiveType type) const;
     /**
      * @brief Retrieve the IdSimplex that is represented by the tuple and primitive type.
      */
@@ -863,6 +864,9 @@ private:
      * @return vector of Tuples referring to each type
      */
     std::vector<Tuple> get_all(PrimitiveType type, const bool include_deleted) const;
+    std::vector<simplex::IdSimplex> get_all_id_simplex(
+        PrimitiveType type,
+        const bool include_deleted) const;
 };
 
 

--- a/src/wmtk/MeshCRTP.hpp
+++ b/src/wmtk/MeshCRTP.hpp
@@ -112,15 +112,11 @@ protected:
     int64_t id(const simplex::Simplex& s) const final override
     {
 
-#if defined(WMTK_ENABLE_SIMPLEX_ID_CACHING)
-        if (s.m_index == -1) {
-            s.m_index = id(s.tuple(), s.primitive_type());
-        }
-        return s.m_index;
-#else
         return id(s.tuple(),s.primitive_type());
-#endif
     }
+
+    // catch any other Mesh id methods that might emerge by default
+    using Mesh::id;
 
 
 protected:

--- a/src/wmtk/attribute/Accessor.hpp
+++ b/src/wmtk/attribute/Accessor.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include "CachingAccessor.hpp"
 #include <wmtk/simplex/Simplex.hpp>
+#include <wmtk/simplex/IdSimplex.hpp>
 
 namespace wmtk {
 class Mesh;
@@ -48,26 +49,23 @@ public:
     Accessor(const Accessor<T, OMType, D>& o);
 
 
+    // =============
+    // Access methods
+    // =============
+    // NOTE: If any compilation warnings occur check that there is an overload for an index method
+
     T const_topological_scalar_attribute(const Tuple& t, PrimitiveType pt) const;
-    T& topological_scalar_attribute(const Tuple& t);
-    T& topological_scalar_attribute(const simplex::Simplex& t);
+    template <typename ArgType>
+    T& topological_scalar_attribute(const ArgType& t);
+    template <typename ArgType>
+    T const_scalar_attribute(const ArgType& t) const;
+    template <typename ArgType>
+    T& scalar_attribute(const ArgType& t);
 
-    T const_scalar_attribute(const Tuple& t) const;
-    T& scalar_attribute(const Tuple& t);
-
-    template <int D = Dim>
-    ConstMapResult<D> const_vector_attribute(const Tuple& t) const;
-    template <int D = Dim>
-    MapResult<D> vector_attribute(const Tuple& t);
-
-    T const_scalar_attribute(const simplex::Simplex& t) const;
-    T& scalar_attribute(const simplex::Simplex& t);
-
-    template <int D = Dim>
-    ConstMapResult<D> const_vector_attribute(const simplex::Simplex& t) const;
-    template <int D = Dim>
-    MapResult<D> vector_attribute(const simplex::Simplex& t);
-
+    template < int D = Dim, typename ArgType = wmtk::Tuple>
+    ConstMapResult<D> const_vector_attribute(const ArgType& t) const;
+    template < int D = Dim, typename ArgType = wmtk::Tuple>
+    MapResult<D> vector_attribute(const ArgType& t);
 
     using BaseType::dimension; // const() -> int64_t
     using BaseType::reserved_size; // const() -> int64_t
@@ -84,8 +82,11 @@ public:
     const MeshType& mesh() const { return static_cast<const MeshType&>(BaseType::mesh()); }
 
 protected:
+
     int64_t index(const Tuple& t) const;
     int64_t index(const simplex::Simplex& t) const;
+    int64_t index(const simplex::IdSimplex& t) const;
+
     using CachingBaseType::base_type;
     CachingBaseType& caching_base_type() { return *this; }
     const CachingBaseType& caching_base_type() const { return *this; }

--- a/src/wmtk/attribute/Accessor.hxx
+++ b/src/wmtk/attribute/Accessor.hxx
@@ -20,11 +20,12 @@ Accessor<T, MeshType, Dim>::Accessor(const Accessor<T, OMType, D>& o)
     static_assert(Dim == Eigen::Dynamic || D == Eigen::Dynamic || Dim == D);
 }
 
+/*
 template <typename T, typename MeshType, int Dim>
 template <int D>
 auto Accessor<T, MeshType, Dim>::const_vector_attribute(const Tuple& t) const -> ConstMapResult<D>
 {
-    const int64_t idx = index(t);
+    const int64_t idx = this->index(t);
     return CachingBaseType::template const_vector_attribute<D>(idx);
 }
 
@@ -32,95 +33,97 @@ template <typename T, typename MeshType, int Dim>
 template <int D>
 auto Accessor<T, MeshType, Dim>::vector_attribute(const Tuple& t) -> MapResult<D>
 {
-    const int64_t idx = index(t);
+    const int64_t idx = this->index(t);
     return CachingBaseType::template vector_attribute<D>(idx);
 }
 
 template <typename T, typename MeshType, int Dim>
 auto Accessor<T, MeshType, Dim>::scalar_attribute(const Tuple& t) -> T&
 {
-    const int64_t idx = index(t);
+    const int64_t idx = this->index(t);
     return CachingBaseType::scalar_attribute(idx);
 }
 
 template <typename T, typename MeshType, int Dim>
 T Accessor<T, MeshType, Dim>::const_scalar_attribute(const Tuple& t) const
 {
-    const int64_t idx = index(t);
+    const int64_t idx = this->index(t);
     return CachingBaseType::const_scalar_attribute(idx);
 }
 
 template <typename T, typename MeshType, int Dim>
-template <int D>
-auto Accessor<T, MeshType, Dim>::const_vector_attribute(const simplex::Simplex& t) const
-    -> ConstMapResult<D>
+auto Accessor<T, MeshType, Dim>::topological_scalar_attribute(const Tuple& t) -> T&
 {
-    const int64_t idx = index(t);
-    return CachingBaseType::template const_vector_attribute<D>(idx);
-}
-
-template <typename T, typename MeshType, int Dim>
-template <int D>
-auto Accessor<T, MeshType, Dim>::vector_attribute(const simplex::Simplex& t) -> MapResult<D>
-{
-    const int64_t idx = index(t);
-    return CachingBaseType::template vector_attribute<D>(idx);
-}
-
-template <typename T, typename MeshType, int Dim>
-auto Accessor<T, MeshType, Dim>::scalar_attribute(const simplex::Simplex& t) -> T&
-{
-    const int64_t idx = index(t);
+    const int64_t idx = this->index(t);
     return CachingBaseType::scalar_attribute(idx);
 }
-
-template <typename T, typename MeshType, int Dim>
-T Accessor<T, MeshType, Dim>::const_scalar_attribute(const simplex::Simplex& t) const
-{
-    const int64_t idx = index(t);
-    return CachingBaseType::const_scalar_attribute(idx);
-}
+*/
 
 template <typename T, typename MeshType, int Dim>
 int64_t Accessor<T, MeshType, Dim>::index(const Tuple& t) const
 {
     assert(mesh().is_valid(t));
-    return static_cast<const MeshType&>(mesh()).id(t, BaseType::typed_handle().primitive_type());
+    return this->mesh().id(t, BaseType::typed_handle().primitive_type());
 }
 
 template <typename T, typename MeshType, int Dim>
 int64_t Accessor<T, MeshType, Dim>::index(const simplex::Simplex& t) const
 {
     assert(t.primitive_type() == primitive_type());
-#if defined(WMTK_ENABLE_SIMPLEX_ID_CACHING)
-    int64_t i = t.m_index;
-    if (i == -1) {
-        assert(mesh().is_valid(t.tuple()));
-        i = static_cast<const MeshType&>(mesh()).id(
-            t.tuple(),
-            BaseType::typed_handle().primitive_type());
-        const_cast<simplex::Simplex&>(t).m_index = i;
-    }
-    return i;
-#else
-    return index(t.tuple());
-#endif
+    return this->index(t.tuple());
 
 }
 
 template <typename T, typename MeshType, int Dim>
-auto Accessor<T, MeshType, Dim>::topological_scalar_attribute(const Tuple& t) -> T&
+int64_t Accessor<T, MeshType, Dim>::index(const simplex::IdSimplex& t) const
 {
-    const int64_t idx = index(t);
+    assert(t.primitive_type() == primitive_type());
+    return this->mesh().id(t);
+
+}
+
+template <typename T, typename MeshType, int Dim>
+template <int D, typename ArgType>
+auto Accessor<T, MeshType, Dim>::const_vector_attribute(const ArgType& t) const
+    -> ConstMapResult<D>
+{
+    const int64_t idx = this->index(t);
+    return CachingBaseType::template const_vector_attribute<D>(idx);
+}
+
+template <typename T, typename MeshType, int Dim>
+template <int D, typename ArgType>
+auto Accessor<T, MeshType, Dim>::vector_attribute(const ArgType& t) -> MapResult<D>
+{
+    const int64_t idx = this->index(t);
+    return CachingBaseType::template vector_attribute<D>(idx);
+}
+
+template <typename T, typename MeshType, int Dim>
+template <typename ArgType>
+auto Accessor<T, MeshType, Dim>::scalar_attribute(const ArgType& t) -> T&
+{
+    const int64_t idx = this->index(t);
     return CachingBaseType::scalar_attribute(idx);
 }
 
 template <typename T, typename MeshType, int Dim>
-auto Accessor<T, MeshType, Dim>::topological_scalar_attribute(const simplex::Simplex& t) -> T&
+template <typename ArgType>
+T Accessor<T, MeshType, Dim>::const_scalar_attribute(const ArgType& t) const
 {
-    const int64_t idx = index(t);
+    const int64_t idx = this->index(t);
+    return CachingBaseType::const_scalar_attribute(idx);
+}
+template <typename T, typename MeshType, int Dim>
+template <typename ArgType>
+auto Accessor<T, MeshType, Dim>::topological_scalar_attribute(const ArgType& t) -> T&
+{
+    const int64_t idx = this->index(t);
     return CachingBaseType::scalar_attribute(idx);
 }
+
+
+
 
 template <typename T, typename MeshType, int Dim>
 T Accessor<T, MeshType, Dim>::const_topological_scalar_attribute(const Tuple& t, PrimitiveType pt)

--- a/tests/attributes/test_accessor.cpp
+++ b/tests/attributes/test_accessor.cpp
@@ -32,12 +32,21 @@ template <typename VectorAcc>
 void check(DEBUG_PointMesh& m, VectorAcc& va, bool for_zeros = false)
 {
     auto vertices = m.get_all(wmtk::PrimitiveType::Vertex);
+    auto vertices_id = m.get_all_id_simplex(wmtk::PrimitiveType::Vertex);
     size_t dimension = va.dimension();
     Eigen::Matrix<typename VectorAcc::Scalar, Eigen::Dynamic, 1> x;
     bool is_scalar = va.dimension() == 1;
     x.resize(va.dimension());
-    for (const wmtk::Tuple& tup : vertices) {
+    for (size_t j = 0; j < vertices.size(); ++j) {
+        const wmtk::Tuple& tup = vertices[j];
+        const wmtk::simplex::IdSimplex& ids = vertices_id[j];
         int64_t id = m.id(tup);
+        int64_t id2 = m.id(ids);
+        REQUIRE(id == id2);
+        REQUIRE(va.const_vector_attribute(tup) == va.const_vector_attribute(tup));
+        if (is_scalar) {
+            REQUIRE(va.const_scalar_attribute(tup) == va.const_scalar_attribute(tup));
+        }
         if (for_zeros) {
             CHECK((va.const_vector_attribute(tup).array() == 0).all());
             if (is_scalar) {

--- a/tests/tools/DEBUG_PointMesh.hpp
+++ b/tests/tools/DEBUG_PointMesh.hpp
@@ -14,6 +14,7 @@ public:
     {
         return PointMesh::id(tup, wmtk::PrimitiveType::Vertex);
     }
+    using PointMesh::id;
     template <typename T>
     attribute::AccessorBase<T> create_base_accessor(const attribute::TypedAttributeHandle<T>& handle)
     {


### PR DESCRIPTION
Made MeshCRTP use any Mesh id overloads in a protected fashion, which enables forwarding to fully derived Mesh types.

Also made accessor access patterns work for any type that `Accessor::index` function exists - implementing a constraint would be nice with cpp20 :-P )