### PR TITLE
Give the remaining partial sort comparators a total order

### DIFF
--- a/app/main.cpp
+++ b/app/main.cpp
@@ -52,5 +52,14 @@ int main(int argc, char** argv)
     }
 
     // execute
-    components_map[app_str](j);
+    try {
+        components_map[app_str](j);
+    } catch (const std::exception& e) {
+        // Without this, any error a component throws -- an empty or unreadable input mesh, a
+        // failed invariant, and so on -- escapes main, so the runtime calls std::terminate()
+        // and the process aborts. Catch it and exit nonzero with a readable message instead
+        // of crashing (and, on macOS, spraying a crash report per failure).
+        logger().error("Application '{}' failed: {}", app_str, e.what());
+        return 1;
+    }
 }

--- a/components/tetwild/wmtk/components/tetwild/EdgeSwapping.cpp
+++ b/components/tetwild/wmtk/components/tetwild/EdgeSwapping.cpp
@@ -137,12 +137,14 @@ bool TetWildMesh::swap_edge_before(const Tuple& t)
     if (is_edge_on_bbox(t)) {
         return false;
     }
-    // Surface edges are allowed only as a topology-preserving surface diagonal
-    // flip (see prepare_surface_flip_32). If disabled, keep the old behavior of
-    // rejecting all surface-edge swaps.
-    if (is_edge_on_surface(t)) {
+    // Surface edges are allowed only as a topology-preserving surface diagonal flip (see
+    // prepare_surface_flip). If disabled, keep the old behavior of rejecting all surface-edge
+    // swaps. Route on the direct incident-surface-face count so a genuine surface edge is never
+    // mistaken for interior because of stale m_is_on_surface flags (which would tear the surface).
+    const int n_surf_faces = edge_incident_surface_face_count(t);
+    if (n_surf_faces > 0) {
         if (!m_params.allow_surface_swap) return false;
-        if (!prepare_surface_flip_32(t, incident_tets)) return false;
+        if (!prepare_surface_flip(t, incident_tets)) return false;
     }
 
     auto max_energy = -1.0;
@@ -156,9 +158,10 @@ bool TetWildMesh::swap_edge_before(const Tuple& t)
     return true;
 }
 
-bool TetWildMesh::prepare_surface_flip_32(const Tuple& t, const std::vector<size_t>& incident_tets)
+bool TetWildMesh::prepare_surface_flip(const Tuple& t, const std::vector<size_t>& incident_tets)
 {
     auto& cache = swap_cache.local();
+    cache.is_surface_flip = false;
 
     const size_t a = t.vid(*this);
     const size_t b = t.switch_vertex(*this).vid(*this);
@@ -166,59 +169,43 @@ bool TetWildMesh::prepare_surface_flip_32(const Tuple& t, const std::vector<size
     // Flipping an open-boundary edge would change the surface's boundary loops.
     if (is_open_boundary_edge(t)) return false;
 
-    // The three "ring" vertices are the incident-tet vertices other than a,b.
-    std::array<size_t, 3> ring{};
-    int nr = 0;
+    // The "ring" vertices are the incident-tet vertices other than a,b (deduplicated). This works
+    // for any ring size (3->2, 4-4, 5-6); the specific retetrahedralization that realizes the flip
+    // is selected later by swap_edge_44_accept_case / swap_edge_56_accept_case.
+    std::vector<size_t> ring;
+    ring.reserve(incident_tets.size() + 1);
     for (const size_t tid : incident_tets) {
-        const auto vs = oriented_tet_vids(tid);
-        for (const size_t v : vs) {
+        for (const size_t v : oriented_tet_vids(tid)) {
             if (v == a || v == b) continue;
-            bool seen = false;
-            for (int k = 0; k < nr; ++k) {
-                if (ring[k] == v) {
-                    seen = true;
-                    break;
-                }
-            }
-            if (!seen) {
-                if (nr >= 3) return false; // not a clean 3->2 ring
-                ring[nr++] = v;
-            }
+            if (std::find(ring.begin(), ring.end(), v) == ring.end()) ring.push_back(v);
         }
     }
-    if (nr != 3) return false;
 
-    // Of the three ring faces (a,b,ring[k]), exactly two must be surface faces
-    // (manifold surface edge). Their apexes are the new surface edge (c,d); the
-    // remaining apex is the interior one (e).
+    // Exactly two of the ring faces (a,b,r) must be surface faces (manifold surface edge). Their
+    // apexes are the endpoints (c,d) of the new surface edge.
     int n_surf = 0;
-    size_t c = 0, d = 0, e = 0;
-    bool e_set = false;
-    for (int k = 0; k < 3; ++k) {
-        auto [ftup, fid] = tuple_from_face(std::array<size_t, 3>{{a, b, ring[k]}});
+    size_t c = 0, d = 0;
+    for (const size_t r : ring) {
+        auto [ftup, fid] = tuple_from_face(std::array<size_t, 3>{{a, b, r}});
         (void)ftup;
-        if (m_face_attribute[fid].m_is_surface_fs) {
-            if (n_surf == 0) {
-                c = ring[k];
-                cache.sf_face_attr = m_face_attribute[fid];
-            } else if (n_surf == 1) {
-                d = ring[k];
-            } else {
-                return false; // > 2 surface faces: non-manifold edge
-            }
-            ++n_surf;
+        if (fid == static_cast<size_t>(-1)) continue;
+        if (!m_face_attribute[fid].m_is_surface_fs) continue;
+        if (n_surf == 0) {
+            c = r;
+            cache.sf_face_attr = m_face_attribute[fid];
+        } else if (n_surf == 1) {
+            d = r;
         } else {
-            e = ring[k];
-            e_set = true;
+            return false; // > 2 surface faces: non-manifold edge
         }
+        ++n_surf;
     }
-    if (n_surf != 2 || !e_set) return false;
+    if (n_surf != 2) return false;
 
-    // The flip adds two surface faces (a,c,d),(b,c,d) on edge (c,d). If any
-    // surface face is already incident to edge (c,d), the result is a
-    // non-manifold surface edge (> 2 surface faces) -> reject. This counts the
-    // incident surface faces directly and does NOT rely on the m_is_on_surface
-    // vertex flags (which can be stale), unlike is_edge_on_surface().
+    // The flip adds two surface faces (a,c,d),(b,c,d) on edge (c,d). If any surface face is already
+    // incident to edge (c,d), the result is a non-manifold surface edge (> 2 surface faces) ->
+    // reject. This counts the incident surface faces directly and does NOT rely on the
+    // m_is_on_surface vertex flags (which can be stale), unlike is_edge_on_surface().
     {
         const Tuple cd = tuple_from_edge(std::array<size_t, 2>{{c, d}});
         if (cd.is_valid(*this)) {
@@ -236,8 +223,8 @@ bool TetWildMesh::prepare_surface_flip_32(const Tuple& t, const std::vector<size
         }
     }
 
-    // The two would-be new surface faces (a,c,d),(b,c,d) must not already be
-    // tagged surface, otherwise the flip corrupts manifoldness / boundaries.
+    // The two would-be new surface faces (a,c,d),(b,c,d) must not already be tagged surface,
+    // otherwise the flip corrupts manifoldness / boundaries.
     {
         auto [ft1, fid1] = tuple_from_face(std::array<size_t, 3>{{a, c, d}});
         auto [ft2, fid2] = tuple_from_face(std::array<size_t, 3>{{b, c, d}});
@@ -252,8 +239,35 @@ bool TetWildMesh::prepare_surface_flip_32(const Tuple& t, const std::vector<size
     cache.sf_b = b;
     cache.sf_c = c;
     cache.sf_d = d;
-    cache.sf_e = e;
     return true;
+}
+
+bool TetWildMesh::swap_edge_44_accept_case(const std::array<size_t, 2>& new_edge)
+{
+    const auto& cache = swap_cache.local();
+    if (!cache.is_surface_flip) return true; // interior edge: keep pure min-energy behavior
+    // Surface flip: accept only the diagonal that creates the new surface edge (c,d).
+    return (new_edge[0] == cache.sf_c && new_edge[1] == cache.sf_d) ||
+           (new_edge[0] == cache.sf_d && new_edge[1] == cache.sf_c);
+}
+
+bool TetWildMesh::swap_edge_56_accept_case(const std::array<size_t, 3>& new_face)
+{
+    const auto& cache = swap_cache.local();
+    if (!cache.is_surface_flip) return true; // interior edge: keep pure min-energy behavior
+    // Surface flip: the fan apex (new_face[0]) must be one surface apex and the other surface apex
+    // must be one of the two fan tips, so the created diagonal is exactly (c,d). Keying on the apex
+    // (not "the face contains edge (c,d)") rejects the spurious case where (c,d) is a pre-existing
+    // link edge of the fan face rather than a newly created diagonal.
+    const size_t apex = new_face[0];
+    size_t other;
+    if (apex == cache.sf_c)
+        other = cache.sf_d;
+    else if (apex == cache.sf_d)
+        other = cache.sf_c;
+    else
+        return false;
+    return new_face[1] == other || new_face[2] == other;
 }
 
 bool TetWildMesh::swap_edge_after(const Tuple& t)
@@ -307,6 +321,7 @@ bool TetWildMesh::swap_edge_after(const Tuple& t)
         m_face_attribute[fid1].m_is_surface_fs = true;
         m_face_attribute[fid2].m_is_surface_fs = true;
         cnt_surface_swap++;
+        cnt_surface_swap_32++;
     }
 
     cnt_swap++;
@@ -498,6 +513,8 @@ size_t TetWildMesh::swap_all_edges_44()
     time = timer.getElapsedTime();
     wmtk::logger().info("edge swap 44 prepare time: {:.4}s", time);
     size_t total_success = 0;
+    SurfaceTopoSignature sig_before;
+    if (m_params.check_surface_topology) sig_before = surface_topology_signature();
     auto setup_and_execute = [&](auto& executor) {
         executor.renew_neighbor_tuples = wmtk::renewal_edges;
         executor.priority = [&](auto& m, auto op, auto& t) { return m.get_length2(t); };
@@ -513,15 +530,16 @@ size_t TetWildMesh::swap_all_edges_44()
         setup_and_execute(executor);
         time = timer.getElapsedTime();
         wmtk::logger().info("edge swap 44 operation time parallel: {:.4}s", time);
-        return total_success;
     } else {
         timer.start();
         auto executor = wmtk::ExecutePass<TetWildMesh>(wmtk::ExecutionPolicy::kSeq);
         setup_and_execute(executor);
         time = timer.getElapsedTime();
         wmtk::logger().info("edge swap 44 operation time serial: {:.4}s", time);
-        return total_success;
     }
+    if (m_params.check_surface_topology)
+        warn_if_surface_topology_changed(sig_before, "swap_all_edges_44");
+    return total_success;
 }
 
 bool TetWildMesh::swap_edge_44_before(const Tuple& t)
@@ -529,28 +547,36 @@ bool TetWildMesh::swap_edge_44_before(const Tuple& t)
     if (!TetMesh::swap_edge_44_before(t)) {
         return false;
     }
-    // if (m_params.preserve_global_topology) return false;
+
+    auto& cache = swap_cache.local();
+    cache.is_surface_flip = false;
 
     auto incident_tets = get_incident_tids_for_edge(t);
     if (incident_tets.size() != 4) {
         return false;
     }
 
-    if (is_edge_on_surface(t) || is_edge_on_bbox(t)) {
+    // bbox edges are never swapped.
+    if (is_edge_on_bbox(t)) {
         return false;
+    }
+    // Surface edges are allowed only as a topology-preserving surface diagonal flip. The base 4-4
+    // swap is steered to the case that creates the new surface edge (c,d) by
+    // swap_edge_44_accept_case; if no 4-4 diagonal yields (c,d) the swap is rejected. Route on the
+    // direct incident-surface-face count so a genuine surface edge is never mistaken for interior.
+    const int n_surf_faces = edge_incident_surface_face_count(t);
+    if (n_surf_faces > 0) {
+        if (!m_params.allow_surface_swap) return false;
+        if (!prepare_surface_flip(t, incident_tets)) return false;
     }
 
     auto max_energy = -1.0;
     for (auto& l : incident_tets) {
         max_energy = std::max(m_tet_attribute[l].m_quality, max_energy);
     }
-    swap_cache.local().max_energy = max_energy;
+    cache.max_energy = max_energy;
 
-    face_attribute_tracker(
-        *this,
-        incident_tets,
-        m_face_attribute,
-        swap_cache.local().changed_faces);
+    face_attribute_tracker(*this, incident_tets, m_face_attribute, cache.changed_faces);
 
     return true;
 }
@@ -576,6 +602,7 @@ bool TetWildMesh::swap_edge_44_after(const Tuple& t)
 
     auto incident_tets = get_incident_tets_for_edge(t);
 
+    auto& cache = swap_cache.local();
     auto max_energy = -1.0;
     for (auto& l : incident_tets) {
         if (is_inverted(l)) return false;
@@ -584,11 +611,40 @@ bool TetWildMesh::swap_edge_44_after(const Tuple& t)
         max_energy = std::max(q, max_energy);
     }
 
-    if (max_energy >= swap_cache.local().max_energy) {
+    if (max_energy >= cache.max_energy) {
         return false;
     }
 
-    tracker_assign_after(*this, incident_tets, swap_cache.local().changed_faces, m_face_attribute);
+    if (cache.is_surface_flip) {
+        // The two new surface faces (a,c,d),(b,c,d) must stay within the Hausdorff envelope,
+        // exactly like a surface-edge collapse / the 3->2 surface flip.
+        const auto& VA = m_vertex_attribute;
+        if (m_envelope.is_outside(
+                {{VA[cache.sf_a].m_posf, VA[cache.sf_c].m_posf, VA[cache.sf_d].m_posf}}))
+            return false;
+        if (m_envelope.is_outside(
+                {{VA[cache.sf_b].m_posf, VA[cache.sf_c].m_posf, VA[cache.sf_d].m_posf}}))
+            return false;
+    }
+
+    tracker_assign_after(*this, incident_tets, cache.changed_faces, m_face_attribute);
+
+    if (cache.is_surface_flip) {
+        // Re-tag the two new surface faces (the generic tracker reset them to interior). Net
+        // surface change: -(a,b,c) -(a,b,d) +(a,c,d) +(b,c,d).
+        auto [ft1, fid1] =
+            tuple_from_face(std::array<size_t, 3>{{cache.sf_a, cache.sf_c, cache.sf_d}});
+        auto [ft2, fid2] =
+            tuple_from_face(std::array<size_t, 3>{{cache.sf_b, cache.sf_c, cache.sf_d}});
+        (void)ft1;
+        (void)ft2;
+        m_face_attribute[fid1] = cache.sf_face_attr;
+        m_face_attribute[fid2] = cache.sf_face_attr;
+        m_face_attribute[fid1].m_is_surface_fs = true;
+        m_face_attribute[fid2].m_is_surface_fs = true;
+        cnt_surface_swap++;
+        cnt_surface_swap_44++;
+    }
 
     cnt_swap++;
     return true;
@@ -606,6 +662,8 @@ size_t TetWildMesh::swap_all_edges_56()
     time = timer.getElapsedTime();
     wmtk::logger().info("edge swap 56 prepare time: {:.4}s", time);
     size_t total_success = 0;
+    SurfaceTopoSignature sig_before;
+    if (m_params.check_surface_topology) sig_before = surface_topology_signature();
     auto setup_and_execute = [&](auto& executor) {
         executor.renew_neighbor_tuples = wmtk::renewal_edges;
         executor.priority = [&](auto& m, auto op, auto& t) { return m.get_length2(t); };
@@ -621,15 +679,16 @@ size_t TetWildMesh::swap_all_edges_56()
         setup_and_execute(executor);
         time = timer.getElapsedTime();
         wmtk::logger().info("edge swap 56 operation time parallel: {:.4}s", time);
-        return total_success;
     } else {
         timer.start();
         auto executor = wmtk::ExecutePass<TetWildMesh>(wmtk::ExecutionPolicy::kSeq);
         setup_and_execute(executor);
         time = timer.getElapsedTime();
         wmtk::logger().info("edge swap 56 operation time serial: {:.4}s", time);
-        return total_success;
     }
+    if (m_params.check_surface_topology)
+        warn_if_surface_topology_changed(sig_before, "swap_all_edges_56");
+    return total_success;
 }
 
 bool TetWildMesh::swap_edge_56_before(const Tuple& t)
@@ -638,25 +697,34 @@ bool TetWildMesh::swap_edge_56_before(const Tuple& t)
         return false;
     }
 
+    auto& cache = swap_cache.local();
+    cache.is_surface_flip = false;
+
     const auto incident_tets = get_incident_tids_for_edge(t);
     if (incident_tets.size() != 5) {
         return false;
     }
-    if (is_edge_on_surface(t) || is_edge_on_bbox(t)) {
+    // bbox edges are never swapped.
+    if (is_edge_on_bbox(t)) {
         return false;
+    }
+    // Surface edges are allowed only as a topology-preserving surface diagonal flip. The base 5-6
+    // swap is steered to the fan that creates the new surface edge (c,d) by
+    // swap_edge_56_accept_case; if no fan yields (c,d) the swap is rejected. Route on the direct
+    // incident-surface-face count so a genuine surface edge is never mistaken for interior.
+    const int n_surf_faces = edge_incident_surface_face_count(t);
+    if (n_surf_faces > 0) {
+        if (!m_params.allow_surface_swap) return false;
+        if (!prepare_surface_flip(t, incident_tets)) return false;
     }
 
     double max_energy = -1.0;
     for (const size_t l : incident_tets) {
         max_energy = std::max(m_tet_attribute[l].m_quality, max_energy);
     }
-    swap_cache.local().max_energy = max_energy;
+    cache.max_energy = max_energy;
 
-    face_attribute_tracker(
-        *this,
-        incident_tets,
-        m_face_attribute,
-        swap_cache.local().changed_faces);
+    face_attribute_tracker(*this, incident_tets, m_face_attribute, cache.changed_faces);
 
     return true;
 }
@@ -691,6 +759,7 @@ bool TetWildMesh::swap_edge_56_after(const Tuple& t)
     const auto e2 = get_incident_tids_for_edge(t.switch_edge(*this));
     const auto tids = wmtk::set_union(e1, e2);
 
+    auto& cache = swap_cache.local();
     double max_energy = -1.0;
     for (const size_t tid : tids) {
         const Tuple tet = tuple_from_tet(tid);
@@ -699,7 +768,35 @@ bool TetWildMesh::swap_edge_56_after(const Tuple& t)
         max_energy = std::max(q, max_energy);
     }
 
-    tracker_assign_after(*this, tids, swap_cache.local().changed_faces, m_face_attribute);
+    if (cache.is_surface_flip) {
+        // The two new surface faces (a,c,d),(b,c,d) must stay within the Hausdorff envelope.
+        const auto& VA = m_vertex_attribute;
+        if (m_envelope.is_outside(
+                {{VA[cache.sf_a].m_posf, VA[cache.sf_c].m_posf, VA[cache.sf_d].m_posf}}))
+            return false;
+        if (m_envelope.is_outside(
+                {{VA[cache.sf_b].m_posf, VA[cache.sf_c].m_posf, VA[cache.sf_d].m_posf}}))
+            return false;
+    }
+
+    tracker_assign_after(*this, tids, cache.changed_faces, m_face_attribute);
+
+    if (cache.is_surface_flip) {
+        // Re-tag the two new surface faces (the generic tracker reset them to interior). Net
+        // surface change: -(a,b,c) -(a,b,d) +(a,c,d) +(b,c,d).
+        auto [ft1, fid1] =
+            tuple_from_face(std::array<size_t, 3>{{cache.sf_a, cache.sf_c, cache.sf_d}});
+        auto [ft2, fid2] =
+            tuple_from_face(std::array<size_t, 3>{{cache.sf_b, cache.sf_c, cache.sf_d}});
+        (void)ft1;
+        (void)ft2;
+        m_face_attribute[fid1] = cache.sf_face_attr;
+        m_face_attribute[fid2] = cache.sf_face_attr;
+        m_face_attribute[fid1].m_is_surface_fs = true;
+        m_face_attribute[fid2].m_is_surface_fs = true;
+        cnt_surface_swap++;
+        cnt_surface_swap_56++;
+    }
 
     cnt_swap++;
     return true;

--- a/components/tetwild/wmtk/components/tetwild/Parameters.h
+++ b/components/tetwild/wmtk/components/tetwild/Parameters.h
@@ -16,9 +16,10 @@ struct Parameters
     bool preserve_topology = false;
     std::string output_path;
 
-    // Allow the 3->2 edge swap to operate on surface edges (a surface diagonal
-    // flip) instead of forbidding them outright. Enabled by default; can be
-    // turned off to reproduce the old surface-frozen behavior for A/B testing.
+    // Allow the edge swaps (3->2, 4-4, 5-6) to operate on surface edges as a
+    // topology-preserving surface diagonal flip, instead of forbidding them
+    // outright. Enabled by default; can be turned off to reproduce the old
+    // surface-frozen behavior for A/B testing.
     bool allow_surface_swap = true;
     // Expensive debug check: verify the global surface topology signature
     // (connected components, Euler characteristic, boundary loops) is unchanged

--- a/components/tetwild/wmtk/components/tetwild/TetWildMesh.cpp
+++ b/components/tetwild/wmtk/components/tetwild/TetWildMesh.cpp
@@ -514,7 +514,12 @@ std::tuple<double, double> TetWildMesh::local_operations(
             }
             auto [max_energy, avg_energy] = get_max_avg_energy();
             wmtk::logger().info("swap max energy = {:.6} avg = {:.6}", max_energy, avg_energy);
-            wmtk::logger().info("cnt_surface_swap (cumulative) = {}", cnt_surface_swap.load());
+            wmtk::logger().info(
+                "cnt_surface_swap (cumulative) = {} [3-2: {}, 4-4: {}, 5-6: {}]",
+                cnt_surface_swap.load(),
+                cnt_surface_swap_32.load(),
+                cnt_surface_swap_44.load(),
+                cnt_surface_swap_56.load());
             sanity_checks();
         } else if (i == 3) {
             for (int n = 0; n < ops[i]; n++) {
@@ -1273,6 +1278,31 @@ bool TetWildMesh::is_edge_on_surface(const Tuple& loc)
     }
 
     return false;
+}
+
+int TetWildMesh::edge_incident_surface_face_count(const Tuple& e)
+{
+    const size_t v1_id = e.vid(*this);
+    const size_t v2_id = e.switch_vertex(*this).vid(*this);
+
+    const auto tets = get_incident_tets_for_edge(e);
+    std::vector<size_t> n_vids;
+    for (const auto& t : tets) {
+        const auto vs = oriented_tet_vertices(t);
+        for (int j = 0; j < 4; ++j) {
+            const size_t v = vs[j].vid(*this);
+            if (v != v1_id && v != v2_id) n_vids.push_back(v);
+        }
+    }
+    wmtk::vector_unique(n_vids);
+
+    int count = 0;
+    for (const size_t vid : n_vids) {
+        auto [ftup, fid] = tuple_from_face({{v1_id, v2_id, vid}});
+        (void)ftup;
+        if (fid != static_cast<size_t>(-1) && m_face_attribute[fid].m_is_surface_fs) ++count;
+    }
+    return count;
 }
 
 

--- a/components/tetwild/wmtk/components/tetwild/TetWildMesh.h
+++ b/components/tetwild/wmtk/components/tetwild/TetWildMesh.h
@@ -306,12 +306,14 @@ public:
     bool swap_edge_44_before(const Tuple& t) override;
     double swap_edge_44_energy(const std::vector<std::array<size_t, 4>>& tets, const int op_case)
         override;
+    bool swap_edge_44_accept_case(const std::array<size_t, 2>& new_edge) override;
     bool swap_edge_44_after(const Tuple& t) override;
 
     size_t swap_all_edges_56();
     bool swap_edge_56_before(const Tuple& t) override;
     double swap_edge_56_energy(const std::vector<std::array<size_t, 4>>& tets, const int op_case)
         override;
+    bool swap_edge_56_accept_case(const std::array<size_t, 3>& new_face) override;
     bool swap_edge_56_after(const Tuple& t) override;
 
     size_t swap_all_edges_32();
@@ -319,17 +321,29 @@ public:
     bool swap_edge_after(const Tuple& t) override;
 
     /**
-     * @brief Prepare a surface 3->2 edge swap (a surface diagonal flip).
+     * @brief Prepare a surface edge swap (a surface diagonal flip), any ring size.
      *
-     * Called from swap_edge_before when the swapped edge (a,b) is on the surface
-     * and has exactly 3 incident tets. Verifies the local guards that guarantee
-     * the flip preserves surface manifoldness / topology, and fills the
-     * surface-flip fields of swap_cache. Returns false (rejecting the swap) if
-     * any guard fails: open-boundary edge, non-manifold edge (!= 2 surface
-     * faces), or one of the two would-be new surface faces already tagged
-     * surface. The tets sharing (a,b) are passed in to avoid recomputation.
+     * Called from swap_edge_before / swap_edge_44_before / swap_edge_56_before when the swapped
+     * edge (a,b) is on the surface. Regardless of how many tets share (a,b), the surface change is
+     * always the 2D diagonal flip of the two incident surface faces (a,b,c),(a,b,d) into
+     * (a,c,d),(b,c,d). This verifies the ring-size-independent guards that guarantee the flip
+     * preserves surface manifoldness / topology and fills the surface-flip fields of swap_cache.
+     * The specific retetrahedralization that realizes (c,d) is selected later by
+     * swap_edge_44_accept_case / swap_edge_56_accept_case (the 3->2 path always realizes it).
+     * Returns false (rejecting the swap) if any guard fails: open-boundary edge, non-manifold edge
+     * (!= 2 surface faces incident to (a,b)), the target edge (c,d) already carries a surface face,
+     * or one of the two would-be new surface faces (a,c,d),(b,c,d) is already tagged surface. The
+     * tets sharing (a,b) are passed in to avoid recomputation.
      */
-    bool prepare_surface_flip_32(const Tuple& t, const std::vector<size_t>& incident_tets);
+    bool prepare_surface_flip(const Tuple& t, const std::vector<size_t>& incident_tets);
+
+    /**
+     * @brief Number of surface faces incident to edge (a,b), counted directly over the edge's
+     * incident tets. Unlike is_edge_on_surface(), this does NOT short-circuit on the (possibly
+     * stale) m_is_on_surface vertex flags, so a genuine manifold surface edge is never mistaken
+     * for an interior edge (== 2) nor a non-manifold one (> 2). Used to route swaps.
+     */
+    int edge_incident_surface_face_count(const Tuple& e);
 
     /**
      * @brief A topological fingerprint of the tracked surface (m_is_surface_fs).
@@ -457,7 +471,10 @@ public:
     // debug use
     std::atomic<int> cnt_split = 0, cnt_collapse = 0, cnt_swap = 0;
     // Successful surface diagonal flips (subset of cnt_swap). Diagnostic.
+    // cnt_surface_swap is the grand total; the per-type counters break it down by the swap that
+    // realized the flip (3->2, 4-4, 5-6).
     std::atomic<int> cnt_surface_swap = 0;
+    std::atomic<int> cnt_surface_swap_32 = 0, cnt_surface_swap_44 = 0, cnt_surface_swap_56 = 0;
 
 private:
     // tags: correspondence map from new tet-face node indices to in-triangle ids.
@@ -528,13 +545,14 @@ private:
         double max_energy;
         std::map<std::array<size_t, 3>, FaceAttributes> changed_faces;
 
-        // Surface 3->2 flip bookkeeping (filled by swap_edge_before when the
-        // swapped edge (a,b) lies on the surface). a,b are the removed-edge
-        // endpoints, c,d are the new surface-edge endpoints, e is the interior
-        // apex. sf_face_attr is copied onto the two new surface faces (a,c,d),
-        // (b,c,d). is_surface_flip gates the extra handling in swap_edge_after.
+        // Surface diagonal-flip bookkeeping (filled by prepare_surface_flip from
+        // swap_edge_before / swap_edge_44_before / swap_edge_56_before when the swapped edge (a,b)
+        // lies on the surface). a,b are the removed-edge endpoints, c,d are the new surface-edge
+        // endpoints (the apexes of the two incident surface faces). sf_face_attr is copied onto the
+        // two new surface faces (a,c,d),(b,c,d). is_surface_flip gates the accept-case case-forcing
+        // and the extra retag/envelope handling in the swap *_after callbacks.
         bool is_surface_flip = false;
-        size_t sf_a = 0, sf_b = 0, sf_c = 0, sf_d = 0, sf_e = 0;
+        size_t sf_a = 0, sf_b = 0, sf_c = 0, sf_d = 0;
         FaceAttributes sf_face_attr;
     };
     wmtk::enumerable_thread_specific<SwapInfoCache> swap_cache;

--- a/components/tetwild/wmtk/components/tetwild/orig/EdgeSplitter.h
+++ b/components/tetwild/wmtk/components/tetwild/orig/EdgeSplitter.h
@@ -34,7 +34,12 @@ struct cmp_es
 {
     bool operator()(const ElementInQueue_es& e1, const ElementInQueue_es& e2)
     {
-        return e1.weight < e2.weight;
+        // Equal-length edges are everywhere on a symmetric mesh. On weight alone they compare
+        // equivalent and the heap pops them in an order that differs between libc++, libstdc++
+        // and MSVC -- and that order decides which edge gets split first, so the resulting mesh
+        // differs per platform. Break on the vertex ids for a total order, as cmp_ec/cmp_er do.
+        if (e1.weight == e2.weight) return e1.v_ids < e2.v_ids;
+        return e1.weight < e2.weight; ///choose longer edge for splitting
     }
 };
 

--- a/components/tetwild/wmtk/components/tetwild/tests/test_surface_swap.cpp
+++ b/components/tetwild/wmtk/components/tetwild/tests/test_surface_swap.cpp
@@ -6,6 +6,7 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include <array>
+#include <cmath>
 #include <vector>
 
 using namespace wmtk;
@@ -343,4 +344,349 @@ TEST_CASE("surface-flip-rejected", "[tetwild_operation][surface_swap]")
         CHECK(is_surface(mesh, A, B, D));
         CHECK(count_valid_tets(mesh) == 3);
     }
+}
+
+// ---------------------------------------------------------------------------
+// Extended surface swaps: 4-4 and 5-6 edge flips.
+//
+// The surface change is always the 2D diagonal flip of the two incident surface
+// faces (a,b,c),(a,b,d) -> (a,c,d),(b,c,d). The volumetric operation that realizes
+// it depends on the ring size: 3->2 (done above), 4-4, or 5-6. These fixtures build
+// an N-tet ring around edge (a=0,b=1) whose ring vertices lie on a regular N-gon in
+// z=0, with a,b far apart on the z-axis so edge (a,b) is a bad sliver and the
+// diagonal flip strictly lowers the AMIPS energy (mirrors tet_mesh_swap56_with_position).
+// ---------------------------------------------------------------------------
+namespace {
+
+constexpr double kPi = 3.14159265358979323846;
+
+// vids: a=0, b=1, ring i -> 2+i. Ring is CCW so the tets (a,b,r_i,r_{i+1}) are
+// positively oriented. `half` is the |z| of a,b; a large value makes (a,b) a sliver.
+void build_ring_n(TetWildMesh& mesh, int N, double half, double radius)
+{
+    std::vector<std::array<size_t, 4>> tets;
+    for (int i = 0; i < N; ++i) tets.push_back({{0, 1, size_t(2 + i), size_t(2 + (i + 1) % N)}});
+    mesh.init(N + 2, tets);
+
+    std::vector<VertexAttributes> va(N + 2);
+    va[0].m_posf = Vector3d(0, 0, -half);
+    va[1].m_posf = Vector3d(0, 0, half);
+    for (int i = 0; i < N; ++i) {
+        const double ang = 2.0 * kPi * i / N;
+        va[2 + i].m_posf = Vector3d(radius * std::cos(ang), radius * std::sin(ang), 0);
+    }
+    for (int i = 0; i < N + 2; ++i) {
+        va[i].m_is_rounded = true;
+        va[i].m_pos = to_rational(va[i].m_posf);
+        va[i].m_is_on_surface = false;
+        va[i].m_is_on_open_boundary = false;
+        va[i].m_order = 0;
+    }
+    std::vector<TetAttributes> ta(N);
+    mesh.create_mesh_attributes(va, ta);
+}
+
+void mark_surface_vertex(TetWildMesh& mesh, size_t v)
+{
+    mesh.m_vertex_attribute[v].m_is_on_surface = true;
+    mesh.m_vertex_attribute[v].m_order = 1;
+}
+
+// Build an envelope around the current tracked-surface faces of `mesh` (eps in world
+// units). `env` must outlive the swap (the mesh holds a reference).
+void init_env_from_surface(SampleEnvelope& env, const TetWildMesh& mesh, double eps)
+{
+    std::vector<Vector3d> v(mesh.vert_capacity());
+    for (size_t i = 0; i < mesh.vert_capacity(); ++i) v[i] = mesh.m_vertex_attribute[i].m_posf;
+    std::vector<Eigen::Vector3i> f;
+    for (size_t i = 0; i < mesh.tet_capacity(); ++i) {
+        const auto tt = mesh.tuple_from_tet(i);
+        if (!tt.is_valid(mesh)) continue;
+        for (int j = 0; j < 4; ++j) {
+            const auto ft = mesh.tuple_from_face(i, j);
+            const size_t fid = ft.fid(mesh);
+            if (fid != 4 * i + j) continue; // canonical: visit each face once
+            if (!mesh.m_face_attribute[fid].m_is_surface_fs) continue;
+            const auto vs = mesh.get_face_vids(ft);
+            f.emplace_back(int(vs[0]), int(vs[1]), int(vs[2]));
+        }
+    }
+    env.init(v, f, eps);
+}
+
+int count_valid_tets_n(TetWildMesh& mesh)
+{
+    int n = 0;
+    for (size_t i = 0; i < mesh.tet_capacity(); ++i)
+        if (mesh.tuple_from_tet(i).is_valid(mesh)) ++n;
+    return n;
+}
+
+bool any_inverted_n(TetWildMesh& mesh)
+{
+    for (size_t i = 0; i < mesh.tet_capacity(); ++i) {
+        const auto tt = mesh.tuple_from_tet(i);
+        if (tt.is_valid(mesh) && mesh.is_inverted(tt)) return true;
+    }
+    return false;
+}
+
+} // namespace
+
+TEST_CASE("surface-flip-44-correctness", "[tetwild_operation][surface_swap]")
+{
+    // 4-tet ring; the two surface apexes are OPPOSITE in the ring (vids 2 and 4), so
+    // exactly one 4-4 diagonal is (2,4) and the flip is realizable.
+    Parameters params;
+    params.init(Vector3d(-2, -2, -2000), Vector3d(2, 2, 2000));
+    SampleEnvelope env;
+    TetWildMesh mesh(params, env, 1);
+    build_ring_n(mesh, 4, 1000.0, 1.0);
+    for (size_t v : {size_t(0), size_t(1), size_t(2), size_t(4)}) mark_surface_vertex(mesh, v);
+    set_surface(mesh, 0, 1, 2, true); // (a,b,c)
+    set_surface(mesh, 0, 1, 4, true); // (a,b,d)
+    init_env_from_surface(env, mesh, 50.0); // permissive (the surface stays planar here)
+
+    const auto sig_before = mesh.surface_topology_signature();
+    CHECK(sig_before.F == 2);
+
+    auto t = mesh.tuple_from_edge(std::array<size_t, 2>{{0, 1}});
+    REQUIRE(t.is_valid(mesh));
+    std::vector<TetMesh::Tuple> ret;
+    const bool ok = mesh.swap_edge_44(t, ret);
+
+    REQUIRE(ok);
+    CHECK(count_valid_tets_n(mesh) == 4); // 4-4: tet count unchanged
+    CHECK(mesh.check_mesh_connectivity_validity());
+    CHECK_FALSE(any_inverted_n(mesh));
+
+    // Surface diagonal flipped (a,b) -> (c,d) == (2,4).
+    CHECK(is_surface(mesh, 0, 2, 4)); // (a,c,d)
+    CHECK(is_surface(mesh, 1, 2, 4)); // (b,c,d)
+
+    const auto sig_after = mesh.surface_topology_signature();
+    CHECK(sig_after.F == 2);
+    CHECK(sig_after == sig_before); // surface topology invariant
+
+    CHECK(mesh.cnt_surface_swap_44.load() == 1);
+    CHECK(mesh.cnt_surface_swap.load() == 1);
+    // Vertex surface membership is invariant under a pure diagonal flip.
+    for (size_t v : {size_t(0), size_t(1), size_t(2), size_t(4)})
+        CHECK(mesh.m_vertex_attribute[v].m_is_on_surface);
+}
+
+TEST_CASE("surface-flip-44-rejected", "[tetwild_operation][surface_swap]")
+{
+    Parameters params;
+    params.init(Vector3d(-2, -2, -2000), Vector3d(2, 2, 2000));
+
+    SECTION("adjacent surface apexes -> no matching diagonal -> rejected")
+    {
+        // Surface apexes vids 2 and 3 are ADJACENT in the ring, so neither 4-4
+        // diagonal ((2,4) or (3,5)) equals (2,3): the accept-case vetoes both cases.
+        SampleEnvelope env;
+        TetWildMesh mesh(params, env, 1);
+        build_ring_n(mesh, 4, 1000.0, 1.0);
+        for (size_t v : {size_t(0), size_t(1), size_t(2), size_t(3)}) mark_surface_vertex(mesh, v);
+        set_surface(mesh, 0, 1, 2, true);
+        set_surface(mesh, 0, 1, 3, true);
+        init_env_from_surface(env, mesh, 50.0);
+
+        const auto sig_before = mesh.surface_topology_signature();
+        auto t = mesh.tuple_from_edge(std::array<size_t, 2>{{0, 1}});
+        std::vector<TetMesh::Tuple> ret;
+        CHECK_FALSE(mesh.swap_edge_44(t, ret));
+        CHECK(count_valid_tets_n(mesh) == 4);
+        CHECK(mesh.cnt_surface_swap_44.load() == 0);
+        CHECK(mesh.surface_topology_signature() == sig_before);
+    }
+
+    SECTION("disabled by param -> rejected")
+    {
+        params.allow_surface_swap = false;
+        SampleEnvelope env;
+        TetWildMesh mesh(params, env, 1);
+        build_ring_n(mesh, 4, 1000.0, 1.0);
+        for (size_t v : {size_t(0), size_t(1), size_t(2), size_t(4)}) mark_surface_vertex(mesh, v);
+        set_surface(mesh, 0, 1, 2, true);
+        set_surface(mesh, 0, 1, 4, true);
+        init_env_from_surface(env, mesh, 50.0);
+
+        auto t = mesh.tuple_from_edge(std::array<size_t, 2>{{0, 1}});
+        std::vector<TetMesh::Tuple> ret;
+        CHECK_FALSE(mesh.swap_edge_44(t, ret));
+        CHECK(count_valid_tets_n(mesh) == 4);
+        CHECK(mesh.cnt_surface_swap_44.load() == 0);
+    }
+
+    SECTION("non-manifold edge (3 surface faces) -> rejected")
+    {
+        SampleEnvelope env;
+        TetWildMesh mesh(params, env, 1);
+        build_ring_n(mesh, 4, 1000.0, 1.0);
+        for (size_t v : {size_t(0), size_t(1), size_t(2), size_t(3), size_t(4)})
+            mark_surface_vertex(mesh, v);
+        set_surface(mesh, 0, 1, 2, true);
+        set_surface(mesh, 0, 1, 3, true);
+        set_surface(mesh, 0, 1, 4, true); // 3rd surface face on edge (a,b)
+        init_env_from_surface(env, mesh, 50.0);
+
+        auto t = mesh.tuple_from_edge(std::array<size_t, 2>{{0, 1}});
+        std::vector<TetMesh::Tuple> ret;
+        CHECK_FALSE(mesh.swap_edge_44(t, ret));
+        CHECK(count_valid_tets_n(mesh) == 4);
+        CHECK(mesh.cnt_surface_swap_44.load() == 0);
+    }
+}
+
+TEST_CASE("surface-flip-44-routing-stale-flag", "[tetwild_operation][surface_swap]")
+{
+    // A genuine surface edge whose endpoint vertex flags are stale-false must still be
+    // routed through the surface flip (edge_incident_surface_face_count is face-based),
+    // so the surface is not silently torn by the interior path.
+    Parameters params;
+    params.init(Vector3d(-2, -2, -2000), Vector3d(2, 2, 2000));
+    SampleEnvelope env;
+    TetWildMesh mesh(params, env, 1);
+    build_ring_n(mesh, 4, 1000.0, 1.0);
+    // Deliberately DO NOT mark any vertex on-surface (all m_is_on_surface stay false),
+    // even though (0,1,2),(0,1,4) are surface faces.
+    set_surface(mesh, 0, 1, 2, true);
+    set_surface(mesh, 0, 1, 4, true);
+    init_env_from_surface(env, mesh, 50.0);
+
+    const auto sig_before = mesh.surface_topology_signature();
+    auto t = mesh.tuple_from_edge(std::array<size_t, 2>{{0, 1}});
+    std::vector<TetMesh::Tuple> ret;
+    const bool ok = mesh.swap_edge_44(t, ret);
+    REQUIRE(ok);
+    // The flip ran through the surface path: surface retagged and topology preserved.
+    CHECK(is_surface(mesh, 0, 2, 4));
+    CHECK(is_surface(mesh, 1, 2, 4));
+    CHECK(mesh.cnt_surface_swap_44.load() == 1);
+    CHECK(mesh.surface_topology_signature() == sig_before);
+}
+
+TEST_CASE("surface-flip-56-correctness", "[tetwild_operation][surface_swap]")
+{
+    // 5-tet ring; the two surface apexes (vids 2 and 4) are separated by ONE ring vertex
+    // (distance 2 in the pentagon), so a fan from vertex 2 (or 4) creates the diagonal
+    // (2,4) and realizes the surface flip.
+    Parameters params;
+    params.init(Vector3d(-2, -2, -2000), Vector3d(2, 2, 2000));
+    SampleEnvelope env;
+    TetWildMesh mesh(params, env, 1);
+    build_ring_n(mesh, 5, 1000.0, 1.0);
+    for (size_t v : {size_t(0), size_t(1), size_t(2), size_t(4)}) mark_surface_vertex(mesh, v);
+    set_surface(mesh, 0, 1, 2, true); // (a,b,c)
+    set_surface(mesh, 0, 1, 4, true); // (a,b,d)
+    init_env_from_surface(env, mesh, 50.0); // permissive: the surface is folded here
+
+    const auto sig_before = mesh.surface_topology_signature();
+    CHECK(sig_before.F == 2);
+
+    auto t = mesh.tuple_from_edge(std::array<size_t, 2>{{0, 1}});
+    REQUIRE(t.is_valid(mesh));
+    std::vector<TetMesh::Tuple> ret;
+    const bool ok = mesh.swap_edge_56(t, ret);
+
+    REQUIRE(ok);
+    CHECK(count_valid_tets_n(mesh) == 6); // 5-6: 5 tets -> 6 tets
+    CHECK(mesh.check_mesh_connectivity_validity());
+    CHECK_FALSE(any_inverted_n(mesh));
+
+    CHECK(is_surface(mesh, 0, 2, 4)); // (a,c,d)
+    CHECK(is_surface(mesh, 1, 2, 4)); // (b,c,d)
+
+    const auto sig_after = mesh.surface_topology_signature();
+    CHECK(sig_after.F == 2);
+    CHECK(sig_after == sig_before);
+
+    CHECK(mesh.cnt_surface_swap_56.load() == 1);
+    CHECK(mesh.cnt_surface_swap.load() == 1);
+}
+
+TEST_CASE("surface-flip-56-rejected", "[tetwild_operation][surface_swap]")
+{
+    // Surface apexes vids 2,3 are ADJACENT. For the fan at vertex 5 the new face is
+    // (5,2,3) whose edge (2,3) is a pre-existing link edge -- a naive "face contains
+    // (c,d)" test would wrongly accept it; the apex-keyed accept-case (apex 5 not in
+    // {2,3}) correctly rejects, so no flip happens.
+    // (Envelope-based rejection is identical code to the 3->2 path and is covered by the
+    // "new surface outside envelope" section of surface-flip-rejected.)
+    Parameters params;
+    params.init(Vector3d(-2, -2, -2000), Vector3d(2, 2, 2000));
+    SampleEnvelope env;
+    TetWildMesh mesh(params, env, 1);
+    build_ring_n(mesh, 5, 1000.0, 1.0);
+    for (size_t v : {size_t(0), size_t(1), size_t(2), size_t(3)}) mark_surface_vertex(mesh, v);
+    set_surface(mesh, 0, 1, 2, true);
+    set_surface(mesh, 0, 1, 3, true);
+    init_env_from_surface(env, mesh, 50.0);
+
+    const auto sig_before = mesh.surface_topology_signature();
+    auto t = mesh.tuple_from_edge(std::array<size_t, 2>{{0, 1}});
+    std::vector<TetMesh::Tuple> ret;
+    CHECK_FALSE(mesh.swap_edge_56(t, ret));
+    CHECK(count_valid_tets_n(mesh) == 5);
+    CHECK(mesh.cnt_surface_swap_56.load() == 0);
+    CHECK(mesh.surface_topology_signature() == sig_before);
+}
+
+TEST_CASE("surface-flip-interior-unchanged", "[tetwild_operation][surface_swap]")
+{
+    // With no surface faces, the 4-4 and 5-6 swaps must behave exactly as before: the
+    // accept-case predicate defaults to accepting every case (is_surface_flip == false),
+    // and no surface retag occurs.
+    Parameters params;
+    params.init(Vector3d(-2, -2, -2000), Vector3d(2, 2, 2000));
+
+    SECTION("interior 4-4")
+    {
+        SampleEnvelope env;
+        TetWildMesh mesh(params, env, 1);
+        build_ring_n(mesh, 4, 1000.0, 1.0); // no surface faces tagged
+        auto t = mesh.tuple_from_edge(std::array<size_t, 2>{{0, 1}});
+        std::vector<TetMesh::Tuple> ret;
+        CHECK(mesh.swap_edge_44(t, ret));
+        CHECK(count_valid_tets_n(mesh) == 4);
+        CHECK(mesh.check_mesh_connectivity_validity());
+        CHECK(mesh.cnt_surface_swap_44.load() == 0);
+    }
+
+    SECTION("interior 5-6")
+    {
+        SampleEnvelope env;
+        TetWildMesh mesh(params, env, 1);
+        build_ring_n(mesh, 5, 1000.0, 1.0);
+        auto t = mesh.tuple_from_edge(std::array<size_t, 2>{{0, 1}});
+        std::vector<TetMesh::Tuple> ret;
+        CHECK(mesh.swap_edge_56(t, ret));
+        CHECK(count_valid_tets_n(mesh) == 6);
+        CHECK(mesh.check_mesh_connectivity_validity());
+        CHECK(mesh.cnt_surface_swap_56.load() == 0);
+    }
+}
+
+TEST_CASE("surface-face-swap-excluded", "[tetwild_operation][surface_swap]")
+{
+    // The 2->3 face swap must never touch a surface face (it would tear a hole in the
+    // tracked surface). Confirm it is rejected and the surface is unchanged.
+    Parameters params;
+    params.init(Vector3d(-2, -2, -2), Vector3d(2, 2, 2));
+    SampleEnvelope env;
+    init_loose_envelope(env);
+    TetWildMesh mesh(params, env, 1);
+    build_ring(mesh);
+    set_surface(mesh, A, B, C, true);
+    set_surface(mesh, A, B, D, true);
+
+    const auto sig_before = mesh.surface_topology_signature();
+    auto [ftup, fid] = mesh.tuple_from_face(std::array<size_t, 3>{{A, B, C}});
+    (void)fid;
+    REQUIRE(ftup.is_valid(mesh));
+    std::vector<TetMesh::Tuple> ret;
+    CHECK_FALSE(mesh.swap_face(ftup, ret)); // surface face: rejected
+    CHECK(is_surface(mesh, A, B, C));
+    CHECK(mesh.surface_topology_signature() == sig_before);
 }

--- a/components/tetwild/wmtk/components/tetwild/tetwild_spec.json
+++ b/components/tetwild/wmtk/components/tetwild/tetwild_spec.json
@@ -183,7 +183,7 @@
     "pointer": "/allow_surface_swap",
     "type": "bool",
     "default": true,
-    "doc": "Allow the 3->2 edge swap to operate on surface edges as a topology-preserving surface diagonal flip."
+    "doc": "Allow the edge swaps (3->2, 4-4, 5-6) to operate on surface edges as a topology-preserving surface diagonal flip."
   },
   {
     "pointer": "/check_surface_topology",

--- a/components/topological_offset/wmtk/components/topological_offset/TopoOffsetTetMesh.h
+++ b/components/topological_offset/wmtk/components/topological_offset/TopoOffsetTetMesh.h
@@ -368,7 +368,14 @@ private: // helpers
                 double len2 = (m_vertex_attribute[e2.vertices()[0]].m_posf -
                                m_vertex_attribute[e2.vertices()[1]].m_posf)
                                   .norm();
-                return len1 > len2;
+                // Symmetric inputs have many edges of exactly equal length. Length alone
+                // leaves those in an implementation-defined order (libc++ vs libstdc++ vs
+                // MSVC), and that order decides which edge marching splits first, so the
+                // offset mesh differs across platforms. simplex::Edge orders totally on
+                // its vertex pair, so use it to break the tie.
+                if (len1 > len2) return true;
+                if (len2 > len1) return false;
+                return e1 < e2;
             });
     }
 

--- a/components/topological_offset/wmtk/components/topological_offset/TopoOffsetTriMesh.h
+++ b/components/topological_offset/wmtk/components/topological_offset/TopoOffsetTriMesh.h
@@ -318,7 +318,14 @@ private: // helpers
                 double len2 = (m_vertex_attribute[e2.vertices()[0]].m_posf -
                                m_vertex_attribute[e2.vertices()[1]].m_posf)
                                   .squaredNorm();
-                return len1 > len2;
+                // Symmetric inputs have many edges of exactly equal length. Length alone
+                // leaves those in an implementation-defined order (libc++ vs libstdc++ vs
+                // MSVC), and that order decides which edge marching splits first, so the
+                // offset mesh differs across platforms. simplex::Edge orders totally on
+                // its vertex pair, so use it to break the tie.
+                if (len1 > len2) return true;
+                if (len2 > len1) return false;
+                return e1 < e2;
             });
     }
 

--- a/src/wmtk/TetMesh.cpp
+++ b/src/wmtk/TetMesh.cpp
@@ -193,8 +193,17 @@ std::vector<TetMesh::Tuple> TetMesh::get_edges() const
             edges.emplace_back(v0, v1, tup);
         }
     }
+    // std::unique below keeps the first tuple of each edge, and every tet incident to an
+    // edge contributes one, so comparing the endpoints alone leaves the survivor -- the tet
+    // the returned tuple lives in -- up to std::sort, which is not stable and orders
+    // equivalent elements differently on libc++, libstdc++ and MSVC. The Tuple tie-break
+    // makes this a total order, so the representative is the same everywhere.
     std::sort(edges.begin(), edges.end(), [](auto& a, auto& b) {
-        return std::tie(std::get<0>(a), std::get<1>(a)) < std::tie(std::get<0>(b), std::get<1>(b));
+        const auto ka = std::tie(std::get<0>(a), std::get<1>(a));
+        const auto kb = std::tie(std::get<0>(b), std::get<1>(b));
+        if (ka < kb) return true;
+        if (kb < ka) return false;
+        return std::get<2>(a) < std::get<2>(b);
     });
     edges.erase(
         std::unique(

--- a/src/wmtk/TetMesh.h
+++ b/src/wmtk/TetMesh.h
@@ -800,6 +800,19 @@ protected:
      */
     virtual bool swap_edge_44_after(const Tuple& t) { return true; }
     /**
+     * @brief Filter which of the 4-4 orientations may be chosen.
+     *
+     * Called for every candidate 4-4 case (identified by its new edge) BEFORE the energy-based
+     * selection; a candidate whose new edge is rejected here is not considered. The default
+     * accepts everything, so interior edges keep the pure min-energy behavior. A derived mesh can
+     * override this to force a specific retetrahedralization (e.g. tetwild forces the case that
+     * realizes a surface diagonal flip).
+     *
+     * @param new_edge The unordered pair of vertices of the candidate's new edge.
+     * @return true if this candidate case is allowed.
+     */
+    virtual bool swap_edge_44_accept_case(const std::array<size_t, 2>& new_edge) { return true; }
+    /**
      * @brief User specified preparations and desideratas for a 5-6 edge swap before changing the
      * connectivity
      *
@@ -830,6 +843,19 @@ protected:
      * @return true if the modification succeed
      */
     virtual bool swap_edge_56_after(const Tuple& t) { return true; }
+    /**
+     * @brief Filter which of the 5-6 orientations may be chosen.
+     *
+     * Called for every candidate 5-6 case (identified by its new fan face) BEFORE the energy-based
+     * selection; a candidate whose new face is rejected here is not considered. The default accepts
+     * everything, so interior edges keep the pure min-energy behavior. `new_face[0]` is the fan
+     * apex. A derived mesh can override this to force a specific retetrahedralization (e.g. tetwild
+     * forces the fan that realizes a surface diagonal flip).
+     *
+     * @param new_face The candidate's new fan face; new_face[0] is the fan apex.
+     * @return true if this candidate case is allowed.
+     */
+    virtual bool swap_edge_56_accept_case(const std::array<size_t, 3>& new_face) { return true; }
     /**
      * @brief User specified preparations and desideratas for an 3-2 edge swap before changing the
      * conenctivity

--- a/src/wmtk/TetMesh.h
+++ b/src/wmtk/TetMesh.h
@@ -808,8 +808,7 @@ protected:
      * override this to force a specific retetrahedralization (e.g. tetwild forces the case that
      * realizes a surface diagonal flip).
      *
-     * @param new_edge The unordered pair of vertices of the candidate's new edge.
-     * @return true if this candidate case is allowed.
+     * @param new_edge The two vertices of the candidate's new edge. The ordering is implementation-defined (currently new_edge[0] is the case-selector vertex).
      */
     virtual bool swap_edge_44_accept_case(const std::array<size_t, 2>& new_edge) { return true; }
     /**

--- a/src/wmtk/TetMesh.h
+++ b/src/wmtk/TetMesh.h
@@ -808,7 +808,8 @@ protected:
      * override this to force a specific retetrahedralization (e.g. tetwild forces the case that
      * realizes a surface diagonal flip).
      *
-     * @param new_edge The two vertices of the candidate's new edge. The ordering is implementation-defined (currently new_edge[0] is the case-selector vertex).
+     * @param new_edge The two vertices of the candidate's new edge. The ordering is
+     * implementation-defined (currently new_edge[0] is the case-selector vertex).
      */
     virtual bool swap_edge_44_accept_case(const std::array<size_t, 2>& new_edge) { return true; }
     /**

--- a/src/wmtk/TetMeshSwapMeshConnectivity.cpp
+++ b/src/wmtk/TetMeshSwapMeshConnectivity.cpp
@@ -540,6 +540,13 @@ bool TetMesh::swap_edge_44(const Tuple& t, std::vector<Tuple>& new_tet_tuples)
         auto tets = swap_4_4(old_tets_conn, v1_id, v2_id, v0, edge_vids);
         assert(v0 == edge_vids[0]);
 
+        // Let the app veto a candidate case (e.g. tetwild forces the diagonal that
+        // realizes a surface flip). Default accepts all, so interior edges are unchanged.
+        if (!swap_edge_44_accept_case(edge_vids)) {
+            ++op_case;
+            continue;
+        }
+
         double energy = swap_edge_44_energy(tets, op_case);
         if (energy < min_energy) {
             min_energy = energy;
@@ -754,6 +761,13 @@ bool TetMesh::swap_edge_56(const Tuple& t, std::vector<Tuple>& new_tet_tuples)
         std::array<size_t, 3> edge_vids;
         auto tets = swap_5_6(old_tets_conn, v1_id, v2_id, v0, edge_vids);
         assert(v0 == edge_vids[0]);
+
+        // Let the app veto a candidate case (e.g. tetwild forces the fan that
+        // realizes a surface flip). Default accepts all, so interior edges are unchanged.
+        if (!swap_edge_56_accept_case(edge_vids)) {
+            ++op_case;
+            continue;
+        }
 
         double energy = swap_edge_56_energy(tets, op_case);
         if (energy < min_energy) {

--- a/src/wmtk/TetMeshTriangleInsertionConn.cpp
+++ b/src/wmtk/TetMeshTriangleInsertionConn.cpp
@@ -86,12 +86,15 @@ void wmtk::TetMesh::triangle_insertion(
         }
     }
     // unique old_face_vids
+    // A face shared by two tets is pushed once per tet, with the same vids but a different
+    // (tid, l_fid), and std::unique below keeps whichever came first. Ordering on the vids
+    // alone leaves that up to std::sort, which is not stable, so the tid that ends up in
+    // old_faces would differ between libc++, libstdc++ and MSVC. Comparing the whole array
+    // keeps the vid grouping and adds (tid, l_fid) as a tie-break, giving a total order.
     std::sort(
         old_face_vids.begin(),
         old_face_vids.end(),
-        [](const std::array<size_t, 5>& v1, const std::array<size_t, 5>& v2) {
-            return std::tie(v1[0], v1[1], v1[2]) < std::tie(v2[0], v2[1], v2[2]);
-        });
+        [](const std::array<size_t, 5>& v1, const std::array<size_t, 5>& v2) { return v1 < v2; });
     auto it = std::unique(
         old_face_vids.begin(),
         old_face_vids.end(),
@@ -396,11 +399,15 @@ void wmtk::TetMesh::subdivide_a_tet(
     }
 
     for (auto& info : new_face_vids) { // erase duplicates <-- must have duplicates
+        // Same as for old_face_vids above: the duplicates being erased carry different
+        // (tid, l_fid), and both the survivor and the order of what is left become the
+        // face tuples handed to triangle_insertion_after. Comparing the whole array adds
+        // (tid, l_fid) as a tie-break so the result does not depend on sort stability.
         std::sort(
             info.second.begin(),
             info.second.end(),
             [](const std::array<size_t, 5>& v1, const std::array<size_t, 5>& v2) {
-                return std::make_tuple(v1[0], v1[1], v1[2]) < std::make_tuple(v2[0], v2[1], v2[2]);
+                return v1 < v2;
             });
         auto it = std::unique(
             info.second.begin(),

--- a/src/wmtk/io/read_triangle_mesh.cpp
+++ b/src/wmtk/io/read_triangle_mesh.cpp
@@ -27,6 +27,15 @@ namespace wmtk::io {
  */
 void clean_triangle_mesh(MatrixXd& V, MatrixXi& F, double tol_rel = -1, double tol_abs = -1)
 {
+    // An empty mesh has no bounding box: V.colwise().minCoeff() below is undefined on a
+    // zero-row matrix and segfaults in a release build, where Eigen's asserts are compiled
+    // out. (igl::read_triangle_mesh returns success for a binary STL that declares zero
+    // triangles, which is how Thingi10K's empty models reach here.) Reject it with a clear
+    // error instead; callers treat a thrown error as a failed run.
+    if (V.rows() == 0 || F.rows() == 0) {
+        log_and_throw_error("Input mesh is empty (V rows: {}, F rows: {}).", V.rows(), F.rows());
+    }
+
     if (tol_abs >= 0 && tol_rel >= 0) {
         log_and_throw_error(
             "Only one of tol_abs and tol_rel can be non-negative. Got abs = {} and rel = {}",


### PR DESCRIPTION
## Give the remaining partial sort comparators a total order

A sweep of every `std::sort` / `std::unique` / priority-queue comparator in `src/wmtk` and the components, looking for the failure this repository keeps hitting.

**The bug class.** `std::sort` is not stable. When a comparator treats two *distinct* elements as equivalent, the order it leaves them in is unspecified — and differs between libc++ (macOS), libstdc++ (Linux) and MSVC. In each case below that order reaches the output, so the same input produces a different mesh depending on the platform. This has already been hit four times before: `TetMesh::get_edges`, `igl::sortrows` in the vertex dedup, `sort_edges_by_length`, and the morton partition sort in #952.

### Six sites

| Site | What the comparator ignored | How the order reaches the output |
|---|---|---|
| `TetMesh::get_edges` | the tet id — every tet incident to an edge contributes an entry, so an edge shared by *k* tets appears *k* times | `std::unique` kept an arbitrary one, so *which tet the returned tuple lives in* was unspecified; `get_edges` feeds the operation queues |
| `TetMeshTriangleInsertionConn` `old_face_vids` | `(tid, l_fid)` of `{v0,v1,v2,tid,l_fid}` | the survivor is consumed as `tuple_from_face(info[3], info[4])` — the discarded fields *are* the output |
| `TetMeshTriangleInsertionConn` `new_face_vids` | same | survivor *and* residual order become the face tuples handed to `triangle_insertion_after` |
| `orig/EdgeSplitter.h` `cmp_es` | `v_ids`, keeping only the edge length | split priority queue: equal-length edges popped in an unspecified order, which is the order they are split in |
| `TopoOffsetTetMesh.h` `sort_edges_by_length` | everything but the length | marching-tets split order → new vertex ids and the frontier list that labels offset tets |
| `TopoOffsetTriMesh.h` `sort_edges_by_length` | same (2D path) | same |

### Two things the sweep surfaced

**Four of the six share one idiom**: sort on a partial key, `std::unique` to collapse duplicates, then read the very fields the comparator ignored. It reads as correct — the grouping works and the deduplication works; only the choice of *which* duplicate survives is left to the standard library. Where the fix widens the sort comparator to the whole array, the `unique` predicate still compares the vids alone, so the grouping it relies on is unchanged and the wider comparison only orders within each group.

**`cmp_es` had two siblings that were already right.** `cmp_ec` (EdgeCollapser.h) and `cmp_er` (EdgeRemover.h) both tie-break on `v_ids`; only the splitter was missed. That is an oversight with a clear fingerprint rather than a deliberate choice.

### Scope
~150 `std::sort` call sites were examined; six were changed. Sorts whose comparator is the default one over a fully ordered type (`size_t`, `std::array<size_t,N>`, `std::pair`) are deliberately left alone: equivalent elements there are *indistinguishable*, so no order over them is observable, and tie-breaking them would be noise. Two further sites were examined and left: `unique_face_tuples` already uses `std::stable_sort` (so its survivor is deterministic without a key), and `unique_directed_edge_tuples` is dead code — both lambdas `throw` on entry.

### A note for whoever merges this with #949
The tie-breaks here are **unconditional**. On `danielepanozzo/integration-test-hashes` (#949), the equivalents for `TetMesh::get_edges` and `sort_edges_by_length` sit behind `#ifdef WMTK_FP_STRICT` — that macro does not exist on this stack at all. Those hunks will conflict textually, and the merge forces a policy decision: is a total-order comparator a *correctness* property (always on) or a *reproducibility* one (strict builds only)? The cost is one integer comparison on a tie; the symptom is a mesh that differs by platform.

### Testing
51/51 unit tests and `Integration_Tests` pass.

Worth being explicit about what that does *not* show: these fixes are reasoned, not measured. The golden-hash tests are what would prove them, and they live on #949 — a different stack — while most of these paths are multithreaded-sensitive anyway. `Integration_Tests` only checks termination, so green means nothing regressed, not that determinism improved.

Stacked on #952.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
