### PR TITLE
Do not treat -Warray-bounds as an error (GCC false positives)

### DIFF
--- a/cmake/wmtk_warnings.cmake
+++ b/cmake/wmtk_warnings.cmake
@@ -33,7 +33,11 @@ set(MY_FLAGS
     -Werror=sequence-point
     -Werror=return-type
     -Werror=trigraphs
-    -Werror=array-bounds
+    # array-bounds is prone to false positives in vectorized (AVX) Eigen/libigl
+    # code on GCC (e.g. GCC 13 flags avxintrin.h as reading "partly outside" a
+    # 1x3 Eigen matrix). Keep the warning but do not make it a hard error, so a
+    # compiler bug does not break the build.
+    -Wno-error=array-bounds
     -Werror=write-strings
     -Werror=address
     -Werror=int-to-pointer-cast


### PR DESCRIPTION
## Problem

Linux CI (all `Linux (Debug)/(Release)` + `ubuntu-latest` jobs) started failing on **every** PR and would fail on `main` too, with:

```
/usr/lib/gcc/x86_64-linux-gnu/13/include/avxintrin.h:893:24: error:
array subscript '__m256d_u[0]' is partly outside array bounds of
'BaryPoint [1]' {aka 'Eigen::Matrix<double, 1, 3> [1]'} [-Werror=array-bounds]
```

This is a well-known GCC `-Warray-bounds` **false positive** in vectorized (AVX) Eigen code (here via libigl's `read_triangle_mesh`/`readPLY`/`boundary_facets` and `topological_offset/Spatial.cpp`). It is not a real out-of-bounds access. It surfaced after a GitHub runner GCC update — the affected source is unchanged (main built it cleanly ~18h earlier), so it broke the build purely from the compiler side.

## Fix

Downgrade `array-bounds` from `-Werror=array-bounds` to `-Wno-error=array-bounds` in `cmake/wmtk_warnings.cmake` — the warning is still emitted, but a compiler false positive no longer breaks the build.

## Notes

- One-line change; unblocks Linux CI repo-wide.
- Split out of #932 (which only needs this to go green on Linux).

🤖 Generated with [Claude Code](https://claude.com/claude-code)