### PR TITLE
Build FastEnvelope from the wildmeshing/fast-envelope fork (AABB box-cut hoist)

### DIFF
--- a/cmake/recipes/fenvelope.cmake
+++ b/cmake/recipes/fenvelope.cmake
@@ -15,7 +15,7 @@ CPMAddPackage(
     # wildmeshing fork tracking PR #1 (perf: hoist per-node box-cut work).
     # Forked from daniel-zint/fast-envelope @ 0a7a6c8; GIT_TAG is the PR branch tip.
     GITHUB_REPOSITORY wildmeshing/fast-envelope
-    GIT_TAG f8bd35d46eaf52898d9653531e5f618826b51c69
+    GIT_TAG 86d41345aa80179790a9142bbafaaf2de21d9054
     OPTIONS
     "FAST_ENVELOPE_WITH_UNIT_TESTS OFF"
     "FAST_ENVELOPE_ENABLE_TBB OFF"

--- a/cmake/recipes/fenvelope.cmake
+++ b/cmake/recipes/fenvelope.cmake
@@ -12,8 +12,10 @@ message(STATUS "Third-party: creating target 'FastEnvelope::FastEnvelope'")
 include(CPM)
 CPMAddPackage(
     NAME FastEnvelope
-    GITHUB_REPOSITORY daniel-zint/fast-envelope
-    GIT_TAG 0a7a6c8f5ada9bbdd66da0b861680453f91e3846
+    # wildmeshing fork tracking PR #1 (perf: hoist per-node box-cut work).
+    # Forked from daniel-zint/fast-envelope @ 0a7a6c8; GIT_TAG is the PR branch tip.
+    GITHUB_REPOSITORY wildmeshing/fast-envelope
+    GIT_TAG f8bd35d46eaf52898d9653531e5f618826b51c69
     OPTIONS
     "FAST_ENVELOPE_WITH_UNIT_TESTS OFF"
     "FAST_ENVELOPE_ENABLE_TBB OFF"

--- a/cmake/recipes/fenvelope.cmake
+++ b/cmake/recipes/fenvelope.cmake
@@ -15,7 +15,7 @@ CPMAddPackage(
     # wildmeshing fork tracking PR #1 (perf: hoist per-node box-cut work).
     # Forked from daniel-zint/fast-envelope @ 0a7a6c8; GIT_TAG is the PR branch tip.
     GITHUB_REPOSITORY wildmeshing/fast-envelope
-    GIT_TAG 86d41345aa80179790a9142bbafaaf2de21d9054
+    GIT_TAG 9a0b16eae615b9c7a20affd4a890e2c9fe69e683
     OPTIONS
     "FAST_ENVELOPE_WITH_UNIT_TESTS OFF"
     "FAST_ENVELOPE_ENABLE_TBB OFF"


### PR DESCRIPTION
Points the FastEnvelope dependency at [`wildmeshing/fast-envelope`](https://github.com/wildmeshing/fast-envelope) (fork of `daniel-zint/fast-envelope @ 0a7a6c8`) at the tip of [wildmeshing/fast-envelope#1](https://github.com/wildmeshing/fast-envelope/pull/1).

That PR hoists the query-triangle-invariant work (2D projections + the 9 triangle-only `orient_2d` edge signs) out of the per-node AABB box-cut test, computing it once per `is_outside` query instead of at every node of the tree descent.

**Measured on tetwild `crown` (exact envelope):**
- `orient_2d` self-time −33%, `is_triangle_cut_bounding_box` −34%, envelope self-time −23%
- **total user CPU −11%**, wall −9%

**Correctness:** unchanged — verified by a 16M-query equivalence fuzz (integer + double coords, exercising the degenerate branch), zero mismatches vs the original control flow.

`GIT_TAG` is the fork PR branch tip; it should be bumped to the squash/merge commit once wildmeshing/fast-envelope#1 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)