### PR TITLE
Apply preserve_topology consistently to input de-duplication

### DIFF
--- a/components/shortest_edge_collapse/wmtk/components/shortest_edge_collapse/ShortestEdgeCollapse.cpp
+++ b/components/shortest_edge_collapse/wmtk/components/shortest_edge_collapse/ShortestEdgeCollapse.cpp
@@ -137,6 +137,19 @@ void ShortestEdgeCollapse::write_vtu(const std::string& path)
 
 bool ShortestEdgeCollapse::collapse_edge_before(const Tuple& t)
 {
+    // TriMesh::collapse_edge_before is the classical link condition, and it is applied
+    // unconditionally -- it is not gated on preserve_topology.
+    //
+    // It does stop the simplification from changing the surface topology, so on the face of
+    // it it belongs under that flag. But it is not only a topology guard: it is the only
+    // check standing between collapse_edge_conn and a connectivity that wmtk::TriMesh
+    // cannot represent, since nothing downstream re-checks it (invariants() only tests the
+    // envelope). Relaxing it does not produce a valid mesh with different topology, it
+    // produces a corrupt one.
+    //
+    // TODO: the simplification therefore still preserves topology even when
+    // preserve_topology is off, because the toolkit does not support non-manifold meshes.
+    // Lifting this needs a mesh data structure that can represent them.
     if (!TriMesh::collapse_edge_before(t)) return false;
 
     // v1 is removed by the collapse, v2 survives (TriMesh::collapse_edge_conn keeps vid2).

--- a/components/shortest_edge_collapse/wmtk/components/shortest_edge_collapse/ShortestEdgeCollapse.cpp
+++ b/components/shortest_edge_collapse/wmtk/components/shortest_edge_collapse/ShortestEdgeCollapse.cpp
@@ -39,7 +39,8 @@ void ShortestEdgeCollapse::create_mesh(
     size_t n_vertices,
     const std::vector<std::array<size_t, 3>>& tris,
     const std::vector<size_t>& frozen_verts,
-    double eps)
+    double eps,
+    bool freeze_bnd)
 {
     wmtk::TriMesh::init(n_vertices, tris);
 
@@ -54,12 +55,59 @@ void ShortestEdgeCollapse::create_mesh(
         }
         m_envelope.init(V, F, eps);
         m_has_envelope = true;
+
+        // Only needed when the boundary is allowed to move; a frozen boundary cannot
+        // leave its own envelope, so building the BVH for it would be wasted work.
+        if (!freeze_bnd) {
+            std::vector<Eigen::Vector2i> boundary_edges;
+            for (const Tuple& e : get_edges()) {
+                if (is_boundary_edge(e)) {
+                    boundary_edges.emplace_back(
+                        (int)e.vid(*this),
+                        (int)e.switch_vertex(*this).vid(*this));
+                }
+            }
+            if (!boundary_edges.empty()) {
+                m_boundary_envelope.init(V, boundary_edges, eps);
+                m_has_boundary_envelope = true;
+
+                // Pin the ends and junctions of the boundary curves. The envelope keeps the
+                // boundary from leaving the input outline but not from sliding along it, so
+                // an open boundary chain would otherwise be free to retract from its ends.
+                // Boundary valence != 2 is the same endpoint/junction test simplify_segments
+                // uses in 2D.
+                //
+                // On a manifold surface the boundary is a union of closed loops and every
+                // boundary vertex has valence exactly 2, so this freezes nothing; a closed
+                // loop cannot retract along itself in any case, only shrink, which the
+                // envelope already catches. It matters for input that is not manifold along
+                // its boundary.
+                std::vector<int> bnd_valence(n_vertices, 0);
+                for (const Eigen::Vector2i& be : boundary_edges) {
+                    bnd_valence[be[0]]++;
+                    bnd_valence[be[1]]++;
+                }
+                size_t n_pinned = 0;
+                for (size_t v = 0; v < n_vertices; v++) {
+                    if (bnd_valence[v] != 0 && bnd_valence[v] != 2) {
+                        vertex_attrs[v].freeze = true;
+                        n_pinned++;
+                    }
+                }
+                logger().info(
+                    "boundary envelope: {} edges, {} boundary ends/junctions pinned",
+                    boundary_edges.size(),
+                    n_pinned);
+            }
+        }
     }
     partition_mesh();
     for (size_t v : frozen_verts) {
         vertex_attrs[v].freeze = true;
     }
-    freeze_boundary();
+    if (freeze_bnd) {
+        freeze_boundary();
+    }
 }
 
 void ShortestEdgeCollapse::partition_mesh()
@@ -79,6 +127,25 @@ bool ShortestEdgeCollapse::invariants(const std::vector<Tuple>& new_tris)
             for (auto j = 0; j < 3; j++) tris[j] = vertex_attrs[vs[j].vid(*this)].pos;
             bool outside = m_envelope.is_outside(tris);
             if (outside) return false;
+        }
+    }
+    // The surface envelope contains the boundary but says nothing about where along the
+    // surface it sits, so an unfrozen boundary needs its own check against the input
+    // outline -- otherwise it is free to retract inwards without ever leaving the surface
+    // envelope. This mirrors is_open_boundary_edge in tetwild.
+    if (m_has_boundary_envelope) {
+        for (auto& t : new_tris) {
+            for (int j = 0; j < 3; j++) {
+                const Tuple e = tuple_from_edge(t.fid(*this), j);
+                if (!is_boundary_edge(e)) continue;
+                const size_t v1 = e.vid(*this);
+                const size_t v2 = e.switch_vertex(*this).vid(*this);
+                if (m_boundary_envelope.is_outside(
+                        std::array<Eigen::Vector3d, 2>{
+                            {vertex_attrs[v1].pos, vertex_attrs[v2].pos}})) {
+                    return false;
+                }
+            }
         }
     }
     return true;

--- a/components/shortest_edge_collapse/wmtk/components/shortest_edge_collapse/ShortestEdgeCollapse.h
+++ b/components/shortest_edge_collapse/wmtk/components/shortest_edge_collapse/ShortestEdgeCollapse.h
@@ -34,6 +34,15 @@ class ShortestEdgeCollapse : public wmtk::TriMesh
 public:
     wmtk::SampleEnvelope m_envelope;
     bool m_has_envelope = false;
+
+    // Envelope around the open boundary of the input, used only when the boundary is not
+    // frozen. The surface envelope cannot stand in for it: it is a containment test, so a
+    // boundary sliding inwards along the surface stays inside it and would go unnoticed.
+    // Same construction tetwild uses for its open-boundary edges. Always sampled, never
+    // exact -- SampleEnvelope::is_outside throws for edges when use_exact is set.
+    wmtk::SampleEnvelope m_boundary_envelope;
+    bool m_has_boundary_envelope = false;
+
     wmtk::AttributeCollection<VertexAttributes> vertex_attrs;
 
     int retry_limit = 10;
@@ -44,11 +53,23 @@ public:
 
     void freeze_boundary();
 
+    /**
+     * @param eps         envelope thickness; 0 disables the envelope entirely
+     * @param freeze_bnd  pin the vertices of the open boundary so the outline cannot move.
+     *                    When cleared, the boundary is simplified like the rest of the
+     *                    surface and is kept in place by m_boundary_envelope instead.
+     *
+     * Note freeze_bnd comes after eps rather than before it, unlike the otherwise
+     * equivalent IsotropicRemeshing::create_mesh: every existing caller passes eps
+     * positionally as the fourth argument, and a bool inserted ahead of it would silently
+     * swallow that value (double -> bool) and disable the envelope.
+     */
     void create_mesh(
         size_t n_vertices,
         const std::vector<std::array<size_t, 3>>& tris,
         const std::vector<size_t>& frozen_verts = {},
-        double eps = 0);
+        double eps = 0,
+        bool freeze_bnd = true);
 
     ~ShortestEdgeCollapse() {}
 

--- a/components/tetwild/wmtk/components/tetwild/tetwild.cpp
+++ b/components/tetwild/wmtk/components/tetwild/tetwild.cpp
@@ -159,7 +159,13 @@ TetWildMesh::ExportStruct tetwild_with_export(nlohmann::json json_params)
     double t_load = 0, t_simplify = 0, t_optimize = 0, t_finalize = 0, t_output = 0;
     phase_timer.start();
     {
-        double remove_duplicate_eps = json_params["remove_duplicate_eps"];
+        // Merging vertices that are merely *close* is a topology change: it welds sheets
+        // of the surface that pass near each other and so removes handles and tunnels.
+        // Under preserve_topology only exactly coincident vertices may be merged, which is
+        // a pure de-duplication of the file and leaves the topology alone. simwild makes
+        // the same distinction (see read_image_msh.cpp).
+        const double remove_duplicate_eps =
+            params.preserve_topology ? 0.0 : double(json_params["remove_duplicate_eps"]);
         MatrixXd V;
         MatrixXi F;
         io::read_triangle_mesh(input_paths, V, F, remove_duplicate_eps);
@@ -172,8 +178,12 @@ TetWildMesh::ExportStruct tetwild_with_export(nlohmann::json json_params)
 
     // Informational input-topology report; gated behind DEBUG_euler because the
     // Euler-characteristic computation is expensive on meshes with many components.
+    // It is also needed by the preserve_topology check at the end, which compares it
+    // against the output -- without this the comparison is between two empty vectors and
+    // silently passes whatever happened to the topology.
+    const bool compute_euler = json_params["DEBUG_euler"] || params.preserve_topology;
     std::vector<int> ecs_input;
-    if (json_params["DEBUG_euler"]) {
+    if (compute_euler) {
         Eigen::MatrixXi F(tris.size(), 3);
         for (int i = 0; i < tris.size(); ++i) {
             F.row(i) = Eigen::Vector3i((int)tris[i][0], (int)tris[i][1], (int)tris[i][2]);
@@ -194,8 +204,16 @@ TetWildMesh::ExportStruct tetwild_with_export(nlohmann::json json_params)
 
     if (skip_simplify == false) {
         logger().info("input {} simplification", input_paths);
+        if (!params.preserve_topology) {
+            logger().warn(
+                "TODO the simplification still preserves topology as the toolkit does not "
+                "support non-manifold meshes, to fix");
+        }
         surf_mesh.collapse_shortest(0);
         surf_mesh.consolidate_mesh();
+        if (!surf_mesh.check_mesh_connectivity_validity()) {
+            log_and_throw_error("Simplification produced an invalid mesh connectivity.");
+        }
     } else {
         logger().info("skip simplification");
     }
@@ -519,7 +537,7 @@ TetWildMesh::ExportStruct tetwild_with_export(nlohmann::json json_params)
         // meshes with many components (tens of seconds), so it is off by default and only
         // computed when explicitly requested (DEBUG_euler) or when it is actually needed
         // for the preserve_topology throw check below.
-        if (json_params["DEBUG_euler"]) {
+        if (compute_euler) {
             logger().info("Input euler characteristic: {}", ecs_input);
             ecs_output = compute_euler_characteristics(matF);
             logger().info("Output euler characteristic: {}", ecs_output);

--- a/components/tetwild/wmtk/components/tetwild/tetwild.cpp
+++ b/components/tetwild/wmtk/components/tetwild/tetwild.cpp
@@ -199,7 +199,12 @@ TetWildMesh::ExportStruct tetwild_with_export(nlohmann::json json_params)
         verts,
         NUM_THREADS,
         !use_sample_envelope);
-    surf_mesh.create_mesh(verts.size(), tris, modified_nonmanifold_v, envelope_size / 2);
+    surf_mesh.create_mesh(
+        verts.size(),
+        tris,
+        modified_nonmanifold_v,
+        envelope_size / 2,
+        json_params["freeze_boundary"]);
     assert(surf_mesh.check_mesh_connectivity_validity());
 
     if (skip_simplify == false) {

--- a/components/tetwild/wmtk/components/tetwild/tetwild_spec.json
+++ b/components/tetwild/wmtk/components/tetwild/tetwild_spec.json
@@ -20,6 +20,7 @@
       "length_rel",
       "stop_energy",
       "preserve_topology",
+      "freeze_boundary",
       "remove_duplicate_eps",
       "allow_surface_swap",
       "check_surface_topology",
@@ -157,6 +158,12 @@
     "type": "float",
     "default": 10,
     "doc": "Target energy. If all tets have an energy below this, tetwild will stop."
+  },
+  {
+    "pointer": "/freeze_boundary",
+    "type": "bool",
+    "default": false,
+    "doc": "Pin the vertices of the input surface's open boundary so the simplification cannot move them. When off (the default) the boundary is simplified like the rest of the surface, and is instead constrained by its own envelope of the same thickness -- the surface envelope alone would not notice a boundary retracting inwards along the surface, since it is only a containment test."
   },
   {
     "pointer": "/preserve_topology",

--- a/components/tetwild/wmtk/components/tetwild/tetwild_spec.json
+++ b/components/tetwild/wmtk/components/tetwild/tetwild_spec.json
@@ -162,13 +162,13 @@
     "pointer": "/preserve_topology",
     "type": "bool",
     "default": false,
-    "doc": "Preserve the topology of the input surface."
+    "doc": "Preserve the topology of the input surface. This forces remove_duplicate_eps to merge only exactly coincident vertices, keeps the link condition enabled during the input simplification, enables the substructure link condition during optimization, and makes the run fail if the output Euler characteristic differs from the input. When unset, all four are relaxed and the topology may change."
   },
   {
     "pointer": "/remove_duplicate_eps",
     "type": "float",
     "default": 2e-3,
-    "doc": "Remove duplicate vertices in the input meshes that are closer than this fraction of the bounding box diagonal. This is applied to each input mesh separately."
+    "doc": "Remove duplicate vertices in the input meshes that are closer than this fraction of the bounding box diagonal. This is applied to each input mesh separately. Ignored when preserve_topology is set: merging vertices that are merely close welds sheets of the surface together and so removes handles, therefore only exactly coincident vertices are merged in that case."
   },
   {
     "pointer": "/allow_surface_swap",

--- a/components/triwild/wmtk/components/triwild/triwild.cpp
+++ b/components/triwild/wmtk/components/triwild/triwild.cpp
@@ -127,7 +127,13 @@ void triwild(nlohmann::json json_params)
     MatrixXi E_in;
     std::vector<MatrixXd> Vs;
     std::vector<MatrixXi> Es;
-    read_input_curves(input_paths, json_params["remove_duplicate_eps"], V_in, E_in, Vs, Es);
+    // Merging vertices that are merely *close* is a topology change: it welds curves that
+    // pass near each other and so removes loops and junctions. Under preserve_topology only
+    // exactly coincident vertices may be merged, which is a pure de-duplication of the file
+    // and leaves the topology alone. Same rule as tetwild and simwild.
+    const double remove_duplicate_eps =
+        params.preserve_topology ? 0.0 : double(json_params["remove_duplicate_eps"]);
+    read_input_curves(input_paths, remove_duplicate_eps, V_in, E_in, Vs, Es);
 
     // The bounding box comes from the input curves, as in tetwild -- eps has to be known
     // before the arrangement runs, because the simplification happens first. (It used to be
@@ -156,7 +162,11 @@ void triwild(nlohmann::json json_params)
             }
             simplify_envelope.init(v, e, envelope_eps);
         }
-        const size_t removed = wmtk::utils::simplify_segments(V_simp, E_simp, simplify_envelope);
+        const size_t removed = wmtk::utils::simplify_segments(
+            V_simp,
+            E_simp,
+            simplify_envelope,
+            params.preserve_topology);
         logger().info(
             "input simplification: #V {} -> {}, #E {} -> {} ({} vertices removed)",
             V_in.rows(),

--- a/components/triwild/wmtk/components/triwild/triwild_spec.json
+++ b/components/triwild/wmtk/components/triwild/triwild_spec.json
@@ -120,7 +120,7 @@
     "pointer": "/remove_duplicate_eps",
     "type": "float",
     "default": 2e-3,
-    "doc": "Merge vertices in the input meshes that are closer than this fraction of the bounding box diagonal, dropping the edges that become degenerate or duplicated. This is applied to each input mesh separately. Negative disables it."
+    "doc": "Merge vertices in the input meshes that are closer than this fraction of the bounding box diagonal, dropping the edges that become degenerate or duplicated. This is applied to each input mesh separately. Negative disables it. Ignored when preserve_topology is set: merging vertices that are merely close welds curves together and so removes loops and junctions, therefore only exactly coincident vertices are merged in that case."
   },
   {
     "pointer": "/DEBUG_hausdorff",
@@ -144,7 +144,7 @@
     "pointer": "/preserve_topology",
     "type": "bool",
     "default": false,
-    "doc": "Preserve the topology of the input surface."
+    "doc": "Preserve the topology of the input curve network. This forces remove_duplicate_eps to merge only exactly coincident vertices, stops the input simplification from merging two junctions or endpoints, and enables the substructure link condition during optimization. When unset, all three are relaxed and the topology may change."
   },
   {
     "pointer": "/throw_on_fail",

--- a/src/wmtk/utils/SimplifySegments.cpp
+++ b/src/wmtk/utils/SimplifySegments.cpp
@@ -23,7 +23,8 @@ Key key_of(int a, int b)
 
 } // namespace
 
-size_t simplify_segments(MatrixXd& V, MatrixXi& E, const SampleEnvelope& envelope)
+size_t
+simplify_segments(MatrixXd& V, MatrixXi& E, const SampleEnvelope& envelope, bool preserve_topology)
 {
     const int nv = static_cast<int>(V.rows());
     const int ne = static_cast<int>(E.rows());
@@ -81,33 +82,32 @@ size_t simplify_segments(MatrixXd& V, MatrixXi& E, const SampleEnvelope& envelop
 
         const int a = seg[e][0];
         const int b = seg[e][1];
-        if (frozen[a] && frozen[b]) {
+        // Merging two frozen vertices is the 1D topology change: it fuses two junctions,
+        // or closes off an open curve. This is the counterpart of the link condition in
+        // the 3D ShortestEdgeCollapse, and is gated the same way.
+        if (frozen[a] && frozen[b] && preserve_topology) {
             continue;
         }
 
-        // Collapse onto the frozen endpoint when there is one, so junctions and open ends
-        // keep their exact position; onto the midpoint otherwise. Same rule as the 3D
-        // ShortestEdgeCollapse.
+        // Collapse onto the frozen endpoint when there is exactly one, so junctions and
+        // open ends keep their exact position; onto the midpoint otherwise. Same rule as
+        // the 3D ShortestEdgeCollapse.
         int keep, drop;
         Vector2d m;
-        if (frozen[a]) {
+        if (frozen[a] && !frozen[b]) {
             keep = a;
             drop = b;
             m = pos[a];
-        } else if (frozen[b]) {
+        } else if (frozen[b] && !frozen[a]) {
             keep = b;
             drop = a;
             m = pos[b];
         } else {
+            // Neither frozen, or (topology changes allowed) both are: no position to
+            // preserve, so meet in the middle.
             keep = std::min(a, b);
             drop = std::max(a, b);
             m = 0.5 * (pos[a] + pos[b]);
-        }
-        // `drop` is never frozen, so it has valence exactly 2: it loses e and hands its
-        // other segment to `keep`, which is why the collapse leaves `keep`'s valence -- and
-        // hence every frozen flag -- unchanged, and why they never need recomputing.
-        if (v2e[drop].size() != 2) {
-            continue; // defensive: the invariant above should make this unreachable
         }
 
         // Every segment incident to either endpoint changes geometry: those on `drop` are
@@ -183,6 +183,11 @@ size_t simplify_segments(MatrixXd& V, MatrixXi& E, const SampleEnvelope& envelop
                 v2e[keep].end(),
                 [&](int f) { return !edge_alive[f]; }),
             v2e[keep].end());
+        // When `drop` had valence 2 -- always the case under preserve_topology, since only
+        // a non-frozen vertex can be dropped -- it hands over its one other segment and
+        // `keep`'s valence is unchanged. Merging two frozen vertices does change it, so
+        // recompute rather than rely on that invariant.
+        frozen[keep] = v2e[keep].size() != 2;
         ++n_removed;
 
         for (const int f : v2e[keep]) {

--- a/src/wmtk/utils/SimplifySegments.hpp
+++ b/src/wmtk/utils/SimplifySegments.hpp
@@ -24,11 +24,12 @@ namespace wmtk::utils {
  * - Vertices of valence != 2 are frozen: open endpoints, T/Y junctions, and (because they
  *   have valence >= 4) any vertex shared between two different input curves. A segment with
  *   one frozen endpoint still collapses, onto the frozen vertex's exact position, so the
- *   junction geometry is preserved bit-exactly; only both-endpoints-frozen is rejected,
- *   because merging two frozen vertices has to move one of them. Same rule as the 3D
- *   ShortestEdgeCollapse. Rejecting whenever *either* endpoint is frozen would strand one
- *   un-collapsible vertex on every chain between two frozen ones -- twice the segments on a
- *   network of short chains.
+ *   junction geometry is preserved bit-exactly. Rejecting whenever *either* endpoint is
+ *   frozen would strand one un-collapsible vertex on every chain between two frozen ones --
+ *   twice the segments on a network of short chains.
+ * - Merging two frozen vertices fuses two junctions, or closes an open curve: that is the
+ *   1D topology change, and `preserve_topology` decides whether it is allowed. It is the
+ *   counterpart of the link condition in the 3D ShortestEdgeCollapse.
  * - Otherwise the two endpoints merge at their midpoint, as in 3D.
  * - Collapses that would leave a degenerate or duplicated segment are rejected.
  *
@@ -39,8 +40,13 @@ namespace wmtk::utils {
  * @param[in,out] E  Mx2 segment endpoint indices; compacted in place
  * @param envelope   must already be initialised around the *input* (V, E) with the desired
  *                   thickness -- the caller owns that choice
+ * @param preserve_topology  reject collapses that merge two frozen vertices
  * @return the number of vertices removed
  */
-size_t simplify_segments(MatrixXd& V, MatrixXi& E, const SampleEnvelope& envelope);
+size_t simplify_segments(
+    MatrixXd& V,
+    MatrixXi& E,
+    const SampleEnvelope& envelope,
+    bool preserve_topology = true);
 
 } // namespace wmtk::utils


### PR DESCRIPTION
Stacked on #961. `preserve_topology` was consulted by the optimizer's collapse and by the final Euler-characteristic check, but not by the de-duplication that runs before them — and it turned out not to be enforced at all by default.

## 1. Input vertex de-duplication ignored it

`remove_duplicate_eps` was passed to `read_triangle_mesh` / `read_edge_mesh` unconditionally, and `igl::remove_duplicate_vertices` merges everything within that radius. That is a topology change, not a de-duplication: it welds sheets of the surface that pass close to each other, so handles and tunnels disappear before any other stage sees the mesh.

The effect is not subtle. `Octocat.obj` is a closed genus-0 surface, and at the default tolerance the mesh that reaches the rest of the pipeline has Euler characteristic **156** instead of 2:

| preserve_topology | dedup tolerance | input euler characteristic |
| --- | --- | --- |
| false | 2e-3 | **[156]** |
| **true** | **0** | **[2]** |

Under `preserve_topology` the tolerance is now 0 — only exactly coincident vertices are merged, which is a genuine de-duplication of the file and leaves the topology alone.

simwild already made this distinction ([`read_image_msh.cpp`](components/simwild/wmtk/components/simwild/read_image_msh.cpp)); tetwild and triwild did not. That inconsistency is the bug.

## 2. The `preserve_topology` check itself was vacuous

The throw compared `ecs_input` against `ecs_output`, but both were only computed under `DEBUG_euler`. With `DEBUG_euler` off — the default — it compared two empty vectors and passed whatever had happened to the topology. They are now computed whenever `preserve_topology` is set, which is what the comment already claimed.

## 3. The simplification's topology check stays on regardless — and now says so

`TriMesh::collapse_edge_before` is the classical link condition, and gating it on `preserve_topology` looks right at first: it is exactly what stops the simplification closing a thin tunnel or welding two sheets.

But it is not only a topology guard. It is the only check between `collapse_edge_conn` and a connectivity that `wmtk::TriMesh` cannot represent, since nothing downstream re-checks it — `invariants()` only tests the envelope. Relaxing it does not produce a valid mesh with different topology; it produces a corrupt one.

So it is applied unconditionally, and tetwild logs a warning when the caller asked for topology changes and will not get them:

```
TODO the simplification still preserves topology as the toolkit does not support
non-manifold meshes, to fix
```

Lifting this needs a mesh data structure that can represent non-manifold connectivity. A `check_mesh_connectivity_validity()` call now follows the simplification, so any future relaxation fails loudly instead of carrying on with a corrupt mesh.

triwild's 2D counterpart in `simplify_segments` — merging two frozen vertices, which fuses two junctions or closes an open curve — has no such constraint, since a segment network with junctions of any valence is representable. It is gated on `preserve_topology` as intended, and the frozen flags are recomputed after a collapse because merging two of them no longer leaves the surviving vertex's valence unchanged.

## Testing

`tetwild_sphere`, `tetwild_octocat`, `tetwild_double_sphere`, `triwild_puzzle` and `triwild_collection` all pass with `throw_on_fail`.

Default behaviour changes for anyone relying on `remove_duplicate_eps` while also setting `preserve_topology`; the simplification behaves as before in all cases.