### PR TITLE
Concurrency cleanup

### DIFF
--- a/components/isotropic_remeshing/wmtk/components/isotropic_remeshing/IsotropicRemeshing.cpp
+++ b/components/isotropic_remeshing/wmtk/components/isotropic_remeshing/IsotropicRemeshing.cpp
@@ -430,11 +430,16 @@ bool IsotropicRemeshing::collapse_remeshing(double L)
     igl::Timer timer;
     timer.start();
     auto collect_all_ops = std::vector<std::pair<std::string, Tuple>>();
-    auto collect_tuples = wmtk::concurrent_vector<Tuple>();
+    // One slot per (triangle, local edge): for_each_edge only invokes the callback for
+    // the triangle that owns the edge, so eid() is unique and no two threads write the
+    // same slot -- no lock, and the order is the slot order rather than whichever thread
+    // won a mutex.
+    auto collect_tuples = wmtk::indexed_collector<Tuple>(3 * tri_capacity());
 
-    for_each_edge([&](auto& tup) { collect_tuples.emplace_back(tup); });
-    collect_all_ops.reserve(collect_tuples.size());
-    for (auto& t : collect_tuples) collect_all_ops.emplace_back("edge_collapse", t);
+    for_each_edge([&](auto& tup) { collect_tuples.set(tup.eid(*this), tup); });
+    const auto collected = collect_tuples.compact();
+    collect_all_ops.reserve(collected.size());
+    for (const auto& t : collected) collect_all_ops.emplace_back("edge_collapse", t);
     wmtk::logger().info(
         "***** collapse get edges time *****: {} ms",
         timer.getElapsedTimeInMilliSec());
@@ -472,11 +477,16 @@ bool IsotropicRemeshing::split_remeshing(double L)
     auto collect_all_ops = std::vector<std::pair<std::string, Tuple>>();
     size_t vid_threshold = 0;
     std::atomic_int count_success = 0;
-    auto collect_tuples = wmtk::concurrent_vector<Tuple>();
+    // One slot per (triangle, local edge): for_each_edge only invokes the callback for
+    // the triangle that owns the edge, so eid() is unique and no two threads write the
+    // same slot -- no lock, and the order is the slot order rather than whichever thread
+    // won a mutex.
+    auto collect_tuples = wmtk::indexed_collector<Tuple>(3 * tri_capacity());
 
-    for_each_edge([&](auto& tup) { collect_tuples.emplace_back(tup); });
-    collect_all_ops.reserve(collect_tuples.size());
-    for (auto& t : collect_tuples) collect_all_ops.emplace_back("edge_split", t);
+    for_each_edge([&](auto& tup) { collect_tuples.set(tup.eid(*this), tup); });
+    const auto collected = collect_tuples.compact();
+    collect_all_ops.reserve(collected.size());
+    for (const auto& t : collected) collect_all_ops.emplace_back("edge_split", t);
     wmtk::logger().info(
         "***** split get edges time *****: {} ms",
         timer.getElapsedTimeInMilliSec());
@@ -555,11 +565,16 @@ bool IsotropicRemeshing::swap_remeshing()
     timer.start();
     auto collect_all_ops = std::vector<std::pair<std::string, Tuple>>();
     wmtk::logger().info("size for edges to swap is {}", collect_all_ops.size());
-    auto collect_tuples = wmtk::concurrent_vector<Tuple>();
+    // One slot per (triangle, local edge): for_each_edge only invokes the callback for
+    // the triangle that owns the edge, so eid() is unique and no two threads write the
+    // same slot -- no lock, and the order is the slot order rather than whichever thread
+    // won a mutex.
+    auto collect_tuples = wmtk::indexed_collector<Tuple>(3 * tri_capacity());
 
-    for_each_edge([&](auto& tup) { collect_tuples.emplace_back(tup); });
-    collect_all_ops.reserve(collect_tuples.size());
-    for (auto& t : collect_tuples) collect_all_ops.emplace_back("edge_swap", t);
+    for_each_edge([&](auto& tup) { collect_tuples.set(tup.eid(*this), tup); });
+    const auto collected = collect_tuples.compact();
+    collect_all_ops.reserve(collected.size());
+    for (const auto& t : collected) collect_all_ops.emplace_back("edge_swap", t);
     wmtk::logger().info("***** swap get edges time *****: {} ms", timer.getElapsedTimeInMilliSec());
 
 

--- a/components/isotropic_remeshing/wmtk/components/isotropic_remeshing/IsotropicRemeshing.cpp
+++ b/components/isotropic_remeshing/wmtk/components/isotropic_remeshing/IsotropicRemeshing.cpp
@@ -1,4 +1,5 @@
 #include "IsotropicRemeshing.h"
+#include <algorithm>
 #include <wmtk/utils/Concurrency.hpp>
 
 #include <igl/Timer.h>
@@ -193,10 +194,16 @@ void IsotropicRemeshing::partition_mesh_morton()
         NUM_THREADS);
 
     const auto morton_compare = [](const sortstruct& a, const sortstruct& b) {
-        return (a.morton < b.morton);
+        // Morton codes are quantised, so distinct vertices routinely share one. Without
+        // the tie-break they compare equal and std::sort, which is not stable, orders
+        // them differently on libc++, libstdc++ and MSVC -- and that order decides the
+        // partition each vertex lands in. Break on the original index for a total order.
+        if (a.morton < b.morton) return true;
+        if (b.morton < a.morton) return false;
+        return a.order < b.order;
     };
 
-    wmtk::parallel_sort(list_v.begin(), list_v.end(), morton_compare);
+    std::sort(list_v.begin(), list_v.end(), morton_compare);
 
     size_t interval = list_v.size() / NUM_THREADS + 1;
 

--- a/components/isotropic_remeshing/wmtk/components/isotropic_remeshing/IsotropicRemeshing.cpp
+++ b/components/isotropic_remeshing/wmtk/components/isotropic_remeshing/IsotropicRemeshing.cpp
@@ -115,98 +115,99 @@ void IsotropicRemeshing::partition_mesh_morton()
     if (NUM_THREADS == 0) return;
     wmtk::logger().info("Number of parts: {} by morton", NUM_THREADS);
 
-    wmtk::task_arena arena(NUM_THREADS);
+    std::vector<Eigen::Vector3d> V_v(vert_capacity());
 
-    arena.execute([&] {
-        std::vector<Eigen::Vector3d> V_v(vert_capacity());
-
-        wmtk::parallel_for(
-            wmtk::blocked_range<size_t>(0, V_v.size()),
-            [&](wmtk::blocked_range<size_t> r) {
-                for (size_t i = r.begin(); i < r.end(); i++) {
-                    V_v[i] = vertex_attrs[i].pos;
-                }
-            });
-
-        struct sortstruct
-        {
-            size_t order;
-            Resorting::MortonCode64 morton;
-        };
-
-        std::vector<sortstruct> list_v;
-        list_v.resize(V_v.size());
-        const int multi = 1000;
-        // since the morton code requires a correct scale of input vertices,
-        //  we need to scale the vertices if their coordinates are out of range
-        std::vector<Eigen::Vector3d> V = V_v; // this is for rescaling vertices
-        Eigen::Vector3d vmin, vmax;
-        vmin = V.front();
-        vmax = V.front();
-
-        for (size_t j = 0; j < V.size(); j++) {
-            for (int i = 0; i < 3; i++) {
-                vmin(i) = std::min(vmin(i), V[j](i));
-                vmax(i) = std::max(vmax(i), V[j](i));
+    wmtk::parallel_for(
+        wmtk::blocked_range<size_t>(0, V_v.size()),
+        [&](wmtk::blocked_range<size_t> r) {
+            for (size_t i = r.begin(); i < r.end(); i++) {
+                V_v[i] = vertex_attrs[i].pos;
             }
+        },
+        NUM_THREADS);
+
+    struct sortstruct
+    {
+        size_t order;
+        Resorting::MortonCode64 morton;
+    };
+
+    std::vector<sortstruct> list_v;
+    list_v.resize(V_v.size());
+    const int multi = 1000;
+    // since the morton code requires a correct scale of input vertices,
+    //  we need to scale the vertices if their coordinates are out of range
+    std::vector<Eigen::Vector3d> V = V_v; // this is for rescaling vertices
+    Eigen::Vector3d vmin, vmax;
+    vmin = V.front();
+    vmax = V.front();
+
+    for (size_t j = 0; j < V.size(); j++) {
+        for (int i = 0; i < 3; i++) {
+            vmin(i) = std::min(vmin(i), V[j](i));
+            vmax(i) = std::max(vmax(i), V[j](i));
         }
+    }
 
-        Eigen::Vector3d center = (vmin + vmax) / 2;
+    Eigen::Vector3d center = (vmin + vmax) / 2;
 
+    wmtk::parallel_for(
+        wmtk::blocked_range<size_t>(0, V.size()),
+        [&](wmtk::blocked_range<size_t> r) {
+            for (size_t i = r.begin(); i < r.end(); i++) {
+                V[i] = V[i] - center;
+            }
+        },
+        NUM_THREADS);
+
+    Eigen::Vector3d scale_point =
+        vmax - center; // after placing box at origin, vmax and vmin are symetric.
+
+    double xscale, yscale, zscale;
+    xscale = fabs(scale_point[0]);
+    yscale = fabs(scale_point[1]);
+    zscale = fabs(scale_point[2]);
+    double scale = std::max(std::max(xscale, yscale), zscale);
+    if (scale > 300) {
         wmtk::parallel_for(
             wmtk::blocked_range<size_t>(0, V.size()),
             [&](wmtk::blocked_range<size_t> r) {
                 for (size_t i = r.begin(); i < r.end(); i++) {
-                    V[i] = V[i] - center;
+                    V[i] = V[i] / scale;
                 }
-            });
+            },
+            NUM_THREADS);
+    }
 
-        Eigen::Vector3d scale_point =
-            vmax - center; // after placing box at origin, vmax and vmin are symetric.
+    wmtk::parallel_for(
+        wmtk::blocked_range<size_t>(0, V.size()),
+        [&](wmtk::blocked_range<size_t> r) {
+            for (size_t i = r.begin(); i < r.end(); i++) {
+                list_v[i].morton = Resorting::MortonCode64(
+                    int(V[i][0] * multi),
+                    int(V[i][1] * multi),
+                    int(V[i][2] * multi));
+                list_v[i].order = i;
+            }
+        },
+        NUM_THREADS);
 
-        double xscale, yscale, zscale;
-        xscale = fabs(scale_point[0]);
-        yscale = fabs(scale_point[1]);
-        zscale = fabs(scale_point[2]);
-        double scale = std::max(std::max(xscale, yscale), zscale);
-        if (scale > 300) {
-            wmtk::parallel_for(
-                wmtk::blocked_range<size_t>(0, V.size()),
-                [&](wmtk::blocked_range<size_t> r) {
-                    for (size_t i = r.begin(); i < r.end(); i++) {
-                        V[i] = V[i] / scale;
-                    }
-                });
-        }
+    const auto morton_compare = [](const sortstruct& a, const sortstruct& b) {
+        return (a.morton < b.morton);
+    };
 
-        wmtk::parallel_for(
-            wmtk::blocked_range<size_t>(0, V.size()),
-            [&](wmtk::blocked_range<size_t> r) {
-                for (size_t i = r.begin(); i < r.end(); i++) {
-                    list_v[i].morton = Resorting::MortonCode64(
-                        int(V[i][0] * multi),
-                        int(V[i][1] * multi),
-                        int(V[i][2] * multi));
-                    list_v[i].order = i;
-                }
-            });
+    wmtk::parallel_sort(list_v.begin(), list_v.end(), morton_compare);
 
-        const auto morton_compare = [](const sortstruct& a, const sortstruct& b) {
-            return (a.morton < b.morton);
-        };
+    size_t interval = list_v.size() / NUM_THREADS + 1;
 
-        wmtk::parallel_sort(list_v.begin(), list_v.end(), morton_compare);
-
-        size_t interval = list_v.size() / NUM_THREADS + 1;
-
-        wmtk::parallel_for(
-            wmtk::blocked_range<size_t>(0, list_v.size()),
-            [&](wmtk::blocked_range<size_t> r) {
-                for (size_t i = r.begin(); i < r.end(); i++) {
-                    vertex_attrs[list_v[i].order].partition_id = i / interval;
-                }
-            });
-    });
+    wmtk::parallel_for(
+        wmtk::blocked_range<size_t>(0, list_v.size()),
+        [&](wmtk::blocked_range<size_t> r) {
+            for (size_t i = r.begin(); i < r.end(); i++) {
+                vertex_attrs[list_v[i].order].partition_id = i / interval;
+            }
+        },
+        NUM_THREADS);
 }
 
 std::vector<TriMesh::Tuple> IsotropicRemeshing::new_edges_after(

--- a/components/qslim/wmtk/components/qslim/QSlimMesh.cpp
+++ b/components/qslim/wmtk/components/qslim/QSlimMesh.cpp
@@ -357,11 +357,16 @@ bool QSlimMesh::collapse_qslim(int target_vert_number)
     auto collect_all_ops = std::vector<std::pair<std::string, Tuple>>();
     int starting_num = vert_capacity();
 
-    auto collect_tuples = wmtk::concurrent_vector<Tuple>();
+    // One slot per (triangle, local edge): for_each_edge only invokes the callback for
+    // the triangle that owns the edge, so eid() is unique and no two threads write the
+    // same slot -- no lock, and the order is the slot order rather than whichever thread
+    // won a mutex.
+    auto collect_tuples = wmtk::indexed_collector<Tuple>(3 * tri_capacity());
 
-    for_each_edge([&](auto& tup) { collect_tuples.emplace_back(tup); });
-    collect_all_ops.reserve(collect_tuples.size());
-    for (auto& t : collect_tuples) collect_all_ops.emplace_back("edge_collapse", t);
+    for_each_edge([&](auto& tup) { collect_tuples.set(tup.eid(*this), tup); });
+    const auto collected = collect_tuples.compact();
+    collect_all_ops.reserve(collected.size());
+    for (const auto& t : collected) collect_all_ops.emplace_back("edge_collapse", t);
 
     auto renew = [](auto& m, auto op, auto& tris) {
         auto edges = m.new_edges_after(tris);

--- a/components/qslim/wmtk/components/qslim/QSlimMesh.cpp
+++ b/components/qslim/wmtk/components/qslim/QSlimMesh.cpp
@@ -1,4 +1,5 @@
 #include "QSlimMesh.h"
+#include <algorithm>
 #include <wmtk/utils/Concurrency.hpp>
 
 #include <wmtk/TriMesh.h>
@@ -198,10 +199,16 @@ void QSlimMesh::partition_mesh_morton()
         NUM_THREADS);
 
     const auto morton_compare = [](const sortstruct& a, const sortstruct& b) {
-        return (a.morton < b.morton);
+        // Morton codes are quantised, so distinct vertices routinely share one. Without
+        // the tie-break they compare equal and std::sort, which is not stable, orders
+        // them differently on libc++, libstdc++ and MSVC -- and that order decides the
+        // partition each vertex lands in. Break on the original index for a total order.
+        if (a.morton < b.morton) return true;
+        if (b.morton < a.morton) return false;
+        return a.order < b.order;
     };
 
-    wmtk::parallel_sort(list_v.begin(), list_v.end(), morton_compare);
+    std::sort(list_v.begin(), list_v.end(), morton_compare);
 
     int interval = list_v.size() / NUM_THREADS + 1;
 

--- a/components/qslim/wmtk/components/qslim/QSlimMesh.cpp
+++ b/components/qslim/wmtk/components/qslim/QSlimMesh.cpp
@@ -120,69 +120,73 @@ void QSlimMesh::partition_mesh_morton()
     if (NUM_THREADS == 0) return;
     wmtk::logger().info("Number of parts: {} by morton", NUM_THREADS);
 
-    wmtk::task_arena arena(NUM_THREADS);
+    std::vector<Eigen::Vector3d> V_v(vert_capacity());
 
-    arena.execute([&] {
-        std::vector<Eigen::Vector3d> V_v(vert_capacity());
-
-        wmtk::parallel_for(
-            wmtk::blocked_range<int>(0, V_v.size()),
-            [&](wmtk::blocked_range<int> r) {
-                for (int i = r.begin(); i < r.end(); i++) {
-                    V_v[i] = vertex_attrs[i].pos;
-                }
-            });
-
-        struct sortstruct
-        {
-            int order;
-            Resorting::MortonCode64 morton;
-        };
-
-        std::vector<sortstruct> list_v;
-        list_v.resize(V_v.size());
-        const int multi = 1000;
-        // since the morton code requires a correct scale of input vertices,
-        //  we need to scale the vertices if their coordinates are out of range
-        std::vector<Eigen::Vector3d> V = V_v; // this is for rescaling vertices
-        Eigen::Vector3d vmin, vmax;
-        vmin = V.front();
-        vmax = V.front();
-
-        for (size_t j = 0; j < V.size(); j++) {
-            for (int i = 0; i < 3; i++) {
-                vmin(i) = std::min(vmin(i), V[j](i));
-                vmax(i) = std::max(vmax(i), V[j](i));
+    wmtk::parallel_for(
+        wmtk::blocked_range<int>(0, V_v.size()),
+        [&](wmtk::blocked_range<int> r) {
+            for (int i = r.begin(); i < r.end(); i++) {
+                V_v[i] = vertex_attrs[i].pos;
             }
+        },
+        NUM_THREADS);
+
+    struct sortstruct
+    {
+        int order;
+        Resorting::MortonCode64 morton;
+    };
+
+    std::vector<sortstruct> list_v;
+    list_v.resize(V_v.size());
+    const int multi = 1000;
+    // since the morton code requires a correct scale of input vertices,
+    //  we need to scale the vertices if their coordinates are out of range
+    std::vector<Eigen::Vector3d> V = V_v; // this is for rescaling vertices
+    Eigen::Vector3d vmin, vmax;
+    vmin = V.front();
+    vmax = V.front();
+
+    for (size_t j = 0; j < V.size(); j++) {
+        for (int i = 0; i < 3; i++) {
+            vmin(i) = std::min(vmin(i), V[j](i));
+            vmax(i) = std::max(vmax(i), V[j](i));
         }
+    }
 
-        Eigen::Vector3d center = (vmin + vmax) / 2;
+    Eigen::Vector3d center = (vmin + vmax) / 2;
 
-        wmtk::parallel_for(wmtk::blocked_range<int>(0, V.size()), [&](wmtk::blocked_range<int> r) {
+    wmtk::parallel_for(
+        wmtk::blocked_range<int>(0, V.size()),
+        [&](wmtk::blocked_range<int> r) {
             for (int i = r.begin(); i < r.end(); i++) {
                 V[i] = V[i] - center;
             }
-        });
+        },
+        NUM_THREADS);
 
-        Eigen::Vector3d scale_point =
-            vmax - center; // after placing box at origin, vmax and vmin are symetric.
+    Eigen::Vector3d scale_point =
+        vmax - center; // after placing box at origin, vmax and vmin are symetric.
 
-        double xscale, yscale, zscale;
-        xscale = fabs(scale_point[0]);
-        yscale = fabs(scale_point[1]);
-        zscale = fabs(scale_point[2]);
-        double scale = std::max(std::max(xscale, yscale), zscale);
-        if (scale > 300) {
-            wmtk::parallel_for(
-                wmtk::blocked_range<int>(0, V.size()),
-                [&](wmtk::blocked_range<int> r) {
-                    for (int i = r.begin(); i < r.end(); i++) {
-                        V[i] = V[i] / scale;
-                    }
-                });
-        }
+    double xscale, yscale, zscale;
+    xscale = fabs(scale_point[0]);
+    yscale = fabs(scale_point[1]);
+    zscale = fabs(scale_point[2]);
+    double scale = std::max(std::max(xscale, yscale), zscale);
+    if (scale > 300) {
+        wmtk::parallel_for(
+            wmtk::blocked_range<int>(0, V.size()),
+            [&](wmtk::blocked_range<int> r) {
+                for (int i = r.begin(); i < r.end(); i++) {
+                    V[i] = V[i] / scale;
+                }
+            },
+            NUM_THREADS);
+    }
 
-        wmtk::parallel_for(wmtk::blocked_range<int>(0, V.size()), [&](wmtk::blocked_range<int> r) {
+    wmtk::parallel_for(
+        wmtk::blocked_range<int>(0, V.size()),
+        [&](wmtk::blocked_range<int> r) {
             for (int i = r.begin(); i < r.end(); i++) {
                 list_v[i].morton = Resorting::MortonCode64(
                     int(V[i][0] * multi),
@@ -190,24 +194,25 @@ void QSlimMesh::partition_mesh_morton()
                     int(V[i][2] * multi));
                 list_v[i].order = i;
             }
-        });
+        },
+        NUM_THREADS);
 
-        const auto morton_compare = [](const sortstruct& a, const sortstruct& b) {
-            return (a.morton < b.morton);
-        };
+    const auto morton_compare = [](const sortstruct& a, const sortstruct& b) {
+        return (a.morton < b.morton);
+    };
 
-        wmtk::parallel_sort(list_v.begin(), list_v.end(), morton_compare);
+    wmtk::parallel_sort(list_v.begin(), list_v.end(), morton_compare);
 
-        int interval = list_v.size() / NUM_THREADS + 1;
+    int interval = list_v.size() / NUM_THREADS + 1;
 
-        wmtk::parallel_for(
-            wmtk::blocked_range<int>(0, list_v.size()),
-            [&](wmtk::blocked_range<int> r) {
-                for (int i = r.begin(); i < r.end(); i++) {
-                    vertex_attrs[list_v[i].order].partition_id = i / interval;
-                }
-            });
-    });
+    wmtk::parallel_for(
+        wmtk::blocked_range<int>(0, list_v.size()),
+        [&](wmtk::blocked_range<int> r) {
+            for (int i = r.begin(); i < r.end(); i++) {
+                vertex_attrs[list_v[i].order].partition_id = i / interval;
+            }
+        },
+        NUM_THREADS);
 }
 
 

--- a/components/simwild/wmtk/components/simwild/SimWildMesh.h
+++ b/components/simwild/wmtk/components/simwild/SimWildMesh.h
@@ -4,6 +4,7 @@
 #include <wmtk/TetMesh.h>
 #include <wmtk/utils/Morton.h>
 #include <wmtk/utils/PartitionMesh.h>
+#include <algorithm>
 #include <polysolve/nonlinear/Problem.hpp>
 #include <wmtk/envelope/Envelope.hpp>
 #include <wmtk/optimization/solver.hpp>
@@ -302,10 +303,16 @@ public:
             NUM_THREADS);
 
         const auto morton_compare = [](const sortstruct& a, const sortstruct& b) {
-            return (a.morton < b.morton);
+            // Morton codes are quantised, so distinct vertices routinely share one. Without
+            // the tie-break they compare equal and std::sort, which is not stable, orders
+            // them differently on libc++, libstdc++ and MSVC -- and that order decides the
+            // partition each vertex lands in. Break on the original index for a total order.
+            if (a.morton < b.morton) return true;
+            if (b.morton < a.morton) return false;
+            return a.order < b.order;
         };
 
-        wmtk::parallel_sort(list_v.begin(), list_v.end(), morton_compare);
+        std::sort(list_v.begin(), list_v.end(), morton_compare);
 
         int interval = list_v.size() / NUM_THREADS + 1;
 

--- a/components/simwild/wmtk/components/simwild/SimWildMesh.h
+++ b/components/simwild/wmtk/components/simwild/SimWildMesh.h
@@ -222,100 +222,101 @@ public:
 
         wmtk::logger().info("Number of parts: {} by morton", NUM_THREADS);
 
-        wmtk::task_arena arena(NUM_THREADS);
+        std::vector<Eigen::Vector3d> V_v(vert_capacity());
 
-        arena.execute([&] {
-            std::vector<Eigen::Vector3d> V_v(vert_capacity());
-
-            wmtk::parallel_for(
-                wmtk::blocked_range<int>(0, V_v.size()),
-                [&](wmtk::blocked_range<int> r) {
-                    for (int i = r.begin(); i < r.end(); i++) {
-                        V_v[i] = m_vertex_attribute[i].m_posf;
-                    }
-                });
-
-
-            struct sortstruct
-            {
-                int order;
-                Resorting::MortonCode64 morton;
-            };
-
-            std::vector<sortstruct> list_v;
-            list_v.resize(V_v.size());
-            // since the morton code requires a correct scale of input vertices,
-            //  we need to scale the vertices if their coordinates are out of range
-            std::vector<Eigen::Vector3d> V = V_v; // this is for rescaling vertices
-            Eigen::Vector3d vmin, vmax;
-            vmin = V.front();
-            vmax = V.front();
-
-            for (size_t j = 0; j < V.size(); j++) {
-                for (int i = 0; i < 3; i++) {
-                    vmin(i) = std::min(vmin(i), V[j](i));
-                    vmax(i) = std::max(vmax(i), V[j](i));
+        wmtk::parallel_for(
+            wmtk::blocked_range<int>(0, V_v.size()),
+            [&](wmtk::blocked_range<int> r) {
+                for (int i = r.begin(); i < r.end(); i++) {
+                    V_v[i] = m_vertex_attribute[i].m_posf;
                 }
+            },
+            NUM_THREADS);
+
+
+        struct sortstruct
+        {
+            int order;
+            Resorting::MortonCode64 morton;
+        };
+
+        std::vector<sortstruct> list_v;
+        list_v.resize(V_v.size());
+        // since the morton code requires a correct scale of input vertices,
+        //  we need to scale the vertices if their coordinates are out of range
+        std::vector<Eigen::Vector3d> V = V_v; // this is for rescaling vertices
+        Eigen::Vector3d vmin, vmax;
+        vmin = V.front();
+        vmax = V.front();
+
+        for (size_t j = 0; j < V.size(); j++) {
+            for (int i = 0; i < 3; i++) {
+                vmin(i) = std::min(vmin(i), V[j](i));
+                vmax(i) = std::max(vmax(i), V[j](i));
             }
+        }
 
-            // get_bb_corners(V, vmin, vmax);
-            Eigen::Vector3d center = (vmin + vmax) / 2;
+        // get_bb_corners(V, vmin, vmax);
+        Eigen::Vector3d center = (vmin + vmax) / 2;
 
+        wmtk::parallel_for(
+            wmtk::blocked_range<int>(0, V.size()),
+            [&](wmtk::blocked_range<int> r) {
+                for (int i = r.begin(); i < r.end(); i++) {
+                    V[i] = V[i] - center;
+                }
+            },
+            NUM_THREADS);
+
+        Eigen::Vector3d scale_point =
+            vmax - center; // after placing box at origin, vmax and vmin are symetric.
+
+        double xscale, yscale, zscale;
+        xscale = fabs(scale_point[0]);
+        yscale = fabs(scale_point[1]);
+        zscale = fabs(scale_point[2]);
+        double scale = std::max(std::max(xscale, yscale), zscale);
+        if (scale > 300) {
             wmtk::parallel_for(
                 wmtk::blocked_range<int>(0, V.size()),
                 [&](wmtk::blocked_range<int> r) {
                     for (int i = r.begin(); i < r.end(); i++) {
-                        V[i] = V[i] - center;
+                        V[i] = V[i] / scale;
                     }
-                });
+                },
+                NUM_THREADS);
+        }
 
-            Eigen::Vector3d scale_point =
-                vmax - center; // after placing box at origin, vmax and vmin are symetric.
+        constexpr int multi = 1000;
+        wmtk::parallel_for(
+            wmtk::blocked_range<int>(0, V.size()),
+            [&](wmtk::blocked_range<int> r) {
+                for (int i = r.begin(); i < r.end(); i++) {
+                    list_v[i].morton = Resorting::MortonCode64(
+                        int(V[i][0] * multi),
+                        int(V[i][1] * multi),
+                        int(V[i][2] * multi));
+                    list_v[i].order = i;
+                }
+            },
+            NUM_THREADS);
 
-            double xscale, yscale, zscale;
-            xscale = fabs(scale_point[0]);
-            yscale = fabs(scale_point[1]);
-            zscale = fabs(scale_point[2]);
-            double scale = std::max(std::max(xscale, yscale), zscale);
-            if (scale > 300) {
-                wmtk::parallel_for(
-                    wmtk::blocked_range<int>(0, V.size()),
-                    [&](wmtk::blocked_range<int> r) {
-                        for (int i = r.begin(); i < r.end(); i++) {
-                            V[i] = V[i] / scale;
-                        }
-                    });
-            }
+        const auto morton_compare = [](const sortstruct& a, const sortstruct& b) {
+            return (a.morton < b.morton);
+        };
 
-            constexpr int multi = 1000;
-            wmtk::parallel_for(
-                wmtk::blocked_range<int>(0, V.size()),
-                [&](wmtk::blocked_range<int> r) {
-                    for (int i = r.begin(); i < r.end(); i++) {
-                        list_v[i].morton = Resorting::MortonCode64(
-                            int(V[i][0] * multi),
-                            int(V[i][1] * multi),
-                            int(V[i][2] * multi));
-                        list_v[i].order = i;
-                    }
-                });
+        wmtk::parallel_sort(list_v.begin(), list_v.end(), morton_compare);
 
-            const auto morton_compare = [](const sortstruct& a, const sortstruct& b) {
-                return (a.morton < b.morton);
-            };
+        int interval = list_v.size() / NUM_THREADS + 1;
 
-            wmtk::parallel_sort(list_v.begin(), list_v.end(), morton_compare);
-
-            int interval = list_v.size() / NUM_THREADS + 1;
-
-            wmtk::parallel_for(
-                wmtk::blocked_range<int>(0, list_v.size()),
-                [&](wmtk::blocked_range<int> r) {
-                    for (int i = r.begin(); i < r.end(); i++) {
-                        m_vertex_attribute[list_v[i].order].partition_id = i / interval;
-                    }
-                });
-        });
+        wmtk::parallel_for(
+            wmtk::blocked_range<int>(0, list_v.size()),
+            [&](wmtk::blocked_range<int> r) {
+                for (int i = r.begin(); i < r.end(); i++) {
+                    m_vertex_attribute[list_v[i].order].partition_id = i / interval;
+                }
+            },
+            NUM_THREADS);
     }
 
     size_t get_partition_id(const Tuple& loc) const

--- a/components/simwild/wmtk/components/simwild/SimWildMeshTri.cpp
+++ b/components/simwild/wmtk/components/simwild/SimWildMeshTri.cpp
@@ -65,95 +65,96 @@ void SimWildMeshTri::partition_mesh_morton()
     if (NUM_THREADS == 0) return;
     wmtk::logger().info("Number of parts: {} by morton", NUM_THREADS);
 
-    wmtk::task_arena arena(NUM_THREADS);
+    std::vector<Vector2d> V_v(vert_capacity());
 
-    arena.execute([&] {
-        std::vector<Vector2d> V_v(vert_capacity());
-
-        wmtk::parallel_for(
-            wmtk::blocked_range<size_t>(0, V_v.size()),
-            [&](wmtk::blocked_range<size_t> r) {
-                for (size_t i = r.begin(); i < r.end(); i++) {
-                    V_v[i] = m_vertex_attribute[i].m_pos;
-                }
-            });
-
-        struct sortstruct
-        {
-            size_t order;
-            Resorting::MortonCode64 morton;
-        };
-
-        std::vector<sortstruct> list_v;
-        list_v.resize(V_v.size());
-        const int multi = 1000;
-        // since the morton code requires a correct scale of input vertices,
-        //  we need to scale the vertices if their coordinates are out of range
-        std::vector<Vector2d> V = V_v; // this is for rescaling vertices
-        Vector2d vmin, vmax;
-        vmin = V.front();
-        vmax = V.front();
-
-        for (size_t j = 0; j < V.size(); j++) {
-            for (int i = 0; i < 2; i++) {
-                vmin(i) = std::min(vmin(i), V[j](i));
-                vmax(i) = std::max(vmax(i), V[j](i));
+    wmtk::parallel_for(
+        wmtk::blocked_range<size_t>(0, V_v.size()),
+        [&](wmtk::blocked_range<size_t> r) {
+            for (size_t i = r.begin(); i < r.end(); i++) {
+                V_v[i] = m_vertex_attribute[i].m_pos;
             }
+        },
+        NUM_THREADS);
+
+    struct sortstruct
+    {
+        size_t order;
+        Resorting::MortonCode64 morton;
+    };
+
+    std::vector<sortstruct> list_v;
+    list_v.resize(V_v.size());
+    const int multi = 1000;
+    // since the morton code requires a correct scale of input vertices,
+    //  we need to scale the vertices if their coordinates are out of range
+    std::vector<Vector2d> V = V_v; // this is for rescaling vertices
+    Vector2d vmin, vmax;
+    vmin = V.front();
+    vmax = V.front();
+
+    for (size_t j = 0; j < V.size(); j++) {
+        for (int i = 0; i < 2; i++) {
+            vmin(i) = std::min(vmin(i), V[j](i));
+            vmax(i) = std::max(vmax(i), V[j](i));
         }
+    }
 
-        Vector2d center = (vmin + vmax) / 2;
+    Vector2d center = (vmin + vmax) / 2;
 
+    wmtk::parallel_for(
+        wmtk::blocked_range<size_t>(0, V.size()),
+        [&](wmtk::blocked_range<size_t> r) {
+            for (size_t i = r.begin(); i < r.end(); i++) {
+                V[i] = V[i] - center;
+            }
+        },
+        NUM_THREADS);
+
+    Vector2d scale_point =
+        vmax - center; // after placing box at origin, vmax and vmin are symetric.
+
+    double xscale, yscale;
+    xscale = fabs(scale_point[0]);
+    yscale = fabs(scale_point[1]);
+    double scale = std::max(xscale, yscale);
+    if (scale > 300) {
         wmtk::parallel_for(
             wmtk::blocked_range<size_t>(0, V.size()),
             [&](wmtk::blocked_range<size_t> r) {
                 for (size_t i = r.begin(); i < r.end(); i++) {
-                    V[i] = V[i] - center;
+                    V[i] = V[i] / scale;
                 }
-            });
+            },
+            NUM_THREADS);
+    }
 
-        Vector2d scale_point =
-            vmax - center; // after placing box at origin, vmax and vmin are symetric.
+    wmtk::parallel_for(
+        wmtk::blocked_range<size_t>(0, V.size()),
+        [&](wmtk::blocked_range<size_t> r) {
+            for (size_t i = r.begin(); i < r.end(); i++) {
+                list_v[i].morton =
+                    Resorting::MortonCode64(int(V[i][0] * multi), int(V[i][1] * multi), 0);
+                list_v[i].order = i;
+            }
+        },
+        NUM_THREADS);
 
-        double xscale, yscale;
-        xscale = fabs(scale_point[0]);
-        yscale = fabs(scale_point[1]);
-        double scale = std::max(xscale, yscale);
-        if (scale > 300) {
-            wmtk::parallel_for(
-                wmtk::blocked_range<size_t>(0, V.size()),
-                [&](wmtk::blocked_range<size_t> r) {
-                    for (size_t i = r.begin(); i < r.end(); i++) {
-                        V[i] = V[i] / scale;
-                    }
-                });
-        }
+    const auto morton_compare = [](const sortstruct& a, const sortstruct& b) {
+        return (a.morton < b.morton);
+    };
 
-        wmtk::parallel_for(
-            wmtk::blocked_range<size_t>(0, V.size()),
-            [&](wmtk::blocked_range<size_t> r) {
-                for (size_t i = r.begin(); i < r.end(); i++) {
-                    list_v[i].morton =
-                        Resorting::MortonCode64(int(V[i][0] * multi), int(V[i][1] * multi), 0);
-                    list_v[i].order = i;
-                }
-            });
+    wmtk::parallel_sort(list_v.begin(), list_v.end(), morton_compare);
 
-        const auto morton_compare = [](const sortstruct& a, const sortstruct& b) {
-            return (a.morton < b.morton);
-        };
+    size_t interval = list_v.size() / NUM_THREADS + 1;
 
-        wmtk::parallel_sort(list_v.begin(), list_v.end(), morton_compare);
-
-        size_t interval = list_v.size() / NUM_THREADS + 1;
-
-        wmtk::parallel_for(
-            wmtk::blocked_range<size_t>(0, list_v.size()),
-            [&](wmtk::blocked_range<size_t> r) {
-                for (size_t i = r.begin(); i < r.end(); i++) {
-                    m_vertex_attribute[list_v[i].order].partition_id = i / interval;
-                }
-            });
-    });
+    wmtk::parallel_for(
+        wmtk::blocked_range<size_t>(0, list_v.size()),
+        [&](wmtk::blocked_range<size_t> r) {
+            for (size_t i = r.begin(); i < r.end(); i++) {
+                m_vertex_attribute[list_v[i].order].partition_id = i / interval;
+            }
+        },
+        NUM_THREADS);
 }
 
 double SimWildMeshTri::get_length2(const Tuple& l) const

--- a/components/simwild/wmtk/components/simwild/SimWildMeshTri.cpp
+++ b/components/simwild/wmtk/components/simwild/SimWildMeshTri.cpp
@@ -1,4 +1,5 @@
 #include "SimWildMeshTri.hpp"
+#include <algorithm>
 #include <wmtk/utils/Concurrency.hpp>
 
 #include <igl/Timer.h>
@@ -140,10 +141,16 @@ void SimWildMeshTri::partition_mesh_morton()
         NUM_THREADS);
 
     const auto morton_compare = [](const sortstruct& a, const sortstruct& b) {
-        return (a.morton < b.morton);
+        // Morton codes are quantised, so distinct vertices routinely share one. Without
+        // the tie-break they compare equal and std::sort, which is not stable, orders
+        // them differently on libc++, libstdc++ and MSVC -- and that order decides the
+        // partition each vertex lands in. Break on the original index for a total order.
+        if (a.morton < b.morton) return true;
+        if (b.morton < a.morton) return false;
+        return a.order < b.order;
     };
 
-    wmtk::parallel_sort(list_v.begin(), list_v.end(), morton_compare);
+    std::sort(list_v.begin(), list_v.end(), morton_compare);
 
     size_t interval = list_v.size() / NUM_THREADS + 1;
 

--- a/components/tetwild/wmtk/components/tetwild/TetWildMesh.cpp
+++ b/components/tetwild/wmtk/components/tetwild/TetWildMesh.cpp
@@ -1459,17 +1459,15 @@ void TetWildMesh::init_vertex_order()
     // Per-vertex, independent: compute_vertex_order is const (reads connectivity
     // only) and each vid writes only its own m_order slot.
     const std::vector<Tuple> vs = get_vertices();
-    wmtk::task_arena arena(std::max(1, NUM_THREADS));
-    arena.execute([&] {
-        wmtk::parallel_for(
-            wmtk::blocked_range<size_t>(0, vs.size()),
-            [&](wmtk::blocked_range<size_t> range) {
-                for (size_t k = range.begin(); k < range.end(); ++k) {
-                    const size_t vid = vs[k].vid(*this);
-                    m_vertex_attribute[vid].m_order = compute_vertex_order(vid);
-                }
-            });
-    });
+    wmtk::parallel_for(
+        wmtk::blocked_range<size_t>(0, vs.size()),
+        [&](wmtk::blocked_range<size_t> range) {
+            for (size_t k = range.begin(); k < range.end(); ++k) {
+                const size_t vid = vs[k].vid(*this);
+                m_vertex_attribute[vid].m_order = compute_vertex_order(vid);
+            }
+        },
+        std::max(1, NUM_THREADS));
 }
 
 bool TetWildMesh::check_vertex_param_type()

--- a/components/tetwild/wmtk/components/tetwild/TetWildMesh.h
+++ b/components/tetwild/wmtk/components/tetwild/TetWildMesh.h
@@ -4,6 +4,7 @@
 #include <wmtk/TetMesh.h>
 #include <wmtk/utils/Morton.h>
 #include <wmtk/utils/PartitionMesh.h>
+#include <algorithm>
 #include <wmtk/envelope/Envelope.hpp>
 #include "Parameters.h"
 
@@ -244,10 +245,16 @@ public:
             NUM_THREADS);
 
         const auto morton_compare = [](const sortstruct& a, const sortstruct& b) {
-            return (a.morton < b.morton);
+            // Morton codes are quantised, so distinct vertices routinely share one. Without
+            // the tie-break they compare equal and std::sort, which is not stable, orders
+            // them differently on libc++, libstdc++ and MSVC -- and that order decides the
+            // partition each vertex lands in. Break on the original index for a total order.
+            if (a.morton < b.morton) return true;
+            if (b.morton < a.morton) return false;
+            return a.order < b.order;
         };
 
-        wmtk::parallel_sort(list_v.begin(), list_v.end(), morton_compare);
+        std::sort(list_v.begin(), list_v.end(), morton_compare);
 
         size_t interval = list_v.size() / NUM_THREADS + 1;
 

--- a/components/tetwild/wmtk/components/tetwild/TetWildMesh.h
+++ b/components/tetwild/wmtk/components/tetwild/TetWildMesh.h
@@ -164,100 +164,101 @@ public:
 
         wmtk::logger().info("Number of parts: {} by morton", NUM_THREADS);
 
-        wmtk::task_arena arena(NUM_THREADS);
+        std::vector<Eigen::Vector3d> V_v(vert_capacity());
 
-        arena.execute([&] {
-            std::vector<Eigen::Vector3d> V_v(vert_capacity());
-
-            wmtk::parallel_for(
-                wmtk::blocked_range<size_t>(0, V_v.size()),
-                [&](wmtk::blocked_range<size_t> r) {
-                    for (size_t i = r.begin(); i < r.end(); i++) {
-                        V_v[i] = m_vertex_attribute[i].m_posf;
-                    }
-                });
-
-
-            struct sortstruct
-            {
-                size_t order;
-                Resorting::MortonCode64 morton;
-            };
-
-            std::vector<sortstruct> list_v;
-            list_v.resize(V_v.size());
-            // since the morton code requires a correct scale of input vertices,
-            //  we need to scale the vertices if their coordinates are out of range
-            std::vector<Eigen::Vector3d> V = V_v; // this is for rescaling vertices
-            Eigen::Vector3d vmin, vmax;
-            vmin = V.front();
-            vmax = V.front();
-
-            for (size_t j = 0; j < V.size(); j++) {
-                for (int i = 0; i < 3; i++) {
-                    vmin(i) = std::min(vmin(i), V[j](i));
-                    vmax(i) = std::max(vmax(i), V[j](i));
+        wmtk::parallel_for(
+            wmtk::blocked_range<size_t>(0, V_v.size()),
+            [&](wmtk::blocked_range<size_t> r) {
+                for (size_t i = r.begin(); i < r.end(); i++) {
+                    V_v[i] = m_vertex_attribute[i].m_posf;
                 }
+            },
+            NUM_THREADS);
+
+
+        struct sortstruct
+        {
+            size_t order;
+            Resorting::MortonCode64 morton;
+        };
+
+        std::vector<sortstruct> list_v;
+        list_v.resize(V_v.size());
+        // since the morton code requires a correct scale of input vertices,
+        //  we need to scale the vertices if their coordinates are out of range
+        std::vector<Eigen::Vector3d> V = V_v; // this is for rescaling vertices
+        Eigen::Vector3d vmin, vmax;
+        vmin = V.front();
+        vmax = V.front();
+
+        for (size_t j = 0; j < V.size(); j++) {
+            for (int i = 0; i < 3; i++) {
+                vmin(i) = std::min(vmin(i), V[j](i));
+                vmax(i) = std::max(vmax(i), V[j](i));
             }
+        }
 
-            // get_bb_corners(V, vmin, vmax);
-            Eigen::Vector3d center = (vmin + vmax) / 2;
+        // get_bb_corners(V, vmin, vmax);
+        Eigen::Vector3d center = (vmin + vmax) / 2;
 
+        wmtk::parallel_for(
+            wmtk::blocked_range<size_t>(0, V.size()),
+            [&](wmtk::blocked_range<size_t> r) {
+                for (size_t i = r.begin(); i < r.end(); i++) {
+                    V[i] = V[i] - center;
+                }
+            },
+            NUM_THREADS);
+
+        Eigen::Vector3d scale_point =
+            vmax - center; // after placing box at origin, vmax and vmin are symetric.
+
+        double xscale, yscale, zscale;
+        xscale = fabs(scale_point[0]);
+        yscale = fabs(scale_point[1]);
+        zscale = fabs(scale_point[2]);
+        double scale = std::max(std::max(xscale, yscale), zscale);
+        if (scale > 300) {
             wmtk::parallel_for(
                 wmtk::blocked_range<size_t>(0, V.size()),
                 [&](wmtk::blocked_range<size_t> r) {
                     for (size_t i = r.begin(); i < r.end(); i++) {
-                        V[i] = V[i] - center;
+                        V[i] = V[i] / scale;
                     }
-                });
+                },
+                NUM_THREADS);
+        }
 
-            Eigen::Vector3d scale_point =
-                vmax - center; // after placing box at origin, vmax and vmin are symetric.
+        constexpr int multi = 1000;
+        wmtk::parallel_for(
+            wmtk::blocked_range<size_t>(0, V.size()),
+            [&](wmtk::blocked_range<size_t> r) {
+                for (size_t i = r.begin(); i < r.end(); i++) {
+                    list_v[i].morton = Resorting::MortonCode64(
+                        int(V[i][0] * multi),
+                        int(V[i][1] * multi),
+                        int(V[i][2] * multi));
+                    list_v[i].order = i;
+                }
+            },
+            NUM_THREADS);
 
-            double xscale, yscale, zscale;
-            xscale = fabs(scale_point[0]);
-            yscale = fabs(scale_point[1]);
-            zscale = fabs(scale_point[2]);
-            double scale = std::max(std::max(xscale, yscale), zscale);
-            if (scale > 300) {
-                wmtk::parallel_for(
-                    wmtk::blocked_range<size_t>(0, V.size()),
-                    [&](wmtk::blocked_range<size_t> r) {
-                        for (size_t i = r.begin(); i < r.end(); i++) {
-                            V[i] = V[i] / scale;
-                        }
-                    });
-            }
+        const auto morton_compare = [](const sortstruct& a, const sortstruct& b) {
+            return (a.morton < b.morton);
+        };
 
-            constexpr int multi = 1000;
-            wmtk::parallel_for(
-                wmtk::blocked_range<size_t>(0, V.size()),
-                [&](wmtk::blocked_range<size_t> r) {
-                    for (size_t i = r.begin(); i < r.end(); i++) {
-                        list_v[i].morton = Resorting::MortonCode64(
-                            int(V[i][0] * multi),
-                            int(V[i][1] * multi),
-                            int(V[i][2] * multi));
-                        list_v[i].order = i;
-                    }
-                });
+        wmtk::parallel_sort(list_v.begin(), list_v.end(), morton_compare);
 
-            const auto morton_compare = [](const sortstruct& a, const sortstruct& b) {
-                return (a.morton < b.morton);
-            };
+        size_t interval = list_v.size() / NUM_THREADS + 1;
 
-            wmtk::parallel_sort(list_v.begin(), list_v.end(), morton_compare);
-
-            size_t interval = list_v.size() / NUM_THREADS + 1;
-
-            wmtk::parallel_for(
-                wmtk::blocked_range<size_t>(0, list_v.size()),
-                [&](wmtk::blocked_range<size_t> r) {
-                    for (size_t i = r.begin(); i < r.end(); i++) {
-                        m_vertex_attribute[list_v[i].order].partition_id = i / interval;
-                    }
-                });
-        });
+        wmtk::parallel_for(
+            wmtk::blocked_range<size_t>(0, list_v.size()),
+            [&](wmtk::blocked_range<size_t> r) {
+                for (size_t i = r.begin(); i < r.end(); i++) {
+                    m_vertex_attribute[list_v[i].order].partition_id = i / interval;
+                }
+            },
+            NUM_THREADS);
     }
 
     size_t get_partition_id(const Tuple& loc) const

--- a/components/tetwild/wmtk/components/tetwild/TriangleInsertion.cpp
+++ b/components/tetwild/wmtk/components/tetwild/TriangleInsertion.cpp
@@ -229,7 +229,7 @@ void TetWildMesh::init_from_input_surface(
     init_from_delaunay_box_mesh(vertices);
 
     // match faces preserved in delaunay
-    wmtk::concurrent_vector<bool> is_matched;
+    std::vector<bool> is_matched;
     wmtk::match_tet_faces_to_triangles(*this, faces, is_matched, tet_face_tags);
     wmtk::logger().info("is_matched: {}", std::count(is_matched.begin(), is_matched.end(), true));
 

--- a/components/tetwild/wmtk/components/tetwild/TriangleInsertion.cpp
+++ b/components/tetwild/wmtk/components/tetwild/TriangleInsertion.cpp
@@ -248,96 +248,90 @@ void TetWildMesh::init_from_input_surface(
         wmtk::logger().info("insertion queue {}: {}", i, insertion_queues[i].size());
     }
 
-    wmtk::task_arena arena((int)insertion_queues.size());
     wmtk::task_group tg;
 
-    arena.execute([&, &m = *this, &tet_face_tags = this->tet_face_tags]() {
-        for (int task_id = 0; task_id < insertion_queues.size(); task_id++) {
-            tg.run([&insertion_queues,
-                    &expired_queue,
-                    &tet_face_tags,
-                    &m,
-                    &vertices,
-                    &faces,
-                    task_id] {
-                auto try_acquire_tetra = [&m, task_id](const auto& intersected_tets) {
-                    if (m.NUM_THREADS == 0) return true;
-                    for (auto t_int : intersected_tets) {
-                        for (auto v_int : m.oriented_tet_vertices(t_int)) {
-                            if (!m.try_set_vertex_mutex_one_ring(v_int, task_id)) {
-                                return false;
-                            }
-                        }
-                    }
-                    return true;
-                };
+    // Aliases the per-task lambdas below capture by reference.
+    auto& m = *this;
+    auto& tet_face_tags = this->tet_face_tags;
 
-                auto try_acquire_edge = [&m, task_id](const auto& intersected_edges) {
-                    if (m.NUM_THREADS == 0) return true;
-                    for (auto e_int : intersected_edges) {
-                        if (!m.try_set_vertex_mutex_one_ring(e_int, task_id)) {
-                            return false;
-                        }
-                        if (!m.try_set_vertex_mutex_one_ring(e_int.switch_vertex(m), task_id)) {
+    for (int task_id = 0; task_id < insertion_queues.size(); task_id++) {
+        tg.run([&insertion_queues, &expired_queue, &tet_face_tags, &m, &vertices, &faces, task_id] {
+            auto try_acquire_tetra = [&m, task_id](const auto& intersected_tets) {
+                if (m.NUM_THREADS == 0) return true;
+                for (auto t_int : intersected_tets) {
+                    for (auto v_int : m.oriented_tet_vertices(t_int)) {
+                        if (!m.try_set_vertex_mutex_one_ring(v_int, task_id)) {
                             return false;
                         }
                     }
-                    return true;
-                };
+                }
+                return true;
+            };
 
-                std::default_random_engine generator;
-                std::uniform_real_distribution<double> distribution(0.0, 100.0);
-                auto retry_processing = [&,
-                                         &Q = insertion_queues[task_id]](auto id, auto retry_time) {
-                    double rand = distribution(generator);
-                    if (retry_time < 5) {
-                        Q.push(std::make_tuple(rand, retry_time + 1, id));
-                    } else {
-                        expired_queue.push(std::make_tuple(rand, 0, id));
+            auto try_acquire_edge = [&m, task_id](const auto& intersected_edges) {
+                if (m.NUM_THREADS == 0) return true;
+                for (auto e_int : intersected_edges) {
+                    if (!m.try_set_vertex_mutex_one_ring(e_int, task_id)) {
+                        return false;
                     }
-                };
-                auto try_acquire_triangle = [&m, task_id](const auto& f) {
-                    if (m.NUM_THREADS == 0) return true;
-                    return m.try_set_face_mutex_two_ring(f[0], f[1], f[2], task_id);
-                };
-
-                auto supply_element = [&m,
-                                       &Q = insertion_queues[task_id],
-                                       &face_id_cache =
-                                           m.triangle_insertion_local_cache.local().face_id,
-                                       &retry_processing](const auto& func) {
-                    std::tuple<double, int, size_t> eiq;
-                    while (Q.try_pop(eiq)) {
-                        const auto& [_, retry_time, face_id] = eiq;
-
-                        face_id_cache = face_id;
-                        if (func(face_id) == false) {
-                            retry_processing(face_id, retry_time);
-                            continue;
-                        };
-                        m.release_vertex_mutex_in_stack();
+                    if (!m.try_set_vertex_mutex_one_ring(e_int.switch_vertex(m), task_id)) {
+                        return false;
                     }
-                };
+                }
+                return true;
+            };
 
-                supply_element([&](auto face_id) {
-                    std::vector<std::array<size_t, 3>> marked_tet_faces;
-                    auto success = internal_insert_single_triangle(
-                        m,
-                        m.m_vertex_attribute,
-                        vertices,
-                        faces[face_id],
-                        marked_tet_faces,
-                        try_acquire_triangle,
-                        try_acquire_edge,
-                        try_acquire_tetra);
-                    if (!success) return false;
-                    for (auto& f : marked_tet_faces) tet_face_tags[f].push_back(face_id);
-                    return true;
-                });
-            }); // tg.run
-        } // parallel for loop
-        tg.wait();
-    });
+            std::default_random_engine generator;
+            std::uniform_real_distribution<double> distribution(0.0, 100.0);
+            auto retry_processing = [&, &Q = insertion_queues[task_id]](auto id, auto retry_time) {
+                double rand = distribution(generator);
+                if (retry_time < 5) {
+                    Q.push(std::make_tuple(rand, retry_time + 1, id));
+                } else {
+                    expired_queue.push(std::make_tuple(rand, 0, id));
+                }
+            };
+            auto try_acquire_triangle = [&m, task_id](const auto& f) {
+                if (m.NUM_THREADS == 0) return true;
+                return m.try_set_face_mutex_two_ring(f[0], f[1], f[2], task_id);
+            };
+
+            auto supply_element = [&m,
+                                   &Q = insertion_queues[task_id],
+                                   &face_id_cache =
+                                       m.triangle_insertion_local_cache.local().face_id,
+                                   &retry_processing](const auto& func) {
+                std::tuple<double, int, size_t> eiq;
+                while (Q.try_pop(eiq)) {
+                    const auto& [_, retry_time, face_id] = eiq;
+
+                    face_id_cache = face_id;
+                    if (func(face_id) == false) {
+                        retry_processing(face_id, retry_time);
+                        continue;
+                    };
+                    m.release_vertex_mutex_in_stack();
+                }
+            };
+
+            supply_element([&](auto face_id) {
+                std::vector<std::array<size_t, 3>> marked_tet_faces;
+                auto success = internal_insert_single_triangle(
+                    m,
+                    m.m_vertex_attribute,
+                    vertices,
+                    faces[face_id],
+                    marked_tet_faces,
+                    try_acquire_triangle,
+                    try_acquire_edge,
+                    try_acquire_tetra);
+                if (!success) return false;
+                for (auto& f : marked_tet_faces) tet_face_tags[f].push_back(face_id);
+                return true;
+            });
+        }); // tg.run
+    } // parallel for loop
+    tg.wait();
 
     wmtk::logger().info("retry insert 5 times expired size: {}", expired_queue.size());
 
@@ -383,10 +377,9 @@ void TetWildMesh::init_from_input_surface(
 
 void TetWildMesh::finalize_triangle_insertion(const std::vector<std::array<size_t, 3>>& faces)
 {
-    wmtk::task_arena arena(std::max(NUM_THREADS, 1));
-
-    arena.execute([&faces, this] {
-        wmtk::parallel_for(this->tet_face_tags.range(), [&faces, this](auto& r) {
+    wmtk::parallel_for(
+        this->tet_face_tags.range(),
+        [&faces, this](auto& r) {
             auto projected_point_in_triangle = [](auto& c, auto& tri) {
                 std::array<Vector2r, 3> tri2d;
                 int squeeze_to_2d_dir = wmtk::project_triangle_to_2d(tri, tri2d);
@@ -423,56 +416,56 @@ void TetWildMesh::finalize_triangle_insertion(const std::vector<std::array<size_
                     }
                 }
             }
-        });
+        },
+        std::max(NUM_THREADS, 1));
 
-        //// track bbox
-        auto faces = get_faces();
+    //// track bbox
+    auto bbox_faces = get_faces();
 
-        for (int i = 0; i < faces.size(); i++) {
-            auto vs = get_face_vertices(faces[i]);
-            std::array<size_t, 3> vids = {{vs[0].vid(*this), vs[1].vid(*this), vs[2].vid(*this)}};
-            int on_bbox = -1;
-            for (int k = 0; k < 3; k++) {
-                if (m_vertex_attribute[vids[0]].m_pos[k] == m_params.box_min[k] &&
-                    m_vertex_attribute[vids[1]].m_pos[k] == m_params.box_min[k] &&
-                    m_vertex_attribute[vids[2]].m_pos[k] == m_params.box_min[k]) {
-                    on_bbox = k * 2;
-                    break;
-                }
-                if (m_vertex_attribute[vids[0]].m_pos[k] == m_params.box_max[k] &&
-                    m_vertex_attribute[vids[1]].m_pos[k] == m_params.box_max[k] &&
-                    m_vertex_attribute[vids[2]].m_pos[k] == m_params.box_max[k]) {
-                    on_bbox = k * 2 + 1;
-                    break;
-                }
+    for (int i = 0; i < bbox_faces.size(); i++) {
+        auto vs = get_face_vertices(bbox_faces[i]);
+        std::array<size_t, 3> vids = {{vs[0].vid(*this), vs[1].vid(*this), vs[2].vid(*this)}};
+        int on_bbox = -1;
+        for (int k = 0; k < 3; k++) {
+            if (m_vertex_attribute[vids[0]].m_pos[k] == m_params.box_min[k] &&
+                m_vertex_attribute[vids[1]].m_pos[k] == m_params.box_min[k] &&
+                m_vertex_attribute[vids[2]].m_pos[k] == m_params.box_min[k]) {
+                on_bbox = k * 2;
+                break;
             }
-            if (on_bbox < 0) continue;
-            auto fid = faces[i].fid(*this);
-            m_face_attribute[fid].m_is_bbox_fs = on_bbox;
-            //
-            for (size_t vid : vids) {
-                m_vertex_attribute[vid].on_bbox_faces.push_back(on_bbox);
+            if (m_vertex_attribute[vids[0]].m_pos[k] == m_params.box_max[k] &&
+                m_vertex_attribute[vids[1]].m_pos[k] == m_params.box_max[k] &&
+                m_vertex_attribute[vids[2]].m_pos[k] == m_params.box_max[k]) {
+                on_bbox = k * 2 + 1;
+                break;
             }
         }
-
-        for_each_vertex(
-            [&](auto& v) { wmtk::vector_unique(m_vertex_attribute[v.vid(*this)].on_bbox_faces); });
-
-        //// rounding
-        std::atomic_int cnt_round(0);
-
-        for (int i = 0; i < vert_capacity(); i++) {
-            auto v = tuple_from_vertex(i);
-            if (round(v)) cnt_round++;
+        if (on_bbox < 0) continue;
+        auto fid = bbox_faces[i].fid(*this);
+        m_face_attribute[fid].m_is_bbox_fs = on_bbox;
+        //
+        for (size_t vid : vids) {
+            m_vertex_attribute[vid].on_bbox_faces.push_back(on_bbox);
         }
+    }
+
+    for_each_vertex(
+        [&](auto& v) { wmtk::vector_unique(m_vertex_attribute[v.vid(*this)].on_bbox_faces); });
+
+    //// rounding
+    std::atomic_int cnt_round(0);
+
+    for (int i = 0; i < vert_capacity(); i++) {
+        auto v = tuple_from_vertex(i);
+        if (round(v)) cnt_round++;
+    }
 
 
-        wmtk::logger().info("cnt_round {}/{}", (int)cnt_round, vert_capacity());
+    wmtk::logger().info("cnt_round {}/{}", (int)cnt_round, vert_capacity());
 
-        //// init qualities
-        auto& m = *this;
-        for_each_tetra([&m](auto& t) { m.m_tet_attribute[t.tid(m)].m_quality = m.get_quality(t); });
-    });
+    //// init qualities
+    auto& m = *this;
+    for_each_tetra([&m](auto& t) { m.m_tet_attribute[t.tid(m)].m_quality = m.get_quality(t); });
 }
 
 } // namespace wmtk::components::tetwild

--- a/components/tetwild/wmtk/components/tetwild/VolumemesherInsertion.cpp
+++ b/components/tetwild/wmtk/components/tetwild/VolumemesherInsertion.cpp
@@ -1988,17 +1988,28 @@ void TetWildMesh::init_from_Volumeremesher(
     });
 
     while (true) {
-        wmtk::concurrent_vector<size_t> to_revert;
+        // A flag per vertex rather than a shared appended list: a vertex is reachable
+        // from several tets, so the old version took a lock per push and then pushed the
+        // same vid repeatedly. Every write here stores the same value to a slot indexed
+        // by vid, so the threads cannot disagree -- relaxed is enough, and the duplicates
+        // collapse for free.
+        std::vector<std::atomic<uint8_t>> to_revert(vert_capacity());
+        for (auto& f : to_revert) f.store(0, std::memory_order_relaxed);
+
+        std::atomic<bool> any{false};
         for_each_tetra([&](const Tuple& t) {
             if (is_inverted(t)) {
                 for (const size_t vid : oriented_tet_vids(t)) {
-                    if (!is_direct_point[vid] && m_vertex_attribute[vid].m_is_rounded)
-                        to_revert.push_back(vid);
+                    if (!is_direct_point[vid] && m_vertex_attribute[vid].m_is_rounded) {
+                        to_revert[vid].store(1, std::memory_order_relaxed);
+                        any.store(true, std::memory_order_relaxed);
+                    }
                 }
             }
         });
-        if (to_revert.empty()) break;
-        for (const size_t vid : to_revert) {
+        if (!any.load(std::memory_order_relaxed)) break;
+        for (size_t vid = 0; vid < to_revert.size(); ++vid) {
+            if (!to_revert[vid].load(std::memory_order_relaxed)) continue;
             if (m_vertex_attribute[vid].m_is_rounded) {
                 m_vertex_attribute[vid].m_pos = v_rational[vid];
                 m_vertex_attribute[vid].m_is_rounded = false;

--- a/components/tetwild/wmtk/components/tetwild/VolumemesherInsertion.cpp
+++ b/components/tetwild/wmtk/components/tetwild/VolumemesherInsertion.cpp
@@ -1786,24 +1786,22 @@ void TetWildMesh::init_from_Volumeremesher(
         // Per-vertex, independent: each i writes only its own m_pos/m_posf/
         // m_is_rounded/is_direct_point; the rational->double conversion and the
         // exact comparison read only local data.
-        wmtk::task_arena arena(std::max(1, NUM_THREADS));
-        arena.execute([&] {
-            wmtk::parallel_for(
-                wmtk::blocked_range<size_t>(0, vert_capacity()),
-                [&](wmtk::blocked_range<size_t> range) {
-                    for (size_t i = range.begin(); i < range.end(); ++i) {
-                        m_vertex_attribute[i].m_pos = v_rational[i];
-                        m_vertex_attribute[i].m_posf = to_double(v_rational[i]);
-                        const Vector3r& rp = m_vertex_attribute[i].m_pos;
-                        const Vector3d& d = m_vertex_attribute[i].m_posf;
-                        const bool direct = (wmtk::Rational(d[0]) == rp[0]) &&
-                                            (wmtk::Rational(d[1]) == rp[1]) &&
-                                            (wmtk::Rational(d[2]) == rp[2]);
-                        is_direct_point[i] = direct ? 1 : 0;
-                        m_vertex_attribute[i].m_is_rounded = direct;
-                    }
-                });
-        });
+        wmtk::parallel_for(
+            wmtk::blocked_range<size_t>(0, vert_capacity()),
+            [&](wmtk::blocked_range<size_t> range) {
+                for (size_t i = range.begin(); i < range.end(); ++i) {
+                    m_vertex_attribute[i].m_pos = v_rational[i];
+                    m_vertex_attribute[i].m_posf = to_double(v_rational[i]);
+                    const Vector3r& rp = m_vertex_attribute[i].m_pos;
+                    const Vector3d& d = m_vertex_attribute[i].m_posf;
+                    const bool direct = (wmtk::Rational(d[0]) == rp[0]) &&
+                                        (wmtk::Rational(d[1]) == rp[1]) &&
+                                        (wmtk::Rational(d[2]) == rp[2]);
+                    is_direct_point[i] = direct ? 1 : 0;
+                    m_vertex_attribute[i].m_is_rounded = direct;
+                }
+            },
+            std::max(1, NUM_THREADS));
     }
 
     // check here
@@ -1815,27 +1813,24 @@ void TetWildMesh::init_from_Volumeremesher(
     const auto faces = get_faces();
     logger().info("#faces = {}", faces.size());
 
-    wmtk::task_arena arena(std::max(1, NUM_THREADS));
-
     // mark surface vertices (parallel). Different faces write `true` to the shared
     // m_is_on_surface of a common vertex; atomic_ref makes those same-value writes
     // well-defined instead of a data race.
-    arena.execute([&] {
-        wmtk::parallel_for(
-            wmtk::blocked_range<size_t>(0, faces.size()),
-            [&](wmtk::blocked_range<size_t> r) {
-                for (size_t i = r.begin(); i < r.end(); i++) {
-                    const Tuple& f = faces[i];
-                    if (m_face_attribute[f.fid(*this)].m_is_surface_fs != 1) continue;
-                    const size_t v1 = f.vid(*this);
-                    const size_t v2 = f.switch_vertex(*this).vid(*this);
-                    const size_t v3 = f.switch_edge(*this).switch_vertex(*this).vid(*this);
-                    std::atomic_ref<bool>(m_vertex_attribute[v1].m_is_on_surface).store(true);
-                    std::atomic_ref<bool>(m_vertex_attribute[v2].m_is_on_surface).store(true);
-                    std::atomic_ref<bool>(m_vertex_attribute[v3].m_is_on_surface).store(true);
-                }
-            });
-    });
+    wmtk::parallel_for(
+        wmtk::blocked_range<size_t>(0, faces.size()),
+        [&](wmtk::blocked_range<size_t> r) {
+            for (size_t i = r.begin(); i < r.end(); i++) {
+                const Tuple& f = faces[i];
+                if (m_face_attribute[f.fid(*this)].m_is_surface_fs != 1) continue;
+                const size_t v1 = f.vid(*this);
+                const size_t v2 = f.switch_vertex(*this).vid(*this);
+                const size_t v3 = f.switch_edge(*this).switch_vertex(*this).vid(*this);
+                std::atomic_ref<bool>(m_vertex_attribute[v1].m_is_on_surface).store(true);
+                std::atomic_ref<bool>(m_vertex_attribute[v2].m_is_on_surface).store(true);
+                std::atomic_ref<bool>(m_vertex_attribute[v3].m_is_on_surface).store(true);
+            }
+        },
+        std::max(1, NUM_THREADS));
 
     // track bounding box (parallel). The per-face exact-rational corner test is the
     // cost; on-bbox faces are rare, so each chunk collects (vertex, bbox-side) pairs
@@ -1843,39 +1838,38 @@ void TetWildMesh::init_from_Volumeremesher(
     {
         std::vector<std::pair<size_t, int>> bbox_vert_faces;
         std::mutex bbox_mutex;
-        arena.execute([&] {
-            wmtk::parallel_for(
-                wmtk::blocked_range<size_t>(0, faces.size()),
-                [&](wmtk::blocked_range<size_t> r) {
-                    std::vector<std::pair<size_t, int>> local;
-                    for (size_t i = r.begin(); i < r.end(); i++) {
-                        auto vs = get_face_vertices(faces[i]);
-                        std::array<size_t, 3> vids = {
-                            {vs[0].vid(*this), vs[1].vid(*this), vs[2].vid(*this)}};
-                        int on_bbox = -1;
-                        for (int k = 0; k < 3; k++) {
-                            if (m_vertex_attribute[vids[0]].m_pos[k] == m_params.box_min[k] &&
-                                m_vertex_attribute[vids[1]].m_pos[k] == m_params.box_min[k] &&
-                                m_vertex_attribute[vids[2]].m_pos[k] == m_params.box_min[k]) {
-                                on_bbox = k * 2;
-                                break;
-                            }
-                            if (m_vertex_attribute[vids[0]].m_pos[k] == m_params.box_max[k] &&
-                                m_vertex_attribute[vids[1]].m_pos[k] == m_params.box_max[k] &&
-                                m_vertex_attribute[vids[2]].m_pos[k] == m_params.box_max[k]) {
-                                on_bbox = k * 2 + 1;
-                                break;
-                            }
+        wmtk::parallel_for(
+            wmtk::blocked_range<size_t>(0, faces.size()),
+            [&](wmtk::blocked_range<size_t> r) {
+                std::vector<std::pair<size_t, int>> local;
+                for (size_t i = r.begin(); i < r.end(); i++) {
+                    auto vs = get_face_vertices(faces[i]);
+                    std::array<size_t, 3> vids = {
+                        {vs[0].vid(*this), vs[1].vid(*this), vs[2].vid(*this)}};
+                    int on_bbox = -1;
+                    for (int k = 0; k < 3; k++) {
+                        if (m_vertex_attribute[vids[0]].m_pos[k] == m_params.box_min[k] &&
+                            m_vertex_attribute[vids[1]].m_pos[k] == m_params.box_min[k] &&
+                            m_vertex_attribute[vids[2]].m_pos[k] == m_params.box_min[k]) {
+                            on_bbox = k * 2;
+                            break;
                         }
-                        if (on_bbox < 0) continue;
-                        m_face_attribute[faces[i].fid(*this)].m_is_bbox_fs = on_bbox;
-                        for (size_t vid : vids) local.emplace_back(vid, on_bbox);
+                        if (m_vertex_attribute[vids[0]].m_pos[k] == m_params.box_max[k] &&
+                            m_vertex_attribute[vids[1]].m_pos[k] == m_params.box_max[k] &&
+                            m_vertex_attribute[vids[2]].m_pos[k] == m_params.box_max[k]) {
+                            on_bbox = k * 2 + 1;
+                            break;
+                        }
                     }
-                    if (local.empty()) return;
-                    std::lock_guard<std::mutex> lk(bbox_mutex);
-                    bbox_vert_faces.insert(bbox_vert_faces.end(), local.begin(), local.end());
-                });
-        });
+                    if (on_bbox < 0) continue;
+                    m_face_attribute[faces[i].fid(*this)].m_is_bbox_fs = on_bbox;
+                    for (size_t vid : vids) local.emplace_back(vid, on_bbox);
+                }
+                if (local.empty()) return;
+                std::lock_guard<std::mutex> lk(bbox_mutex);
+                bbox_vert_faces.insert(bbox_vert_faces.end(), local.begin(), local.end());
+            },
+            std::max(1, NUM_THREADS));
         for (const auto& [vid, on_bbox] : bbox_vert_faces)
             m_vertex_attribute[vid].on_bbox_faces.push_back(on_bbox);
     }
@@ -2182,55 +2176,49 @@ void TetWildMesh::find_open_boundary()
         v_posf[i] = m_vertex_attribute[i].m_posf;
     }
 
-    wmtk::task_arena arena(std::max(1, NUM_THREADS));
-
     // count incident surface faces per edge (parallel; atomic_ref increments the shared array)
-    arena.execute([&] {
-        wmtk::parallel_for(
-            wmtk::blocked_range<size_t>(0, fs.size()),
-            [&](wmtk::blocked_range<size_t> r) {
-                for (size_t i = r.begin(); i < r.end(); i++) {
-                    const Tuple& f = fs[i];
-                    if (!m_face_attribute[f.fid(*this)].m_is_surface_fs) continue;
-                    const size_t eid1 = f.eid(*this);
-                    const size_t eid2 = f.switch_edge(*this).eid(*this);
-                    const size_t eid3 = f.switch_vertex(*this).switch_edge(*this).eid(*this);
-                    std::atomic_ref<int>(edge_on_open_boundary[eid1])
-                        .fetch_add(1, std::memory_order_relaxed);
-                    std::atomic_ref<int>(edge_on_open_boundary[eid2])
-                        .fetch_add(1, std::memory_order_relaxed);
-                    std::atomic_ref<int>(edge_on_open_boundary[eid3])
-                        .fetch_add(1, std::memory_order_relaxed);
-                }
-            });
-    });
+    wmtk::parallel_for(
+        wmtk::blocked_range<size_t>(0, fs.size()),
+        [&](wmtk::blocked_range<size_t> r) {
+            for (size_t i = r.begin(); i < r.end(); i++) {
+                const Tuple& f = fs[i];
+                if (!m_face_attribute[f.fid(*this)].m_is_surface_fs) continue;
+                const size_t eid1 = f.eid(*this);
+                const size_t eid2 = f.switch_edge(*this).eid(*this);
+                const size_t eid3 = f.switch_vertex(*this).switch_edge(*this).eid(*this);
+                std::atomic_ref<int>(edge_on_open_boundary[eid1])
+                    .fetch_add(1, std::memory_order_relaxed);
+                std::atomic_ref<int>(edge_on_open_boundary[eid2])
+                    .fetch_add(1, std::memory_order_relaxed);
+                std::atomic_ref<int>(edge_on_open_boundary[eid3])
+                    .fetch_add(1, std::memory_order_relaxed);
+            }
+        },
+        std::max(1, NUM_THREADS));
 
     // collect open-boundary edges (exactly one incident surface face), parallel with a
     // per-chunk merge. The collected order differs from serial but the set is identical
     // and the boundary envelope built from it is order-independent.
     {
         std::mutex ob_mutex;
-        arena.execute([&] {
-            wmtk::parallel_for(
-                wmtk::blocked_range<size_t>(0, es.size()),
-                [&](wmtk::blocked_range<size_t> r) {
-                    std::vector<Eigen::Vector2i> local;
-                    for (size_t i = r.begin(); i < r.end(); i++) {
-                        const Tuple& e = es[i];
-                        if (edge_on_open_boundary[e.eid(*this)] != 1) continue;
-                        const size_t v1 = e.vid(*this);
-                        const size_t v2 = e.switch_vertex(*this).vid(*this);
-                        std::atomic_ref<bool>(m_vertex_attribute[v1].m_is_on_open_boundary)
-                            .store(true);
-                        std::atomic_ref<bool>(m_vertex_attribute[v2].m_is_on_open_boundary)
-                            .store(true);
-                        local.emplace_back(v1, v2);
-                    }
-                    if (local.empty()) return;
-                    std::lock_guard<std::mutex> lk(ob_mutex);
-                    open_boundaries.insert(open_boundaries.end(), local.begin(), local.end());
-                });
-        });
+        wmtk::parallel_for(
+            wmtk::blocked_range<size_t>(0, es.size()),
+            [&](wmtk::blocked_range<size_t> r) {
+                std::vector<Eigen::Vector2i> local;
+                for (size_t i = r.begin(); i < r.end(); i++) {
+                    const Tuple& e = es[i];
+                    if (edge_on_open_boundary[e.eid(*this)] != 1) continue;
+                    const size_t v1 = e.vid(*this);
+                    const size_t v2 = e.switch_vertex(*this).vid(*this);
+                    std::atomic_ref<bool>(m_vertex_attribute[v1].m_is_on_open_boundary).store(true);
+                    std::atomic_ref<bool>(m_vertex_attribute[v2].m_is_on_open_boundary).store(true);
+                    local.emplace_back(v1, v2);
+                }
+                if (local.empty()) return;
+                std::lock_guard<std::mutex> lk(ob_mutex);
+                open_boundaries.insert(open_boundaries.end(), local.begin(), local.end());
+            },
+            std::max(1, NUM_THREADS));
     }
 
     wmtk::logger().info("open boundary num: {}", open_boundaries.size());

--- a/components/triwild/wmtk/components/triwild/TriWildMesh.cpp
+++ b/components/triwild/wmtk/components/triwild/TriWildMesh.cpp
@@ -5,6 +5,7 @@
 
 #include <wmtk/utils/AMIPS.h>
 #include <wmtk/utils/AMIPS2D.h>
+#include <algorithm>
 #include <wmtk/envelope/KNN.hpp>
 #include <wmtk/io/read_edge_mesh.hpp>
 #include <wmtk/utils/Logger.hpp>
@@ -789,10 +790,16 @@ void TriWildMesh::partition_mesh_morton()
         NUM_THREADS);
 
     const auto morton_compare = [](const sortstruct& a, const sortstruct& b) {
-        return (a.morton < b.morton);
+        // Morton codes are quantised, so distinct vertices routinely share one. Without
+        // the tie-break they compare equal and std::sort, which is not stable, orders
+        // them differently on libc++, libstdc++ and MSVC -- and that order decides the
+        // partition each vertex lands in. Break on the original index for a total order.
+        if (a.morton < b.morton) return true;
+        if (b.morton < a.morton) return false;
+        return a.order < b.order;
     };
 
-    wmtk::parallel_sort(list_v.begin(), list_v.end(), morton_compare);
+    std::sort(list_v.begin(), list_v.end(), morton_compare);
 
     size_t interval = list_v.size() / NUM_THREADS + 1;
 

--- a/components/triwild/wmtk/components/triwild/TriWildMesh.cpp
+++ b/components/triwild/wmtk/components/triwild/TriWildMesh.cpp
@@ -714,95 +714,96 @@ void TriWildMesh::partition_mesh_morton()
     if (NUM_THREADS == 0) return;
     logger().info("Number of parts: {} by morton", NUM_THREADS);
 
-    wmtk::task_arena arena(NUM_THREADS);
+    std::vector<Vector2d> V_v(vert_capacity());
 
-    arena.execute([&] {
-        std::vector<Vector2d> V_v(vert_capacity());
-
-        wmtk::parallel_for(
-            wmtk::blocked_range<size_t>(0, V_v.size()),
-            [&](wmtk::blocked_range<size_t> r) {
-                for (size_t i = r.begin(); i < r.end(); i++) {
-                    V_v[i] = m_vertex_attribute[i].m_posf;
-                }
-            });
-
-        struct sortstruct
-        {
-            size_t order;
-            Resorting::MortonCode64 morton;
-        };
-
-        std::vector<sortstruct> list_v;
-        list_v.resize(V_v.size());
-        const int multi = 1000;
-        // since the morton code requires a correct scale of input vertices,
-        //  we need to scale the vertices if their coordinates are out of range
-        std::vector<Vector2d> V = V_v; // this is for rescaling vertices
-        Vector2d vmin, vmax;
-        vmin = V.front();
-        vmax = V.front();
-
-        for (size_t j = 0; j < V.size(); j++) {
-            for (int i = 0; i < 2; i++) {
-                vmin(i) = std::min(vmin(i), V[j](i));
-                vmax(i) = std::max(vmax(i), V[j](i));
+    wmtk::parallel_for(
+        wmtk::blocked_range<size_t>(0, V_v.size()),
+        [&](wmtk::blocked_range<size_t> r) {
+            for (size_t i = r.begin(); i < r.end(); i++) {
+                V_v[i] = m_vertex_attribute[i].m_posf;
             }
+        },
+        NUM_THREADS);
+
+    struct sortstruct
+    {
+        size_t order;
+        Resorting::MortonCode64 morton;
+    };
+
+    std::vector<sortstruct> list_v;
+    list_v.resize(V_v.size());
+    const int multi = 1000;
+    // since the morton code requires a correct scale of input vertices,
+    //  we need to scale the vertices if their coordinates are out of range
+    std::vector<Vector2d> V = V_v; // this is for rescaling vertices
+    Vector2d vmin, vmax;
+    vmin = V.front();
+    vmax = V.front();
+
+    for (size_t j = 0; j < V.size(); j++) {
+        for (int i = 0; i < 2; i++) {
+            vmin(i) = std::min(vmin(i), V[j](i));
+            vmax(i) = std::max(vmax(i), V[j](i));
         }
+    }
 
-        Vector2d center = (vmin + vmax) / 2;
+    Vector2d center = (vmin + vmax) / 2;
 
+    wmtk::parallel_for(
+        wmtk::blocked_range<size_t>(0, V.size()),
+        [&](wmtk::blocked_range<size_t> r) {
+            for (size_t i = r.begin(); i < r.end(); i++) {
+                V[i] = V[i] - center;
+            }
+        },
+        NUM_THREADS);
+
+    Vector2d scale_point =
+        vmax - center; // after placing box at origin, vmax and vmin are symetric.
+
+    double xscale, yscale;
+    xscale = fabs(scale_point[0]);
+    yscale = fabs(scale_point[1]);
+    double scale = std::max(xscale, yscale);
+    if (scale > 300) {
         wmtk::parallel_for(
             wmtk::blocked_range<size_t>(0, V.size()),
             [&](wmtk::blocked_range<size_t> r) {
                 for (size_t i = r.begin(); i < r.end(); i++) {
-                    V[i] = V[i] - center;
+                    V[i] = V[i] / scale;
                 }
-            });
+            },
+            NUM_THREADS);
+    }
 
-        Vector2d scale_point =
-            vmax - center; // after placing box at origin, vmax and vmin are symetric.
+    wmtk::parallel_for(
+        wmtk::blocked_range<size_t>(0, V.size()),
+        [&](wmtk::blocked_range<size_t> r) {
+            for (size_t i = r.begin(); i < r.end(); i++) {
+                list_v[i].morton =
+                    Resorting::MortonCode64(int(V[i][0] * multi), int(V[i][1] * multi), 0);
+                list_v[i].order = i;
+            }
+        },
+        NUM_THREADS);
 
-        double xscale, yscale;
-        xscale = fabs(scale_point[0]);
-        yscale = fabs(scale_point[1]);
-        double scale = std::max(xscale, yscale);
-        if (scale > 300) {
-            wmtk::parallel_for(
-                wmtk::blocked_range<size_t>(0, V.size()),
-                [&](wmtk::blocked_range<size_t> r) {
-                    for (size_t i = r.begin(); i < r.end(); i++) {
-                        V[i] = V[i] / scale;
-                    }
-                });
-        }
+    const auto morton_compare = [](const sortstruct& a, const sortstruct& b) {
+        return (a.morton < b.morton);
+    };
 
-        wmtk::parallel_for(
-            wmtk::blocked_range<size_t>(0, V.size()),
-            [&](wmtk::blocked_range<size_t> r) {
-                for (size_t i = r.begin(); i < r.end(); i++) {
-                    list_v[i].morton =
-                        Resorting::MortonCode64(int(V[i][0] * multi), int(V[i][1] * multi), 0);
-                    list_v[i].order = i;
-                }
-            });
+    wmtk::parallel_sort(list_v.begin(), list_v.end(), morton_compare);
 
-        const auto morton_compare = [](const sortstruct& a, const sortstruct& b) {
-            return (a.morton < b.morton);
-        };
+    size_t interval = list_v.size() / NUM_THREADS + 1;
 
-        wmtk::parallel_sort(list_v.begin(), list_v.end(), morton_compare);
-
-        size_t interval = list_v.size() / NUM_THREADS + 1;
-
-        wmtk::parallel_for(
-            wmtk::blocked_range<size_t>(0, list_v.size()),
-            [&](wmtk::blocked_range<size_t> r) {
-                for (size_t i = r.begin(); i < r.end(); i++) {
-                    m_vertex_attribute[list_v[i].order].partition_id = i / interval;
-                }
-            });
-    });
+    wmtk::parallel_for(
+        wmtk::blocked_range<size_t>(0, list_v.size()),
+        [&](wmtk::blocked_range<size_t> r) {
+            for (size_t i = r.begin(); i < r.end(); i++) {
+                m_vertex_attribute[list_v[i].order].partition_id = i / interval;
+            }
+        },
+        NUM_THREADS);
 }
 
 double TriWildMesh::get_length2(const Tuple& l) const

--- a/src/wmtk/ExecutionScheduler.hpp
+++ b/src/wmtk/ExecutionScheduler.hpp
@@ -357,16 +357,13 @@ public:
                 queues[get_partition_id(m, e)].emplace(priority(m, op, e), op, e, 0);
             }
             // Comment out parallel: work on serial first.
-            wmtk::task_arena arena(num_threads);
             wmtk::task_group tg;
-            arena.execute([&queues, &run_single_queue, &tg]() {
-                for (int task_id = 0; task_id < queues.size(); task_id++) {
-                    tg.run([&run_single_queue, &queues, task_id] {
-                        run_single_queue(queues[task_id], task_id);
-                    });
-                }
-                tg.wait();
-            });
+            for (int task_id = 0; task_id < queues.size(); task_id++) {
+                tg.run([&run_single_queue, &queues, task_id] {
+                    run_single_queue(queues[task_id], task_id);
+                });
+            }
+            tg.wait();
             logger().debug("Parallel Complete, remains element {}", final_queue.size());
             run_single_queue(final_queue, 0);
         }

--- a/src/wmtk/TetMesh.cpp
+++ b/src/wmtk/TetMesh.cpp
@@ -1327,22 +1327,20 @@ void TetMesh::for_each_edge(const std::function<void(const TetMesh::Tuple&)>& fu
             }
         }
     } else {
-        wmtk::task_arena arena(NUM_THREADS);
-        arena.execute([&] {
-            wmtk::parallel_for(
-                wmtk::blocked_range<size_t>(0, tet_capacity()),
-                [&](wmtk::blocked_range<size_t> r) {
-                    for (size_t i = r.begin(); i < r.end(); i++) {
-                        if (!tuple_from_tet(i).is_valid(*this)) continue;
-                        for (int j = 0; j < 6; j++) {
-                            auto tup = tuple_from_edge(i, j);
-                            if (tup.eid(*this) == 6 * i + j) {
-                                func(tup);
-                            }
+        wmtk::parallel_for(
+            wmtk::blocked_range<size_t>(0, tet_capacity()),
+            [&](wmtk::blocked_range<size_t> r) {
+                for (size_t i = r.begin(); i < r.end(); i++) {
+                    if (!tuple_from_tet(i).is_valid(*this)) continue;
+                    for (int j = 0; j < 6; j++) {
+                        auto tup = tuple_from_edge(i, j);
+                        if (tup.eid(*this) == 6 * i + j) {
+                            func(tup);
                         }
                     }
-                });
-        });
+                }
+            },
+            NUM_THREADS);
     }
 }
 
@@ -1359,18 +1357,16 @@ void TetMesh::for_each_tetra(const std::function<void(const TetMesh::Tuple&)>& f
     } else {
         // std::cout << "in parallel for each tet" << std::endl;
 
-        wmtk::task_arena arena(NUM_THREADS);
-        arena.execute([&] {
-            wmtk::parallel_for(
-                wmtk::blocked_range<size_t>(0, tet_capacity()),
-                [&](wmtk::blocked_range<size_t> r) {
-                    for (size_t i = r.begin(); i < r.end(); i++) {
-                        auto tup = tuple_from_tet(i);
-                        if (!tup.is_valid(*this)) continue;
-                        func(tup);
-                    }
-                });
-        });
+        wmtk::parallel_for(
+            wmtk::blocked_range<size_t>(0, tet_capacity()),
+            [&](wmtk::blocked_range<size_t> r) {
+                for (size_t i = r.begin(); i < r.end(); i++) {
+                    auto tup = tuple_from_tet(i);
+                    if (!tup.is_valid(*this)) continue;
+                    func(tup);
+                }
+            },
+            NUM_THREADS);
     }
 }
 
@@ -1386,18 +1382,16 @@ void TetMesh::for_each_vertex(const std::function<void(const TetMesh::Tuple&)>& 
         }
     } else {
         // std::cout << "in parallel for each vertex" << std::endl;
-        wmtk::task_arena arena(NUM_THREADS);
-        arena.execute([&] {
-            wmtk::parallel_for(
-                wmtk::blocked_range<size_t>(0, vert_capacity()),
-                [&](wmtk::blocked_range<size_t> r) {
-                    for (size_t i = r.begin(); i < r.end(); i++) {
-                        auto tup = tuple_from_vertex(i);
-                        if (!tup.is_valid(*this)) continue;
-                        func(tup);
-                    }
-                });
-        });
+        wmtk::parallel_for(
+            wmtk::blocked_range<size_t>(0, vert_capacity()),
+            [&](wmtk::blocked_range<size_t> r) {
+                for (size_t i = r.begin(); i < r.end(); i++) {
+                    auto tup = tuple_from_vertex(i);
+                    if (!tup.is_valid(*this)) continue;
+                    func(tup);
+                }
+            },
+            NUM_THREADS);
     }
 }
 

--- a/src/wmtk/TriMesh.cpp
+++ b/src/wmtk/TriMesh.cpp
@@ -1977,54 +1977,48 @@ bool TriMesh::try_set_face_mutex_one_ring(const Tuple& f, int threadid)
 
 void wmtk::TriMesh::for_each_edge(const std::function<void(const TriMesh::Tuple&)>& func)
 {
-    wmtk::task_arena arena(NUM_THREADS);
-    arena.execute([&] {
-        wmtk::parallel_for(
-            wmtk::blocked_range<size_t>(0, tri_capacity()),
-            [&](const wmtk::blocked_range<size_t>& r) {
-                for (size_t i = r.begin(); i < r.end(); i++) {
-                    if (!tuple_from_tri(i).is_valid(*this)) continue;
-                    for (int j = 0; j < 3; j++) {
-                        auto tup = tuple_from_edge(i, j);
-                        if (tup.eid(*this) == 3 * i + j) {
-                            func(tup);
-                        }
+    wmtk::parallel_for(
+        wmtk::blocked_range<size_t>(0, tri_capacity()),
+        [&](const wmtk::blocked_range<size_t>& r) {
+            for (size_t i = r.begin(); i < r.end(); i++) {
+                if (!tuple_from_tri(i).is_valid(*this)) continue;
+                for (int j = 0; j < 3; j++) {
+                    auto tup = tuple_from_edge(i, j);
+                    if (tup.eid(*this) == 3 * i + j) {
+                        func(tup);
                     }
                 }
-            });
-    });
+            }
+        },
+        NUM_THREADS);
 }
 
 void wmtk::TriMesh::for_each_vertex(const std::function<void(const TriMesh::Tuple&)>& func)
 {
-    wmtk::task_arena arena(NUM_THREADS);
-    arena.execute([&] {
-        wmtk::parallel_for(
-            wmtk::blocked_range<size_t>(0, vert_capacity()),
-            [&](wmtk::blocked_range<size_t> r) {
-                for (size_t i = r.begin(); i < r.end(); i++) {
-                    auto tup = tuple_from_vertex(i);
-                    if (!tup.is_valid(*this)) continue;
-                    func(tup);
-                }
-            });
-    });
+    wmtk::parallel_for(
+        wmtk::blocked_range<size_t>(0, vert_capacity()),
+        [&](wmtk::blocked_range<size_t> r) {
+            for (size_t i = r.begin(); i < r.end(); i++) {
+                auto tup = tuple_from_vertex(i);
+                if (!tup.is_valid(*this)) continue;
+                func(tup);
+            }
+        },
+        NUM_THREADS);
 }
 
 void wmtk::TriMesh::for_each_face(const std::function<void(const TriMesh::Tuple&)>& func)
 {
-    wmtk::task_arena arena(NUM_THREADS);
-    arena.execute([&] {
-        wmtk::parallel_for(
-            wmtk::blocked_range<size_t>(0, tri_capacity()),
-            [&](wmtk::blocked_range<size_t> r) {
-                for (size_t i = r.begin(); i < r.end(); i++) {
-                    auto tup = tuple_from_tri(i);
-                    if (!tup.is_valid(*this)) continue;
-                    func(tup);
-                }
-            });
-    });
+    wmtk::parallel_for(
+        wmtk::blocked_range<size_t>(0, tri_capacity()),
+        [&](wmtk::blocked_range<size_t> r) {
+            for (size_t i = r.begin(); i < r.end(); i++) {
+                auto tup = tuple_from_tri(i);
+                if (!tup.is_valid(*this)) continue;
+                func(tup);
+            }
+        },
+        NUM_THREADS);
 }
 
 

--- a/src/wmtk/utils/Concurrency.hpp
+++ b/src/wmtk/utils/Concurrency.hpp
@@ -11,13 +11,19 @@
 // Notes / intentional simplifications:
 //  * Containers that used to grow concurrently (attribute / connectivity storage)
 //    are NOT provided here -- they became plain std::vector, preallocated up front
-//    (see TetMesh/TriMesh). `concurrent_vector` here only backs the few "collect
-//    results from parallel loops" sites, and is a mutex-guarded deque so that
-//    references to existing elements stay valid while other threads append and so
-//    that bool elements are not bit-packed (concurrent distinct-index writes stay
-//    safe).
+//    (see TetMesh/TriMesh). What remains is collecting results out of a parallel
+//    loop: `indexed_collector` where the loop already knows a unique slot per result
+//    (no synchronisation at all, and a reproducible output order), and
+//    `concurrent_vector` for the scattered appends that have no such slot.
 //  * enumerable_thread_specific is lock-free on the hot path: each thread keeps a
-//    small thread_local list of (instance-id -> value) slots.
+//    small thread_local list of (instance-id -> value) slots. It cannot enumerate
+//    them, though -- they live in thread_local storage, so the owning object cannot
+//    reach other threads' copies.
+//  * Thread count is an explicit argument to parallel_for. It used to travel through
+//    a thread_local set by a task_arena shim, which meant a parallel_for's width
+//    depended on invisible caller state -- and silently fell back to
+//    hardware_concurrency() anywhere the arena had not been entered, including inside
+//    threads spawned by task_group.
 
 #include <algorithm>
 #include <atomic>
@@ -454,46 +460,12 @@ public:
 };
 
 // ---------------------------------------------------------------------------
-// task_arena: replaces tbb::task_arena. It only limits concurrency; here we just
-// record the requested concurrency in a thread-local that parallel_for reads.
-// ---------------------------------------------------------------------------
-namespace detail {
-inline int& arena_concurrency()
-{
-    static thread_local int value = 0; // 0 => auto (hardware_concurrency)
-    return value;
-}
-} // namespace detail
-
-class task_arena
-{
-    int m_max_concurrency;
-
-public:
-    explicit task_arena(int max_concurrency = 0)
-        : m_max_concurrency(max_concurrency)
-    {}
-
-    template <typename F>
-    void execute(F&& f)
-    {
-        int previous = detail::arena_concurrency();
-        detail::arena_concurrency() = m_max_concurrency;
-        try {
-            f();
-        } catch (...) {
-            detail::arena_concurrency() = previous;
-            throw;
-        }
-        detail::arena_concurrency() = previous;
-    }
-};
-
-// ---------------------------------------------------------------------------
 // parallel_for: replaces tbb::parallel_for.
+// The thread count is an explicit argument: `num_threads > 0` runs on that many
+// threads, anything else (the default 0) falls back to hardware_concurrency().
 // ---------------------------------------------------------------------------
 template <typename Index, typename Func>
-void parallel_for(const blocked_range<Index>& range, Func&& func)
+void parallel_for(const blocked_range<Index>& range, Func&& func, int num_threads = 0)
 {
     const Index begin = range.begin();
     const Index end = range.end();
@@ -503,7 +475,7 @@ void parallel_for(const blocked_range<Index>& range, Func&& func)
 
     unsigned hw = std::thread::hardware_concurrency();
     if (hw == 0) hw = 1;
-    int requested = detail::arena_concurrency();
+    int requested = num_threads;
     std::size_t nthreads = requested > 0 ? static_cast<std::size_t>(requested) : hw;
     nthreads = std::min<std::size_t>(nthreads, total);
     if (nthreads <= 1) {
@@ -547,7 +519,7 @@ void parallel_for(const blocked_range<Index>& range, Func&& func)
 
 // Serial overload used for iterating a concurrent_map via .range().
 template <typename It, typename Func>
-void parallel_for(container_range<It> range, Func&& func)
+void parallel_for(container_range<It> range, Func&& func, int /*num_threads*/ = 0)
 {
     func(range);
 }

--- a/src/wmtk/utils/Concurrency.hpp
+++ b/src/wmtk/utils/Concurrency.hpp
@@ -148,23 +148,66 @@ public:
 };
 
 // ---------------------------------------------------------------------------
-// concurrent_vector: replaces tbb::concurrent_vector for the "append from a
-// parallel loop, read afterwards" use cases. Backed by std::deque so that
-// (a) references to existing elements survive concurrent appends, and
-// (b) bool is stored unpacked (safe concurrent distinct-index writes).
+// Collecting results out of a parallel loop. This is all tbb::concurrent_vector was
+// ever used for here, and neither of the two shapes below needs a lock.
 // ---------------------------------------------------------------------------
+
+// indexed_collector: when the loop already knows a unique slot for each result --
+// the edge collectors know it as `tup.eid(m)`, which is what the loop tests to decide
+// which triangle owns an edge -- each thread writes to a slot no other thread can
+// touch, so no synchronisation is required at all. compact() then returns the results
+// in slot order, which does not depend on how the range was scheduled: unlike a
+// mutex-guarded append, whose order is whichever thread got the lock first, this is
+// reproducible run to run.
+template <typename T>
+class indexed_collector
+{
+    std::vector<T> m_slots;
+    std::vector<char> m_filled;
+
+public:
+    explicit indexed_collector(std::size_t n)
+        : m_slots(n)
+        , m_filled(n, 0)
+    {}
+
+    // Callable concurrently as long as callers pass distinct `i`.
+    void set(std::size_t i, const T& v)
+    {
+        m_slots[i] = v;
+        m_filled[i] = 1;
+    }
+
+    std::vector<T> compact() const
+    {
+        std::vector<T> out;
+        out.reserve(m_slots.size());
+        for (std::size_t i = 0; i < m_slots.size(); ++i) {
+            if (m_filled[i]) out.push_back(m_slots[i]);
+        }
+        return out;
+    }
+};
+
+// concurrent_vector: the remaining shape, where results arrive from scattered points
+// inside an operation rather than from an indexed sweep, so there is no slot to write
+// to. Kept mutex-guarded over a std::vector. A per-thread-bucket version would be
+// lock-free, but this shim's enumerable_thread_specific cannot enumerate its slots
+// (they live in thread_local storage, so the owner cannot reach other threads'), and
+// the remaining users append at most once per *failed mesh operation* -- the lock is
+// nowhere near the cost of the operation that preceded it.
 template <typename T>
 class concurrent_vector
 {
-    std::deque<T> m_data;
+    std::vector<T> m_data;
     mutable std::mutex m_mutex;
 
 public:
     using value_type = T;
-    using iterator = typename std::deque<T>::iterator;
-    using const_iterator = typename std::deque<T>::const_iterator;
-    using reference = typename std::deque<T>::reference;
-    using const_reference = typename std::deque<T>::const_reference;
+    using iterator = typename std::vector<T>::iterator;
+    using const_iterator = typename std::vector<T>::const_iterator;
+    using reference = typename std::vector<T>::reference;
+    using const_reference = typename std::vector<T>::const_reference;
 
     concurrent_vector() = default;
     explicit concurrent_vector(std::size_t n)
@@ -186,24 +229,18 @@ public:
         std::lock_guard<std::mutex> lock(m_mutex);
         m_data.push_back(v);
     }
-    void push_back(T&& v)
-    {
-        std::lock_guard<std::mutex> lock(m_mutex);
-        m_data.push_back(std::move(v));
-    }
     template <typename... Args>
-    reference emplace_back(Args&&... args)
+    void emplace_back(Args&&... args)
     {
         std::lock_guard<std::mutex> lock(m_mutex);
         m_data.emplace_back(std::forward<Args>(args)...);
-        return m_data.back();
     }
 
     // Single-threaded sizing/clearing (used outside parallel regions).
     void resize(std::size_t n) { m_data.resize(n); }
     void resize(std::size_t n, const T& value) { m_data.resize(n, value); }
     void clear() { m_data.clear(); }
-    void reserve(std::size_t) {}
+    void reserve(std::size_t n) { m_data.reserve(n); }
 
     reference operator[](std::size_t i) { return m_data[i]; }
     const_reference operator[](std::size_t i) const { return m_data[i]; }
@@ -215,8 +252,6 @@ public:
     iterator end() { return m_data.end(); }
     const_iterator begin() const { return m_data.begin(); }
     const_iterator end() const { return m_data.end(); }
-    const_iterator cbegin() const { return m_data.cbegin(); }
-    const_iterator cend() const { return m_data.cend(); }
 };
 
 // ---------------------------------------------------------------------------

--- a/src/wmtk/utils/Concurrency.hpp
+++ b/src/wmtk/utils/Concurrency.hpp
@@ -572,19 +572,4 @@ public:
     }
 };
 
-// ---------------------------------------------------------------------------
-// parallel_sort: replaces tbb::parallel_sort (plain std::sort here).
-// ---------------------------------------------------------------------------
-template <typename RandomIt>
-void parallel_sort(RandomIt first, RandomIt last)
-{
-    std::sort(first, last);
-}
-
-template <typename RandomIt, typename Compare>
-void parallel_sort(RandomIt first, RandomIt last, Compare comp)
-{
-    std::sort(first, last, comp);
-}
-
 } // namespace wmtk

--- a/src/wmtk/utils/InsertTriangleUtils.cpp
+++ b/src/wmtk/utils/InsertTriangleUtils.cpp
@@ -9,7 +9,7 @@ namespace wmtk {
 void match_tet_faces_to_triangles(
     const TetMesh& m,
     const std::vector<std::array<size_t, 3>>& faces,
-    wmtk::concurrent_vector<bool>& is_matched,
+    std::vector<bool>& is_matched,
     wmtk::concurrent_map<std::array<size_t, 3>, std::vector<int>>& tet_face_tags)
 {
     is_matched.resize(faces.size(), false);

--- a/src/wmtk/utils/InsertTriangleUtils.hpp
+++ b/src/wmtk/utils/InsertTriangleUtils.hpp
@@ -26,7 +26,7 @@ namespace wmtk {
 void match_tet_faces_to_triangles(
     const wmtk::TetMesh& m,
     const std::vector<std::array<size_t, 3>>& faces,
-    wmtk::concurrent_vector<bool>& is_matched,
+    std::vector<bool>& is_matched,
     wmtk::concurrent_map<std::array<size_t, 3>, std::vector<int>>& tet_face_tags);
 
 bool remove_duplicates(

--- a/src/wmtk/utils/ParallelCollect.hpp
+++ b/src/wmtk/utils/ParallelCollect.hpp
@@ -24,27 +24,25 @@ parallel_collect_edge_ops(Mesh& m, int num_threads, Emit&& emit)
     using Tuple = typename Mesh::Tuple;
     std::vector<std::pair<Op, Tuple>> out;
     std::mutex merge_mutex;
-    wmtk::task_arena arena(std::max(1, num_threads));
-    arena.execute([&] {
-        wmtk::parallel_for(
-            wmtk::blocked_range<size_t>(0, m.tet_capacity()),
-            [&](wmtk::blocked_range<size_t> r) {
-                std::vector<std::pair<Op, Tuple>> local;
-                for (size_t i = r.begin(); i < r.end(); i++) {
-                    if (!m.tuple_from_tet(i).is_valid(m)) continue;
-                    for (int j = 0; j < 6; j++) {
-                        const Tuple e = m.tuple_from_edge(i, j);
-                        if (e.eid(m) == 6 * i + j) emit(m, e, local); // canonical edge only
-                    }
+    wmtk::parallel_for(
+        wmtk::blocked_range<size_t>(0, m.tet_capacity()),
+        [&](wmtk::blocked_range<size_t> r) {
+            std::vector<std::pair<Op, Tuple>> local;
+            for (size_t i = r.begin(); i < r.end(); i++) {
+                if (!m.tuple_from_tet(i).is_valid(m)) continue;
+                for (int j = 0; j < 6; j++) {
+                    const Tuple e = m.tuple_from_edge(i, j);
+                    if (e.eid(m) == 6 * i + j) emit(m, e, local); // canonical edge only
                 }
-                if (local.empty()) return;
-                std::lock_guard<std::mutex> lk(merge_mutex);
-                out.insert(
-                    out.end(),
-                    std::make_move_iterator(local.begin()),
-                    std::make_move_iterator(local.end()));
-            });
-    });
+            }
+            if (local.empty()) return;
+            std::lock_guard<std::mutex> lk(merge_mutex);
+            out.insert(
+                out.end(),
+                std::make_move_iterator(local.begin()),
+                std::make_move_iterator(local.end()));
+        },
+        std::max(1, num_threads));
     return out;
 }
 
@@ -55,27 +53,25 @@ parallel_collect_face_ops(Mesh& m, int num_threads, Emit&& emit)
     using Tuple = typename Mesh::Tuple;
     std::vector<std::pair<Op, Tuple>> out;
     std::mutex merge_mutex;
-    wmtk::task_arena arena(std::max(1, num_threads));
-    arena.execute([&] {
-        wmtk::parallel_for(
-            wmtk::blocked_range<size_t>(0, m.tet_capacity()),
-            [&](wmtk::blocked_range<size_t> r) {
-                std::vector<std::pair<Op, Tuple>> local;
-                for (size_t i = r.begin(); i < r.end(); i++) {
-                    if (!m.tuple_from_tet(i).is_valid(m)) continue;
-                    for (int j = 0; j < 4; j++) {
-                        const Tuple f = m.tuple_from_face(i, j);
-                        if (f.fid(m) == 4 * i + j) emit(m, f, local); // canonical face only
-                    }
+    wmtk::parallel_for(
+        wmtk::blocked_range<size_t>(0, m.tet_capacity()),
+        [&](wmtk::blocked_range<size_t> r) {
+            std::vector<std::pair<Op, Tuple>> local;
+            for (size_t i = r.begin(); i < r.end(); i++) {
+                if (!m.tuple_from_tet(i).is_valid(m)) continue;
+                for (int j = 0; j < 4; j++) {
+                    const Tuple f = m.tuple_from_face(i, j);
+                    if (f.fid(m) == 4 * i + j) emit(m, f, local); // canonical face only
                 }
-                if (local.empty()) return;
-                std::lock_guard<std::mutex> lk(merge_mutex);
-                out.insert(
-                    out.end(),
-                    std::make_move_iterator(local.begin()),
-                    std::make_move_iterator(local.end()));
-            });
-    });
+            }
+            if (local.empty()) return;
+            std::lock_guard<std::mutex> lk(merge_mutex);
+            out.insert(
+                out.end(),
+                std::make_move_iterator(local.begin()),
+                std::make_move_iterator(local.end()));
+        },
+        std::max(1, num_threads));
     return out;
 }
 

--- a/src/wmtk/utils/PartitionMesh.cpp
+++ b/src/wmtk/utils/PartitionMesh.cpp
@@ -48,81 +48,82 @@ std::vector<size_t> partition_TetMesh(wmtk::TetMesh& m, int num_partition)
 std::vector<size_t> partition_morton(std::vector<Eigen::Vector3d> vertex_position, int NUM_THREADS)
 {
     std::vector<size_t> partition_id(vertex_position.size());
-    wmtk::task_arena arena(NUM_THREADS);
 
-    arena.execute([&] {
-        std::vector<Eigen::Vector3d> V_v = vertex_position;
-        struct sortstruct
-        {
-            size_t order = -1;
-            Resorting::MortonCode64 morton;
-        };
-        std::vector<sortstruct> list_v;
-        list_v.resize(V_v.size());
-        const int multi = 1000;
-        // since the morton code requires a correct scale of input vertices,
-        //  we need to scale the vertices if their coordinates are out of range
-        std::vector<Eigen::Vector3d> V = V_v; // this is for rescaling vertices
-        Eigen::Vector3d vmin, vmax;
-        vmin = V.front();
-        vmax = V.front();
-        for (size_t j = 0; j < V.size(); j++) {
-            for (int i = 0; i < 3; i++) {
-                vmin(i) = std::min(vmin(i), V[j](i));
-                vmax(i) = std::max(vmax(i), V[j](i));
+    std::vector<Eigen::Vector3d> V_v = vertex_position;
+    struct sortstruct
+    {
+        size_t order = -1;
+        Resorting::MortonCode64 morton;
+    };
+    std::vector<sortstruct> list_v;
+    list_v.resize(V_v.size());
+    const int multi = 1000;
+    // since the morton code requires a correct scale of input vertices,
+    //  we need to scale the vertices if their coordinates are out of range
+    std::vector<Eigen::Vector3d> V = V_v; // this is for rescaling vertices
+    Eigen::Vector3d vmin, vmax;
+    vmin = V.front();
+    vmax = V.front();
+    for (size_t j = 0; j < V.size(); j++) {
+        for (int i = 0; i < 3; i++) {
+            vmin(i) = std::min(vmin(i), V[j](i));
+            vmax(i) = std::max(vmax(i), V[j](i));
+        }
+    }
+    // get_bb_corners(V, vmin, vmax);
+    Eigen::Vector3d center = (vmin + vmax) / 2;
+    wmtk::parallel_for(
+        wmtk::blocked_range<size_t>(0, V.size()),
+        [&](wmtk::blocked_range<size_t> r) {
+            for (size_t i = r.begin(); i < r.end(); i++) {
+                V[i] = V[i] - center;
             }
-        }
-        // get_bb_corners(V, vmin, vmax);
-        Eigen::Vector3d center = (vmin + vmax) / 2;
+        },
+        NUM_THREADS);
+    Eigen::Vector3d scale_point =
+        vmax - center; // after placing box at origin, vmax and vmin are symetric.
+    double xscale, yscale, zscale;
+    xscale = fabs(scale_point[0]);
+    yscale = fabs(scale_point[1]);
+    zscale = fabs(scale_point[2]);
+    double scale = std::max(std::max(xscale, yscale), zscale);
+    if (scale > 300) {
         wmtk::parallel_for(
             wmtk::blocked_range<size_t>(0, V.size()),
             [&](wmtk::blocked_range<size_t> r) {
                 for (size_t i = r.begin(); i < r.end(); i++) {
-                    V[i] = V[i] - center;
+                    V[i] = V[i] / scale;
                 }
-            });
-        Eigen::Vector3d scale_point =
-            vmax - center; // after placing box at origin, vmax and vmin are symetric.
-        double xscale, yscale, zscale;
-        xscale = fabs(scale_point[0]);
-        yscale = fabs(scale_point[1]);
-        zscale = fabs(scale_point[2]);
-        double scale = std::max(std::max(xscale, yscale), zscale);
-        if (scale > 300) {
-            wmtk::parallel_for(
-                wmtk::blocked_range<size_t>(0, V.size()),
-                [&](wmtk::blocked_range<size_t> r) {
-                    for (size_t i = r.begin(); i < r.end(); i++) {
-                        V[i] = V[i] / scale;
-                    }
-                });
-        }
-        wmtk::parallel_for(
-            wmtk::blocked_range<size_t>(0, V.size()),
-            [&](wmtk::blocked_range<size_t> r) {
-                for (size_t i = r.begin(); i < r.end(); i++) {
-                    list_v[i].morton = Resorting::MortonCode64(
-                        int(V[i][0] * multi),
-                        int(V[i][1] * multi),
-                        int(V[i][2] * multi));
-                    list_v[i].order = i;
-                }
-            });
+            },
+            NUM_THREADS);
+    }
+    wmtk::parallel_for(
+        wmtk::blocked_range<size_t>(0, V.size()),
+        [&](wmtk::blocked_range<size_t> r) {
+            for (size_t i = r.begin(); i < r.end(); i++) {
+                list_v[i].morton = Resorting::MortonCode64(
+                    int(V[i][0] * multi),
+                    int(V[i][1] * multi),
+                    int(V[i][2] * multi));
+                list_v[i].order = i;
+            }
+        },
+        NUM_THREADS);
 
-        const auto morton_compare = [](const sortstruct& a, const sortstruct& b) {
-            return (a.morton < b.morton);
-        };
-        wmtk::parallel_sort(list_v.begin(), list_v.end(), morton_compare);
-        size_t interval = list_v.size() / NUM_THREADS + 1;
+    const auto morton_compare = [](const sortstruct& a, const sortstruct& b) {
+        return (a.morton < b.morton);
+    };
+    wmtk::parallel_sort(list_v.begin(), list_v.end(), morton_compare);
+    size_t interval = list_v.size() / NUM_THREADS + 1;
 
-        wmtk::parallel_for(
-            wmtk::blocked_range<size_t>(0, list_v.size()),
-            [&](wmtk::blocked_range<size_t> r) {
-                for (size_t i = r.begin(); i < r.end(); i++) {
-                    partition_id[list_v[i].order] = i / interval;
-                }
-            });
-    });
+    wmtk::parallel_for(
+        wmtk::blocked_range<size_t>(0, list_v.size()),
+        [&](wmtk::blocked_range<size_t> r) {
+            for (size_t i = r.begin(); i < r.end(); i++) {
+                partition_id[list_v[i].order] = i / interval;
+            }
+        },
+        NUM_THREADS);
 
     return partition_id;
 }

--- a/src/wmtk/utils/PartitionMesh.cpp
+++ b/src/wmtk/utils/PartitionMesh.cpp
@@ -1,4 +1,5 @@
 #include <wmtk/utils/PartitionMesh.h>
+#include <algorithm>
 
 #include <igl/remove_unreferenced.h>
 #include <wmtk/utils/Morton.h>
@@ -111,9 +112,15 @@ std::vector<size_t> partition_morton(std::vector<Eigen::Vector3d> vertex_positio
         NUM_THREADS);
 
     const auto morton_compare = [](const sortstruct& a, const sortstruct& b) {
-        return (a.morton < b.morton);
+        // Morton codes are quantised, so distinct vertices routinely share one. Without
+        // the tie-break they compare equal and std::sort, which is not stable, orders
+        // them differently on libc++, libstdc++ and MSVC -- and that order decides the
+        // partition each vertex lands in. Break on the original index for a total order.
+        if (a.morton < b.morton) return true;
+        if (b.morton < a.morton) return false;
+        return a.order < b.order;
     };
-    wmtk::parallel_sort(list_v.begin(), list_v.end(), morton_compare);
+    std::sort(list_v.begin(), list_v.end(), morton_compare);
     size_t interval = list_v.size() / NUM_THREADS + 1;
 
     wmtk::parallel_for(

--- a/src/wmtk/utils/WindingNumber.hpp
+++ b/src/wmtk/utils/WindingNumber.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
 // A local copy of libigl's winding-number evaluation, but with the per-query
-// parallelism driven by wmtk's own threading framework (task_arena + parallel_for)
-// instead of igl::parallel_for. This means the winding number honours the
+// parallelism driven by wmtk's own threading framework (wmtk::parallel_for, given
+// an explicit thread count) instead of igl::parallel_for. This means the winding number honours the
 // requested `num_threads` (like every other parallel section in wmtk) rather than
 // always grabbing all hardware cores.
 //
@@ -28,7 +28,7 @@ namespace wmtk::utils {
 /**
  * @brief Winding number of every query point O.row(i) with respect to the triangle
  * mesh (V, F). Equivalent to igl::winding_number(V, F, O, W), but the query loop is
- * parallelised with wmtk::parallel_for inside a wmtk::task_arena(num_threads).
+ * parallelised with wmtk::parallel_for, passed `num_threads` explicitly.
  */
 inline void winding_number(
     const Eigen::MatrixXd& V,
@@ -48,16 +48,14 @@ inline void winding_number(
 
     // hier.winding_number(p) is const and used by igl the same way from parallel_for,
     // so concurrent queries against the shared hierarchy are safe.
-    wmtk::task_arena arena(std::max(num_threads, 1));
-    arena.execute([&]() {
-        wmtk::parallel_for(
-            wmtk::blocked_range<int>(0, static_cast<int>(O.rows())),
-            [&](wmtk::blocked_range<int> r) {
-                for (int o = r.begin(); o < r.end(); ++o) {
-                    W(o) = hier.winding_number(O.row(o));
-                }
-            });
-    });
+    wmtk::parallel_for(
+        wmtk::blocked_range<int>(0, static_cast<int>(O.rows())),
+        [&](wmtk::blocked_range<int> r) {
+            for (int o = r.begin(); o < r.end(); ++o) {
+                W(o) = hier.winding_number(O.row(o));
+            }
+        },
+        std::max(num_threads, 1));
 }
 
 } // namespace wmtk::utils

--- a/src/wmtk/utils/partition_utils.cpp
+++ b/src/wmtk/utils/partition_utils.cpp
@@ -1,6 +1,7 @@
 #include "partition_utils.hpp"
 
 // clang-format off
+#include <algorithm>
 #include <wmtk/utils/DisableWarnings.hpp>
 #include <wmtk/utils/Concurrency.hpp>
 #include <wmtk/utils/EnableWarnings.hpp>
@@ -94,10 +95,16 @@ void wmtk::partition_vertex_morton(
         num_partition);
 
     const auto morton_compare = [](const sortstruct& a, const sortstruct& b) {
-        return (a.morton < b.morton);
+        // Morton codes are quantised, so distinct vertices routinely share one. Without
+        // the tie-break they compare equal and std::sort, which is not stable, orders
+        // them differently on libc++, libstdc++ and MSVC -- and that order decides the
+        // partition each vertex lands in. Break on the original index for a total order.
+        if (a.morton < b.morton) return true;
+        if (b.morton < a.morton) return false;
+        return a.order < b.order;
     };
 
-    wmtk::parallel_sort(list_v.begin(), list_v.end(), morton_compare);
+    std::sort(list_v.begin(), list_v.end(), morton_compare);
 
     size_t interval = list_v.size() / num_partition + 1;
 

--- a/src/wmtk/utils/partition_utils.cpp
+++ b/src/wmtk/utils/partition_utils.cpp
@@ -14,100 +14,101 @@ void wmtk::partition_vertex_morton(
     int num_partition,
     std::vector<size_t>& result)
 {
-    wmtk::task_arena arena(num_partition);
-
     std::vector<Eigen::Vector3d> V_v(vert_size);
-    arena.execute([&] {
-        wmtk::parallel_for(
-            wmtk::blocked_range<size_t>(0, V_v.size()),
-            [&](wmtk::blocked_range<size_t> r) {
-                for (size_t i = r.begin(); i < r.end(); i++) {
-                    V_v[i] = pos(i);
-                }
-            });
-
-
-        struct sortstruct
-        {
-            size_t order;
-            Resorting::MortonCode64 morton;
-        };
-
-        std::vector<sortstruct> list_v;
-        list_v.resize(V_v.size());
-        // std::vector<sortstruct> list;
-        const int multi = 1000;
-        // since the morton code requires a correct scale of input vertices,
-        //  we need to scale the vertices if their coordinates are out of range
-        std::vector<Eigen::Vector3d> V = V_v; // this is for rescaling vertices
-        Eigen::Vector3d vmin, vmax;
-        vmin = V.front();
-        vmax = V.front();
-
-        for (size_t j = 0; j < V.size(); j++) {
-            for (int i = 0; i < 3; i++) {
-                vmin(i) = std::min(vmin(i), V[j](i));
-                vmax(i) = std::max(vmax(i), V[j](i));
+    wmtk::parallel_for(
+        wmtk::blocked_range<size_t>(0, V_v.size()),
+        [&](wmtk::blocked_range<size_t> r) {
+            for (size_t i = r.begin(); i < r.end(); i++) {
+                V_v[i] = pos(i);
             }
+        },
+        num_partition);
+
+
+    struct sortstruct
+    {
+        size_t order;
+        Resorting::MortonCode64 morton;
+    };
+
+    std::vector<sortstruct> list_v;
+    list_v.resize(V_v.size());
+    // std::vector<sortstruct> list;
+    const int multi = 1000;
+    // since the morton code requires a correct scale of input vertices,
+    //  we need to scale the vertices if their coordinates are out of range
+    std::vector<Eigen::Vector3d> V = V_v; // this is for rescaling vertices
+    Eigen::Vector3d vmin, vmax;
+    vmin = V.front();
+    vmax = V.front();
+
+    for (size_t j = 0; j < V.size(); j++) {
+        for (int i = 0; i < 3; i++) {
+            vmin(i) = std::min(vmin(i), V[j](i));
+            vmax(i) = std::max(vmax(i), V[j](i));
         }
+    }
 
-        // get_bb_corners(V, vmin, vmax);
-        Eigen::Vector3d center = (vmin + vmax) / 2;
+    // get_bb_corners(V, vmin, vmax);
+    Eigen::Vector3d center = (vmin + vmax) / 2;
 
+    wmtk::parallel_for(
+        wmtk::blocked_range<size_t>(0, V.size()),
+        [&](wmtk::blocked_range<size_t> r) {
+            for (size_t i = r.begin(); i < r.end(); i++) {
+                V[i] = V[i] - center;
+            }
+        },
+        num_partition);
+
+    Eigen::Vector3d scale_point =
+        vmax - center; // after placing box at origin, vmax and vmin are symetric.
+
+    double xscale, yscale, zscale;
+    xscale = fabs(scale_point[0]);
+    yscale = fabs(scale_point[1]);
+    zscale = fabs(scale_point[2]);
+    double scale = std::max(std::max(xscale, yscale), zscale);
+    if (scale > 300) {
         wmtk::parallel_for(
             wmtk::blocked_range<size_t>(0, V.size()),
             [&](wmtk::blocked_range<size_t> r) {
                 for (size_t i = r.begin(); i < r.end(); i++) {
-                    V[i] = V[i] - center;
+                    V[i] = V[i] / scale;
                 }
-            });
+            },
+            num_partition);
+    }
 
-        Eigen::Vector3d scale_point =
-            vmax - center; // after placing box at origin, vmax and vmin are symetric.
+    wmtk::parallel_for(
+        wmtk::blocked_range<size_t>(0, V.size()),
+        [&](wmtk::blocked_range<size_t> r) {
+            for (size_t i = r.begin(); i < r.end(); i++) {
+                list_v[i].morton = Resorting::MortonCode64(
+                    int(V[i][0] * multi),
+                    int(V[i][1] * multi),
+                    int(V[i][2] * multi));
+                list_v[i].order = i;
+            }
+        },
+        num_partition);
 
-        double xscale, yscale, zscale;
-        xscale = fabs(scale_point[0]);
-        yscale = fabs(scale_point[1]);
-        zscale = fabs(scale_point[2]);
-        double scale = std::max(std::max(xscale, yscale), zscale);
-        if (scale > 300) {
-            wmtk::parallel_for(
-                wmtk::blocked_range<size_t>(0, V.size()),
-                [&](wmtk::blocked_range<size_t> r) {
-                    for (size_t i = r.begin(); i < r.end(); i++) {
-                        V[i] = V[i] / scale;
-                    }
-                });
-        }
+    const auto morton_compare = [](const sortstruct& a, const sortstruct& b) {
+        return (a.morton < b.morton);
+    };
 
-        wmtk::parallel_for(
-            wmtk::blocked_range<size_t>(0, V.size()),
-            [&](wmtk::blocked_range<size_t> r) {
-                for (size_t i = r.begin(); i < r.end(); i++) {
-                    list_v[i].morton = Resorting::MortonCode64(
-                        int(V[i][0] * multi),
-                        int(V[i][1] * multi),
-                        int(V[i][2] * multi));
-                    list_v[i].order = i;
-                }
-            });
+    wmtk::parallel_sort(list_v.begin(), list_v.end(), morton_compare);
 
-        const auto morton_compare = [](const sortstruct& a, const sortstruct& b) {
-            return (a.morton < b.morton);
-        };
+    size_t interval = list_v.size() / num_partition + 1;
 
-        wmtk::parallel_sort(list_v.begin(), list_v.end(), morton_compare);
-
-        size_t interval = list_v.size() / num_partition + 1;
-
-        result.clear();
-        result.resize(vert_size);
-        wmtk::parallel_for(
-            wmtk::blocked_range<size_t>(0, list_v.size()),
-            [&](wmtk::blocked_range<size_t> r) {
-                for (size_t i = r.begin(); i < r.end(); i++) {
-                    result[list_v[i].order] = i / interval;
-                }
-            });
-    });
+    result.clear();
+    result.resize(vert_size);
+    wmtk::parallel_for(
+        wmtk::blocked_range<size_t>(0, list_v.size()),
+        [&](wmtk::blocked_range<size_t> r) {
+            for (size_t i = r.begin(); i < r.end(); i++) {
+                result[list_v[i].order] = i / interval;
+            }
+        },
+        num_partition);
 }


### PR DESCRIPTION
## Concurrency cleanup

Three independent commits over the concurrency shim left behind by the TBB removal. Each builds and passes the suite on its own.

### 1. Collect parallel results without a lock
`tbb::concurrent_vector` was only ever used to collect results out of a parallel loop, and most of those sites need no lock at all.

The four edge collectors (isotropic remeshing's collapse/split/swap, qslim's collapse) already know a unique slot per result: `for_each_edge` invokes the callback only for the triangle that *owns* an edge, and tests `tup.eid(m)` to decide that. Writing into a preallocated slot indexed by `eid` means no two threads ever touch the same element, so `indexed_collector` needs no synchronisation whatsoever — and the output order becomes slot order rather than whichever thread won the mutex, removing a source of multithreaded irreproducibility.

- `is_matched` needed no wrapper at all — `match_tet_faces_to_triangles` fills it from a plain serial loop — so it is a `std::vector<bool>`.
- `to_revert` becomes a flag per vertex. A vertex is reachable from several tets, so the old code took the lock once per push and then pushed the same vid repeatedly; every write now stores the same value to a slot indexed by vid, so relaxed ordering suffices and the duplicates collapse for free.

What remains of `concurrent_vector` (the failure list in `LocalizedRetry`, the sub-edge list in `split_remeshing`) keeps its mutex, over a `std::vector` rather than a deque now that no caller holds a reference across an append. Per-thread buckets would drop that lock too, but this shim's `enumerable_thread_specific` cannot enumerate its slots — they live in `thread_local` storage, so the owner cannot reach other threads' copies — and both sites append at most once per *failed mesh operation*, where the lock is nowhere near the cost of the operation that preceded it.

**Measured** on crown (tetwild, 10 threads): insertion **8.497s** against a baseline of 8.850 / 8.748 / 9.007s over three runs — below all of them. Only insertion is worth quoting: total runtime varies by **32%** run to run at this thread count (406–535s over three identical runs), so it cannot resolve a change this size.

### 2. Pass the thread count to `parallel_for` instead of `task_arena`
The `task_arena` shim held no threads. `execute()` wrote its concurrency into a `thread_local`, ran the lambda, and restored it; `parallel_for` read that `thread_local` to size its pool. A `parallel_for`'s width therefore depended on invisible caller state, and silently fell back to `hardware_concurrency()` anywhere the arena had not been entered — including inside threads spawned by `task_group`, whose `thread_local` copy is its own zero-initialised one, so the two sites that wrapped a `task_group` in an arena were getting nothing from it.

The count is now an explicit trailing argument of `parallel_for`, and the shim is gone. 55 call sites say what width they want where they ask for it. No behaviour change: the resolution rule is unchanged (`> 0` uses that many threads, otherwise `hardware_concurrency`).

### 3. Drop `parallel_sort`; give the morton sort a total order
`wmtk::parallel_sort` was a two-line forward to `std::sort`, so the name claimed something the code did not do, and none of its eight callers is inside a `parallel_for` — each sorts a vertex list once to assign morton-order partitions.

The comparator was the real problem:

```cpp
return (a.morton < b.morton);
```

Morton codes are quantised, so distinct vertices routinely share one. Tied elements compare equal, `std::sort` is not stable, and the order it leaves them in **differs between libc++, libstdc++ and MSVC** — and that order decides which partition, and therefore which thread, each vertex belongs to. It now breaks the tie on the original index.

Same class of bug as the non-stable sorts previously fixed in `TetMesh::get_edges` and `sort_edges_by_length`. It stayed hidden because the reproducibility tests run single-threaded, where there is one partition and the order cannot matter.

### Why not the C++17 parallel algorithms?
Worth stating explicitly, since `std::sort(std::execution::par, ...)` and `std::for_each(std::execution::par, ...)` look like they would make the whole shim redundant. Three reasons they do not:

1. **On Linux they resurrect TBB.** libstdc++ implements the parallel execution policies on top of Intel TBB — `<execution>` with a parallel policy requires linking it. This repository has just removed TBB (#951) because nothing needed it; adopting `par` would bring it straight back on the platform where it is most standard.
2. **On macOS they may not exist.** libc++'s PSTL support is partial and recent; on many Apple clang versions the parallel policies are simply absent. MSVC is the one platform with a solid implementation.
3. **They cannot honour `num_threads` — the disqualifying one.** `std::execution::par` offers no way to request a specific width; the thread count is implementation-defined and unspecified. This codebase depends on it everywhere: `num_threads: 1` is what makes the golden-hash tests reproducible. Under `par` you cannot ask for exactly one thread, so single-threaded determinism would be unachievable.

There is also a shape mismatch: `parallel_for` hands its callback a **chunk** (`blocked_range`), and several sites exploit that to accumulate into a per-chunk local vector and merge once. `std::for_each(par, ...)` is per-element, so each would need restructuring for a weaker guarantee.

So the shim is not redundant with C++17 — it exists to do the one thing the standard algorithms explicitly will not, namely let the caller fix the thread count. `parallel_sort` was the exception: it did no work the standard did not already do, which is why it goes.

### Testing
51/51 unit tests and `Integration_Tests` pass, at each commit.

Stacked on #951.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
