### PR TITLE
Fix is_valid debug messages

### DIFF
--- a/src/wmtk/EdgeMesh.cpp
+++ b/src/wmtk/EdgeMesh.cpp
@@ -216,7 +216,19 @@ bool EdgeMesh::is_valid(const Tuple& tuple) const
         return false;
     }
 
-    if (tuple.m_local_vid < 0 || tuple.m_global_cid < 0) return false;
+    const bool is_connectivity_valid = tuple.m_local_vid < 0 || tuple.m_global_cid < 0;
+    if (!is_connectivity_valid) {
+#if !defined(NDEBUG)
+        logger().debug(
+            "tuple.m_local_vid={} >= 0"
+            " tuple.m_global_cid={} >= 0",
+            tuple.m_local_vid,
+            tuple.m_global_cid);
+        assert(tuple.m_local_vid >= 0);
+        assert(tuple.m_global_cid >= 0);
+#endif
+        return false;
+    }
     return true;
 }
 

--- a/src/wmtk/EdgeMesh.cpp
+++ b/src/wmtk/EdgeMesh.cpp
@@ -216,7 +216,7 @@ bool EdgeMesh::is_valid(const Tuple& tuple) const
         return false;
     }
 
-    const bool is_connectivity_valid = tuple.m_local_vid < 0 || tuple.m_global_cid < 0;
+    const bool is_connectivity_valid = tuple.m_local_vid >= 0 && tuple.m_global_cid >= 0;
     if (!is_connectivity_valid) {
 #if !defined(NDEBUG)
         logger().debug(

--- a/src/wmtk/TetMesh.cpp
+++ b/src/wmtk/TetMesh.cpp
@@ -340,6 +340,23 @@ bool TetMesh::is_valid(const Tuple& tuple) const
                                        autogen::tet_mesh::tuple_is_valid_for_ccw(tuple);
 
     if (!is_connectivity_valid) {
+#if !defined(NDEBUG)
+        logger().debug(
+            "tuple.m_local_vid={} >= 0 && tuple.m_local_eid={} >= 0 &&"
+            "tuple.m_local_fid={} >= 0 &&"
+            " tuple.m_global_cid={} >= 0 &&"
+            " autogen::tet_mesh::tuple_is_valid_for_ccw(tuple)={}",
+            tuple.m_local_vid,
+            tuple.m_local_eid,
+            tuple.m_local_fid,
+            tuple.m_global_cid,
+            autogen::tet_mesh::tuple_is_valid_for_ccw(tuple));
+        assert(tuple.m_local_vid >= 0);
+        assert(tuple.m_local_eid >= 0);
+        assert(tuple.m_local_fid >= 0);
+        assert(tuple.m_global_cid >= 0);
+        assert(autogen::tet_mesh::tuple_is_valid_for_ccw(tuple));
+#endif
         return false;
     }
 

--- a/src/wmtk/TriMesh.cpp
+++ b/src/wmtk/TriMesh.cpp
@@ -347,10 +347,6 @@ bool TriMesh::is_valid(const Tuple& tuple) const
 
     if (!is_connectivity_valid) {
 #if !defined(NDEBUG)
-        assert(tuple.m_local_vid >= 0);
-        assert(tuple.m_local_eid >= 0);
-        assert(tuple.m_global_cid);
-        assert(autogen::tri_mesh::tuple_is_valid_for_ccw(tuple));
         logger().debug(
             "tuple.m_local_vid={} >= 0 && tuple.m_local_eid={} >= 0 &&"
             " tuple.m_global_cid={} >= 0 &&"
@@ -359,7 +355,10 @@ bool TriMesh::is_valid(const Tuple& tuple) const
             tuple.m_local_eid,
             tuple.m_global_cid,
             autogen::tri_mesh::tuple_is_valid_for_ccw(tuple));
-        ;
+        assert(tuple.m_local_vid >= 0);
+        assert(tuple.m_local_eid >= 0);
+        assert(tuple.m_global_cid >= 0);
+        assert(autogen::tri_mesh::tuple_is_valid_for_ccw(tuple));
 #endif
         return false;
     }


### PR DESCRIPTION
TriMesh allowed is_valid to assert upon failures in debug mode and also had some debug printouts available but they would only show up after an assertion had happened, making it useless. This PR does the debug message and then assertions to show all of the tuple state before identifying the first part of the tuple that was invalid.

On top of reordering the assert/print in TriMesh, this PR pushes this behvaior to EdgeMesh and TetMesh to all nontrivial mesh types.