### PR TITLE
sec: let the simplification move the boundary, bounded by its own envelope

### DIFF
--- a/components/shortest_edge_collapse/wmtk/components/shortest_edge_collapse/ShortestEdgeCollapse.cpp
+++ b/components/shortest_edge_collapse/wmtk/components/shortest_edge_collapse/ShortestEdgeCollapse.cpp
@@ -39,7 +39,8 @@ void ShortestEdgeCollapse::create_mesh(
     size_t n_vertices,
     const std::vector<std::array<size_t, 3>>& tris,
     const std::vector<size_t>& frozen_verts,
-    double eps)
+    double eps,
+    bool freeze_bnd)
 {
     wmtk::TriMesh::init(n_vertices, tris);
 
@@ -54,12 +55,59 @@ void ShortestEdgeCollapse::create_mesh(
         }
         m_envelope.init(V, F, eps);
         m_has_envelope = true;
+
+        // Only needed when the boundary is allowed to move; a frozen boundary cannot
+        // leave its own envelope, so building the BVH for it would be wasted work.
+        if (!freeze_bnd) {
+            std::vector<Eigen::Vector2i> boundary_edges;
+            for (const Tuple& e : get_edges()) {
+                if (is_boundary_edge(e)) {
+                    boundary_edges.emplace_back(
+                        (int)e.vid(*this),
+                        (int)e.switch_vertex(*this).vid(*this));
+                }
+            }
+            if (!boundary_edges.empty()) {
+                m_boundary_envelope.init(V, boundary_edges, eps);
+                m_has_boundary_envelope = true;
+
+                // Pin the ends and junctions of the boundary curves. The envelope keeps the
+                // boundary from leaving the input outline but not from sliding along it, so
+                // an open boundary chain would otherwise be free to retract from its ends.
+                // Boundary valence != 2 is the same endpoint/junction test simplify_segments
+                // uses in 2D.
+                //
+                // On a manifold surface the boundary is a union of closed loops and every
+                // boundary vertex has valence exactly 2, so this freezes nothing; a closed
+                // loop cannot retract along itself in any case, only shrink, which the
+                // envelope already catches. It matters for input that is not manifold along
+                // its boundary.
+                std::vector<int> bnd_valence(n_vertices, 0);
+                for (const Eigen::Vector2i& be : boundary_edges) {
+                    bnd_valence[be[0]]++;
+                    bnd_valence[be[1]]++;
+                }
+                size_t n_pinned = 0;
+                for (size_t v = 0; v < n_vertices; v++) {
+                    if (bnd_valence[v] != 0 && bnd_valence[v] != 2) {
+                        vertex_attrs[v].freeze = true;
+                        n_pinned++;
+                    }
+                }
+                logger().info(
+                    "boundary envelope: {} edges, {} boundary ends/junctions pinned",
+                    boundary_edges.size(),
+                    n_pinned);
+            }
+        }
     }
     partition_mesh();
     for (size_t v : frozen_verts) {
         vertex_attrs[v].freeze = true;
     }
-    freeze_boundary();
+    if (freeze_bnd) {
+        freeze_boundary();
+    }
 }
 
 void ShortestEdgeCollapse::partition_mesh()
@@ -79,6 +127,25 @@ bool ShortestEdgeCollapse::invariants(const std::vector<Tuple>& new_tris)
             for (auto j = 0; j < 3; j++) tris[j] = vertex_attrs[vs[j].vid(*this)].pos;
             bool outside = m_envelope.is_outside(tris);
             if (outside) return false;
+        }
+    }
+    // The surface envelope contains the boundary but says nothing about where along the
+    // surface it sits, so an unfrozen boundary needs its own check against the input
+    // outline -- otherwise it is free to retract inwards without ever leaving the surface
+    // envelope. This mirrors is_open_boundary_edge in tetwild.
+    if (m_has_boundary_envelope) {
+        for (auto& t : new_tris) {
+            for (int j = 0; j < 3; j++) {
+                const Tuple e = tuple_from_edge(t.fid(*this), j);
+                if (!is_boundary_edge(e)) continue;
+                const size_t v1 = e.vid(*this);
+                const size_t v2 = e.switch_vertex(*this).vid(*this);
+                if (m_boundary_envelope.is_outside(
+                        std::array<Eigen::Vector3d, 2>{
+                            {vertex_attrs[v1].pos, vertex_attrs[v2].pos}})) {
+                    return false;
+                }
+            }
         }
     }
     return true;

--- a/components/shortest_edge_collapse/wmtk/components/shortest_edge_collapse/ShortestEdgeCollapse.h
+++ b/components/shortest_edge_collapse/wmtk/components/shortest_edge_collapse/ShortestEdgeCollapse.h
@@ -34,6 +34,15 @@ class ShortestEdgeCollapse : public wmtk::TriMesh
 public:
     wmtk::SampleEnvelope m_envelope;
     bool m_has_envelope = false;
+
+    // Envelope around the open boundary of the input, used only when the boundary is not
+    // frozen. The surface envelope cannot stand in for it: it is a containment test, so a
+    // boundary sliding inwards along the surface stays inside it and would go unnoticed.
+    // Same construction tetwild uses for its open-boundary edges. Always sampled, never
+    // exact -- SampleEnvelope::is_outside throws for edges when use_exact is set.
+    wmtk::SampleEnvelope m_boundary_envelope;
+    bool m_has_boundary_envelope = false;
+
     wmtk::AttributeCollection<VertexAttributes> vertex_attrs;
 
     int retry_limit = 10;
@@ -44,11 +53,23 @@ public:
 
     void freeze_boundary();
 
+    /**
+     * @param eps         envelope thickness; 0 disables the envelope entirely
+     * @param freeze_bnd  pin the vertices of the open boundary so the outline cannot move.
+     *                    When cleared, the boundary is simplified like the rest of the
+     *                    surface and is kept in place by m_boundary_envelope instead.
+     *
+     * Note freeze_bnd comes after eps rather than before it, unlike the otherwise
+     * equivalent IsotropicRemeshing::create_mesh: every existing caller passes eps
+     * positionally as the fourth argument, and a bool inserted ahead of it would silently
+     * swallow that value (double -> bool) and disable the envelope.
+     */
     void create_mesh(
         size_t n_vertices,
         const std::vector<std::array<size_t, 3>>& tris,
         const std::vector<size_t>& frozen_verts = {},
-        double eps = 0);
+        double eps = 0,
+        bool freeze_bnd = true);
 
     ~ShortestEdgeCollapse() {}
 

--- a/components/tetwild/wmtk/components/tetwild/tetwild.cpp
+++ b/components/tetwild/wmtk/components/tetwild/tetwild.cpp
@@ -199,7 +199,12 @@ TetWildMesh::ExportStruct tetwild_with_export(nlohmann::json json_params)
         verts,
         NUM_THREADS,
         !use_sample_envelope);
-    surf_mesh.create_mesh(verts.size(), tris, modified_nonmanifold_v, envelope_size / 2);
+    surf_mesh.create_mesh(
+        verts.size(),
+        tris,
+        modified_nonmanifold_v,
+        envelope_size / 2,
+        json_params["freeze_boundary"]);
     assert(surf_mesh.check_mesh_connectivity_validity());
 
     if (skip_simplify == false) {

--- a/components/tetwild/wmtk/components/tetwild/tetwild_spec.json
+++ b/components/tetwild/wmtk/components/tetwild/tetwild_spec.json
@@ -20,6 +20,7 @@
       "length_rel",
       "stop_energy",
       "preserve_topology",
+      "freeze_boundary",
       "remove_duplicate_eps",
       "allow_surface_swap",
       "check_surface_topology",
@@ -157,6 +158,12 @@
     "type": "float",
     "default": 10,
     "doc": "Target energy. If all tets have an energy below this, tetwild will stop."
+  },
+  {
+    "pointer": "/freeze_boundary",
+    "type": "bool",
+    "default": false,
+    "doc": "Pin the vertices of the input surface's open boundary so the simplification cannot move them. When off (the default) the boundary is simplified like the rest of the surface, and is instead constrained by its own envelope of the same thickness -- the surface envelope alone would not notice a boundary retracting inwards along the surface, since it is only a containment test."
   },
   {
     "pointer": "/preserve_topology",


### PR DESCRIPTION
Stacked on #962.

`ShortestEdgeCollapse` froze every boundary vertex unconditionally, so the outline of an open surface came through simplification exactly as it went in. That was a sensible default only because the surface envelope cannot police the boundary: it is a *containment* test, so a boundary sliding inwards along the surface never leaves it and goes unnoticed.

## What this does

Gives the boundary its own envelope, built the way tetwild builds `m_open_boundary_envelope`: collect the open-boundary edges of the input, `SampleEnvelope::init` on them at the same thickness as the surface envelope, and reject any collapse that takes a boundary edge out of it. The check mirrors `is_open_boundary_edge`.

A new **`freeze_boundary` flag, default `false`**, selects between the two behaviours. The envelope and its BVH are only built when the boundary is actually free to move.

It is always a *sampled* envelope regardless of `use_sample_envelope`, because `SampleEnvelope::is_outside` for edges calls `log_and_throw_error("Cannot use an exact envelope for edges")` — again as in tetwild.

## Measurements — circle.obj, 160 boundary edges

| freeze_boundary | simplified #v | boundary segs | max deviation from input outline |
| --- | ---: | ---: | ---: |
| true | 160 | 160 | 0 |
| **false** | **111** | **110** | **3.1e-4** (envelope 8.0e-4) |

Raising `eps_rel` from 1e-3 to 1e-2 takes it to 41 vertices, so the envelope is what binds rather than the check never firing.

Closed surfaces have no boundary edges, so no envelope is built and nothing changes — `tetwild_sphere`, `tetwild_octocat`, `tetwild_double_sphere` and `triwild_puzzle` all pass unchanged.

## Two review notes

**Boundary ends and junctions are pinned even when the boundary is free.** The envelope stops the boundary leaving the input outline but not sliding *along* it, so an open chain could otherwise retract from its ends. The rule is boundary valence != 2 — the same endpoint/junction test `simplify_segments` uses in 2D.

Being straight about its reach: this pins **nothing on manifold input**, where the boundary is a union of closed loops and every boundary vertex has valence exactly 2 (verified on `circle`, `bunny`, `fan`, `crown` — all `{2: n}`). And a closed loop cannot retract along itself; it can only shrink, which the envelope already catches. It is there for input that is not manifold along its boundary, tested on a synthetic two-strips-sharing-a-vertex case (boundary valence 4) where it pins the junction.

**`freeze_bnd` is the last parameter of `create_mesh`**, rather than sitting before `eps` as in the otherwise equivalent `IsotropicRemeshing::create_mesh`. Every existing caller passes `eps` positionally as the fourth argument, and a `bool` inserted ahead of it would silently swallow that value (`double` -> `bool`) and disable the envelope. The inconsistency with the sibling class is deliberate and commented.