### PR TITLE
Flag Accessor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,7 @@ endif()
 project(WildMeshingToolkit DESCRIPTION "A mesh optimization toolkit" LANGUAGES C CXX)
 
 # ###############################################################################
+option(WMTK_ENABLE_APPLICATIONS "Enable applications (required for any applications to build)" ${WILDMESHING_TOOLKIT_TOPLEVEL_PROJECT})
 option(WMTK_BUILD_DOCS "Build doxygen" OFF)
 option (BUILD_SHARED_LIBS "Build Shared Libraries" OFF) # we globally want to disable this option due to use of TBB
 
@@ -207,5 +208,7 @@ endif()
 # Compile extras only if this is a top-level project
 if(WILDMESHING_TOOLKIT_TOPLEVEL_PROJECT)
     add_subdirectory(tests)
+endif()
+if(WMTK_ENABLE_APPLICATIONS)
     add_subdirectory(applications)
 endif()

--- a/src/wmtk/EdgeMesh.cpp
+++ b/src/wmtk/EdgeMesh.cpp
@@ -247,17 +247,23 @@ bool EdgeMesh::is_connectivity_valid() const
     // VE and EV
     for (int64_t i = 0; i < capacity(PrimitiveType::Vertex); ++i) {
         if (!v_flag_accessor.index_access().is_active(i)) {
-            wmtk::logger().debug("Vertex {} is deleted", i);
             continue;
         }
         int cnt = 0;
         for (int64_t j = 0; j < 2; ++j) {
             if (ev_accessor.index_access().const_vector_attribute<2>(
-                    ve_accessor.index_access().const_scalar_attribute(i))[j] == i) {
+                    ve_accessor.index_access().const_scalar_attribute(i))(j) == i) {
                 cnt++;
             }
         }
         if (cnt == 0) {
+            int64_t idx = ve_accessor.index_access().const_scalar_attribute(i);
+            wmtk::logger().error(
+                "EV[VE[{}]={},:]] ({}) = doesn't contain {}",
+                i,
+                idx,
+                fmt::join(ev_accessor.index_access().const_vector_attribute<2>(idx), ","),
+                i);
             return false;
         }
     }
@@ -265,7 +271,6 @@ bool EdgeMesh::is_connectivity_valid() const
     // EV and EE
     for (int64_t i = 0; i < capacity(PrimitiveType::Edge); ++i) {
         if (!e_flag_accessor.index_access().is_active(i)) {
-            wmtk::logger().debug("Edge {} is deleted", i);
             continue;
         }
         // TODO: need to handle cornor case (self-loop)

--- a/src/wmtk/EdgeMeshOperationExecutor.cpp
+++ b/src/wmtk/EdgeMeshOperationExecutor.cpp
@@ -38,7 +38,7 @@ void EdgeMesh::EdgeMeshOperationExecutor::delete_simplices()
 {
     for (size_t d = 0; d < simplex_ids_to_delete.size(); ++d) {
         for (const int64_t id : simplex_ids_to_delete[d]) {
-            flag_accessors[d].index_access().scalar_attribute(id) = 0;
+            flag_accessors[d].index_access().deactivate(id) ;
         }
     }
 }

--- a/src/wmtk/EdgeMeshOperationExecutor.hpp
+++ b/src/wmtk/EdgeMeshOperationExecutor.hpp
@@ -11,7 +11,7 @@ public:
     void delete_simplices();
     void update_cell_hash();
 
-    std::array<attribute::Accessor<char>, 2> flag_accessors;
+    std::array<attribute::FlagAccessor<EdgeMesh>, 2> flag_accessors;
     attribute::Accessor<int64_t, EdgeMesh> ee_accessor;
     attribute::Accessor<int64_t, EdgeMesh> ev_accessor;
     attribute::Accessor<int64_t, EdgeMesh> ve_accessor;

--- a/src/wmtk/Mesh.hpp
+++ b/src/wmtk/Mesh.hpp
@@ -24,6 +24,7 @@
 #include "attribute/AttributeScopeHandle.hpp"
 #include "attribute/MeshAttributeHandle.hpp"
 #include "attribute/MeshAttributes.hpp"
+#include "attribute/FlagAccessor.hpp"
 #include "multimesh/attribute/AttributeScopeHandle.hpp"
 
 #include "multimesh/attribute/UseParentScopeRAII.hpp"
@@ -295,8 +296,8 @@ public:
     decltype(auto) parent_scope(Functor&& f, Args&&... args) const;
 
 
-    const attribute::Accessor<char> get_flag_accessor(PrimitiveType type) const;
-    const attribute::Accessor<char> get_const_flag_accessor(PrimitiveType type) const;
+    const attribute::FlagAccessor<Mesh> get_flag_accessor(PrimitiveType type) const;
+    const attribute::FlagAccessor<Mesh> get_const_flag_accessor(PrimitiveType type) const;
 
 
     bool operator==(const Mesh& other) const;
@@ -307,7 +308,7 @@ public:
     virtual std::vector<Tuple> orient_vertices(const Tuple& t) const = 0;
 
 protected: // member functions
-    attribute::Accessor<char> get_flag_accessor(PrimitiveType type);
+    attribute::FlagAccessor<> get_flag_accessor(PrimitiveType type);
 
 
 protected:

--- a/src/wmtk/PointMesh.cpp
+++ b/src/wmtk/PointMesh.cpp
@@ -52,9 +52,9 @@ void PointMesh::initialize(int64_t count)
 {
     set_capacities({count});
     reserve_attributes_to_fit();
-    attribute::Accessor<char> v_flag_accessor = get_flag_accessor(PrimitiveType::Vertex);
+    attribute::FlagAccessor<PointMesh> v_flag_accessor = get_flag_accessor(PrimitiveType::Vertex);
     for (int64_t i = 0; i < capacity(PrimitiveType::Vertex); ++i) {
-        v_flag_accessor.index_access().scalar_attribute(i) |= 0x1;
+        v_flag_accessor.index_access().activate(i);
     }
 }
 

--- a/src/wmtk/TetMesh.cpp
+++ b/src/wmtk/TetMesh.cpp
@@ -421,9 +421,9 @@ bool TetMesh::is_connectivity_valid() const
             wmtk::logger().debug("Tet {} is deleted", i);
             continue;
         }
-        auto tf = tf_accessor.index_access().const_vector_attribute<3>(i);
-        auto te = te_accessor.index_access().const_vector_attribute<3>(i);
-        auto tv = tv_accessor.index_access().const_vector_attribute<3>(i);
+        auto tf = tf_accessor.index_access().const_vector_attribute<4>(i);
+        auto te = te_accessor.index_access().const_vector_attribute<6>(i);
+        auto tv = tv_accessor.index_access().const_vector_attribute<4>(i);
 
         bool bad_face = false;
         for (int64_t j = 0; j < 6; ++j) {
@@ -438,7 +438,7 @@ bool TetMesh::is_connectivity_valid() const
             }
         }
 
-        for (int64_t j = 0; j < 3; ++j) {
+        for (int64_t j = 0; j < 4; ++j) {
             int64_t vi = tv(j);
             int64_t fi = tf(j);
             if (!v_flag_accessor.index_access().is_active(vi)) {

--- a/src/wmtk/TetMesh.cpp
+++ b/src/wmtk/TetMesh.cpp
@@ -103,10 +103,11 @@ void TetMesh::initialize(
     auto te_accessor = create_accessor<int64_t>(m_te_handle);
     auto tf_accessor = create_accessor<int64_t>(m_tf_handle);
     auto tt_accessor = create_accessor<int64_t>(m_tt_handle);
-    attribute::Accessor<char> v_flag_accessor = get_flag_accessor(PrimitiveType::Vertex);
-    attribute::Accessor<char> e_flag_accessor = get_flag_accessor(PrimitiveType::Edge);
-    attribute::Accessor<char> f_flag_accessor = get_flag_accessor(PrimitiveType::Triangle);
-    attribute::Accessor<char> t_flag_accessor = get_flag_accessor(PrimitiveType::Tetrahedron);
+    attribute::FlagAccessor<TetMesh> v_flag_accessor = get_flag_accessor(PrimitiveType::Vertex);
+    attribute::FlagAccessor<TetMesh> e_flag_accessor = get_flag_accessor(PrimitiveType::Edge);
+    attribute::FlagAccessor<TetMesh> f_flag_accessor = get_flag_accessor(PrimitiveType::Triangle);
+    attribute::FlagAccessor<TetMesh> t_flag_accessor =
+        get_flag_accessor(PrimitiveType::Tetrahedron);
 
     // iterate over the matrices and fill attributes
     for (int64_t i = 0; i < capacity(PrimitiveType::Tetrahedron); ++i) {
@@ -114,22 +115,23 @@ void TetMesh::initialize(
         te_accessor.index_access().vector_attribute<6>(i) = TE.row(i).transpose();
         tf_accessor.index_access().vector_attribute<4>(i) = TF.row(i).transpose();
         tt_accessor.index_access().vector_attribute<4>(i) = TT.row(i).transpose();
-        t_flag_accessor.index_access().scalar_attribute(i) |= 0x1;
+        t_flag_accessor.index_access().activate(i);
+        e_flag_accessor.index_access().activate(i);
     }
     // m_vt
     for (int64_t i = 0; i < capacity(PrimitiveType::Vertex); ++i) {
         vt_accessor.index_access().scalar_attribute(i) = VT(i);
-        v_flag_accessor.index_access().scalar_attribute(i) |= 0x1;
+        v_flag_accessor.index_access().activate(i);
     }
     // m_et
     for (int64_t i = 0; i < capacity(PrimitiveType::Edge); ++i) {
         et_accessor.index_access().scalar_attribute(i) = ET(i);
-        e_flag_accessor.index_access().scalar_attribute(i) |= 0x1;
+        e_flag_accessor.index_access().activate(i);
     }
     // m_ft
     for (int64_t i = 0; i < capacity(PrimitiveType::Triangle); ++i) {
         ft_accessor.index_access().scalar_attribute(i) = FT(i);
-        f_flag_accessor.index_access().scalar_attribute(i) |= 0x1;
+        f_flag_accessor.index_access().activate(i);
     }
 }
 
@@ -405,10 +407,13 @@ bool TetMesh::is_connectivity_valid() const
     const attribute::Accessor<int64_t> vt_accessor = create_const_accessor<int64_t>(m_vt_handle);
     const attribute::Accessor<int64_t> et_accessor = create_const_accessor<int64_t>(m_et_handle);
     const attribute::Accessor<int64_t> ft_accessor = create_const_accessor<int64_t>(m_ft_handle);
-    const attribute::Accessor<char> v_flag_accessor = get_flag_accessor(PrimitiveType::Vertex);
-    const attribute::Accessor<char> e_flag_accessor = get_flag_accessor(PrimitiveType::Edge);
-    const attribute::Accessor<char> f_flag_accessor = get_flag_accessor(PrimitiveType::Triangle);
-    const attribute::Accessor<char> t_flag_accessor = get_flag_accessor(PrimitiveType::Tetrahedron);
+    const attribute::FlagAccessor<TetMesh> v_flag_accessor =
+        get_flag_accessor(PrimitiveType::Vertex);
+    const attribute::FlagAccessor<TetMesh> e_flag_accessor = get_flag_accessor(PrimitiveType::Edge);
+    const attribute::FlagAccessor<TetMesh> f_flag_accessor =
+        get_flag_accessor(PrimitiveType::Triangle);
+    const attribute::FlagAccessor<TetMesh> t_flag_accessor =
+        get_flag_accessor(PrimitiveType::Tetrahedron);
 
 
     for (int64_t i = 0; i < capacity(PrimitiveType::Tetrahedron); ++i) {
@@ -459,7 +464,7 @@ bool TetMesh::is_connectivity_valid() const
     }
     // VT and TV
     for (int64_t i = 0; i < capacity(PrimitiveType::Vertex); ++i) {
-        if (v_flag_accessor.index_access().const_scalar_attribute(i) == 0) {
+        if (!v_flag_accessor.index_access().is_active(i)) {
             wmtk::logger().debug("Vertex {} is deleted", i);
             continue;
         }
@@ -478,7 +483,7 @@ bool TetMesh::is_connectivity_valid() const
 
     // ET and TE
     for (int64_t i = 0; i < capacity(PrimitiveType::Edge); ++i) {
-        if (e_flag_accessor.index_access().const_scalar_attribute(i) == 0) {
+        if (!e_flag_accessor.index_access().is_active(i)) {
             wmtk::logger().debug("Edge {} is deleted", i);
             continue;
         }
@@ -497,7 +502,7 @@ bool TetMesh::is_connectivity_valid() const
 
     // FT and TF
     for (int64_t i = 0; i < capacity(PrimitiveType::Triangle); ++i) {
-        if (f_flag_accessor.index_access().const_scalar_attribute(i) == 0) {
+        if (!f_flag_accessor.index_access().is_active(i)) {
             wmtk::logger().debug("Face {} is deleted", i);
             continue;
         }
@@ -516,7 +521,7 @@ bool TetMesh::is_connectivity_valid() const
 
     // TF and TT
     for (int64_t i = 0; i < capacity(PrimitiveType::Tetrahedron); ++i) {
-        if (t_flag_accessor.index_access().const_scalar_attribute(i) == 0) {
+        if (!t_flag_accessor.index_access().is_active(i)) {
             wmtk::logger().debug("Tet {} is deleted", i);
             continue;
         }

--- a/src/wmtk/TetMeshOperationExecutor.cpp
+++ b/src/wmtk/TetMeshOperationExecutor.cpp
@@ -186,7 +186,7 @@ void TetMesh::TetMeshOperationExecutor::delete_simplices()
 {
     for (size_t d = 0; d < simplex_ids_to_delete.size(); ++d) {
         for (const int64_t id : simplex_ids_to_delete[d]) {
-            flag_accessors[d].index_access().scalar_attribute(id) = 0; // TODO: reset single bit
+            flag_accessors[d].index_access().deactivate(id);
         }
     }
 }

--- a/src/wmtk/TetMeshOperationExecutor.hpp
+++ b/src/wmtk/TetMeshOperationExecutor.hpp
@@ -11,7 +11,7 @@ public:
     void delete_simplices();
     void update_cell_hash();
 
-    std::array<attribute::Accessor<char>, 4> flag_accessors;
+    std::array<attribute::FlagAccessor<TetMesh>, 4> flag_accessors;
     attribute::Accessor<int64_t,TetMesh>& tt_accessor;
     attribute::Accessor<int64_t,TetMesh>& tf_accessor;
     attribute::Accessor<int64_t,TetMesh>& te_accessor;

--- a/src/wmtk/TriMesh.cpp
+++ b/src/wmtk/TriMesh.cpp
@@ -368,6 +368,41 @@ bool TriMesh::is_connectivity_valid() const
     const attribute::Accessor<char> e_flag_accessor = get_flag_accessor(PrimitiveType::Edge);
     const attribute::Accessor<char> f_flag_accessor = get_flag_accessor(PrimitiveType::Triangle);
 
+
+    for (int64_t i = 0; i < capacity(PrimitiveType::Triangle); ++i) {
+        if (!f_flag_accessor.index_access().is_active(i)) {
+            wmtk::logger().debug("Face {} is deleted", i);
+            continue;
+        }
+        auto fe = fe_accessor.index_access().const_vector_attribute<3>(i);
+        auto fv = fv_accessor.index_access().const_vector_attribute<3>(i);
+
+        bool bad_face = false;
+
+        for (int64_t j = 0; j < 3; ++j) {
+            int64_t ei = fe(j);
+            int64_t vi = fv(j);
+            if (!e_flag_accessor.index_access().is_active(ei)) {
+                wmtk::logger().debug(
+                    "Face {} refers to edge {} at local index {} which was deleted",
+                    i,
+                    ei,
+                    j);
+                bad_face = true;
+            }
+            if (!v_flag_accessor.index_access().is_active(vi)) {
+                wmtk::logger().debug(
+                    "Face {} refers to vertex{} at local index {} which was deleted",
+                    i,
+                    vi,
+                    j);
+                bad_face = true;
+            }
+        }
+        if (bad_face) {
+            return false;
+        }
+    }
     // EF and FE
     for (int64_t i = 0; i < capacity(PrimitiveType::Edge); ++i) {
         if (e_flag_accessor.index_access().const_scalar_attribute(i) == 0) {

--- a/src/wmtk/TriMesh.cpp
+++ b/src/wmtk/TriMesh.cpp
@@ -329,7 +329,7 @@ Tuple TriMesh::face_tuple_from_id(int64_t id) const
 bool TriMesh::is_valid(const Tuple& tuple) const
 {
     if (!Mesh::is_valid(tuple)) {
-        logger().debug("Tuple was null and therefore not valid");
+        logger().trace("Tuple was null and therefore not valid");
         return false;
     }
     const bool is_connectivity_valid = tuple.m_local_vid >= 0 && tuple.m_local_eid >= 0 &&
@@ -338,7 +338,7 @@ bool TriMesh::is_valid(const Tuple& tuple) const
 
     if (!is_connectivity_valid) {
 #if !defined(NDEBUG)
-        logger().debug(
+        logger().trace(
             "tuple.m_local_vid={} >= 0 && tuple.m_local_eid={} >= 0 &&"
             " tuple.m_global_cid={} >= 0 &&"
             " autogen::tri_mesh::tuple_is_valid_for_ccw(tuple)={}",
@@ -373,7 +373,6 @@ bool TriMesh::is_connectivity_valid() const
 
     for (int64_t i = 0; i < capacity(PrimitiveType::Triangle); ++i) {
         if (!f_flag_accessor.index_access().is_active(i)) {
-            wmtk::logger().debug("Face {} is deleted", i);
             continue;
         }
         auto fe = fe_accessor.index_access().const_vector_attribute<3>(i);
@@ -385,7 +384,7 @@ bool TriMesh::is_connectivity_valid() const
             int64_t ei = fe(j);
             int64_t vi = fv(j);
             if (!e_flag_accessor.index_access().is_active(ei)) {
-                wmtk::logger().debug(
+                wmtk::logger().error(
                     "Face {} refers to edge {} at local index {} which was deleted",
                     i,
                     ei,
@@ -393,7 +392,7 @@ bool TriMesh::is_connectivity_valid() const
                 bad_face = true;
             }
             if (!v_flag_accessor.index_access().is_active(vi)) {
-                wmtk::logger().debug(
+                wmtk::logger().error(
                     "Face {} refers to vertex{} at local index {} which was deleted",
                     i,
                     vi,
@@ -408,7 +407,6 @@ bool TriMesh::is_connectivity_valid() const
     // EF and FE
     for (int64_t i = 0; i < capacity(PrimitiveType::Edge); ++i) {
         if (!e_flag_accessor.index_access().is_active(i)) {
-            wmtk::logger().debug("Edge {} is deleted", i);
             continue;
         }
         int cnt = 0;
@@ -421,7 +419,7 @@ bool TriMesh::is_connectivity_valid() const
             }
         }
         if (cnt == 0) {
-            wmtk::logger().debug(
+            wmtk::logger().error(
                 "EF[{0}] {1} and FE:[EF[{0}]] = {2} are not "
                 "compatible ",
                 i,
@@ -437,7 +435,6 @@ bool TriMesh::is_connectivity_valid() const
     for (int64_t i = 0; i < capacity(PrimitiveType::Vertex); ++i) {
         const int64_t vf = vf_accessor.index_access().const_scalar_attribute(i);
         if (!v_flag_accessor.index_access().is_active(i)) {
-            wmtk::logger().debug("Vertex {} is deleted", i);
             continue;
         }
         int cnt = 0;
@@ -449,7 +446,7 @@ bool TriMesh::is_connectivity_valid() const
             }
         }
         if (cnt == 0) {
-            wmtk::logger().debug(
+            wmtk::logger().error(
                 "VF and FV not compatible, could not find VF[{}] = {} "
                 "in FV[{}] = [{}]",
                 i,
@@ -463,7 +460,6 @@ bool TriMesh::is_connectivity_valid() const
     // FE and EF
     for (int64_t i = 0; i < capacity(PrimitiveType::Triangle); ++i) {
         if (!f_flag_accessor.index_access().is_active(i)) {
-            wmtk::logger().debug("Face {} is deleted", i);
             continue;
         }
         auto fe = fe_accessor.index_access().const_vector_attribute<3>(i);
@@ -475,7 +471,7 @@ bool TriMesh::is_connectivity_valid() const
             if (is_boundary) {
                 auto ef = ef_accessor.index_access().const_scalar_attribute(fe(j));
                 if (ef != i) {
-                    wmtk::logger().debug(
+                    wmtk::logger().error(
                         "Even though local edge {} of face {} is "
                         "boundary (global eid is {}), "
                         "ef[{}] = {} != {}",
@@ -489,7 +485,7 @@ bool TriMesh::is_connectivity_valid() const
                 }
             } else {
                 if (neighbor_fid == i) {
-                    logger().warn(
+                    logger().error(
                         "Connectivity check cannot work when mapping a "
                         "face to itself (face {})",
                         i);
@@ -513,7 +509,7 @@ bool TriMesh::is_connectivity_valid() const
                         }
                     }
                     if (edge_shared_count != 1) {
-                        wmtk::logger().debug(
+                        wmtk::logger().error(
                             "face {} with fe={} neighbor fe[{}] = {} "
                             "was unable to find itself "
                             "uniquely (found {})",
@@ -525,7 +521,7 @@ bool TriMesh::is_connectivity_valid() const
                         return false;
                     }
                 } else {
-                    wmtk::logger().debug(
+                    wmtk::logger().error(
                         "face {} with ff={} neighbor ff[{}] = {} was "
                         "unable to find itself",
                         i,

--- a/src/wmtk/TriMeshOperationExecutor.cpp
+++ b/src/wmtk/TriMeshOperationExecutor.cpp
@@ -129,7 +129,7 @@ void TriMesh::TriMeshOperationExecutor::delete_simplices()
             d,
             fmt::join(simplex_ids_to_delete[d], ","));
         for (const int64_t id : simplex_ids_to_delete[d]) {
-            flag_accessors[d].index_access().scalar_attribute(id) = 0;
+            flag_accessors[d].index_access().deactivate(id);
         }
     }
 }

--- a/src/wmtk/TriMeshOperationExecutor.hpp
+++ b/src/wmtk/TriMeshOperationExecutor.hpp
@@ -12,7 +12,7 @@ public:
     TriMeshOperationExecutor(TriMesh& m, const Tuple& operating_tuple);
     void delete_simplices();
 
-    std::array<attribute::Accessor<char>, 3> flag_accessors;
+    std::array<attribute::FlagAccessor<TriMesh>, 3> flag_accessors;
     attribute::Accessor<int64_t, TriMesh>& ff_accessor;
     attribute::Accessor<int64_t, TriMesh>& fe_accessor;
     attribute::Accessor<int64_t, TriMesh>& fv_accessor;

--- a/src/wmtk/attribute/FlagAccessor.hpp
+++ b/src/wmtk/attribute/FlagAccessor.hpp
@@ -1,0 +1,90 @@
+#pragma once
+
+#include "Accessor.hpp"
+namespace wmtk::attribute {
+
+
+template <typename MeshType = wmtk::Mesh>
+class IndexFlagAccessor
+{
+public:
+    enum class FlagBit : char { Active = 0x1 };
+    static bool _is_active(char value) { return value & static_cast<char>(FlagBit::Active); }
+    static void _activate(char& value) { value |= static_cast<char>(FlagBit::Active); }
+    static void _deactivate(char& value) { value &= inverse_mask(FlagBit::Active); }
+    using BaseAccessor = Accessor<char, MeshType, 1>;
+
+
+    IndexFlagAccessor(BaseAccessor acc)
+        : m_base_accessor{std::move(acc)}
+    {}
+    template <typename MeshType2>
+    IndexFlagAccessor(const IndexFlagAccessor<MeshType2>& o)
+        : m_base_accessor{o.m_base_accessor}
+    {}
+
+    bool is_active(int64_t t) const
+    {
+        return _is_active(m_base_accessor.index_access().const_scalar_attribute(t));
+    }
+    void activate(int64_t t)
+    {
+        return _activate(m_base_accessor.index_access().scalar_attribute(t));
+    }
+    void deactivate(int64_t t)
+    {
+        return _deactivate(m_base_accessor.index_access().scalar_attribute(t));
+    }
+
+    constexpr static char inverse_mask(FlagBit bit) { return 0xFF ^ static_cast<char>(bit); }
+
+
+    BaseAccessor& base_accessor() { return m_base_accessor; }
+    const BaseAccessor& base_accessor() const { return m_base_accessor; }
+    operator BaseAccessor() const { return m_base_accessor; }
+
+protected:
+    BaseAccessor m_base_accessor;
+
+
+    IndexFlagAccessor index_access() const { return IndexAccessor(*this); }
+};
+
+template <typename MeshType = wmtk::Mesh>
+class FlagAccessor : private IndexFlagAccessor<MeshType>
+{
+public:
+    enum class FlagBit : char { Active = 1 };
+    using IndexBaseType = IndexFlagAccessor<MeshType>;
+
+    using IndexBaseType::base_accessor;
+    using IndexBaseType::IndexBaseType;
+
+    template <typename MeshType2>
+    FlagAccessor(const FlagAccessor<MeshType2>& o)
+        : IndexBaseType{o.base_accessor()}
+    {}
+
+    template <typename T>
+    bool is_active(const T& t) const
+    {
+        return IndexBaseType::_is_active(IndexBaseType::m_base_accessor.const_scalar_attribute(t));
+    }
+    template <typename T>
+    void activate(const T& t)
+    {
+        IndexBaseType::_activate(IndexBaseType::m_base_accessor.scalar_attribute(t));
+    }
+    template <typename T>
+    void deactivate(const T& t)
+    {
+        IndexBaseType::_deactivate(IndexBaseType::m_base_accessor.scalar_attribute(t));
+    }
+
+
+    const IndexBaseType& index_access() const { return *this; }
+    IndexBaseType& index_access() { return *this; }
+};
+
+
+} // namespace wmtk::attribute

--- a/src/wmtk/multimesh/MultiMeshManager.cpp
+++ b/src/wmtk/multimesh/MultiMeshManager.cpp
@@ -689,10 +689,10 @@ std::vector<std::array<Tuple, 2>> MultiMeshManager::same_simplex_dimension_surje
     for (int64_t index = 0; index < size; ++index) {
         const Tuple ct = child.tuple_from_id(primitive_type, index);
         const Tuple pt = parent.tuple_from_id(primitive_type, parent_simplices.at(index));
-        if ((parent_flag_accessor.const_scalar_attribute(pt) & 1) == 0) {
+        if (!(parent_flag_accessor.is_active(pt))) {
             continue;
         }
-        if ((child_flag_accessor.const_scalar_attribute(ct) & 1) == 0) {
+        if (!(child_flag_accessor.is_active(ct))) {
             continue;
         }
 

--- a/src/wmtk/operations/AttributesUpdate.cpp
+++ b/src/wmtk/operations/AttributesUpdate.cpp
@@ -33,14 +33,9 @@ std::vector<simplex::Simplex> AttributesUpdate::execute(const simplex::Simplex& 
     //
     // assert(!mesh().is_valid(simplex.tuple(), accessor));
 
-#if defined(WMTK_ENABLE_HASH_UPDATE) 
-    auto new_tuple = resurrect_tuple(simplex.tuple());
-#else
-    auto new_tuple = simplex.tuple();
-#endif
-    assert(mesh().is_valid(new_tuple));
+    assert(mesh().is_valid(simplex.tuple()));
 
-    return {simplex::Simplex(mesh(), primitive_type(), new_tuple)};
+    return {simplex};
 }
 
 AttributesUpdateWithFunction::AttributesUpdateWithFunction(Mesh& m)

--- a/src/wmtk/operations/Operation.cpp
+++ b/src/wmtk/operations/Operation.cpp
@@ -148,9 +148,19 @@ void Operation::apply_attribute_transfer(const std::vector<simplex::Simplex>& di
     simplex::IdSimplexCollection all(m_mesh);
     all.reserve(100);
 
+<<<<<<< Updated upstream
 
     for (const auto& s : direct_mods) {
         if (!s.tuple().is_null()) {
+=======
+    // MTAO: todo: delete this
+    assert(m_mesh.is_connectivity_valid());
+
+    for (const auto& s : direct_mods) {
+        if (!s.tuple().is_null()) {
+            assert(m_mesh.is_valid(s));
+            assert(m_mesh.get_const_flag_accessor(s.primitive_type()).is_active(s));
+>>>>>>> Stashed changes
             for (const simplex::IdSimplex& ss : simplex::closed_star_iterable(m_mesh, s)) {
                 all.add(ss);
             }

--- a/src/wmtk/operations/Operation.cpp
+++ b/src/wmtk/operations/Operation.cpp
@@ -148,19 +148,11 @@ void Operation::apply_attribute_transfer(const std::vector<simplex::Simplex>& di
     simplex::IdSimplexCollection all(m_mesh);
     all.reserve(100);
 
-<<<<<<< Updated upstream
-
-    for (const auto& s : direct_mods) {
-        if (!s.tuple().is_null()) {
-=======
-    // MTAO: todo: delete this
-    assert(m_mesh.is_connectivity_valid());
 
     for (const auto& s : direct_mods) {
         if (!s.tuple().is_null()) {
             assert(m_mesh.is_valid(s));
             assert(m_mesh.get_const_flag_accessor(s.primitive_type()).is_active(s));
->>>>>>> Stashed changes
             for (const simplex::IdSimplex& ss : simplex::closed_star_iterable(m_mesh, s)) {
                 all.add(ss);
             }

--- a/src/wmtk/operations/utils/UpdateEdgeOperationMultiMeshMapFunctor.cpp
+++ b/src/wmtk/operations/utils/UpdateEdgeOperationMultiMeshMapFunctor.cpp
@@ -88,9 +88,7 @@ void UpdateEdgeOperationMultiMeshMapFunctor::update_ear_replacement(
 
 
                 //  check also the flag accessor of child mesh
-                const char child_flag =
-                    child_cell_flag_accessor.const_scalar_attribute(child_tuple);
-                bool child_tuple_exists = 1 == (child_flag & 1);
+                const bool child_tuple_exists = child_cell_flag_accessor.is_active(child_tuple);
                 if (!child_tuple_exists) {
                     continue;
                 }
@@ -184,9 +182,7 @@ void UpdateEdgeOperationMultiMeshMapFunctor::update_ear_replacement(
                     }
 
 
-                    const char child_flag =
-                        child_cell_flag_accessor.const_scalar_attribute(child_tuple);
-                    bool child_tuple_exists = 1 == (child_flag & 1);
+                    bool child_tuple_exists = child_cell_flag_accessor.is_active(child_tuple);
                     if (!child_tuple_exists) {
                         continue;
                     }
@@ -294,9 +290,7 @@ void UpdateEdgeOperationMultiMeshMapFunctor::update_ear_replacement(
                         }
 
 
-                        const char child_flag =
-                            child_cell_flag_accessor.const_scalar_attribute(child_tuple);
-                        bool child_tuple_exists = 1 == (child_flag & 1);
+                        bool child_tuple_exists = child_cell_flag_accessor.is_active(child_tuple);
                         if (!child_tuple_exists) {
                             continue;
                         }

--- a/tests/multimesh/consolidate.cpp
+++ b/tests/multimesh/consolidate.cpp
@@ -80,8 +80,8 @@ TEST_CASE("consolidate_multimesh", "[mesh][consolidate_multimesh]")
 
         // CHECK_THROWS(m.tuple_from_id(PrimitiveType::Vertex, 4));
 
-        REQUIRE(executor.flag_accessors[2].index_access().const_scalar_attribute(2) == 0);
-        REQUIRE(executor.flag_accessors[2].index_access().const_scalar_attribute(7) == 0);
+        REQUIRE(executor.flag_accessors[2].index_access().is_active(2) == false);
+        REQUIRE(executor.flag_accessors[2].index_access().is_active(7) == false);
         CHECK(fv_accessor.vector_attribute(0)[1] == 5);
         CHECK(fv_accessor.vector_attribute(1)[0] == 5);
         CHECK(fv_accessor.vector_attribute(3)[0] == 5);

--- a/tests/operations/collapse_2d.cpp
+++ b/tests/operations/collapse_2d.cpp
@@ -64,8 +64,8 @@ TEST_CASE("collapse_edge", "[operations][collapse][2D]")
 
         // CHECK_THROWS(m.tuple_from_id(PrimitiveType::Vertex, 4));
 
-        REQUIRE(face_flag_accessor.index_access().const_scalar_attribute(2) == 0);
-        REQUIRE(face_flag_accessor.index_access().const_scalar_attribute(7) == 0);
+        REQUIRE(face_flag_accessor.index_access().is_active(2) == false);
+        REQUIRE(face_flag_accessor.index_access().is_active(7) == false);
         CHECK(fv_accessor.vector_attribute(0)[1] == 5);
         CHECK(fv_accessor.vector_attribute(1)[0] == 5);
         CHECK(fv_accessor.vector_attribute(3)[0] == 5);
@@ -84,8 +84,8 @@ TEST_CASE("collapse_edge", "[operations][collapse][2D]")
 
         // CHECK_THROWS(m.tuple_from_id(PrimitiveType::Vertex, 4));
 
-        REQUIRE(face_flag_accessor.index_access().const_scalar_attribute(0) == 0);
-        REQUIRE(face_flag_accessor.index_access().const_scalar_attribute(1) == 0);
+        REQUIRE(face_flag_accessor.index_access().is_active(0) == false);
+        REQUIRE(face_flag_accessor.index_access().is_active(1) == false);
 
         CHECK(fv_accessor.vector_attribute(2)[0] == 0);
         CHECK(fv_accessor.vector_attribute(5)[2] == 0);
@@ -125,7 +125,7 @@ TEST_CASE("collapse_edge", "[operations][collapse][2D]")
 
         // CHECK_THROWS(m.tuple_from_id(PrimitiveType::Vertex, 0));
 
-        REQUIRE(face_flag_accessor.index_access().const_scalar_attribute(1) == 0);
+        REQUIRE(face_flag_accessor.index_access().is_active(1) == false);
 
         CHECK(fv_accessor.vector_attribute(0)[2] == 1);
     }

--- a/tests/operations/split_2d.cpp
+++ b/tests/operations/split_2d.cpp
@@ -132,8 +132,8 @@ TEST_CASE("delete_simplices", "[operations][2D]")
     executor.simplex_ids_to_delete = TMOE::get_split_simplices_to_delete(edge, m);
 
     executor.delete_simplices();
-    REQUIRE(executor.flag_accessors[1].index_access().const_scalar_attribute(edge_index) == 0);
-    REQUIRE(executor.flag_accessors[2].index_access().const_scalar_attribute(face_index) == 0);
+    REQUIRE(executor.flag_accessors[1].index_access().is_active(edge_index) == false);
+    REQUIRE(executor.flag_accessors[2].index_access().is_active(face_index) == false);
     REQUIRE(executor.ff_accessor.index_access().const_vector_attribute(face_index)[0] == -1);
     REQUIRE(executor.ff_accessor.index_access().const_vector_attribute(face_index)[1] == 2);
     REQUIRE(executor.ff_accessor.index_access().const_vector_attribute(face_index)[2] == 1);

--- a/tests/test_mesh.cpp
+++ b/tests/test_mesh.cpp
@@ -99,8 +99,8 @@ TEST_CASE("consolidate", "[mesh][consolidate]")
 
         // CHECK_THROWS(m.tuple_from_id(PrimitiveType::Vertex, 4));
 
-        REQUIRE(executor.flag_accessors[2].index_access().scalar_attribute(2) == 0);
-        REQUIRE(executor.flag_accessors[2].index_access().scalar_attribute(7) == 0);
+        REQUIRE(executor.flag_accessors[2].index_access().is_active(2) == false);
+        REQUIRE(executor.flag_accessors[2].index_access().is_active(7) == false);
         CHECK(fv_accessor.vector_attribute(0)[1] == 5);
         CHECK(fv_accessor.vector_attribute(1)[0] == 5);
         CHECK(fv_accessor.vector_attribute(3)[0] == 5);

--- a/tests/tools/DEBUG_EdgeMesh.cpp
+++ b/tests/tools/DEBUG_EdgeMesh.cpp
@@ -33,7 +33,7 @@ void DEBUG_EdgeMesh::print_ve() const
     auto e_flag_accessor = get_flag_accessor(PrimitiveType::Edge);
     for (int64_t id = 0; id < capacity(PrimitiveType::Edge); ++id) {
         auto ev = ev_accessor.const_vector_attribute(id);
-        if (e_flag_accessor.const_scalar_attribute(tuple_from_id(PrimitiveType::Edge, id)) == 0) {
+        if (!e_flag_accessor.is_active(tuple_from_id(PrimitiveType::Edge, id))) {
             std::cout << "edge " << id << " is deleted" << std::endl;
         } else {
             std::cout << ev(0) << " " << ev(1) << std::endl;
@@ -111,6 +111,6 @@ auto DEBUG_EdgeMesh::get_emoe(const Tuple& t) -> EdgeMeshOperationExecutor
 bool DEBUG_EdgeMesh::is_simplex_deleted(PrimitiveType type, const int64_t id) const
 {
     const auto flag_accessor = get_flag_accessor(type);
-    return flag_accessor.index_access().scalar_attribute(id) == 0;
+    return !flag_accessor.index_access().is_active(id) ;
 }
 } // namespace wmtk::tests

--- a/tests/tools/DEBUG_TetMesh.cpp
+++ b/tests/tools/DEBUG_TetMesh.cpp
@@ -286,7 +286,7 @@ int64_t DEBUG_TetMesh::valid_primitive_count(PrimitiveType type) const
     int64_t cnt = 0;
     const auto& flag_accessor = get_const_flag_accessor(type);
     for (int i = 0; i < capacity(type); i++) {
-        if (flag_accessor.index_access().const_scalar_attribute(i) != 0) {
+        if (flag_accessor.index_access().is_active(i)) {
             cnt++;
         }
     }

--- a/tests/tools/DEBUG_TriMesh.cpp
+++ b/tests/tools/DEBUG_TriMesh.cpp
@@ -34,8 +34,7 @@ void DEBUG_TriMesh::print_vf() const
     auto f_flag_accessor = get_flag_accessor(PrimitiveType::Triangle);
     for (int64_t id = 0; id < capacity(PrimitiveType::Triangle); ++id) {
         auto fv = fv_accessor.const_vector_attribute(id);
-        if (f_flag_accessor.const_scalar_attribute(tuple_from_id(PrimitiveType::Triangle, id)) ==
-            0) {
+        if (!f_flag_accessor.is_active(tuple_from_id(PrimitiveType::Triangle, id))) {
             std::cout << "face " << id << " is deleted" << std::endl;
         } else {
             std::cout << fv(0) << " " << fv(1) << " " << fv(2) << std::endl;


### PR DESCRIPTION
Added a wrapper over our accessor class to enable use of `is_active` / `activate` / `deactivate` member functions instead of inconsistent  bitwise actions on `.const_scalar_attribute(t)` values