### PR TITLE
Refactoring of swap and minor c hanges to other operations

### DIFF
--- a/components/wildmeshing/wmtk/components/wildmeshing/internal/wildmeshing2d.cpp
+++ b/components/wildmeshing/wmtk/components/wildmeshing/internal/wildmeshing2d.cpp
@@ -85,7 +85,10 @@ using namespace invariants;
 std::vector<std::pair<std::shared_ptr<Mesh>, std::string>> wildmeshing2d(
     const WildMeshingOptions& options)
 {
-    auto mesh = options.input_mesh;
+    auto mesh = std::dynamic_pointer_cast<TriMesh>(options.input_mesh);
+    if(!bool(mesh)) {
+        throw std::runtime_error("input mesh of wildmeshing3d must be a trimesh");
+    }
 
     if (!mesh->is_connectivity_valid()) {
         throw std::runtime_error("input mesh for wildmeshing connectivity invalid");

--- a/components/wildmeshing/wmtk/components/wildmeshing/internal/wildmeshing3d.cpp
+++ b/components/wildmeshing/wmtk/components/wildmeshing/internal/wildmeshing3d.cpp
@@ -88,7 +88,10 @@ using namespace invariants;
 std::vector<std::pair<std::shared_ptr<Mesh>, std::string>> wildmeshing3d(
     const WildMeshingOptions& options)
 {
-    auto mesh = options.input_mesh;
+    auto mesh = std::dynamic_pointer_cast<TetMesh>(options.input_mesh);
+    if(!bool(mesh)) {
+        throw std::runtime_error("input mesh of wildmeshing3d must be a tetmesh");
+    }
 
     if (!mesh->is_connectivity_valid()) {
         throw std::runtime_error("input mesh for wildmeshing connectivity invalid");

--- a/src/wmtk/EdgeMesh.hpp
+++ b/src/wmtk/EdgeMesh.hpp
@@ -44,6 +44,7 @@ public:
         Eigen::Ref<const RowVectors2l> EE,
         Eigen::Ref<const VectorXl> VE);
 
+    using Mesh::is_valid;
     bool is_valid(const Tuple& tuple) const final override;
 
     bool is_connectivity_valid() const override;

--- a/src/wmtk/Mesh.cpp
+++ b/src/wmtk/Mesh.cpp
@@ -38,7 +38,7 @@ simplex::IdSimplex Mesh::get_id_simplex(const simplex::Simplex& s) const
 simplex::Simplex Mesh::get_simplex(const simplex::IdSimplex& s) const
 {
     const Tuple& t = tuple_from_id(s.primitive_type(), s.index());
-    return simplex::Simplex(*this, s.primitive_type(), t);
+    return simplex::Simplex(s.primitive_type(), t);
 }
 
 Tuple Mesh::get_tuple_from_id_simplex(const simplex::IdSimplex& s) const
@@ -112,7 +112,16 @@ bool Mesh::is_boundary(const simplex::Simplex& s) const
 
 bool Mesh::is_valid(const Tuple& tuple) const
 {
-    return !tuple.is_null() && !is_removed(tuple);
+    const bool nullity = tuple.is_null();
+    const bool removed = is_removed(tuple);
+    const bool bad = nullity || removed;
+#if !defined(NDEBUG)
+    if(bad) {
+        logger().debug("Mesh::is_valid failed, got nullity:{} removedness:{}", nullity, removed);
+
+    }
+#endif
+    return !bad;
 }
 
 bool Mesh::is_removed(const Tuple& tuple) const
@@ -143,16 +152,7 @@ bool Mesh::is_removed(int64_t index, PrimitiveType pt) const
 
 bool Mesh::is_valid(const simplex::Simplex& s) const
 {
-#if defined(WMTK_ENABLE_SIMPLEX_ID_CACHING)
-    if (!is_valid(s.tuple())) {
-        return false;
-    } else {
-        const int64_t id_tuple = id(s.tuple(), s.primitive_type());
-        return id_tuple == s.m_index;
-    }
-#else
     return is_valid(s.tuple()) && !is_removed(s.tuple(), s.primitive_type());
-#endif
 }
 
 

--- a/src/wmtk/Mesh.cpp
+++ b/src/wmtk/Mesh.cpp
@@ -117,7 +117,7 @@ bool Mesh::is_valid(const Tuple& tuple) const
     const bool bad = nullity || removed;
 #if !defined(NDEBUG)
     if(bad) {
-        logger().debug("Mesh::is_valid failed, got nullity:{} removedness:{}", nullity, removed);
+        logger().trace("Mesh::is_valid failed, got nullity:{} removedness:{}", nullity, removed);
 
     }
 #endif

--- a/src/wmtk/Mesh.hpp
+++ b/src/wmtk/Mesh.hpp
@@ -29,6 +29,7 @@
 
 #include "multimesh/attribute/UseParentScopeRAII.hpp"
 
+
 #include "simplex/IdSimplex.hpp"
 #include "simplex/NavigatableSimplex.hpp"
 #include "simplex/Simplex.hpp"

--- a/src/wmtk/TetMesh.hpp
+++ b/src/wmtk/TetMesh.hpp
@@ -34,6 +34,7 @@ public:
     bool is_boundary_edge(const Tuple& tuple) const;
     bool is_boundary_face(const Tuple& tuple) const;
 
+    using Mesh::is_valid;
     bool is_valid(const Tuple& tuple) const final override;
 
     void initialize(

--- a/src/wmtk/TriMesh.hpp
+++ b/src/wmtk/TriMesh.hpp
@@ -54,6 +54,7 @@ public:
     void initialize(Eigen::Ref<const RowVectors3l> F, bool make_free = false);
     void initialize_free(int64_t count);
 
+    using Mesh::is_valid;
     bool is_valid(const Tuple& tuple) const final override;
 
     bool is_connectivity_valid() const final override;

--- a/src/wmtk/operations/Operation.cpp
+++ b/src/wmtk/operations/Operation.cpp
@@ -145,8 +145,6 @@ void Operation::apply_attribute_transfer(const std::vector<simplex::Simplex>& di
         if (!s.tuple().is_null()) {
             assert(m_mesh.is_valid(s));
             for (const simplex::IdSimplex& ss : simplex::closed_star_iterable(m_mesh, s)) {
-                // trying to get a simplex and this crashes
-                m_mesh.get_simplex(ss);
                 all.add(ss);
             }
         }

--- a/src/wmtk/operations/Operation.cpp
+++ b/src/wmtk/operations/Operation.cpp
@@ -65,9 +65,6 @@ void Operation::add_transfer_strategy(
 
 std::vector<simplex::Simplex> Operation::operator()(const simplex::Simplex& simplex)
 {
-    if (!mesh().is_valid(simplex)) {
-        return {};
-    }
     if (!before(simplex)) {
         return {};
     }
@@ -97,14 +94,9 @@ std::vector<simplex::Simplex> Operation::operator()(const simplex::Simplex& simp
 bool Operation::before(const simplex::Simplex& simplex) const
 {
     // const attribute::Accessor<int64_t> accessor = hash_accessor();
-
-    // if (!mesh().is_valid(
-    //         simplex.tuple(),
-    //         accessor)) { // TODO: chang to is_removed and resurrect later
-    //     return false;
-    // }
-
-    if (mesh().is_removed(simplex.tuple()) || !mesh().is_valid(simplex)) {
+    // we assume the current MeshType's is_valid calls Mesh::is_valid first, which checks if the
+    // simplex is removed or not
+    if (!mesh().is_valid(simplex)) {
         return false;
     }
 
@@ -152,8 +144,9 @@ void Operation::apply_attribute_transfer(const std::vector<simplex::Simplex>& di
     for (const auto& s : direct_mods) {
         if (!s.tuple().is_null()) {
             assert(m_mesh.is_valid(s));
-            assert(m_mesh.get_const_flag_accessor(s.primitive_type()).is_active(s));
             for (const simplex::IdSimplex& ss : simplex::closed_star_iterable(m_mesh, s)) {
+                // trying to get a simplex and this crashes
+                m_mesh.get_simplex(ss);
                 all.add(ss);
             }
         }
@@ -165,6 +158,7 @@ void Operation::apply_attribute_transfer(const std::vector<simplex::Simplex>& di
     for (const auto& at_ptr : m_attr_transfer_strategies) {
         if (&m_mesh == &(at_ptr->mesh())) {
             for (const simplex::IdSimplex& s : all.simplex_vector()) {
+                assert(m_mesh.get_const_flag_accessor(s.primitive_type()).is_active(s));
                 if (s.primitive_type() == at_ptr->primitive_type()) {
                     at_ptr->run(m_mesh.get_simplex(s));
                 }

--- a/src/wmtk/operations/composite/CMakeLists.txt
+++ b/src/wmtk/operations/composite/CMakeLists.txt
@@ -1,4 +1,8 @@
 set(SRC_FILES
+
+    EdgeSwap.cpp
+    EdgeSwap.hpp
+
     TriFaceSplit.hpp
     TriFaceSplit.cpp
 

--- a/src/wmtk/operations/composite/EdgeSwap.cpp
+++ b/src/wmtk/operations/composite/EdgeSwap.cpp
@@ -1,0 +1,15 @@
+#include "EdgeSwap.hpp"
+
+namespace wmtk::operations::composite {
+EdgeSwap::EdgeSwap(Mesh& m)
+    : EdgeSwap(m, std::make_shared<EdgeSplit>(m), std::make_shared<EdgeCollapse>(m))
+{}
+EdgeSwap::EdgeSwap(
+    Mesh& m,
+    std::shared_ptr<EdgeSplit> split,
+    std::shared_ptr<EdgeCollapse> collapse)
+    : Operation(m)
+    , m_split(std::move(split))
+    , m_collapse(std::move(collapse))
+{}
+} // namespace wmtk::operations::composite

--- a/src/wmtk/operations/composite/EdgeSwap.hpp
+++ b/src/wmtk/operations/composite/EdgeSwap.hpp
@@ -1,0 +1,23 @@
+#pragma once
+#include <wmtk/operations/EdgeCollapse.hpp>
+#include <wmtk/operations/EdgeSplit.hpp>
+#include <wmtk/operations/Operation.hpp>
+
+namespace wmtk::operations::composite {
+class EdgeSwap : public Operation
+{
+public:
+    EdgeSwap(Mesh& m);
+    EdgeSwap(Mesh& m, std::shared_ptr<EdgeSplit> split, std::shared_ptr<EdgeCollapse> collapse);
+
+    EdgeSplit& split() { return *m_split; }
+    EdgeCollapse& collapse() { return *m_collapse; }
+    const EdgeSplit& split() const { return *m_split; }
+    const EdgeCollapse& collapse() const { return *m_collapse; }
+
+protected:
+    std::shared_ptr<EdgeSplit> m_split;
+    std::shared_ptr<EdgeCollapse> m_collapse;
+};
+} // namespace wmtk::operations::composite
+

--- a/src/wmtk/operations/composite/ProjectOperation.hpp
+++ b/src/wmtk/operations/composite/ProjectOperation.hpp
@@ -22,11 +22,19 @@ public:
 
     ProjectOperation(
         std::shared_ptr<Operation> main_op,
-        const std::vector<MeshConstrainPair>& mesh_constaint_pairs);
+        const std::vector<MeshConstrainPair>& mesh_constaint_pairs = {});
 
     std::vector<simplex::Simplex> execute(const simplex::Simplex& simplex) override;
     PrimitiveType primitive_type() const override { return m_main_op->primitive_type(); }
 
+
+    void add_constraint(
+        const attribute::MeshAttributeHandle& mah,
+        std::shared_ptr<SimpleBVH::BVH> bvh);
+
+    void add_constraint(
+        const attribute::MeshAttributeHandle& mah,
+        const attribute::MeshAttributeHandle& bvh_mesh_attribute);
 
 private:
     using BVHConstrainPair =

--- a/src/wmtk/operations/composite/TetCellSplit.cpp
+++ b/src/wmtk/operations/composite/TetCellSplit.cpp
@@ -5,7 +5,7 @@
 namespace wmtk::operations::composite {
 
 
-TetCellSplit::TetCellSplit(Mesh& m)
+TetCellSplit::TetCellSplit(TetMesh& m)
     : Operation(m)
     , m_split(m)
     , m_collapse(m)

--- a/src/wmtk/operations/composite/TetCellSplit.hpp
+++ b/src/wmtk/operations/composite/TetCellSplit.hpp
@@ -18,7 +18,7 @@ namespace wmtk::operations::composite {
 class TetCellSplit : public Operation
 {
 public:
-    TetCellSplit(Mesh& m);
+    TetCellSplit(TetMesh& m);
 
     PrimitiveType primitive_type() const override { return PrimitiveType::Tetrahedron; }
 

--- a/src/wmtk/operations/composite/TetEdgeSwap.cpp
+++ b/src/wmtk/operations/composite/TetEdgeSwap.cpp
@@ -7,16 +7,14 @@
 #include <wmtk/Mesh.hpp>
 
 namespace wmtk::operations::composite {
-TetEdgeSwap::TetEdgeSwap(Mesh& m, int64_t collapse_index)
-    : Operation(m)
-    , m_split(m)
-    , m_collapse(m)
+TetEdgeSwap::TetEdgeSwap(TetMesh& m, int64_t collapse_index)
+    : EdgeSwap(m)
     , m_collapse_index(collapse_index)
 {}
 
 std::vector<simplex::Simplex> TetEdgeSwap::execute(const simplex::Simplex& simplex)
 {
-    const auto split_simplicies = m_split(simplex);
+    const auto split_simplicies = split()(simplex);
     if (split_simplicies.empty()) return {};
     assert(split_simplicies.size() == 1);
 
@@ -135,7 +133,7 @@ std::vector<simplex::Simplex> TetEdgeSwap::execute(const simplex::Simplex& simpl
 
     // do collapse
     const auto collapse_simplicies =
-        m_collapse(simplex::Simplex(mesh(), m_collapse.primitive_type(), collapse_tuple));
+        collapse()(simplex::Simplex(mesh(), collapse().primitive_type(), collapse_tuple));
     if (collapse_simplicies.empty()) return {};
     assert(collapse_simplicies.size() == 1);
 

--- a/src/wmtk/operations/composite/TetEdgeSwap.hpp
+++ b/src/wmtk/operations/composite/TetEdgeSwap.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
-#include <wmtk/operations/EdgeCollapse.hpp>
-#include <wmtk/operations/EdgeSplit.hpp>
+#include "EdgeSwap.hpp"
 
 namespace wmtk::operations::composite {
 
@@ -15,15 +14,13 @@ namespace wmtk::operations::composite {
  *
  */
 
-class TetEdgeSwap : public Operation
+class TetEdgeSwap : public EdgeSwap
 {
 public:
-    TetEdgeSwap(Mesh& m, int64_t collapse_index = 0);
+    TetEdgeSwap(TetMesh& m, int64_t collapse_index = 0);
 
     PrimitiveType primitive_type() const override { return PrimitiveType::Edge; }
 
-    inline EdgeSplit& split() { return m_split; }
-    inline EdgeCollapse& collapse() { return m_collapse; }
 
 
 protected:
@@ -32,8 +29,6 @@ protected:
     std::vector<simplex::Simplex> execute(const simplex::Simplex& simplex) override;
 
 private:
-    EdgeSplit m_split;
-    EdgeCollapse m_collapse;
     int64_t m_collapse_index;
 };
 

--- a/src/wmtk/operations/composite/TetFaceSwap.cpp
+++ b/src/wmtk/operations/composite/TetFaceSwap.cpp
@@ -2,7 +2,7 @@
 #include <wmtk/Mesh.hpp>
 
 namespace wmtk::operations::composite {
-TetFaceSwap::TetFaceSwap(Mesh& m)
+TetFaceSwap::TetFaceSwap(TetMesh& m)
     : Operation(m)
     , m_split(m)
     , m_collapse(m)

--- a/src/wmtk/operations/composite/TetFaceSwap.hpp
+++ b/src/wmtk/operations/composite/TetFaceSwap.hpp
@@ -37,7 +37,7 @@ namespace wmtk::operations::composite {
 class TetFaceSwap : public Operation
 {
 public:
-    TetFaceSwap(Mesh& m);
+    TetFaceSwap(TetMesh& m);
 
     PrimitiveType primitive_type() const override { return PrimitiveType::Triangle; }
 

--- a/src/wmtk/operations/composite/TriEdgeSwap.cpp
+++ b/src/wmtk/operations/composite/TriEdgeSwap.cpp
@@ -4,10 +4,8 @@
 
 namespace wmtk::operations::composite {
 
-TriEdgeSwap::TriEdgeSwap(Mesh& m)
-    : Operation(m)
-    , m_split(m)
-    , m_collapse(m)
+TriEdgeSwap::TriEdgeSwap(TriMesh& m)
+    : EdgeSwap(m)
 {}
 
 
@@ -21,7 +19,7 @@ std::vector<simplex::Simplex> TriEdgeSwap::execute(const simplex::Simplex& simpl
     //  \     /
     //   \   /
     //    \ /
-    const auto split_simplicies = m_split(simplex);
+    const auto split_simplicies = split()(simplex);
     if (split_simplicies.empty()) return {};
     assert(split_simplicies.size() == 1);
 
@@ -47,7 +45,7 @@ std::vector<simplex::Simplex> TriEdgeSwap::execute(const simplex::Simplex& simpl
     //   \ | /
     //    \|/
     const auto collapse_simplicies =
-        m_collapse(simplex::Simplex(mesh(), m_collapse.primitive_type(), collapse_input_tuple));
+        collapse()(simplex::Simplex(mesh(), collapse().primitive_type(), collapse_input_tuple));
     if (collapse_simplicies.empty()) return {};
     assert(collapse_simplicies.size() == 1);
 

--- a/src/wmtk/operations/composite/TriEdgeSwap.hpp
+++ b/src/wmtk/operations/composite/TriEdgeSwap.hpp
@@ -1,8 +1,7 @@
 
 #pragma once
 
-#include <wmtk/operations/EdgeCollapse.hpp>
-#include <wmtk/operations/EdgeSplit.hpp>
+#include "EdgeSwap.hpp"
 
 namespace wmtk::operations::composite {
 /**
@@ -37,24 +36,19 @@ namespace wmtk::operations::composite {
  *     X
  */
 
-class TriEdgeSwap : public Operation
+class TriEdgeSwap : public EdgeSwap
 {
 public:
-    TriEdgeSwap(Mesh& m);
+    TriEdgeSwap(TriMesh& m);
 
     PrimitiveType primitive_type() const override { return PrimitiveType::Edge; }
 
-    inline EdgeSplit& split() { return m_split; }
-    inline EdgeCollapse& collapse() { return m_collapse; }
 
 protected:
     std::vector<simplex::Simplex> unmodified_primitives(
         const simplex::Simplex& simplex) const override;
     std::vector<simplex::Simplex> execute(const simplex::Simplex& simplex) override;
 
-private:
-    EdgeSplit m_split;
-    EdgeCollapse m_collapse;
 };
 
 } // namespace wmtk::operations::composite

--- a/src/wmtk/operations/composite/TriFaceSplit.cpp
+++ b/src/wmtk/operations/composite/TriFaceSplit.cpp
@@ -4,7 +4,7 @@
 
 namespace wmtk::operations::composite {
 
-TriFaceSplit::TriFaceSplit(Mesh& m)
+TriFaceSplit::TriFaceSplit(TriMesh& m)
     : Operation(m)
     , m_split(m)
     , m_collapse(m)

--- a/src/wmtk/operations/composite/TriFaceSplit.hpp
+++ b/src/wmtk/operations/composite/TriFaceSplit.hpp
@@ -20,7 +20,7 @@ namespace wmtk::operations::composite {
 class TriFaceSplit : public Operation
 {
 public:
-    TriFaceSplit(Mesh& m);
+    TriFaceSplit(TriMesh& m);
 
     PrimitiveType primitive_type() const override { return PrimitiveType::Triangle; }
 

--- a/src/wmtk/operations/utils/MultiMeshEdgeCollapseFunctor.cpp
+++ b/src/wmtk/operations/utils/MultiMeshEdgeCollapseFunctor.cpp
@@ -24,6 +24,7 @@ tri_mesh::EdgeOperationData MultiMeshEdgeCollapseFunctor::operator()(
     TriMesh& m,
     const simplex::Simplex& s) const
 {
+    assert(m.is_valid(s));
     TriMesh::TriMeshOperationExecutor exec(m, s.tuple());
     exec.collapse_edge();
     return std::move(static_cast<tri_mesh::EdgeOperationData&>(exec));


### PR DESCRIPTION
MAkes it so that code can generically access the swap/collapse in edge swaps despite their dimension