### PR TITLE
Share simwild's vertex smoothing with tetwild and triwild

### DIFF
--- a/components/simwild/wmtk/components/simwild/SimWildMesh.h
+++ b/components/simwild/wmtk/components/simwild/SimWildMesh.h
@@ -5,6 +5,7 @@
 #include <wmtk/utils/PartitionMesh.h>
 #include <polysolve/nonlinear/Problem.hpp>
 #include <wmtk/envelope/Envelope.hpp>
+#include <wmtk/optimization/SmoothVertex.hpp>
 #include <wmtk/optimization/solver.hpp>
 #include <wmtk/simplex/Simplex.hpp>
 #include <wmtk/threading/enumerable_thread_specific.hpp>
@@ -149,6 +150,14 @@ public:
     // scaling factors
     double m_s_amips = -1;
     double m_s_envelope = -1;
+
+    /// Why smoothing attempts were refused, reported once per pass.
+    optimization::SmoothRejectCounters m_smooth_rejects;
+
+    /// Envelope a vertex is pulled toward while smoothing.
+    std::shared_ptr<SampleEnvelope> smoothing_energy_envelope(const size_t vid) const;
+    /// Envelope the resulting surface triangles are checked against.
+    std::shared_ptr<SampleEnvelope> smoothing_containment_envelope(const size_t vid) const;
 
     // When set, split_edge_after binary-searches vmid onto the zero-crossing of this function.
     // Negative = stays on v1 side, positive = stays on v2 side.
@@ -358,11 +367,6 @@ public:
     bool is_inverted(const Tuple& loc) const;
     double get_quality(const std::array<size_t, 4>& vs) const;
     double get_quality(const Tuple& loc) const;
-
-    std::vector<std::array<double, 12>> get_amips_assembles(const Tuple& t) const;
-
-    std::shared_ptr<polysolve::nonlinear::Problem> get_amips_energy(const Tuple& t) const;
-    std::shared_ptr<polysolve::nonlinear::Problem> get_envelope_energy(const Tuple& t) const;
 
     /**
      * @brief Round a vertex position to floating point.

--- a/components/simwild/wmtk/components/simwild/SimWildMeshTri.cpp
+++ b/components/simwild/wmtk/components/simwild/SimWildMeshTri.cpp
@@ -1,4 +1,6 @@
 #include "SimWildMeshTri.hpp"
+
+#include <wmtk/optimization/SmoothVertex.hpp>
 #include <wmtk/threading/enumerable_thread_specific.hpp>
 #include <wmtk/threading/parallel_for.hpp>
 
@@ -1479,123 +1481,46 @@ bool SimWildMeshTri::smooth_before(const Tuple& t)
 
 bool SimWildMeshTri::smooth_after(const Tuple& t)
 {
-    // Newton iterations are encapsulated here.
-    logger().trace("Newton iteration for vertex smoothing.");
-    const size_t vid = t.vid(*this);
+    // The body lives in wmtk::optimization::smooth_vertex_2d, shared with triwild.
+    optimization::SmoothVertexOptions opts;
+    opts.w_amips = m_params.w_amips;
+    opts.w_envelope = m_params.w_envelope;
+    opts.s_amips = m_s_amips;
+    opts.s_envelope = m_s_envelope;
+    opts.two_stage = true;
+    opts.quality_veto_on_surface = false;
 
-    const auto& VA = m_vertex_attribute;
-
-    const auto& locs = get_one_ring_fids_for_vertex(t);
-    assert(locs.size() > 0);
-
-    double max_quality = 0.;
-    for (const size_t fid : locs) {
-        max_quality = std::max(max_quality, m_face_attribute[fid].m_quality);
-    }
-
-    auto& solver = m_solver.local();
-    if (!solver) {
-        solver = optimization::create_basic_solver();
-    }
-
-    std::vector<std::array<double, 6>> assembles = get_amips_assembles(t);
-
-    const Vector2d old_pos = VA[vid].m_pos;
-
-    // call to polysolve
-    std::shared_ptr<polysolve::nonlinear::Problem> total_energy;
-
-    auto amips_energy = get_amips_energy(t);
-
-    const auto surf_assembles = get_surface_assembles(t);
-    if (VA[vid].m_is_on_surface) {
-        assert(!surf_assembles.empty());
-
-        auto energy_sum = std::make_shared<optimization::EnergySum>();
-
-        if (m_params.w_amips > 0) {
-            energy_sum->add_energy(amips_energy);
-        }
-        if (m_params.w_envelope > 0) {
-            energy_sum->add_energy(get_envelope_energy(t));
-        }
-
-        total_energy = energy_sum;
-    } else {
-        total_energy = amips_energy;
-    }
-
-    // solve
-    {
-        VectorXd x = old_pos;
-        try {
-            solver->minimize(*total_energy, x);
-        } catch (const std::exception&) {
-            // polysolve might throw errors that we want to ignore (e.g., line search failed)
-        }
-        m_vertex_attribute[vid].m_pos = x;
-    }
-
-    logger().trace("old pos {} -> new pos {}", old_pos.transpose(), VA[vid].m_pos.transpose());
-
-    // check surface containment
-    if (VA[vid].m_is_on_surface) {
-        // write_vtu_with_energies(fmt::format("debug_smooth_{}", m_debug_print_counter++));
-
-        for (size_t i = 1; i < surf_assembles.size(); ++i) {
-            std::array<Eigen::Vector2d, 2> edge;
-            edge[0] = VA[vid].m_pos;
-            edge[1] = surf_assembles[i];
-            if (m_envelope->is_outside(edge)) {
-                return false;
-            }
-        }
-    }
-
-    // quality (only check if not on surface)
-    auto max_after_quality = 0.;
-    for (const size_t fid : locs) {
-        if (is_inverted(fid)) {
-            return false;
-        }
-        const double q = get_quality(fid);
-        m_face_attribute[fid].m_quality = q;
-        max_after_quality = std::max(max_after_quality, q);
-    }
-    if (!VA[vid].m_is_on_surface) {
-        if (max_after_quality > max_quality) {
-            return false;
-        }
-    }
-
-    return true;
+    return optimization::smooth_vertex_2d(*this, t, opts, m_solver.local(), &m_smooth_rejects);
 }
 
-std::vector<Vector2d> SimWildMeshTri::get_surface_assembles(const Tuple& t) const
+Vector2d SimWildMeshTri::smoothing_position(const size_t vid) const
 {
-    const auto& VA = m_vertex_attribute;
-    const size_t vid = t.vid(*this);
-
-    std::vector<Vector2d> surface_pts;
-
-    if (!VA[vid].m_is_on_surface) {
-        return surface_pts;
-    }
-
-    const auto es = get_surface_edges_for_vertex(vid);
-
-    surface_pts.resize(es.size() + 1);
-    surface_pts[0] = VA[vid].m_pos;
-
-    for (size_t i = 0; i < es.edges().size(); ++i) {
-        const auto& vs = es.edges()[i].vertices();
-        size_t neighbor_id = vs[0] != vid ? vs[0] : vs[1];
-        surface_pts[i + 1] = VA[neighbor_id].m_pos;
-    }
-
-    return surface_pts;
+    return m_vertex_attribute[vid].m_pos;
 }
 
+void SimWildMeshTri::set_smoothing_position(const size_t vid, const Vector2d& p)
+{
+    // No exact position to keep in step here: this mesh stores only the double one.
+    m_vertex_attribute[vid].m_pos = p;
+}
+
+bool SimWildMeshTri::is_inverted_f(const size_t fid) const
+{
+    // Positions are doubles throughout, so the exact and floating predicates coincide.
+    return is_inverted(fid);
+}
+
+std::shared_ptr<SampleEnvelope> SimWildMeshTri::smoothing_energy_envelope(const size_t) const
+{
+    return m_envelope_orig;
+}
+
+std::shared_ptr<SampleEnvelope> SimWildMeshTri::smoothing_containment_envelope(const size_t) const
+{
+    // Not m_envelope_orig: the pull target and the containment test are different objects,
+    // the same split the 3D mesh has.
+    return m_envelope;
+}
 
 std::shared_ptr<polysolve::nonlinear::Problem> SimWildMeshTri::get_envelope_energy(
     const Tuple& t) const
@@ -1657,6 +1582,7 @@ std::shared_ptr<polysolve::nonlinear::Problem> SimWildMeshTri::get_amips_energy(
     assert(amips_energy->initial_position() == m_vertex_attribute.at(t.vid(*this)).m_pos);
     return amips_energy;
 }
+
 
 void SimWildMeshTri::log_total_surface_energy()
 {

--- a/components/simwild/wmtk/components/simwild/SimWildMeshTri.hpp
+++ b/components/simwild/wmtk/components/simwild/SimWildMeshTri.hpp
@@ -9,6 +9,7 @@
 #include <wmtk/AttributeCollection.hpp>
 #include <wmtk/Types.hpp>
 #include <wmtk/envelope/Envelope.hpp>
+#include <wmtk/optimization/SmoothVertex.hpp>
 #include <wmtk/optimization/solver.hpp>
 
 // clang-format off
@@ -115,6 +116,17 @@ public:
 
     wmtk::threading::enumerable_thread_specific<std::unique_ptr<polysolve::nonlinear::Solver>>
         m_solver;
+
+    /// Why smoothing attempts were refused, reported once per pass.
+    optimization::SmoothRejectCounters m_smooth_rejects;
+
+    /// Hooks for the shared 2D smoothing driver. This mesh stores only a double position,
+    /// so is_inverted_f coincides with is_inverted.
+    Vector2d smoothing_position(const size_t vid) const;
+    void set_smoothing_position(const size_t vid, const Vector2d& p);
+    bool is_inverted_f(const size_t fid) const;
+    std::shared_ptr<SampleEnvelope> smoothing_energy_envelope(const size_t vid) const;
+    std::shared_ptr<SampleEnvelope> smoothing_containment_envelope(const size_t vid) const;
 
     // scaling factors
     double m_s_amips = -1;

--- a/components/simwild/wmtk/components/simwild/Smooth.cpp
+++ b/components/simwild/wmtk/components/simwild/Smooth.cpp
@@ -1,5 +1,7 @@
 
 #include "SimWildMesh.h"
+
+#include <wmtk/optimization/SmoothVertex.hpp>
 #include "wmtk/ExecutionScheduler.hpp"
 
 #include <Eigen/src/Core/util/Constants.h>
@@ -37,117 +39,37 @@ bool SimWildMesh::smooth_before(const Tuple& t)
 
 bool SimWildMesh::smooth_after(const Tuple& t)
 {
-    // Newton iterations are encapsulated here.
-    logger().trace("Newton iteration for vertex smoothing.");
-    auto vid = t.vid(*this);
+    // The body lives in wmtk::optimization::smooth_vertex_3d, shared with tetwild.
+    optimization::SmoothVertexOptions opts;
+    opts.w_amips = m_params.w_amips;
+    opts.w_envelope = m_params.w_envelope;
+    opts.s_amips = m_s_amips;
+    opts.s_envelope = m_s_envelope;
+    opts.two_stage = true;
+    opts.quality_veto_on_surface = false;
 
-    const auto& VA = m_vertex_attribute;
-    const auto& TA = m_tet_attribute;
+    return optimization::smooth_vertex_3d(*this, t, opts, m_solver.local(), &m_smooth_rejects);
+}
 
-    const auto locs = get_one_ring_tets_for_vertex(t);
-    assert(!locs.empty());
-    double max_quality = 0.;
-    for (auto& tet : locs) {
-        max_quality = std::max(max_quality, TA[tet.tid(*this)].m_quality);
-        if (is_inverted_f(tet)) {
-            // Neighbors that are not rounded could cause a tet to be inverted in floats
-            // std::cout << "Inverted tet " << m_vertex_attribute[vid].m_posf.transpose() <<
-            // std::endl;
-            return false;
-        }
+std::shared_ptr<SampleEnvelope> SimWildMesh::smoothing_energy_envelope(const size_t vid) const
+{
+    // Order 2 means the vertex sits on a surface boundary or a non-manifold edge, so it is
+    // pulled toward the feature-edge envelope rather than the original surface.
+    const std::shared_ptr<SampleEnvelope> env =
+        m_vertex_attribute[vid].m_order == 2 ? m_order_2_edge_envelope : m_envelope_orig;
+    if (!env) {
+        log_and_throw_error(
+            "Envelope was not initialized. Vertex was of order {}",
+            m_vertex_attribute[vid].m_order);
     }
+    return env;
+}
 
-    auto& solver = m_solver.local();
-    if (!solver) {
-        solver = optimization::create_basic_solver();
-    }
-
-    const Vector3d old_pos = VA[vid].m_posf;
-
-    auto amips_energy = get_amips_energy(t);
-
-    std::shared_ptr<polysolve::nonlinear::Problem> total_energy = amips_energy;
-
-    auto solve = [&]() {
-        VectorXd x = VA[vid].m_posf;
-        try {
-            solver->minimize(*total_energy, x);
-        } catch (const std::exception&) {
-            // polysolve might throw errors that we want to ignore (e.g., line search failed)
-        }
-        m_vertex_attribute[vid].m_posf = x;
-    };
-
-    if (VA[vid].m_is_on_surface) {
-        auto energy_sum = std::make_shared<optimization::EnergySum>();
-
-        auto envelope_energy = get_envelope_energy(t);
-        // do one solve without weights for amips and envelope
-        if (m_params.w_amips > 0) {
-            energy_sum->add_energy(amips_energy, 1. / m_params.w_amips);
-        }
-        if (m_params.w_envelope > 0) {
-            energy_sum->add_energy(envelope_energy, 1. / m_params.w_envelope);
-        }
-        total_energy = energy_sum;
-        solve();
-
-        // second solve (with proper weights)
-        energy_sum = std::make_shared<optimization::EnergySum>();
-
-        if (m_params.w_amips > 0) {
-            energy_sum->add_energy(amips_energy);
-        }
-        if (m_params.w_envelope > 0) {
-            energy_sum->add_energy(envelope_energy);
-        }
-        total_energy = energy_sum;
-        solve();
-    } else {
-        // not on the surface
-        solve();
-    }
-
-    logger().trace("old pos {} -> new pos {}", old_pos, VA[vid].m_posf);
-
-    // check surface containment
-    if (VA[vid].m_is_on_surface) {
-        // write_vtu_with_energies(fmt::format("debug_smooth_{}", debug_print_counter++));
-        const simplex::SimplexCollection surf_assembles = get_surface_faces_for_vertex(vid);
-        for (size_t i = 0; i < surf_assembles.faces().size(); ++i) {
-            const simplex::Face& f = surf_assembles.faces()[i];
-
-            std::array<Eigen::Vector3d, 3> face;
-            face[0] = VA[f.vertices()[0]].m_posf;
-            face[1] = VA[f.vertices()[1]].m_posf;
-            face[2] = VA[f.vertices()[2]].m_posf;
-
-            if (m_envelope->is_outside(face)) {
-                return false;
-            }
-        }
-    }
-
-    // rational position must be updated before the inversion check!
-    m_vertex_attribute[vid].m_pos = to_rational(VA[vid].m_posf);
-
-    // quality
-    auto max_after_quality = 0.;
-    for (const Tuple& loc : locs) {
-        if (is_inverted(loc)) {
-            return false;
-        }
-        auto t_id = loc.tid(*this);
-        m_tet_attribute[t_id].m_quality = get_quality(loc);
-        max_after_quality = std::max(max_after_quality, TA[t_id].m_quality);
-    }
-    if (!VA[vid].m_is_on_surface) {
-        if (max_after_quality > max_quality) {
-            return false;
-        }
-    }
-
-    return true;
+std::shared_ptr<SampleEnvelope> SimWildMesh::smoothing_containment_envelope(const size_t) const
+{
+    // The working envelope, which is not m_envelope_orig: the pull target and the
+    // containment test are deliberately different objects here.
+    return m_envelope;
 }
 
 void SimWildMesh::smooth_all_vertices(const size_t n_iters = 1)
@@ -156,6 +78,7 @@ void SimWildMesh::smooth_all_vertices(const size_t n_iters = 1)
         igl::Timer timer;
         double time;
         timer.start();
+        m_smooth_rejects.reset();
         auto collect_all_ops = std::vector<std::pair<std::string, Tuple>>();
         if (m_params.skip_good_regions) {
             // Only smooth vertices incident to an "active" (non-good) tet -- smoothing
@@ -190,68 +113,12 @@ void SimWildMesh::smooth_all_vertices(const size_t n_iters = 1)
             time = timer.getElapsedTime();
             wmtk::logger().info("vertex smoothing operation time serial: {:.4}s", time);
         }
+        logger().info("\tsmooth: {}", m_smooth_rejects.to_string());
         if (m_params.debug_output) {
             write_vtu(fmt::format("debug_{}", m_debug_print_counter++));
         }
     }
 }
 
-std::vector<std::array<double, 12>> SimWildMesh::get_amips_assembles(const Tuple& t) const
-{
-    const size_t vid = t.vid(*this);
-    const auto locs = get_one_ring_tets_for_vertex(t);
-
-    std::vector<std::array<double, 12>> assembles(locs.size());
-    int loc_id = 0;
-
-    for (const Tuple& loc : locs) {
-        auto& T = assembles[loc_id];
-        auto t_id = loc.tid(*this);
-        assert(!is_inverted_f(loc));
-
-        std::array<size_t, 4> local_verts = oriented_tet_vids(t_id);
-        local_verts = wmtk::orient_preserve_tet_reorder(local_verts, vid);
-
-        for (int i = 0; i < 4; i++) {
-            for (int j = 0; j < 3; j++) {
-                T[i * 3 + j] = m_vertex_attribute[local_verts[i]].m_posf[j];
-            }
-        }
-        loc_id++;
-    }
-
-    return assembles;
-}
-
-std::shared_ptr<polysolve::nonlinear::Problem> SimWildMesh::get_amips_energy(const Tuple& t) const
-{
-    const double w = m_params.w_amips > 0 ? m_s_amips * m_params.w_amips : 1;
-
-    const auto assembles = get_amips_assembles(t);
-    auto amips_energy = std::make_shared<optimization::AMIPSEnergy3D>(assembles, w);
-    assert(amips_energy->initial_position() == m_vertex_attribute.at(t.vid(*this)).m_posf);
-    return amips_energy;
-}
-
-std::shared_ptr<polysolve::nonlinear::Problem> SimWildMesh::get_envelope_energy(
-    const Tuple& t) const
-{
-    size_t vid = t.vid(*this);
-    const double w = m_s_envelope * m_params.w_envelope;
-
-    auto env = m_envelope_orig;
-    if (m_vertex_attribute[vid].m_order == 2) {
-        env = m_order_2_edge_envelope;
-    }
-
-    if (!env) {
-        log_and_throw_error(
-            "Envelope was not initialized. Vertex was of order {}",
-            m_vertex_attribute[vid].m_order);
-    }
-
-    auto envelope_energy = std::make_shared<optimization::EnvelopeEnergy3D>(env, w);
-    return envelope_energy;
-}
 
 } // namespace wmtk::components::simwild

--- a/components/tetwild/wmtk/components/tetwild/EdgeCollapsing.cpp
+++ b/components/tetwild/wmtk/components/tetwild/EdgeCollapsing.cpp
@@ -123,8 +123,7 @@ bool TetWildMesh::collapse_edge_before(const Tuple& loc) // input is an edge
 
     // open boundary
     if (cache.edge_length > 0 && VA[v1_id].m_is_on_open_boundary) {
-        if (!VA[v2_id].m_is_on_open_boundary &&
-            m_order2_envelope->is_outside(VA[v2_id].m_posf)) {
+        if (!VA[v2_id].m_is_on_open_boundary && m_order2_envelope->is_outside(VA[v2_id].m_posf)) {
             return false;
         }
     }

--- a/components/tetwild/wmtk/components/tetwild/EdgeCollapsing.cpp
+++ b/components/tetwild/wmtk/components/tetwild/EdgeCollapsing.cpp
@@ -116,7 +116,7 @@ bool TetWildMesh::collapse_edge_before(const Tuple& loc) // input is an edge
 
     // surface
     if (cache.edge_length > 0 && VA[v1_id].m_is_on_surface) {
-        if (!VA[v2_id].m_is_on_surface && m_envelope.is_outside(VA[v2_id].m_posf)) {
+        if (!VA[v2_id].m_is_on_surface && m_envelope->is_outside(VA[v2_id].m_posf)) {
             return false;
         }
     }
@@ -124,7 +124,7 @@ bool TetWildMesh::collapse_edge_before(const Tuple& loc) // input is an edge
     // open boundary
     if (cache.edge_length > 0 && VA[v1_id].m_is_on_open_boundary) {
         if (!VA[v2_id].m_is_on_open_boundary &&
-            m_open_boundary_envelope.is_outside(VA[v2_id].m_posf)) {
+            m_order2_envelope->is_outside(VA[v2_id].m_posf)) {
             return false;
         }
     }
@@ -316,7 +316,7 @@ bool TetWildMesh::collapse_edge_after(const Tuple& loc)
     if (cache.edge_length > 0) {
         for (auto& vids : cache.surface_faces) {
             // surface envelope
-            bool is_out = m_envelope.is_outside(
+            bool is_out = m_envelope->is_outside(
                 {{VA.at(vids[0]).m_posf, VA.at(vids[1]).m_posf, VA.at(vids[2]).m_posf}});
             if (is_out) {
                 return false;
@@ -325,17 +325,17 @@ bool TetWildMesh::collapse_edge_after(const Tuple& loc)
             // // open boundary envelope
             // // by checking each edge on cached surface
             // if (VA[vids[0]].m_is_on_open_boundary && VA[vids[1]].m_is_on_open_boundary) {
-            //     if (m_open_boundary_envelope.is_outside(
+            //     if (m_order2_envelope->is_outside(
             //             {{VA[vids[0]].m_posf, VA[vids[1]].m_posf, VA[vids[0]].m_posf}}))
             //         return false;
             // }
             // if (VA[vids[1]].m_is_on_open_boundary && VA[vids[2]].m_is_on_open_boundary) {
-            //     if (m_open_boundary_envelope.is_outside(
+            //     if (m_order2_envelope->is_outside(
             //             {{VA[vids[1]].m_posf, VA[vids[2]].m_posf, VA[vids[1]].m_posf}}))
             //         return false;
             // }
             // if (VA[vids[2]].m_is_on_open_boundary && VA[vids[0]].m_is_on_open_boundary) {
-            //     if (m_open_boundary_envelope.is_outside(
+            //     if (m_order2_envelope->is_outside(
             //             {{VA[vids[2]].m_posf, VA[vids[0]].m_posf, VA[vids[2]].m_posf}}))
             //         return false;
             // }

--- a/components/tetwild/wmtk/components/tetwild/EdgeSwapping.cpp
+++ b/components/tetwild/wmtk/components/tetwild/EdgeSwapping.cpp
@@ -304,10 +304,10 @@ bool TetWildMesh::swap_edge_after(const Tuple& t)
         // The two new surface faces (a,c,d),(b,c,d) must stay within the
         // Hausdorff envelope, exactly like a surface-edge collapse.
         const auto& VA = m_vertex_attribute;
-        if (m_envelope.is_outside(
+        if (m_envelope->is_outside(
                 {{VA[cache.sf_a].m_posf, VA[cache.sf_c].m_posf, VA[cache.sf_d].m_posf}}))
             return false;
-        if (m_envelope.is_outside(
+        if (m_envelope->is_outside(
                 {{VA[cache.sf_b].m_posf, VA[cache.sf_c].m_posf, VA[cache.sf_d].m_posf}}))
             return false;
     }

--- a/components/tetwild/wmtk/components/tetwild/Parameters.h
+++ b/components/tetwild/wmtk/components/tetwild/Parameters.h
@@ -98,7 +98,7 @@ struct Parameters
      * changing connectivity, so on meshes where split/collapse/swap have run out of useful
      * moves it is the only thing left that can lower the energy.
      */
-    int num_smoothing_passes = 50;
+    int num_smoothing_passes = 10;
 
     bool debug_output = false;
     bool perform_sanity_checks = false;

--- a/components/tetwild/wmtk/components/tetwild/Parameters.h
+++ b/components/tetwild/wmtk/components/tetwild/Parameters.h
@@ -82,6 +82,15 @@ struct Parameters
     double stop_energy = 10;
 
     /**
+     * Relative weight of the AMIPS (quality) term against the envelope (stay-on-surface)
+     * term during smoothing. w_envelope is derived as 1 - w_amips in the TetWildMesh
+     * constructor, so the small default means the envelope dominates and AMIPS acts as a
+     * light quality preference. Matches simwild.
+     */
+    double w_amips = 1e-4;
+    double w_envelope = 1. - 1e-4; // derived; not read from json
+
+    /**
      * How many smoothing passes each optimization iteration runs.
      *
      * This is ops[3] in local_operations({{split, collapse, swap, smooth}}), which was

--- a/components/tetwild/wmtk/components/tetwild/Parameters.h
+++ b/components/tetwild/wmtk/components/tetwild/Parameters.h
@@ -81,6 +81,16 @@ struct Parameters
 
     double stop_energy = 10;
 
+    /**
+     * How many smoothing passes each optimization iteration runs.
+     *
+     * This is ops[3] in local_operations({{split, collapse, swap, smooth}}), which was
+     * hard-coded to 1. Smoothing is the only phase that improves element quality without
+     * changing connectivity, so on meshes where split/collapse/swap have run out of useful
+     * moves it is the only thing left that can lower the energy.
+     */
+    int num_smoothing_passes = 50;
+
     bool debug_output = false;
     bool perform_sanity_checks = false;
 

--- a/components/tetwild/wmtk/components/tetwild/Smooth.cpp
+++ b/components/tetwild/wmtk/components/tetwild/Smooth.cpp
@@ -23,11 +23,6 @@ bool TetWildMesh::smooth_before(const Tuple& t)
 
     if (!m_vertex_attribute[vid].on_bbox_faces.empty()) return false;
 
-    // update if vertex is on boundary
-    if (!is_vertex_on_boundary(vid)) {
-        m_vertex_attribute[vid].m_is_on_open_boundary = false;
-    }
-
     if (m_vertex_attribute[vid].m_is_rounded) return true;
     // try to round.
     // Note: no need to roll back.
@@ -37,273 +32,40 @@ bool TetWildMesh::smooth_before(const Tuple& t)
 
 bool TetWildMesh::smooth_after(const Tuple& t)
 {
-    // Newton iterations are encapsulated here.
-    wmtk::logger().trace("Newton iteration for vertex smoothing.");
-    auto vid = t.vid(*this);
-
-    auto locs = get_one_ring_tets_for_vertex(t);
-    auto max_quality = 0.;
-    for (auto& tet : locs) {
-        max_quality = std::max(max_quality, m_tet_attribute[tet.tid(*this)].m_quality);
-    }
-
-    assert(locs.size() > 0);
-    std::vector<std::array<double, 12>> assembles(locs.size());
-    int loc_id = 0;
-
-    for (const Tuple& loc : locs) {
-        auto& T = assembles[loc_id];
-        auto t_id = loc.tid(*this);
-
-        // assert(!is_inverted(loc));
-        if (is_inverted_f(loc)) {
-            // Neighbors that are not rounded could cause a tet to be inverted in floats
-            // std::cout << "Inverted tet " << m_vertex_attribute[vid].m_posf.transpose() <<
-            // std::endl;
-            return false;
-        }
-        std::array<size_t, 4> local_verts = oriented_tet_vids(t_id);
-        local_verts = wmtk::orient_preserve_tet_reorder(local_verts, vid);
-
-        for (int i = 0; i < 4; i++) {
-            for (int j = 0; j < 3; j++) {
-                T[i * 3 + j] = m_vertex_attribute[local_verts[i]].m_posf[j];
-            }
-        }
-        loc_id++;
-    }
-
-    const Vector3d old_pos = m_vertex_attribute[vid].m_posf;
-    const auto old_asssembles = assembles;
-
-    // std::vector<std::array<double, 9>> boundary_assemble;
-    //// boundary must be collected before smoothing!!!
-    // if (m_vertex_attribute[vid].m_is_on_open_boundary) {
-    //    // debug code
-    //    // std::cout << "in smoothing open boundary" << std::endl;
+    // The body lives in wmtk::optimization::smooth_vertex_3d, shared with simwild.
     //
-    //    std::set<size_t> unique_eid;
-    //    for (const Tuple& t : locs) {
-    //        for (int j = 0; j < 6; j++) {
-    //            auto e_t = tuple_from_edge(t.tid(*this), j);
-    //            size_t v1_id = e_t.vid(*this);
-    //            size_t v2_id = e_t.switch_vertex(*this).vid(*this);
-    //            if (v1_id != vid && v2_id != vid) {
-    //                // edge does not contain point of interest
-    //                continue;
-    //            }
-    //
-    //
-    //            auto eid = e_t.eid(*this);
-    //            auto [it, suc] = unique_eid.emplace(eid);
-    //            if (!suc) continue;
-    //
-    //            if (is_open_boundary_edge(e_t)) {
-    //                if (v2_id == vid) {
-    //                    std::swap(v1_id, v2_id);
-    //                }
-    //                std::array<double, 9> coords = {
-    //                    {m_vertex_attribute[v1_id].m_posf[0],
-    //                     m_vertex_attribute[v1_id].m_posf[1],
-    //                     m_vertex_attribute[v1_id].m_posf[2],
-    //                     m_vertex_attribute[v2_id].m_posf[0],
-    //                     m_vertex_attribute[v2_id].m_posf[1],
-    //                     m_vertex_attribute[v2_id].m_posf[2],
-    //                     m_vertex_attribute[v1_id].m_posf[0],
-    //                     m_vertex_attribute[v1_id].m_posf[1],
-    //                     m_vertex_attribute[v1_id].m_posf[2]}}; // {v1, v2, v1}
-    //                boundary_assemble.emplace_back(coords);
-    //            }
-    //        }
-    //    }
-    //}
+    // This replaces the previous scheme, which optimized AMIPS alone and then snapped the
+    // vertex onto the envelope with nearest_point. That snap moved a drifted vertex the
+    // whole way in one jump, which almost always worsened an incident tet, so the operation
+    // was vetoed and the rollback discarded the projection -- a vertex near the envelope
+    // wall could never come back. The envelope is now a term in the objective instead, so
+    // the pull is gradual and the line search refuses steps that leave the envelope.
+    optimization::SmoothVertexOptions opts;
+    opts.w_amips = m_params.w_amips;
+    opts.w_envelope = m_params.w_envelope;
+    opts.s_amips = m_s_amips;
+    opts.s_envelope = m_s_envelope;
+    opts.two_stage = true;
+    opts.quality_veto_on_surface = false;
 
-    m_vertex_attribute[vid].m_posf = wmtk::newton_method_from_stack(
-        assembles,
-        wmtk::AMIPS_energy,
-        wmtk::AMIPS_jacobian,
-        wmtk::AMIPS_hessian);
-
-    wmtk::logger().trace(
-        "old pos {} -> new pos {}",
-        old_pos.transpose(),
-        m_vertex_attribute[vid].m_posf.transpose());
-
-    // project to open boundary
-    if (m_vertex_attribute[vid].m_is_on_open_boundary) {
-        auto project = Eigen::Vector3d();
-
-        if (m_open_boundary_envelope.initialized()) {
-            // project to envelope
-            m_open_boundary_envelope.nearest_point(m_vertex_attribute[vid].m_posf, project);
-        } else {
-            // project to neighborhood
-            log_and_throw_error("Deprecated code that should not be used.");
-            // project = wmtk::try_project(m_vertex_attribute[vid].m_posf, boundary_assemble);
-        }
-
-        m_vertex_attribute[vid].m_posf = project;
-        // m_vertex_attribute[vid].m_posf = 0.5 * (m_vertex_attribute[vid].m_posf + project); // Project only half way
-    }
-
-    // TODO directly store an array of Vector3d here
-    std::vector<std::array<double, 9>> surface_assemble;
-    if (m_vertex_attribute[vid].m_is_on_surface) {
-        std::set<size_t> unique_fid;
-        for (const Tuple& t : locs) {
-            for (auto j = 0; j < 4; j++) {
-                auto f_t = tuple_from_face(t.tid(*this), j);
-                auto fid = f_t.fid(*this);
-                auto [it, suc] = unique_fid.emplace(fid);
-                if (!suc) continue;
-                if (m_face_attribute[fid].m_is_surface_fs) {
-                    auto vs_id = get_face_vids(f_t);
-                    for (int k : {1, 2}) {
-                        if (vs_id[k] == vid) {
-                            std::swap(vs_id[k], vs_id[0]);
-                        }
-                    }
-                    if (vs_id[0] != vid) {
-                        continue; // does not contain point of interest
-                    }
-                    std::array<double, 9> coords;
-                    for (int k = 0; k < 3; k++) {
-                        for (int kk = 0; kk < 3; kk++) {
-                            coords[k * 3 + kk] = m_vertex_attribute[vs_id[k]].m_posf[kk];
-                        }
-                    }
-                    surface_assemble.emplace_back(coords);
-                }
-            }
-        }
-        if (!m_vertex_attribute[vid].m_is_on_open_boundary) {
-            Vector3d project;
-            if (m_envelope.initialized()) {
-                m_envelope.nearest_point(m_vertex_attribute[vid].m_posf, project);
-            } else {
-                log_and_throw_error("Deprecated code that should not be used.");
-                project = wmtk::try_project(m_vertex_attribute[vid].m_posf, surface_assemble);
-            }
-
-            m_vertex_attribute[vid].m_posf = project;
-        }
-
-        for (auto& n : surface_assemble) {
-            for (int kk = 0; kk < 3; kk++) {
-                n[kk] = m_vertex_attribute[vid].m_posf[kk];
-            }
-        }
-    }
-
-    //// update position in boundary_assemble
-    // for (auto& n : boundary_assemble) {
-    //     n[0] = m_vertex_attribute[vid].m_posf[0];
-    //     n[1] = m_vertex_attribute[vid].m_posf[1];
-    //     n[2] = m_vertex_attribute[vid].m_posf[2];
-    //     n[6] = m_vertex_attribute[vid].m_posf[0];
-    //     n[7] = m_vertex_attribute[vid].m_posf[1];
-    //     n[8] = m_vertex_attribute[vid].m_posf[2];
-    // }
-    //
-    //// check boundary containment
-    // for (const auto& n : boundary_assemble) {
-    //     std::array<Eigen::Vector3d, 3> tri;
-    //     for (int k = 0; k < 3; k++) {
-    //         for (int kk = 0; kk < 3; kk++) {
-    //             tri[k][kk] = n[k * 3 + kk];
-    //         }
-    //     }
-    //     if (m_open_boundary_envelope.is_outside(tri)) {
-    //         return false;
-    //     }
-    // }
-
-    // check surface containment
-    for (const auto& n : surface_assemble) {
-        std::array<Eigen::Vector3d, 3> tri;
-        for (int k = 0; k < 3; k++) {
-            for (int kk = 0; kk < 3; kk++) {
-                tri[k][kk] = n[k * 3 + kk];
-            }
-        }
-        if (m_envelope.is_outside(tri)) {
-            return false;
-        }
-    }
-
-    // rational position must be updated  before the inversion check!
-    m_vertex_attribute[vid].m_pos = to_rational(m_vertex_attribute[vid].m_posf);
-
-    // quality
-    auto max_after_quality = 0.;
-    for (const Tuple& loc : locs) {
-        if (is_inverted(loc)) {
-            return false;
-        }
-        auto t_id = loc.tid(*this);
-        m_tet_attribute[t_id].m_quality = get_quality(loc);
-        max_after_quality = std::max(max_after_quality, m_tet_attribute[t_id].m_quality);
-    }
-    if (max_after_quality > max_quality) {
-        return false;
-    }
-
-    return true;
+    return optimization::smooth_vertex_3d(*this, t, opts, m_solver.local(), &m_smooth_rejects);
 }
 
-// DIAGNOSTIC (uncommitted): how far are surface vertices from the input surface?
-//
-// Surface vertices are projected back onto the surface by smooth_after -- but only when
-// they are NOT on an open boundary, and the open-boundary envelope check that would have
-// constrained the rest is commented out. So the question is whether open-boundary vertices
-// drift outward with nothing pulling them back.
-void TetWildMesh::debug_report_surface_drift(const char* when)
+std::shared_ptr<SampleEnvelope> TetWildMesh::smoothing_energy_envelope(const size_t vid) const
 {
-    const double eps = std::sqrt(m_envelope.eps2);
-    struct Acc
-    {
-        size_t n = 0, near90 = 0, over = 0;
-        double maxd = 0, sumd = 0;
-        void add(double d, double eps)
-        {
-            ++n;
-            sumd += d;
-            maxd = std::max(maxd, d);
-            if (d > 0.9 * eps) ++near90;
-            if (d > eps) ++over;
-        }
-    };
-    Acc interior_surf, open_bnd;
-
-    for (const Tuple& v : get_vertices()) {
-        const size_t vid = v.vid(*this);
-        if (!m_vertex_attribute[vid].m_is_on_surface) continue;
-        const double d = std::sqrt(m_envelope.squared_distance(m_vertex_attribute[vid].m_posf));
-        if (m_vertex_attribute[vid].m_is_on_open_boundary) {
-            open_bnd.add(d, eps);
-        } else {
-            interior_surf.add(d, eps);
-        }
+    // Order 2 means the vertex is on a surface boundary or a non-manifold edge. This is
+    // broader than the old m_is_on_open_boundary flag, which covered only open boundaries.
+    if (get_order_of_vertex(vid) >= 2 && m_order2_envelope && m_order2_envelope->initialized()) {
+        return m_order2_envelope;
     }
+    return m_envelope;
+}
 
-    auto line = [&](const char* label, const Acc& a) {
-        if (a.n == 0) {
-            logger().info("[drift {}] {}: none", when, label);
-            return;
-        }
-        logger().info(
-            "[drift {}] {}: n={} maxd={:.5} meand={:.5} (eps={:.5}) | >0.9eps: {} | >eps: {}",
-            when,
-            label,
-            a.n,
-            a.maxd,
-            a.sumd / a.n,
-            eps,
-            a.near90,
-            a.over);
-    };
-    line("surface, projected  ", interior_surf);
-    line("surface, OPEN BOUND ", open_bnd);
+std::shared_ptr<SampleEnvelope> TetWildMesh::smoothing_containment_envelope(const size_t) const
+{
+    // tetwild keeps one surface envelope, so pull target and containment test coincide --
+    // unlike simwild, which has a separate working envelope.
+    return m_envelope;
 }
 
 void TetWildMesh::smooth_all_vertices()
@@ -315,6 +77,7 @@ void TetWildMesh::smooth_all_vertices()
     igl::Timer timer;
     double time;
     timer.start();
+    m_smooth_rejects.reset();
     auto collect_all_ops = std::vector<std::pair<std::string, Tuple>>();
     if (m_params.skip_good_regions) {
         // Only smooth vertices incident to an "active" (non-good) tet -- smoothing
@@ -332,7 +95,6 @@ void TetWildMesh::smooth_all_vertices()
     time = timer.getElapsedTime();
     wmtk::logger().info("vertex smoothing prepare time: {:.4}s", time);
     wmtk::logger().debug("Num verts {}", collect_all_ops.size());
-    debug_report_surface_drift("before smooth");
     if (NUM_THREADS > 0) {
         timer.start();
         auto executor = wmtk::ExecutePass<TetWildMesh>(wmtk::ExecutionPolicy::kPartition);
@@ -351,7 +113,7 @@ void TetWildMesh::smooth_all_vertices()
         time = timer.getElapsedTime();
         wmtk::logger().info("vertex smoothing operation time serial: {:.4}s", time);
     }
-    debug_report_surface_drift("after  smooth");
+    wmtk::logger().info("\tsmooth: {}", m_smooth_rejects.to_string());
 }
 
 } // namespace wmtk::components::tetwild

--- a/components/tetwild/wmtk/components/tetwild/Smooth.cpp
+++ b/components/tetwild/wmtk/components/tetwild/Smooth.cpp
@@ -251,6 +251,61 @@ bool TetWildMesh::smooth_after(const Tuple& t)
     return true;
 }
 
+// DIAGNOSTIC (uncommitted): how far are surface vertices from the input surface?
+//
+// Surface vertices are projected back onto the surface by smooth_after -- but only when
+// they are NOT on an open boundary, and the open-boundary envelope check that would have
+// constrained the rest is commented out. So the question is whether open-boundary vertices
+// drift outward with nothing pulling them back.
+void TetWildMesh::debug_report_surface_drift(const char* when)
+{
+    const double eps = std::sqrt(m_envelope.eps2);
+    struct Acc
+    {
+        size_t n = 0, near90 = 0, over = 0;
+        double maxd = 0, sumd = 0;
+        void add(double d, double eps)
+        {
+            ++n;
+            sumd += d;
+            maxd = std::max(maxd, d);
+            if (d > 0.9 * eps) ++near90;
+            if (d > eps) ++over;
+        }
+    };
+    Acc interior_surf, open_bnd;
+
+    for (const Tuple& v : get_vertices()) {
+        const size_t vid = v.vid(*this);
+        if (!m_vertex_attribute[vid].m_is_on_surface) continue;
+        const double d = std::sqrt(m_envelope.squared_distance(m_vertex_attribute[vid].m_posf));
+        if (m_vertex_attribute[vid].m_is_on_open_boundary) {
+            open_bnd.add(d, eps);
+        } else {
+            interior_surf.add(d, eps);
+        }
+    }
+
+    auto line = [&](const char* label, const Acc& a) {
+        if (a.n == 0) {
+            logger().info("[drift {}] {}: none", when, label);
+            return;
+        }
+        logger().info(
+            "[drift {}] {}: n={} maxd={:.5} meand={:.5} (eps={:.5}) | >0.9eps: {} | >eps: {}",
+            when,
+            label,
+            a.n,
+            a.maxd,
+            a.sumd / a.n,
+            eps,
+            a.near90,
+            a.over);
+    };
+    line("surface, projected  ", interior_surf);
+    line("surface, OPEN BOUND ", open_bnd);
+}
+
 void TetWildMesh::smooth_all_vertices()
 {
     // the order is randomized in every iteration but deterministic when executed sequentially
@@ -277,6 +332,7 @@ void TetWildMesh::smooth_all_vertices()
     time = timer.getElapsedTime();
     wmtk::logger().info("vertex smoothing prepare time: {:.4}s", time);
     wmtk::logger().debug("Num verts {}", collect_all_ops.size());
+    debug_report_surface_drift("before smooth");
     if (NUM_THREADS > 0) {
         timer.start();
         auto executor = wmtk::ExecutePass<TetWildMesh>(wmtk::ExecutionPolicy::kPartition);
@@ -295,6 +351,7 @@ void TetWildMesh::smooth_all_vertices()
         time = timer.getElapsedTime();
         wmtk::logger().info("vertex smoothing operation time serial: {:.4}s", time);
     }
+    debug_report_surface_drift("after  smooth");
 }
 
 } // namespace wmtk::components::tetwild

--- a/components/tetwild/wmtk/components/tetwild/TetWildMesh.cpp
+++ b/components/tetwild/wmtk/components/tetwild/TetWildMesh.cpp
@@ -76,7 +76,8 @@ void TetWildMesh::mesh_improvement(int max_its)
     for (int it = 0; it < max_its; it++) {
         ///ops
         logger().info("\n========it {}========", it);
-        auto [max_energy, avg_energy] = local_operations({{1, 1, 1, 1}});
+        auto [max_energy, avg_energy] =
+            local_operations({{1, 1, 1, m_params.num_smoothing_passes}});
 
         ///energy check
         logger().info("max energy {:.6} | stop {:.6}", max_energy, m_params.stop_energy);

--- a/components/tetwild/wmtk/components/tetwild/TetWildMesh.cpp
+++ b/components/tetwild/wmtk/components/tetwild/TetWildMesh.cpp
@@ -127,16 +127,11 @@ void TetWildMesh::mesh_improvement_legacy(int max_its)
 {
     logger().set_level(spdlog::level::level_enum::debug);
 
-    SampleEnvelope* env;
-    if (SampleEnvelope* d = dynamic_cast<SampleEnvelope*>(&m_envelope); d != nullptr) {
-        env = d;
-    } else {
-        log_and_throw_error("Legacy TetWild can only be used with sample envelope.");
-    }
-    SampleEnvelope* env_b;
-    if (SampleEnvelope* d = dynamic_cast<SampleEnvelope*>(&m_envelope); d != nullptr) {
-        env_b = d;
-    } else {
+    // m_envelope is a SampleEnvelope already; the dynamic_cast these lines used to do was
+    // a no-op left over from when it was held as the Envelope base.
+    SampleEnvelope* env = m_envelope.get();
+    SampleEnvelope* env_b = m_envelope.get();
+    if (env == nullptr) {
         log_and_throw_error("Legacy TetWild can only be used with sample envelope.");
     }
 
@@ -380,7 +375,7 @@ std::tuple<double, double> TetWildMesh::local_operations(
             const auto p0 = m_vertex_attribute[verts[0]].m_posf;
             const auto p1 = m_vertex_attribute[verts[1]].m_posf;
             const auto p2 = m_vertex_attribute[verts[2]].m_posf;
-            if (m_envelope.is_outside({{p0, p1, p2}})) {
+            if (m_envelope->is_outside({{p0, p1, p2}})) {
                 logger().error("Face {} is outside!", verts);
             }
         }

--- a/components/tetwild/wmtk/components/tetwild/TetWildMesh.h
+++ b/components/tetwild/wmtk/components/tetwild/TetWildMesh.h
@@ -4,6 +4,7 @@
 #include <wmtk/TetMesh.h>
 #include <wmtk/utils/PartitionMesh.h>
 #include <wmtk/envelope/Envelope.hpp>
+#include <wmtk/optimization/SmoothVertex.hpp>
 #include <wmtk/threading/concurrent_map.hpp>
 #include <wmtk/threading/enumerable_thread_specific.hpp>
 #include <wmtk/threading/parallel_for.hpp>
@@ -103,18 +104,40 @@ public:
     const double MAX_ENERGY = 1e50;
 
     Parameters& m_params;
-    SampleEnvelope& m_envelope;
+    /// Surface envelope: what a surface vertex is pulled toward and checked against.
+    std::shared_ptr<SampleEnvelope> m_envelope;
+    /// Envelope for order-2 vertices, i.e. those on a surface boundary or a non-manifold
+    /// edge. Named for the order rather than for "open boundary" because that is what
+    /// TetMesh::compute_vertex_order actually reports, and it is the broader set.
+    std::shared_ptr<SampleEnvelope> m_order2_envelope;
 
     /// Optional per-input names (JSON "input_names"), used to label the per-input
     /// winding-number output fields. Empty => the fields are numbered.
     std::vector<std::string> m_input_names;
 
-    // for open boundary
-    SampleEnvelope m_open_boundary_envelope; // todo: add sample envelope option
+    /// Per-thread Newton solver for smoothing; created on first use.
+    wmtk::threading::enumerable_thread_specific<std::unique_ptr<polysolve::nonlinear::Solver>>
+        m_solver;
 
-    TetWildMesh(Parameters& _m_params, SampleEnvelope& _m_envelope, int _num_threads = 1)
+    /// Why smoothing attempts were refused, reported once per pass.
+    optimization::SmoothRejectCounters m_smooth_rejects;
+
+    /// Scale factors putting AMIPS (dimensionless) and the envelope energy (a squared
+    /// distance) on a comparable footing.
+    double m_s_amips = 1.;
+    double m_s_envelope = -1.;
+
+    /// Envelope a vertex is pulled toward while smoothing.
+    std::shared_ptr<SampleEnvelope> smoothing_energy_envelope(const size_t vid) const;
+    /// Envelope the resulting surface triangles are checked against.
+    std::shared_ptr<SampleEnvelope> smoothing_containment_envelope(const size_t vid) const;
+
+    TetWildMesh(
+        Parameters& _m_params,
+        std::shared_ptr<SampleEnvelope> _m_envelope,
+        int _num_threads = 1)
         : m_params(_m_params)
-        , m_envelope(_m_envelope)
+        , m_envelope(std::move(_m_envelope))
     {
         NUM_THREADS = _num_threads;
         p_vertex_attrs = &m_vertex_attribute;
@@ -122,6 +145,11 @@ public:
         p_tet_attrs = &m_tet_attribute;
         m_collapse_check_link_condition = false;
         m_collapse_check_manifold = false;
+
+        optimization::deactivate_opt_logger();
+        m_s_amips = 1.;
+        m_s_envelope = 1. / (m_params.diag_l * m_params.eps * m_params.eps);
+        m_params.w_envelope = 1. - m_params.w_amips;
     }
 
     ~TetWildMesh() {}
@@ -210,7 +238,6 @@ public:
     bool split_edge_after(const Tuple& loc) override;
 
     void smooth_all_vertices();
-    void debug_report_surface_drift(const char* when);
     bool smooth_before(const Tuple& t) override;
     bool smooth_after(const Tuple& t) override;
 

--- a/components/tetwild/wmtk/components/tetwild/TetWildMesh.h
+++ b/components/tetwild/wmtk/components/tetwild/TetWildMesh.h
@@ -210,6 +210,7 @@ public:
     bool split_edge_after(const Tuple& loc) override;
 
     void smooth_all_vertices();
+    void debug_report_surface_drift(const char* when);
     bool smooth_before(const Tuple& t) override;
     bool smooth_after(const Tuple& t) override;
 

--- a/components/tetwild/wmtk/components/tetwild/TriangleInsertion.cpp
+++ b/components/tetwild/wmtk/components/tetwild/TriangleInsertion.cpp
@@ -77,7 +77,7 @@ void TetWildMesh::init_from_delaunay_box_mesh(const std::vector<Eigen::Vector3d>
                 const Vector3d p(ds[0][i], ds[1][j], ds[2][k]);
 
                 Eigen::Vector3d n;
-                const double sqd = m_envelope.nearest_point(p, n);
+                const double sqd = m_envelope->nearest_point(p, n);
 
                 if (sqd < min_dis) {
                     continue;

--- a/components/tetwild/wmtk/components/tetwild/VolumemesherInsertion.cpp
+++ b/components/tetwild/wmtk/components/tetwild/VolumemesherInsertion.cpp
@@ -1619,8 +1619,11 @@ void TetWildMesh::find_open_boundary()
         return;
     }
 
-    // init open boundary envelope
-    m_open_boundary_envelope.init(v_posf, open_boundaries, m_params.epsr * m_params.diag_l / 2.0);
+    // init the order-2 envelope (surface boundaries and non-manifold edges)
+    if (!m_order2_envelope) {
+        m_order2_envelope = std::make_shared<SampleEnvelope>();
+    }
+    m_order2_envelope->init(v_posf, open_boundaries, m_params.epsr * m_params.diag_l / 2.0);
 }
 
 bool TetWildMesh::is_open_boundary_edge(const Tuple& e)
@@ -1631,7 +1634,7 @@ bool TetWildMesh::is_open_boundary_edge(const Tuple& e)
         !m_vertex_attribute[v2].m_is_on_open_boundary)
         return false;
 
-    return !m_open_boundary_envelope.is_outside(
+    return !m_order2_envelope->is_outside(
         std::array<Eigen::Vector3d, 2>{
             {m_vertex_attribute[v1].m_posf, m_vertex_attribute[v2].m_posf}});
 }
@@ -1644,7 +1647,7 @@ bool TetWildMesh::is_open_boundary_edge(const std::array<size_t, 2>& e)
         !m_vertex_attribute[v2].m_is_on_open_boundary)
         return false;
 
-    return !m_open_boundary_envelope.is_outside(
+    return !m_order2_envelope->is_outside(
         std::array<Eigen::Vector3d, 2>{
             {m_vertex_attribute[v1].m_posf, m_vertex_attribute[v2].m_posf}});
 }

--- a/components/tetwild/wmtk/components/tetwild/tests/test_insertion.cpp
+++ b/components/tetwild/wmtk/components/tetwild/tests/test_insertion.cpp
@@ -216,6 +216,10 @@ TEST_CASE("vertex_order", "[tetwild]")
     }
     REQUIRE(surf_mesh.check_mesh_connectivity_validity());
 
+    // TetWildMesh now holds the envelope by shared_ptr; surf_mesh owns this one and
+    // outlives both meshes below, so alias it with a no-op deleter rather than copying the
+    // BVH. Same aliasing the old `SampleEnvelope&` parameter gave.
+    const std::shared_ptr<SampleEnvelope> env(&surf_mesh.m_envelope, [](SampleEnvelope*) {});
 
     std::vector<Vector3r> v_rational;
     std::vector<std::array<size_t, 3>> facets;
@@ -223,7 +227,7 @@ TEST_CASE("vertex_order", "[tetwild]")
     std::vector<std::array<size_t, 4>> tets;
     std::vector<bool> tet_face_on_input_surface;
     {
-        TetWildMesh mesh_insertion(params, surf_mesh.m_envelope, 0);
+        TetWildMesh mesh_insertion(params, env, 0);
         mesh_insertion.insertion_by_volumeremesher(
             vertices,
             faces,
@@ -235,7 +239,7 @@ TEST_CASE("vertex_order", "[tetwild]")
     }
 
     // generate new mesh
-    TetWildMesh mesh(params, surf_mesh.m_envelope, 0);
+    TetWildMesh mesh(params, env, 0);
 
     mesh.init_from_Volumeremesher(
         v_rational,

--- a/components/tetwild/wmtk/components/tetwild/tests/test_sizing_refine.cpp
+++ b/components/tetwild/wmtk/components/tetwild/tests/test_sizing_refine.cpp
@@ -58,7 +58,7 @@ TEST_CASE("stuck-refine-region-and-factor", "[tetwild_operation][stuck_refine]")
     params.stuck_refine_min_scalar = 0.1;
     params.stuck_refine_gradation = 1.0; // disable smoothing to isolate the refinement
 
-    SampleEnvelope env;
+    auto env = std::make_shared<SampleEnvelope>();
     TetWildMesh mesh(params, env, 1);
     build_two_tets(mesh);
     // Make tet 0 the single worst element.
@@ -86,7 +86,7 @@ TEST_CASE("stuck-refine-floor-clamp", "[tetwild_operation][stuck_refine]")
     params.stuck_refine_min_scalar = 0.7; // floor above factor*1.0 => clamps
     params.stuck_refine_gradation = 1.0;
 
-    SampleEnvelope env;
+    auto env = std::make_shared<SampleEnvelope>();
     TetWildMesh mesh(params, env, 1);
     build_two_tets(mesh);
     mesh.m_tet_attribute[0].m_quality = 1e40;
@@ -107,7 +107,7 @@ TEST_CASE("stuck-refine-num-worst", "[tetwild_operation][stuck_refine]")
     params.stuck_refine_min_scalar = 0.01;
     params.stuck_refine_gradation = 1.0;
 
-    SampleEnvelope env;
+    auto env = std::make_shared<SampleEnvelope>();
     TetWildMesh mesh(params, env, 1);
     build_two_tets(mesh);
     mesh.m_tet_attribute[0].m_quality = 1e40;
@@ -125,7 +125,7 @@ TEST_CASE("stuck-refine-gradation-monotone", "[tetwild_operation][stuck_refine]"
     Parameters params;
     params.init(Vector3d(-1, -1, -1), Vector3d(12, 2, 2));
 
-    SampleEnvelope env;
+    auto env = std::make_shared<SampleEnvelope>();
     TetWildMesh mesh(params, env, 1);
     build_two_tets(mesh);
 
@@ -156,7 +156,7 @@ TEST_CASE("stuck-refine-disabled-noop", "[tetwild_operation][stuck_refine]")
     // grade <= 1 disables the smoothing entirely.
     Parameters params;
     params.init(Vector3d(-1, -1, -1), Vector3d(12, 2, 2));
-    SampleEnvelope env;
+    auto env = std::make_shared<SampleEnvelope>();
     TetWildMesh mesh(params, env, 1);
     build_two_tets(mesh);
     mesh.m_vertex_attribute[0].m_sizing_scalar = 0.1;
@@ -173,7 +173,7 @@ TEST_CASE("skip-good-regions-active-vertices", "[tetwild_operation][skip_good_re
     params.stop_energy = 100;
     params.skip_good_regions_margin = 0.9; // active energy >= 90 -> m_quality >= 90^3 = 729000
 
-    SampleEnvelope env;
+    auto env = std::make_shared<SampleEnvelope>();
     TetWildMesh mesh(params, env, 1);
     build_two_tets(mesh);
 

--- a/components/tetwild/wmtk/components/tetwild/tests/test_surface_swap.cpp
+++ b/components/tetwild/wmtk/components/tetwild/tests/test_surface_swap.cpp
@@ -113,8 +113,8 @@ TEST_CASE("surface-flip-topology-signature", "[tetwild_operation][surface_swap]"
 {
     Parameters params;
     params.init(Vector3d(-1, -1, -1), Vector3d(1, 1, 1));
-    SampleEnvelope env;
-    init_loose_envelope(env);
+    auto env = std::make_shared<SampleEnvelope>();
+    init_loose_envelope(*env);
     TetWildMesh mesh(params, env, 1);
     build_ring(mesh);
     set_surface(mesh, A, B, C, true);
@@ -135,8 +135,8 @@ TEST_CASE("surface-flip-correctness", "[tetwild_operation][surface_swap]")
 {
     Parameters params;
     params.init(Vector3d(-1, -1, -1), Vector3d(1, 1, 1));
-    SampleEnvelope env;
-    init_loose_envelope(env);
+    auto env = std::make_shared<SampleEnvelope>();
+    init_loose_envelope(*env);
     TetWildMesh mesh(params, env, 1);
     build_ring(mesh);
     set_surface(mesh, A, B, C, true);
@@ -193,8 +193,8 @@ TEST_CASE("surface-flip-rejected", "[tetwild_operation][surface_swap]")
     SECTION("disabled by param -> no surface swap")
     {
         params.allow_surface_swap = false;
-        SampleEnvelope env;
-        init_loose_envelope(env);
+        auto env = std::make_shared<SampleEnvelope>();
+        init_loose_envelope(*env);
         TetWildMesh mesh(params, env, 1);
         build_ring(mesh);
         set_surface(mesh, A, B, C, true);
@@ -212,8 +212,8 @@ TEST_CASE("surface-flip-rejected", "[tetwild_operation][surface_swap]")
 
     SECTION("non-manifold edge (3 surface faces) -> rejected")
     {
-        SampleEnvelope env;
-        init_loose_envelope(env);
+        auto env = std::make_shared<SampleEnvelope>();
+        init_loose_envelope(*env);
         TetWildMesh mesh(params, env, 1);
         build_ring(mesh);
         set_surface(mesh, A, B, C, true);
@@ -230,8 +230,8 @@ TEST_CASE("surface-flip-rejected", "[tetwild_operation][surface_swap]")
 
     SECTION("new surface face already tagged -> rejected")
     {
-        SampleEnvelope env;
-        init_loose_envelope(env);
+        auto env = std::make_shared<SampleEnvelope>();
+        init_loose_envelope(*env);
         TetWildMesh mesh(params, env, 1);
         build_ring(mesh);
         set_surface(mesh, A, B, C, true);
@@ -247,8 +247,8 @@ TEST_CASE("surface-flip-rejected", "[tetwild_operation][surface_swap]")
 
     SECTION("energy would not improve -> rejected")
     {
-        SampleEnvelope env;
-        init_loose_envelope(env);
+        auto env = std::make_shared<SampleEnvelope>();
+        init_loose_envelope(*env);
         TetWildMesh mesh(params, env, 1);
         build_ring(mesh);
         set_surface(mesh, A, B, C, true);
@@ -282,8 +282,8 @@ TEST_CASE("surface-flip-rejected", "[tetwild_operation][surface_swap]")
         // flag is only written in four places and the collapse rule ORs it, so it
         // cannot silently drop. Poking the attribute by hand therefore built a state
         // the code cannot reach, and the test failed against correct behaviour.
-        SampleEnvelope env;
-        init_loose_envelope(env);
+        auto env = std::make_shared<SampleEnvelope>();
+        init_loose_envelope(*env);
         TetWildMesh mesh(params, env, 1);
 
         constexpr size_t F = 5;
@@ -327,7 +327,7 @@ TEST_CASE("surface-flip-rejected", "[tetwild_operation][surface_swap]")
 
     SECTION("new surface outside envelope -> rejected")
     {
-        SampleEnvelope env;
+        auto env = std::make_shared<SampleEnvelope>();
         // Tight envelope around the *original* surface (a,b,c),(a,b,d). The
         // flipped faces (a,c,d),(b,c,d) deviate from it by ~0.29 (their interiors
         // leave the y=0 / (a,b,d) planes), far more than eps, so they are
@@ -335,7 +335,7 @@ TEST_CASE("surface-flip-rejected", "[tetwild_operation][surface_swap]")
         std::vector<Vector3d> v =
             {{0, 0, -1}, {0, 0, 1}, {1, 0, 0}, {-0.5, 0.8660254, 0}, {-0.5, -0.8660254, 0}};
         std::vector<Eigen::Vector3i> f = {{A, B, C}, {A, B, D}};
-        env.init(v, f, 1e-3);
+        env->init(v, f, 1e-3);
         TetWildMesh mesh(params, env, 1);
         build_ring(mesh);
         set_surface(mesh, A, B, C, true);

--- a/components/tetwild/wmtk/components/tetwild/tetwild.cpp
+++ b/components/tetwild/wmtk/components/tetwild/tetwild.cpp
@@ -237,9 +237,10 @@ TetWildMesh::ExportStruct tetwild_with_export(nlohmann::json json_params)
         }
         // SampleEnvelope::init builds both the exact structure and the sampled BVH, and
         // is_outside picks between them per query, so switching predicates for the
-        // simplification alone is a flag flip with nothing to rebuild. It has to be put
-        // back afterwards: this same envelope object is handed to TetWildMesh below, and
-        // the tet phase must keep whatever the user asked for.
+        // simplification alone is a flag flip with nothing to rebuild. Restoring it
+        // afterwards no longer matters to the tet phase -- that now gets its own
+        // envelope object at the full eps, built below -- but surf_mesh outlives this
+        // block and is written out, so leave it as the caller asked for.
         const bool saved_use_exact = surf_mesh.m_envelope.use_exact;
         if (simplify_use_sample_envelope) {
             logger().info("simplification uses the sampled envelope; tet phase unaffected");

--- a/components/tetwild/wmtk/components/tetwild/tetwild.cpp
+++ b/components/tetwild/wmtk/components/tetwild/tetwild.cpp
@@ -120,6 +120,7 @@ TetWildMesh::ExportStruct tetwild_with_export(nlohmann::json json_params)
     bool skip_simplify = json_params["skip_simplify"];
     const bool simplify_use_link_condition = json_params["simplify_use_link_condition"];
     const bool simplify_use_sample_envelope = json_params["simplify_use_sample_envelope"];
+    const double simplify_envelope_ratio = json_params["simplify_envelope_ratio"];
     bool use_sample_envelope = json_params["use_sample_envelope"];
     int NUM_THREADS = json_params["num_threads"];
     int max_its = json_params["max_iterations"];
@@ -128,6 +129,7 @@ TetWildMesh::ExportStruct tetwild_with_export(nlohmann::json json_params)
     params.epsr = json_params["eps_rel"];
     params.lr = json_params["length_rel"];
     params.stop_energy = json_params["stop_energy"];
+    params.num_smoothing_passes = json_params["num_smoothing_passes"];
 
     params.preserve_topology = json_params["preserve_topology"];
 
@@ -192,7 +194,23 @@ TetWildMesh::ExportStruct tetwild_with_export(nlohmann::json json_params)
         NUM_THREADS,
         !use_sample_envelope);
     surf_mesh.set_use_link_condition(simplify_use_link_condition);
-    surf_mesh.create_mesh(verts.size(), tris, modified_nonmanifold_v, envelope_size / 2);
+    // The simplification and the tetrahedralisation used to share one envelope object at
+    // the same eps, which leaves the optimizer no room: a simplification free to place a
+    // vertex right at the limit hands the optimizer a mesh where almost every move is
+    // already outside. Measured on crown.obj, a third of the simplified vertices sat
+    // outside the envelope before the tet phase began, and ~94% of smoothing attempts were
+    // then vetoed.
+    //
+    // Simplifying inside a fraction of the envelope reserves the rest as headroom.
+    const double tet_eps = envelope_size / 2;
+    const double simplify_eps = tet_eps * simplify_envelope_ratio;
+    logger().info(
+        "envelope eps: simplification {:.6} ({:.0f}% of tetrahedralisation {:.6})",
+        simplify_eps,
+        100 * simplify_envelope_ratio,
+        tet_eps);
+
+    surf_mesh.create_mesh(verts.size(), tris, modified_nonmanifold_v, simplify_eps);
     assert(surf_mesh.check_mesh_connectivity_validity());
 
     if (skip_simplify == false) {
@@ -271,7 +289,32 @@ TetWildMesh::ExportStruct tetwild_with_export(nlohmann::json json_params)
     params.init(box_minmax.first, box_minmax.second);
     wmtk::remove_duplicates(vsimp, fsimp, 1e-10 * params.diag_l);
 
-    tetwild::TetWildMesh mesh(params, surf_mesh.m_envelope, NUM_THREADS);
+    // Built around the ORIGINAL input, like the simplification one, but at the full tet eps.
+    // A separate object because surf_mesh's is deliberately tighter now.
+    wmtk::SampleEnvelope tet_envelope(!use_sample_envelope);
+    {
+        std::vector<Eigen::Vector3d> env_V(verts.size());
+        std::vector<Eigen::Vector3i> env_F(tris.size());
+        for (size_t i = 0; i < verts.size(); ++i) env_V[i] = verts[i];
+        for (size_t i = 0; i < tris.size(); ++i) {
+            env_F[i] << (int)tris[i][0], (int)tris[i][1], (int)tris[i][2];
+        }
+        tet_envelope.init(env_V, env_F, tet_eps);
+    }
+
+    logger().info(
+        "tetrahedralisation envelope: {} (eps {:.6})",
+        tet_envelope.use_exact ? "EXACT" : "sampled",
+        std::sqrt(tet_envelope.eps2));
+
+    if (json_params["DEBUG_disable_envelope"]) {
+        logger().warn(
+            "DEBUG_disable_envelope: envelope checks are OFF for the tetrahedralisation. "
+            "The output has no containment guarantee and is for diagnosis only.");
+        tet_envelope.disabled = true;
+    }
+
+    tetwild::TetWildMesh mesh(params, tet_envelope, NUM_THREADS);
     wmtk::set_preallocation_factor_from_json(mesh, json_params);
 
     /////////////////////////////////////////////////////
@@ -316,7 +359,7 @@ TetWildMesh::ExportStruct tetwild_with_export(nlohmann::json json_params)
     logger().info("=== finished insertion");
 
     // generate new mesh
-    tetwild::TetWildMesh mesh_new(params, surf_mesh.m_envelope, NUM_THREADS);
+    tetwild::TetWildMesh mesh_new(params, tet_envelope, NUM_THREADS);
     wmtk::set_preallocation_factor_from_json(mesh_new, json_params);
     mesh_new.m_input_names = json_params["input_names"].get<std::vector<std::string>>();
 

--- a/components/tetwild/wmtk/components/tetwild/tetwild.cpp
+++ b/components/tetwild/wmtk/components/tetwild/tetwild.cpp
@@ -130,6 +130,7 @@ TetWildMesh::ExportStruct tetwild_with_export(nlohmann::json json_params)
     params.lr = json_params["length_rel"];
     params.stop_energy = json_params["stop_energy"];
     params.num_smoothing_passes = json_params["num_smoothing_passes"];
+    params.w_amips = json_params["w_amips"];
 
     params.preserve_topology = json_params["preserve_topology"];
 
@@ -291,7 +292,7 @@ TetWildMesh::ExportStruct tetwild_with_export(nlohmann::json json_params)
 
     // Built around the ORIGINAL input, like the simplification one, but at the full tet eps.
     // A separate object because surf_mesh's is deliberately tighter now.
-    wmtk::SampleEnvelope tet_envelope(!use_sample_envelope);
+    auto tet_envelope = std::make_shared<wmtk::SampleEnvelope>(!use_sample_envelope);
     {
         std::vector<Eigen::Vector3d> env_V(verts.size());
         std::vector<Eigen::Vector3i> env_F(tris.size());
@@ -299,19 +300,19 @@ TetWildMesh::ExportStruct tetwild_with_export(nlohmann::json json_params)
         for (size_t i = 0; i < tris.size(); ++i) {
             env_F[i] << (int)tris[i][0], (int)tris[i][1], (int)tris[i][2];
         }
-        tet_envelope.init(env_V, env_F, tet_eps);
+        tet_envelope->init(env_V, env_F, tet_eps);
     }
 
     logger().info(
         "tetrahedralisation envelope: {} (eps {:.6})",
-        tet_envelope.use_exact ? "EXACT" : "sampled",
-        std::sqrt(tet_envelope.eps2));
+        tet_envelope->use_exact ? "EXACT" : "sampled",
+        std::sqrt(tet_envelope->eps2));
 
     if (json_params["DEBUG_disable_envelope"]) {
         logger().warn(
             "DEBUG_disable_envelope: envelope checks are OFF for the tetrahedralisation. "
             "The output has no containment guarantee and is for diagnosis only.");
-        tet_envelope.disabled = true;
+        tet_envelope->disabled = true;
     }
 
     tetwild::TetWildMesh mesh(params, tet_envelope, NUM_THREADS);

--- a/components/tetwild/wmtk/components/tetwild/tetwild_spec.json
+++ b/components/tetwild/wmtk/components/tetwild/tetwild_spec.json
@@ -191,7 +191,7 @@
   {
     "pointer": "/num_smoothing_passes",
     "type": "int",
-    "default": 50,
+    "default": 10,
     "doc": "Number of smoothing passes per optimization iteration. Smoothing is the only phase that improves quality without changing connectivity, so when split, collapse and swap have run out of useful moves it is the only thing that can still lower the energy."
   },
   {

--- a/components/tetwild/wmtk/components/tetwild/tetwild_spec.json
+++ b/components/tetwild/wmtk/components/tetwild/tetwild_spec.json
@@ -22,6 +22,7 @@
       "eps_rel",
       "length_rel",
       "stop_energy",
+      "w_amips",
       "num_smoothing_passes",
       "preserve_topology",
       "remove_duplicate_eps",
@@ -180,6 +181,12 @@
     "type": "float",
     "default": 10,
     "doc": "Target energy. If all tets have an energy below this, tetwild will stop."
+  },
+  {
+    "pointer": "/w_amips",
+    "type": "float",
+    "default": 0.0001,
+    "doc": "Relative weight of the AMIPS quality term against the envelope term during smoothing; the envelope weight is 1 - w_amips. The small default makes smoothing primarily about staying on the surface, with quality as a secondary preference."
   },
   {
     "pointer": "/num_smoothing_passes",

--- a/components/tetwild/wmtk/components/tetwild/tetwild_spec.json
+++ b/components/tetwild/wmtk/components/tetwild/tetwild_spec.json
@@ -13,6 +13,7 @@
       "skip_simplify",
       "simplify_use_link_condition",
       "simplify_use_sample_envelope",
+      "simplify_envelope_ratio",
       "use_sample_envelope",
       "use_legacy_code",
       "num_threads",
@@ -21,6 +22,7 @@
       "eps_rel",
       "length_rel",
       "stop_energy",
+      "num_smoothing_passes",
       "preserve_topology",
       "remove_duplicate_eps",
       "allow_surface_swap",
@@ -32,6 +34,7 @@
       "DEBUG_sanity_checks",
       "DEBUG_hausdorff",
       "DEBUG_euler",
+      "DEBUG_disable_envelope",
       "stuck_refine_stall_eps",
       "stuck_refine_cooldown",
       "stuck_refine_num_worst",
@@ -118,6 +121,12 @@
     "doc": "Use the sampled envelope instead of the exact one for the input simplification only; the tetrahedralisation keeps whatever use_sample_envelope selects. The exact envelope dominates the cost of simplifying a large input. Note the toolkit itself warns that the sampled envelope is unreliable, and on thin lattice geometry it has been observed to over-collapse badly."
   },
   {
+    "pointer": "/simplify_envelope_ratio",
+    "type": "float",
+    "default": 0.5,
+    "doc": "Envelope thickness used for the input simplification, as a fraction of the one used for the tetrahedralisation. Simplifying inside a tighter envelope reserves the remainder as headroom: if the simplification is allowed to place vertices at the full limit, the optimizer starts with a mesh where almost every move already lies outside and most operations are vetoed. 1.0 restores the old behaviour of sharing a single envelope."
+  },
+  {
     "pointer": "/use_sample_envelope",
     "type": "bool",
     "default": false,
@@ -171,6 +180,12 @@
     "type": "float",
     "default": 10,
     "doc": "Target energy. If all tets have an energy below this, tetwild will stop."
+  },
+  {
+    "pointer": "/num_smoothing_passes",
+    "type": "int",
+    "default": 50,
+    "doc": "Number of smoothing passes per optimization iteration. Smoothing is the only phase that improves quality without changing connectivity, so when split, collapse and swap have run out of useful moves it is the only thing that can still lower the energy."
   },
   {
     "pointer": "/preserve_topology",
@@ -237,6 +252,12 @@
     "type": "bool",
     "default": false,
     "doc": "Sanity Check: Compute and report the Euler characteristic of the input and output surfaces and warn if they differ. Off by default because on meshes with many components it can take tens of seconds. It is computed regardless when preserve_topology is set (the topology check needs it)."
+  },
+  {
+    "pointer": "/DEBUG_disable_envelope",
+    "type": "bool",
+    "default": false,
+    "doc": "Diagnostic only. Disables every envelope containment check during the tetrahedralisation, after the input simplification has run. The envelope is the only thing that rejects an operation for geometric rather than combinatorial reasons, so this answers whether a stalled optimization is blocked by the envelope or by the mesh. The output has no containment guarantee and must not be used."
   },
   {
     "pointer": "/stuck_refine_stall_eps",

--- a/components/triwild/wmtk/components/triwild/Smooth.cpp
+++ b/components/triwild/wmtk/components/triwild/Smooth.cpp
@@ -1,5 +1,7 @@
 
 #include "TriWildMesh.h"
+
+#include <wmtk/optimization/SmoothVertex.hpp>
 #include "wmtk/ExecutionScheduler.hpp"
 
 #include <igl/Timer.h>
@@ -34,111 +36,38 @@ bool TriWildMesh::smooth_before(const Tuple& t)
 
 bool TriWildMesh::smooth_after(const Tuple& t)
 {
-    // Newton iterations are encapsulated here.
-    logger().trace("Newton iteration for vertex smoothing.");
-    const size_t vid = t.vid(*this);
+    // The body lives in wmtk::optimization::smooth_vertex_2d, shared with simwild's 2D mesh.
+    optimization::SmoothVertexOptions opts;
+    opts.w_amips = m_params.w_amips;
+    opts.w_envelope = m_params.w_envelope;
+    opts.s_amips = m_s_amips;
+    opts.s_envelope = m_s_envelope;
+    opts.two_stage = true;
+    opts.quality_veto_on_surface = false;
 
-    const auto& VA = m_vertex_attribute;
+    return optimization::smooth_vertex_2d(*this, t, opts, m_solver.local(), &m_smooth_rejects);
+}
 
-    const auto& locs = get_one_ring_fids_for_vertex(t);
-    assert(locs.size() > 0);
+Vector2d TriWildMesh::smoothing_position(const size_t vid) const
+{
+    return m_vertex_attribute[vid].m_posf;
+}
 
-    double max_quality = 0.;
-    for (const size_t fid : locs) {
-        max_quality = std::max(max_quality, m_face_attribute[fid].m_quality);
-        if (is_inverted_f(fid)) {
-            // Neighbors that are not rounded could cause a face to be inverted in floats
-            return false;
-        }
-    }
+void TriWildMesh::set_smoothing_position(const size_t vid, const Vector2d& p)
+{
+    m_vertex_attribute[vid].m_posf = p;
+    m_vertex_attribute[vid].m_pos = to_rational(p);
+}
 
-    auto& solver = m_solver.local();
-    if (!solver) {
-        solver = optimization::create_basic_solver();
-    }
+std::shared_ptr<SampleEnvelope> TriWildMesh::smoothing_energy_envelope(const size_t) const
+{
+    return m_envelope;
+}
 
-    std::vector<std::array<double, 6>> assembles = get_amips_assembles(t);
-
-    const Vector2d old_pos = VA[vid].m_posf;
-
-    auto amips_energy = get_amips_energy(t);
-    std::shared_ptr<polysolve::nonlinear::Problem> total_energy = amips_energy;
-
-    auto solve = [&]() {
-        VectorXd x = VA[vid].m_posf;
-        try {
-            solver->minimize(*total_energy, x);
-        } catch (const std::exception&) {
-            // polysolve might throw errors that we want to ignore (e.g., line search failed)
-        }
-        m_vertex_attribute[vid].m_posf = x;
-        m_vertex_attribute[vid].m_pos = to_rational(Vector2d(x));
-    };
-
-    const auto surf_assembles = get_surface_assembles(t);
-    if (VA[vid].m_is_on_surface) {
-        assert(!surf_assembles.empty());
-
-        auto energy_sum = std::make_shared<optimization::EnergySum>();
-
-        auto envelope_energy = get_envelope_energy(t);
-        // do one solve without weights for amips and envelope
-        if (m_params.w_amips > 0) {
-            energy_sum->add_energy(amips_energy, 1. / m_params.w_amips);
-        }
-        if (m_params.w_envelope > 0) {
-            energy_sum->add_energy(envelope_energy, 1. / m_params.w_envelope);
-        }
-        total_energy = energy_sum;
-        solve();
-
-        // second solve (with proper weights)
-        energy_sum = std::make_shared<optimization::EnergySum>();
-
-        if (m_params.w_amips > 0) {
-            energy_sum->add_energy(amips_energy);
-        }
-        if (m_params.w_envelope > 0) {
-            energy_sum->add_energy(envelope_energy);
-        }
-        total_energy = energy_sum;
-        solve();
-    } else {
-        // not on the surface
-        solve();
-    }
-
-    logger().trace("old pos {} -> new pos {}", old_pos.transpose(), VA[vid].m_posf.transpose());
-
-    // check surface containment
-    if (VA[vid].m_is_on_surface) {
-        for (size_t i = 1; i < surf_assembles.size(); ++i) {
-            std::array<Eigen::Vector2d, 2> edge;
-            edge[0] = VA[vid].m_posf;
-            edge[1] = surf_assembles[i];
-            if (m_envelope->is_outside(edge)) {
-                return false;
-            }
-        }
-    }
-
-    // quality (only check if not on surface)
-    auto max_after_quality = 0.;
-    for (const size_t fid : locs) {
-        if (is_inverted(fid)) {
-            return false;
-        }
-        const double q = get_quality(fid);
-        m_face_attribute[fid].m_quality = q;
-        max_after_quality = std::max(max_after_quality, q);
-    }
-    if (!VA[vid].m_is_on_surface) {
-        if (max_after_quality > max_quality) {
-            return false;
-        }
-    }
-
-    return true;
+std::shared_ptr<SampleEnvelope> TriWildMesh::smoothing_containment_envelope(const size_t) const
+{
+    // triwild keeps a single envelope, so the pull target and the containment test coincide.
+    return m_envelope;
 }
 
 void TriWildMesh::smooth_all_vertices(const size_t n_iters)
@@ -184,89 +113,5 @@ void TriWildMesh::smooth_all_vertices(const size_t n_iters)
     }
 }
 
-std::vector<Vector2d> TriWildMesh::get_surface_assembles(const Tuple& t) const
-{
-    const auto& VA = m_vertex_attribute;
-    const size_t vid = t.vid(*this);
-
-    std::vector<Vector2d> surface_pts;
-
-    if (!VA[vid].m_is_on_surface) {
-        return surface_pts;
-    }
-
-    const auto es = get_surface_edges_for_vertex(vid);
-
-    surface_pts.resize(es.size() + 1);
-    surface_pts[0] = VA[vid].m_posf;
-
-    for (size_t i = 0; i < es.edges().size(); ++i) {
-        const auto& vs = es.edges()[i].vertices();
-        size_t neighbor_id = vs[0] != vid ? vs[0] : vs[1];
-        surface_pts[i + 1] = VA[neighbor_id].m_posf;
-    }
-
-    return surface_pts;
-}
-
-std::shared_ptr<polysolve::nonlinear::Problem> TriWildMesh::get_envelope_energy(
-    const Tuple& t) const
-{
-    const double w = m_s_envelope * m_params.w_envelope;
-
-    auto envelope_energy = std::make_shared<optimization::EnvelopeEnergy2D>(m_envelope, w);
-    return envelope_energy;
-}
-
-std::vector<std::array<double, 6>> TriWildMesh::get_amips_assembles(const Tuple& t) const
-{
-    const size_t vid = t.vid(*this);
-    const auto& locs = get_one_ring_fids_for_vertex(t);
-
-    const auto& VA = m_vertex_attribute;
-
-    std::vector<std::array<double, 6>> assembles;
-    assembles.reserve(locs.size());
-
-    for (const size_t fid : locs) {
-        if (is_inverted(fid)) {
-            log_and_throw_error("Inverted face in amips assemble!");
-        }
-        std::array<size_t, 3> local_verts = oriented_tri_vids(fid);
-        {
-            size_t v_loc = 0;
-            for (size_t i = 0; i < 3; ++i) {
-                if (local_verts[i] == vid) {
-                    v_loc = i;
-                    break;
-                }
-            }
-            std::array<size_t, 3> buf = local_verts;
-            local_verts[0] = buf[v_loc];
-            local_verts[1] = buf[(v_loc + 1) % 3];
-            local_verts[2] = buf[(v_loc + 2) % 3];
-        }
-
-        std::array<double, 6> T;
-        for (int i = 0; i < 3; i++) {
-            for (int j = 0; j < 2; j++) {
-                T[i * 2 + j] = VA[local_verts[i]].m_posf[j];
-            }
-        }
-        assembles.push_back(T);
-    }
-
-    return assembles;
-}
-
-std::shared_ptr<polysolve::nonlinear::Problem> TriWildMesh::get_amips_energy(const Tuple& t) const
-{
-    const double w = m_params.w_amips > 0 ? m_s_amips * m_params.w_amips : 1;
-
-    const auto assembles = get_amips_assembles(t);
-    auto amips_energy = std::make_shared<optimization::AMIPSEnergy2D>(assembles, w);
-    assert(amips_energy->initial_position() == m_vertex_attribute.at(t.vid(*this)).m_posf);
-    return amips_energy;
-}
 
 } // namespace wmtk::components::triwild

--- a/components/triwild/wmtk/components/triwild/TriWildMesh.h
+++ b/components/triwild/wmtk/components/triwild/TriWildMesh.h
@@ -6,6 +6,7 @@
 #include <wmtk/AttributeCollection.hpp>
 #include <wmtk/Types.hpp>
 #include <wmtk/envelope/Envelope.hpp>
+#include <wmtk/optimization/SmoothVertex.hpp>
 #include <wmtk/optimization/solver.hpp>
 #include <wmtk/threading/enumerable_thread_specific.hpp>
 
@@ -103,6 +104,16 @@ public:
 
     wmtk::threading::enumerable_thread_specific<std::unique_ptr<polysolve::nonlinear::Solver>>
         m_solver;
+
+    /// Why smoothing attempts were refused, reported once per pass.
+    optimization::SmoothRejectCounters m_smooth_rejects;
+
+    /// Position hooks for the shared 2D smoothing driver. triwild keeps both a working
+    /// double position and an exact rational one, so writing goes through here.
+    Vector2d smoothing_position(const size_t vid) const;
+    void set_smoothing_position(const size_t vid, const Vector2d& p);
+    std::shared_ptr<SampleEnvelope> smoothing_energy_envelope(const size_t vid) const;
+    std::shared_ptr<SampleEnvelope> smoothing_containment_envelope(const size_t vid) const;
 
     // scaling factors
     double m_s_amips = -1;
@@ -258,11 +269,7 @@ public:
      *
      * Returns an empty vector if vertex is not on the surface.
      */
-    std::vector<Vector2d> get_surface_assembles(const Tuple& t) const;
-    std::shared_ptr<polysolve::nonlinear::Problem> get_envelope_energy(const Tuple& t) const;
 
-    std::vector<std::array<double, 6>> get_amips_assembles(const Tuple& t) const;
-    std::shared_ptr<polysolve::nonlinear::Problem> get_amips_energy(const Tuple& t) const;
 
     /**
      * @brief Inversion check using only floating point numbers.

--- a/src/wmtk/envelope/Envelope.cpp
+++ b/src/wmtk/envelope/Envelope.cpp
@@ -196,6 +196,7 @@ void SampleEnvelope::init(
 
 bool SampleEnvelope::is_outside(const Eigen::Vector3d& pts) const
 {
+    if (disabled) return false;
     if (use_exact) {
         return exact_envelope.is_outside(pts);
     }
@@ -211,6 +212,7 @@ bool SampleEnvelope::is_outside(const Eigen::Vector2d& pts) const
 
 bool SampleEnvelope::is_outside(const std::array<Eigen::Vector3d, 3>& tri) const
 {
+    if (disabled) return false;
     if (use_exact) {
         return exact_envelope.is_outside(tri);
     }
@@ -267,6 +269,7 @@ bool SampleEnvelope::is_outside(const std::array<Eigen::Vector3d, 3>& tri) const
 
 bool SampleEnvelope::is_outside(const std::array<Vector3d, 2>& edge) const
 {
+    if (disabled) return false;
     if (use_exact) {
         log_and_throw_error("Cannot use an exact envelope for edges.");
     }

--- a/src/wmtk/envelope/Envelope.hpp
+++ b/src/wmtk/envelope/Envelope.hpp
@@ -64,9 +64,10 @@ public:
      * optimization is blocked by the envelope or by the mesh itself. It removes the
      * containment guarantee entirely -- the output is not usable, only diagnostic.
      *
-     * Note nearest_point() is unaffected: smoothing still projects surface vertices onto
-     * the envelope surface, because that is a constraint on where a vertex goes rather
-     * than a veto on the operation.
+     * Note nearest_point() is unaffected, so EnvelopeEnergy still pulls surface vertices
+     * toward the input while smoothing. Only the veto goes away, which is the point: it
+     * separates "the optimizer cannot move because the envelope forbids it" from "the
+     * optimizer cannot move at all".
      */
     bool disabled = false;
     void init(

--- a/src/wmtk/envelope/Envelope.hpp
+++ b/src/wmtk/envelope/Envelope.hpp
@@ -55,6 +55,20 @@ public:
     double eps2 = 1e-6;
     double sampling_dist = 1e-3;
     bool use_exact = false;
+
+    /**
+     * Debug escape hatch: when set, every is_outside() answers "inside".
+     *
+     * The envelope is the only thing that can reject an operation for geometric rather
+     * than combinatorial reasons, so turning it off tells you whether a stalled
+     * optimization is blocked by the envelope or by the mesh itself. It removes the
+     * containment guarantee entirely -- the output is not usable, only diagnostic.
+     *
+     * Note nearest_point() is unaffected: smoothing still projects surface vertices onto
+     * the envelope surface, because that is a constraint on where a vertex goes rather
+     * than a veto on the operation.
+     */
+    bool disabled = false;
     void init(
         const std::vector<Eigen::Vector3d>& m_ver,
         const std::vector<Eigen::Vector3i>& m_faces,

--- a/src/wmtk/optimization/SmoothVertex.hpp
+++ b/src/wmtk/optimization/SmoothVertex.hpp
@@ -1,0 +1,234 @@
+#pragma once
+
+#include <wmtk/optimization/AMIPSEnergy.hpp>
+#include <wmtk/optimization/EnergySum.hpp>
+#include <wmtk/optimization/EnvelopeEnergy.hpp>
+#include <wmtk/optimization/solver.hpp>
+
+#include <wmtk/Types.hpp>
+#include <wmtk/envelope/Envelope.hpp>
+#include <wmtk/utils/Logger.hpp>
+#include <wmtk/utils/TetraQualityUtils.hpp>
+
+#include <array>
+#include <atomic>
+#include <memory>
+#include <vector>
+
+namespace wmtk::optimization {
+
+/**
+ * @brief Why a smoothing attempt was refused, counted per pass.
+ *
+ * A smoothing pass that rejects most of what it tries looks identical from outside to one
+ * that is converging, and the difference between "the envelope will not let this vertex
+ * move" and "moving it inverts a tet" points at completely different fixes. Counting is
+ * cheap and turns that question into a log line.
+ */
+struct SmoothRejectCounters
+{
+    std::atomic<size_t> already_inverted{0}; ///< incident tet inverted in floats on entry
+    std::atomic<size_t> envelope{0}; ///< a surface triangle left the envelope
+    std::atomic<size_t> inverted{0}; ///< the move inverted a tet (exact predicate)
+    std::atomic<size_t> quality{0}; ///< the move made the worst incident tet worse
+    std::atomic<size_t> accepted{0};
+
+    void reset()
+    {
+        already_inverted = 0;
+        envelope = 0;
+        inverted = 0;
+        quality = 0;
+        accepted = 0;
+    }
+
+    std::string to_string() const
+    {
+        return fmt::format(
+            "accepted {} | rejected: pre-inverted {}, envelope {}, inverted {}, quality {}",
+            accepted.load(),
+            already_inverted.load(),
+            envelope.load(),
+            inverted.load(),
+            quality.load());
+    }
+};
+
+/**
+ * @brief Weights and policy for smooth_vertex_3d.
+ *
+ * The weights follow simwild's convention: `w_envelope = 1 - w_amips`, with w_amips small
+ * (1e-4), so the envelope term dominates and the AMIPS term acts as a light quality
+ * preference. The scale factors put the two on a comparable footing --- AMIPS is
+ * dimensionless while the envelope energy is a squared distance, so s_envelope is normally
+ * 1 / (diag * eps^2).
+ */
+struct SmoothVertexOptions
+{
+    double w_amips = 1e-4;
+    double w_envelope = 1.0 - 1e-4;
+    double s_amips = 1.0;
+    double s_envelope = 1.0;
+
+    /// Solve once with reciprocal weights before the weighted solve. Cheap warm-up that
+    /// gets the vertex into the right basin before the envelope term dominates.
+    bool two_stage = true;
+
+    /**
+     * Refuse a move that makes the worst incident tet worse.
+     *
+     * Applied to interior vertices always. Applying it to *surface* vertices as well is
+     * what deadlocks a mesh whose surface vertices have drifted: the envelope pulls the
+     * vertex back, that pull worsens some incident tet, the move is refused, and the vertex
+     * never returns. Left false, matching simwild.
+     */
+    bool quality_veto_on_surface = false;
+};
+
+/**
+ * @brief One Newton smoothing step for a single vertex, shared by the 3D applications.
+ *
+ * The envelope enters the objective as a squared-distance penalty rather than as a
+ * projection applied afterwards, so a vertex is drawn back toward the surface gradually and
+ * the line search refuses any step that leaves the envelope
+ * (EnvelopeEnergy3D::is_step_valid). That is the difference from a hard `nearest_point`
+ * snap, which moves the vertex the whole way in one jump and is therefore rejected exactly
+ * when the vertex most needs moving.
+ *
+ * `Mesh` must provide, on top of what wmtk::TetMesh already gives:
+ *   - m_vertex_attribute[vid].{m_pos, m_posf, m_is_on_surface}
+ *   - m_tet_attribute[tid].m_quality
+ *   - is_inverted_f(Tuple), is_inverted(Tuple), get_quality(Tuple)
+ *   - std::shared_ptr<SampleEnvelope> smoothing_envelope(size_t vid) const
+ *     (null is allowed and means "no envelope term for this vertex")
+ *
+ * @return true if the new position was accepted; false leaves it to the caller's rollback.
+ */
+template <class Mesh>
+bool smooth_vertex_3d(
+    Mesh& m,
+    const typename Mesh::Tuple& t,
+    const SmoothVertexOptions& opts,
+    std::unique_ptr<polysolve::nonlinear::Solver>& solver,
+    SmoothRejectCounters* counters = nullptr)
+{
+    using Tuple = typename Mesh::Tuple;
+
+    const size_t vid = t.vid(m);
+    auto& VA = m.m_vertex_attribute;
+    auto& TA = m.m_tet_attribute;
+
+    const auto locs = m.get_one_ring_tets_for_vertex(t);
+    assert(!locs.empty());
+
+    double max_quality = 0.;
+    for (const Tuple& tet : locs) {
+        max_quality = std::max(max_quality, TA[tet.tid(m)].m_quality);
+        if (m.is_inverted_f(tet)) {
+            // A neighbour that is not rounded can leave a tet inverted in floats even
+            // though it is fine in exact arithmetic; there is nothing to optimize from.
+            if (counters) ++counters->already_inverted;
+            return false;
+        }
+    }
+
+    // AMIPS wants each tet as 12 doubles with the moving vertex first, so that the solver
+    // can overwrite the leading xyz.
+    std::vector<std::array<double, 12>> assembles(locs.size());
+    for (size_t i = 0; i < locs.size(); ++i) {
+        std::array<size_t, 4> local_verts = m.oriented_tet_vids(locs[i].tid(m));
+        local_verts = wmtk::orient_preserve_tet_reorder(local_verts, vid);
+        for (int k = 0; k < 4; k++) {
+            for (int j = 0; j < 3; j++) {
+                assembles[i][k * 3 + j] = VA[local_verts[k]].m_posf[j];
+            }
+        }
+    }
+
+    if (!solver) {
+        solver = create_basic_solver();
+    }
+
+    const double amips_w = opts.w_amips > 0 ? opts.s_amips * opts.w_amips : 1.0;
+    auto amips_energy = std::make_shared<AMIPSEnergy3D>(assembles, amips_w);
+    std::shared_ptr<polysolve::nonlinear::Problem> total_energy = amips_energy;
+
+    auto solve = [&]() {
+        VectorXd x = VA[vid].m_posf;
+        try {
+            solver->minimize(*total_energy, x);
+        } catch (const std::exception&) {
+            // polysolve reports a failed line search by throwing; the position it reached
+            // is still the best it found, and the checks below decide whether to keep it.
+        }
+        VA[vid].m_posf = x;
+    };
+
+    const std::shared_ptr<SampleEnvelope> pull_env =
+        VA[vid].m_is_on_surface ? m.smoothing_energy_envelope(vid) : nullptr;
+
+    if (pull_env) {
+        auto envelope_energy =
+            std::make_shared<EnvelopeEnergy3D>(pull_env, opts.s_envelope * opts.w_envelope);
+
+        if (opts.two_stage) {
+            auto warmup = std::make_shared<EnergySum>();
+            if (opts.w_amips > 0) warmup->add_energy(amips_energy, 1. / opts.w_amips);
+            if (opts.w_envelope > 0) warmup->add_energy(envelope_energy, 1. / opts.w_envelope);
+            total_energy = warmup;
+            solve();
+        }
+
+        auto weighted = std::make_shared<EnergySum>();
+        if (opts.w_amips > 0) weighted->add_energy(amips_energy);
+        if (opts.w_envelope > 0) weighted->add_energy(envelope_energy);
+        total_energy = weighted;
+        solve();
+    } else {
+        solve();
+    }
+
+    // Containment: every surface triangle at this vertex must still be inside. Checked
+    // against the containment envelope, which is not necessarily the one it was pulled to.
+    const std::shared_ptr<SampleEnvelope> check_env =
+        VA[vid].m_is_on_surface ? m.smoothing_containment_envelope(vid) : nullptr;
+    if (check_env) {
+        const simplex::SimplexCollection surf = m.get_surface_faces_for_vertex(vid);
+        for (const simplex::Face& f : surf.faces()) {
+            const std::array<Eigen::Vector3d, 3> face = {
+                {VA[f.vertices()[0]].m_posf,
+                 VA[f.vertices()[1]].m_posf,
+                 VA[f.vertices()[2]].m_posf}};
+            if (check_env->is_outside(face)) {
+                if (counters) ++counters->envelope;
+                return false;
+            }
+        }
+    }
+
+    // The rational position must be current before the exact inversion test.
+    VA[vid].m_pos = to_rational(VA[vid].m_posf);
+
+    double max_after_quality = 0.;
+    for (const Tuple& loc : locs) {
+        if (m.is_inverted(loc)) {
+            if (counters) ++counters->inverted;
+            return false;
+        }
+        const size_t tid = loc.tid(m);
+        TA[tid].m_quality = m.get_quality(loc);
+        max_after_quality = std::max(max_after_quality, TA[tid].m_quality);
+    }
+
+    if (!VA[vid].m_is_on_surface || opts.quality_veto_on_surface) {
+        if (max_after_quality > max_quality) {
+            if (counters) ++counters->quality;
+            return false;
+        }
+    }
+
+    if (counters) ++counters->accepted;
+    return true;
+}
+
+} // namespace wmtk::optimization

--- a/src/wmtk/optimization/SmoothVertex.hpp
+++ b/src/wmtk/optimization/SmoothVertex.hpp
@@ -7,6 +7,7 @@
 
 #include <wmtk/Types.hpp>
 #include <wmtk/envelope/Envelope.hpp>
+#include <wmtk/simplex/SimplexCollection.hpp>
 #include <wmtk/utils/Logger.hpp>
 #include <wmtk/utils/TetraQualityUtils.hpp>
 
@@ -218,6 +219,171 @@ bool smooth_vertex_3d(
         const size_t tid = loc.tid(m);
         TA[tid].m_quality = m.get_quality(loc);
         max_after_quality = std::max(max_after_quality, TA[tid].m_quality);
+    }
+
+    if (!VA[vid].m_is_on_surface || opts.quality_veto_on_surface) {
+        if (max_after_quality > max_quality) {
+            if (counters) ++counters->quality;
+            return false;
+        }
+    }
+
+    if (counters) ++counters->accepted;
+    return true;
+}
+
+
+/**
+ * @brief One Newton smoothing step for a single vertex of a 2D mesh.
+ *
+ * The 3D sibling above, one dimension down: 3-vertex elements assembled as 6 doubles, and
+ * containment tested on the surface *edges* incident to the vertex rather than on triangles.
+ * Deliberately a separate function rather than a dimension-templated one -- the arity, the
+ * containment test and the position handling all differ, so branching on a dimension
+ * parameter throughout would read worse than two bodies that each say what they do.
+ *
+ * `Mesh` must provide, on top of what wmtk::TriMesh already gives:
+ *   - m_vertex_attribute[vid].m_is_on_surface, m_face_attribute[fid].m_quality
+ *   - is_inverted_f(size_t fid), is_inverted(size_t fid), get_quality(size_t fid)
+ *   - Vector2d smoothing_position(size_t vid) const
+ *   - void set_smoothing_position(size_t vid, const Vector2d& p)
+ *       writes the working position and any exact/rational copy the mesh keeps; the meshes
+ *       differ here (triwild carries m_posf plus a rational m_pos, simwild 2D carries only
+ *       m_pos), which is why this is a hook rather than a field the driver writes directly
+ *   - smoothing_energy_envelope(vid) / smoothing_containment_envelope(vid), as in 3D
+ */
+template <class Mesh>
+bool smooth_vertex_2d(
+    Mesh& m,
+    const typename Mesh::Tuple& t,
+    const SmoothVertexOptions& opts,
+    std::unique_ptr<polysolve::nonlinear::Solver>& solver,
+    SmoothRejectCounters* counters = nullptr)
+{
+    const size_t vid = t.vid(m);
+    auto& VA = m.m_vertex_attribute;
+    auto& FA = m.m_face_attribute;
+
+    const std::vector<size_t>& locs = m.get_one_ring_fids_for_vertex(t);
+    assert(!locs.empty());
+
+    double max_quality = 0.;
+    for (const size_t fid : locs) {
+        max_quality = std::max(max_quality, FA[fid].m_quality);
+        if (m.is_inverted_f(fid)) {
+            // Nothing to optimize from: a neighbour that is not rounded can leave a face
+            // inverted in floats even when it is fine exactly.
+            if (counters) ++counters->already_inverted;
+            return false;
+        }
+    }
+
+    // AMIPS wants each face as 6 doubles with the moving vertex first, keeping the winding.
+    std::vector<std::array<double, 6>> assembles;
+    assembles.reserve(locs.size());
+    for (const size_t fid : locs) {
+        std::array<size_t, 3> vs = m.oriented_tri_vids(fid);
+        size_t v_loc = 0;
+        for (size_t i = 0; i < 3; ++i) {
+            if (vs[i] == vid) {
+                v_loc = i;
+                break;
+            }
+        }
+        const std::array<size_t, 3> buf = vs;
+        vs[0] = buf[v_loc];
+        vs[1] = buf[(v_loc + 1) % 3];
+        vs[2] = buf[(v_loc + 2) % 3];
+
+        std::array<double, 6> T;
+        for (int i = 0; i < 3; i++) {
+            const Vector2d p = m.smoothing_position(vs[i]);
+            T[i * 2] = p[0];
+            T[i * 2 + 1] = p[1];
+        }
+        assembles.push_back(T);
+    }
+
+    if (!solver) {
+        solver = create_basic_solver();
+    }
+
+    const double amips_w = opts.w_amips > 0 ? opts.s_amips * opts.w_amips : 1.0;
+    auto amips_energy = std::make_shared<AMIPSEnergy2D>(assembles, amips_w);
+    std::shared_ptr<polysolve::nonlinear::Problem> total_energy = amips_energy;
+
+    auto solve = [&]() {
+        VectorXd x = m.smoothing_position(vid);
+        try {
+            solver->minimize(*total_energy, x);
+        } catch (const std::exception&) {
+            // A failed line search is reported by throwing; the position reached is still
+            // the best found, and the checks below decide whether to keep it.
+        }
+        m.set_smoothing_position(vid, Vector2d(x));
+    };
+
+    // Neighbours along the incident surface edges, captured before the solve. Only `vid`
+    // moves, so their positions are the same either way, but taking them first matches what
+    // both applications did and keeps the assert below meaningful.
+    std::vector<Vector2d> surf_neighbors;
+    if (VA[vid].m_is_on_surface) {
+        const simplex::SimplexCollection es = m.get_surface_edges_for_vertex(vid);
+        surf_neighbors.reserve(es.edges().size());
+        for (const simplex::Edge& e : es.edges()) {
+            const auto& evs = e.vertices();
+            surf_neighbors.push_back(m.smoothing_position(evs[0] != vid ? evs[0] : evs[1]));
+        }
+        assert(!surf_neighbors.empty());
+    }
+
+    const std::shared_ptr<SampleEnvelope> pull_env =
+        VA[vid].m_is_on_surface ? m.smoothing_energy_envelope(vid) : nullptr;
+
+    if (pull_env) {
+        auto envelope_energy =
+            std::make_shared<EnvelopeEnergy2D>(pull_env, opts.s_envelope * opts.w_envelope);
+
+        if (opts.two_stage) {
+            auto warmup = std::make_shared<EnergySum>();
+            if (opts.w_amips > 0) warmup->add_energy(amips_energy, 1. / opts.w_amips);
+            if (opts.w_envelope > 0) warmup->add_energy(envelope_energy, 1. / opts.w_envelope);
+            total_energy = warmup;
+            solve();
+        }
+
+        auto weighted = std::make_shared<EnergySum>();
+        if (opts.w_amips > 0) weighted->add_energy(amips_energy);
+        if (opts.w_envelope > 0) weighted->add_energy(envelope_energy);
+        total_energy = weighted;
+        solve();
+    } else {
+        solve();
+    }
+
+    // Containment, edge by edge rather than face by face as in 3D.
+    const std::shared_ptr<SampleEnvelope> check_env =
+        VA[vid].m_is_on_surface ? m.smoothing_containment_envelope(vid) : nullptr;
+    if (check_env) {
+        const Vector2d p = m.smoothing_position(vid);
+        for (const Vector2d& q : surf_neighbors) {
+            const std::array<Eigen::Vector2d, 2> edge = {{p, q}};
+            if (check_env->is_outside(edge)) {
+                if (counters) ++counters->envelope;
+                return false;
+            }
+        }
+    }
+
+    double max_after_quality = 0.;
+    for (const size_t fid : locs) {
+        if (m.is_inverted(fid)) {
+            if (counters) ++counters->inverted;
+            return false;
+        }
+        const double q = m.get_quality(fid);
+        FA[fid].m_quality = q;
+        max_after_quality = std::max(max_after_quality, q);
     }
 
     if (!VA[vid].m_is_on_surface || opts.quality_veto_on_surface) {


### PR DESCRIPTION
Gives tetwild simwild's vertex smoothing, extracted so all four applications run one of two
shared drivers. Rebased onto `main`, which now carries #966 (the lean rewrite that replaced
#964), #967, #968 and #969.

## Why

tetwild froze on `crown.obj`: max energy stuck at ~10¹² against a target of 100, with **94%
of smoothing attempts rejected** (117 accepted, 1,694 refused per pass) and 85 surface
vertices pinned at >90% of the envelope thickness, unchanged to five decimal places across
ten consecutive passes.

Comparing the two smoothers explains it. tetwild optimized AMIPS alone, then **teleported**
the vertex onto the envelope with `nearest_point`, then accepted or rejected the whole thing.
A vertex at 99% of eps is moved ~0.18 in one jump; through a bad neighbourhood that almost
always worsens an incident tet, so the operation was vetoed, the rollback discarded the
projection, and the vertex could never come back. tetwild also applied the quality veto to
surface vertices, which simwild does not.

simwild puts the envelope *in the objective* as a squared-distance penalty, so the pull is a
gradient rather than a teleport and the line search refuses steps that leave the envelope.

## Result on the crown

Same configuration that never converged:

| | old | new |
| --- | ---: | ---: |
| max energy, iterations 0→2 | 7.78e11 → 7.78e11 → **1.13e12 rising** | 7.08e7 → 4232.91 → **86.73** ✓ |
| smoothing | accepted 117, rejected 1694 | accepted 56, rejected 30 |
| rejections by cause | — | envelope 26, quality 4, **inverted 0** |
| Hausdorff vs eps 0.364 | — | **0.212** ✓ |

Zero inversion rejections is the mechanism. It converges *inside* the envelope — disabling
the envelope also "converged" but left the mesh 12.11 away, i.e. by abandoning the constraint
rather than satisfying it.

## What's shared

`src/wmtk/optimization/SmoothVertex.hpp` holds two functions:

- `smooth_vertex_3d` — simwild 3D, tetwild
- `smooth_vertex_2d` — triwild, simwild 2D

Separate rather than dimension-templated: element arity, the containment test (envelope edges
vs triangles) and the position representation all differ.

Each mesh supplies two envelope accessors. **They are two and not one on purpose** — simwild
pulls toward `m_envelope_orig` (or `m_order_2_edge_envelope` for order-2 vertices) while
checking containment against `m_envelope`, and collapsing them changed one config out of
fourteen. The byte comparison is what caught it.

Also adds `SmoothRejectCounters`, logged once per pass. A pass that refuses most of what it
tries is indistinguishable from a converging one without it, and it is the measurement that
would have identified this problem immediately.

## Verification

- **simwild: all 14 configs byte-identical** after the 3D extraction. It is the reference, so
  any difference means the extraction is wrong rather than that something improved.
- **triwild: both configs byte-identical** after the 2D extraction, same role, both with
  `throw_on_fail`.
- **simwild 2D moves and improves** — it gains the float-inversion pre-check and the two-stage
  solve. Of its eight 2D configs, the two that run smoothing passes moved and the six that
  run zero passes are byte-identical:

  | | max energy | #V | #F |
  | --- | --- | --- | --- |
  | energies_2d | 4.907 → 4.782 | 1383 → 1217 | 2686 → 2351 |
  | remeshing_2d | 4.607 → 4.063 | 204 → 198 | 347 → 335 |

- **All four tetwild configs pass**, all with `throw_on_fail`, all under target energy, all
  rounded, all inside the envelope. Re-measured on the rebase (`num_smoothing_passes` 10):

  | config | max energy / stop | containment d(output→input) / eps |
  | --- | ---: | --- |
  | crown | 97.79 / 100 | 0.1182 / 0.3644 |
  | double_sphere | 8.54 / 10 | 0.001341 / 0.005195 |
  | octocat | 9.91 / 10 | 0.08487 / 0.272 |
  | sphere | 5.95 / 10 | 0.001167 / 0.00485 |

  The containment column is the invariant the envelope actually promises, per #967. crown
  sits higher on energy than the pre-rebase 88.72 because the passes went from 50 to 10;
  it still lands under the 100 target.

## Read this before merging — three default changes

The smoothing rewrite is the point of the PR, but the branch also carries three tetwild
defaults that were set while debugging and are **not obviously right for everyone**:

1. **`num_smoothing_passes` defaults to 10** (was effectively 1, hard-coded as `ops[3]`).
   That is 10x the smoothing work per optimization iteration for every tetwild user. The
   integration configs all still pass, but the default deserves a decision rather than
   inheritance.
2. **`simplify_envelope_ratio` defaults to 0.5.** The simplification and the tetrahedralisation
   previously shared one `SampleEnvelope` object at the same eps, leaving the optimizer no
   headroom. They are now two envelopes with the simplification at half. Reasonable, but it
   changes tetwild's simplification for everyone; 1.0 restores the old shared behaviour.
3. **`w_amips` defaults to 1e-4**, hence `w_envelope` ≈ 0.9999. This is simwild's convention
   and is what makes the new smoothing work, but it means smoothing is now primarily about
   staying on the surface with quality as a secondary preference.

`DEBUG_disable_envelope` is also included; it defaults to false and is diagnostic only.

## Not fixed by this

The crown's simplified input has 75 non-manifold edges, 10 components where the original had
7, and Euler characteristic +4 against −9,634. That comes from simplifying with the link
condition off and no smoothing change repairs it. This removes one specific deadlock; whether
crown then produces a *good* mesh is a separate question.

## Rebase notes

Four conflicts, all where `main` moved under the branch:

- **`tetwild.cpp` / `tetwild_spec.json`** — `main` gained `simplify_use_link_condition` and
  `simplify_use_sample_envelope` (#966) next to this branch's `simplify_envelope_ratio`.
  All three kept; they are independent knobs.
- **`TetWildMesh.cpp`** — `main` deleted `check_attributes`, this branch had edited it for the
  `shared_ptr` envelope. Took the deletion.
- **`TetWildMesh.h`** — kept `main`'s `m_input_names` alongside this branch's per-thread solver.
- **`test_surface_swap.cpp`** — kept #969's corrected comment (the "stale flag" state does not
  occur), with only the `shared_ptr` conversion on top.

`src/wmtk/envelope/Envelope.cpp` merged cleanly, so the branch's `disabled` flag now sits on
top of #968's sampling shrink. The data2 pin is `main`'s, unchanged.

One commit on top of the rebase fixes two comments that the rebase made false: the
`SampleEnvelope::disabled` doc still described the `nearest_point` snap this branch removes,
and `tetwild.cpp` still claimed the simplification envelope is handed to `TetWildMesh` (it
gets its own now).

## Verification after the rebase

- `ctest` **91/91 green**, which now includes the component tests (#969 registered them).
- All 33 integration configs pass, 133 s. Six of them run with `throw_on_fail`.
- `clang-format` 21.1.8 clean on every changed file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

