### PR TITLE
cleaning up mah and making attributetype printable

### DIFF
--- a/components/CMakeLists.txt
+++ b/components/CMakeLists.txt
@@ -8,7 +8,9 @@ include(add_component_test)
 # wmtk::component_utils
 add_subdirectory(utils)
 
-if(WILDMESHING_TOOLKIT_TOPLEVEL_PROJECT)
+option(WMTK_ENABLE_COMPONENT_TESTS "Enable unit tests for components" ${WILDMESHING_TOOLKIT_TOPLEVEL_PROJECT})
+
+if(WMTK_ENABLE_COMPONENT_TESTS)
     add_subdirectory(tests)
 endif()
 

--- a/components/cmake/add_component_test.cmake
+++ b/components/cmake/add_component_test.cmake
@@ -1,6 +1,6 @@
 function(add_component_test COMPONENT_TARGET_NAME ...)
 
-    if(NOT WILDMESHING_TOOLKIT_TOPLEVEL_PROJECT)
+    if(NOT WMTK_ENABLE_COMPONENT_TESTS)
         return()
     endif()
     list(REMOVE_AT ARGV 0)

--- a/components/input/CMakeLists.txt
+++ b/components/input/CMakeLists.txt
@@ -1,3 +1,5 @@
 set(COMPONENT_NAME input)
 add_subdirectory("src/wmtk/components/input")
+if(WMTK_ENABLE_COMPONENT_TESTS)
 add_subdirectory("tests")
+endif()

--- a/components/multimesh/CMakeLists.txt
+++ b/components/multimesh/CMakeLists.txt
@@ -1,3 +1,5 @@
 set(COMPONENT_NAME multimesh)
 add_subdirectory("src/wmtk/components/${COMPONENT_NAME}")
+if(WMTK_ENABLE_COMPONENT_TESTS)
 add_subdirectory("tests")
+endif()

--- a/src/wmtk/attribute/AttributeType.cpp
+++ b/src/wmtk/attribute/AttributeType.cpp
@@ -1,0 +1,24 @@
+#include "AttributeType.hpp"
+namespace wmtk::attribute {
+const std::string_view attribute_type_name(AttributeType pt) {
+
+    switch(pt) {
+        case AttributeType::Char:
+            return attribute_type_traits<AttributeType::Char>::name;
+        case AttributeType::Int64:
+            return attribute_type_traits<AttributeType::Int64>::name;
+        case AttributeType::Double:
+            return attribute_type_traits<AttributeType::Double>::name;
+        case AttributeType::Rational:
+            return attribute_type_traits<AttributeType::Rational>::name;
+        default:
+            break;
+    }
+    return "";
+}
+
+const std::string_view attribute_type_traits<AttributeType::Rational>::name = "Rational";
+const std::string_view attribute_type_traits<AttributeType::Double>::name = "Double";
+const std::string_view attribute_type_traits<AttributeType::Int64>::name = "Int64";
+const std::string_view attribute_type_traits<AttributeType::Char>::name = "Char";
+}

--- a/src/wmtk/attribute/AttributeType.hpp
+++ b/src/wmtk/attribute/AttributeType.hpp
@@ -5,32 +5,36 @@ namespace wmtk::attribute {
 enum class AttributeType { Char = 0, Int64 = 1, Double = 2, Rational = 3 };
 
 template <AttributeType AT>
-struct type_from_attribute_type_enum
+struct attribute_type_traits
 {
 };
 template <>
-struct type_from_attribute_type_enum<AttributeType::Char>
+struct attribute_type_traits<AttributeType::Char>
 {
     using type = char;
+    const static std::string_view name;
 };
 template <>
-struct type_from_attribute_type_enum<AttributeType::Double>
+struct attribute_type_traits<AttributeType::Double>
 {
     using type = double;
+    const static std::string_view name;
 };
 template <>
-struct type_from_attribute_type_enum<AttributeType::Int64>
+struct attribute_type_traits<AttributeType::Int64>
 {
     using type = int64_t;
+    const static std::string_view name;
 };
 template <>
-struct type_from_attribute_type_enum<AttributeType::Rational>
+struct attribute_type_traits<AttributeType::Rational>
 {
     using type = wmtk::Rational;
+    const static std::string_view name;
 };
 
 template <AttributeType AT>
-using type_from_attribute_type_enum_t = typename type_from_attribute_type_enum<AT>::type;
+using type_from_attribute_type_enum_t = typename attribute_type_traits<AT>::type;
 
 template <typename T>
 inline constexpr auto attribute_type_enum_from_type() -> AttributeType
@@ -53,4 +57,5 @@ inline constexpr auto attribute_type_enum_from_type() -> AttributeType
         return AttributeType::Char;
     }
 }
+const std::string_view attribute_type_name(AttributeType pt);
 } // namespace wmtk::attribute

--- a/src/wmtk/attribute/CMakeLists.txt
+++ b/src/wmtk/attribute/CMakeLists.txt
@@ -35,6 +35,7 @@ set(SRC_FILES
     Accessor.hpp
     
     AttributeType.hpp
+    AttributeType.cpp
 
 )
 target_sources(wildmeshing_toolkit PRIVATE ${SRC_FILES})

--- a/src/wmtk/attribute/MeshAttributeHandle.hpp
+++ b/src/wmtk/attribute/MeshAttributeHandle.hpp
@@ -10,6 +10,7 @@
 
 #include <tuple>
 #include <variant>
+#include <tuple>
 
 namespace wmtk {
 class Mesh;
@@ -76,21 +77,13 @@ public:
 
     bool operator==(const MeshAttributeHandle& o) const
     {
-#if defined(MTAO_DEBUG_MESH_COMP)
-        std::visit(
-            [&](const auto& h, const auto& oh) {
-                spdlog::warn(
-                    "{} {} == {} {}",
-                    std::string(h),
-                    fmt::ptr(m_mesh),
-                    std::string(oh),
-                    fmt::ptr(m_mesh));
-            },
-            m_handle,
-            o.m_handle);
-#endif
-        return m_handle == o.m_handle && m_mesh == o.m_mesh;
+        return std::tie(m_mesh, m_handle) == std::tie(o.m_mesh, o.m_handle);
     }
+    bool operator<(const MeshAttributeHandle& o) const
+    {
+        return std::tie(m_mesh, m_handle) < std::tie(o.m_mesh, o.m_handle);
+    }
+
 
     // reutrns if the target mesh is the same as the one represented in the handle
     bool is_same_mesh(const Mesh&) const;

--- a/tests/attributes/CMakeLists.txt
+++ b/tests/attributes/CMakeLists.txt
@@ -8,6 +8,8 @@ set(TEST_SOURCES
     old_wmtk_attributecollection.cpp
 
     transaction_stack.cpp
+
+    attribute_type.cpp
 )
 target_sources(wmtk_tests PRIVATE ${TEST_SOURCES})
 

--- a/tests/attributes/attribute_type.cpp
+++ b/tests/attributes/attribute_type.cpp
@@ -1,0 +1,18 @@
+#include <numeric>
+
+#include <catch2/catch_test_macros.hpp>
+#include <wmtk/attribute/AttributeType.hpp>
+
+
+using namespace wmtk::attribute;
+
+TEST_CASE("test_attribute_type_names", "[attributes]")
+{
+    using AT = AttributeType;
+    CHECK(attribute_type_name(AT::Char) == "Char");
+    CHECK(attribute_type_name(AT::Double) == "Double");
+    CHECK(attribute_type_name(AT::Int64) == "Int64");
+    CHECK(attribute_type_name(AT::Rational) == "Rational");
+
+}
+

--- a/tests/attributes/attribute_type.cpp
+++ b/tests/attributes/attribute_type.cpp
@@ -9,10 +9,11 @@ using namespace wmtk::attribute;
 TEST_CASE("test_attribute_type_names", "[attributes]")
 {
     using AT = AttributeType;
-    CHECK(attribute_type_name(AT::Char) == "Char");
-    CHECK(attribute_type_name(AT::Double) == "Double");
-    CHECK(attribute_type_name(AT::Int64) == "Int64");
-    CHECK(attribute_type_name(AT::Rational) == "Rational");
+    // converting to string because some compilers fail with this combo of catch + string_view comparisons?
+    CHECK(std::string(attribute_type_name(AT::Char)) == "Char");
+    CHECK(std::string(attribute_type_name(AT::Double)) == "Double");
+    CHECK(std::string(attribute_type_name(AT::Int64)) == "Int64");
+    CHECK(std::string(attribute_type_name(AT::Rational)) == "Rational");
 
 }
 


### PR DESCRIPTION
Making it so AttributeType is printable and cleaning up some debug in MeshAttribtueHAndle

Also adding a cmake option to enable/disable component unit tests (disabling components turns out to be useful when internet is flaky due to use of wmtk_data repo).
