### PR TITLE
Sampled triangle envelope is anti-conservative (an existing CI test is outside the envelope)

### DIFF
--- a/cmake/wmtk_data.cmake
+++ b/cmake/wmtk_data.cmake
@@ -16,7 +16,7 @@ ExternalProject_Add(
     SOURCE_DIR ${WMTK_DATA_ROOT}
 
     GIT_REPOSITORY https://github.com/wildmeshing/data2.git
-    GIT_TAG f5363122a5ae8ca1679788a9373ce3af2e4b1cf5
+    GIT_TAG a4f4e34658aab3cdbd603d13857ebd51e9588f15
 
     CONFIGURE_COMMAND ""
     BUILD_COMMAND ""

--- a/cmake/wmtk_data.cmake
+++ b/cmake/wmtk_data.cmake
@@ -16,7 +16,7 @@ ExternalProject_Add(
     SOURCE_DIR ${WMTK_DATA_ROOT}
 
     GIT_REPOSITORY https://github.com/wildmeshing/data2.git
-    GIT_TAG a4f4e34658aab3cdbd603d13857ebd51e9588f15
+    GIT_TAG 7b255709d6da9253550905308bd0ea68bef7ac59
 
     CONFIGURE_COMMAND ""
     BUILD_COMMAND ""

--- a/src/wmtk/envelope/Envelope.cpp
+++ b/src/wmtk/envelope/Envelope.cpp
@@ -100,8 +100,29 @@ void SampleEnvelope::init(
     }
     exact_envelope.init(V, F, _eps);
 
-    eps2 = _eps * _eps;
-    sampling_dist = std::sqrt(eps2);
+    // sampleTriangle lays samples on a triangular lattice of spacing `sampling_dist`, whose
+    // covering radius is sampling_dist / sqrt(3): every point of the triangle is within that
+    // distance of some sample. So for "every sample is inside" to imply "the whole triangle
+    // is inside the true eps-envelope", the per-sample test has to use the shrunk radius
+    //
+    //     real_envelope = _eps - sampling_dist / sqrt(3)
+    //
+    // Testing against the unshrunk _eps made this anti-conservative: a triangle straying up
+    // to _eps * (1 + 1/sqrt(3)) ~= 1.577 * _eps outside the input could still pass every
+    // sample and be accepted.
+    //
+    // This is what both reference implementations do. TetWild, src/tetwild/State.cpp:
+    //     sampling_dist = eps_input / args.stage;
+    //     eps = eps_input - sampling_dist / std::sqrt(3) * (args.stage + 1 - sub_stage);
+    // and fTetWild, src/Parameters.h, on the sampled (non-NEW_ENVELOPE) path:
+    //     dd = eps_input / 1.5;
+    //     eps_usable = eps_input - dd / std::sqrt(3);
+    // Neither shrinks on its exact-envelope path, because the shrink exists purely to pay
+    // for the sampling. The two edge overloads below already did this; only the triangle
+    // one did not.
+    sampling_dist = _eps;
+    const double real_envelope = _eps - _eps / std::sqrt(3);
+    eps2 = real_envelope * real_envelope;
 
     MatrixXd VV;
     VV.resize(V.size(), 3);


### PR DESCRIPTION
The sampled triangle envelope was anti-conservative: it accepted triangles that lie outside
the envelope it is supposed to enforce.

## An existing CI test already demonstrates this

`shortest_edge_collapse_101633` is an integration config on `main` today, using the sampled
envelope with `eps_rel` 1e-3. It passes. Its output is **outside the envelope**:

| | d(output → input) | eps | ratio | |
| --- | ---: | ---: | ---: | --- |
| `main` today | 0.01820 | 0.01794 | **1.01×** | **outside** |
| with this fix | 0.00771 | 0.01794 | 0.43× | inside |

Measured with `igl::point_mesh_squared_distance` over 300k points sampled on the output
surface. So this is not a theoretical bound being tightened — the envelope guarantee is
already being violated in CI, and the test is green.

`shortest_edge_collapse_double_sphere` is at 0.86× — inside, but only by luck.

## Why

`is_outside(triangle)` accepts a triangle when every sample taken on it is within `eps` of the
input. `sampleTriangle` lays those samples on a triangular lattice of spacing `sampling_dist`,
whose covering radius is `sampling_dist / sqrt(3)` — a point of the triangle can sit that far
from the nearest sample. Testing each sample against the unshrunk `eps` therefore proves
nothing about the triangle between samples: it can stray up to

```
eps * (1 + 1/sqrt(3))  ~=  1.577 * eps
```

outside the input and still pass every sample.

The per-sample test has to use the shrunk radius `eps - sampling_dist / sqrt(3)`.

## This is what both reference implementations do

**TetWild**, `src/tetwild/State.cpp`:

```cpp
sampling_dist = eps_input / args.stage;
eps = eps_input - sampling_dist / std::sqrt(3) * (args.stage + 1 - sub_stage);
eps_2 = eps * eps;
```

At the default `stage == 1` that is exactly `sampling_dist = eps_input` and
`eps = eps_input * (1 - 1/sqrt(3)) = 0.4226 * eps_input` — this patch's formula and its
constants.

**fTetWild**, `src/Parameters.h`, on the sampled (non-`NEW_ENVELOPE`) path:

```cpp
dd = eps_input; dd /= 1.5;
double eps_usable = eps_input - dd / std::sqrt(3);
```

with `dd` the sampling distance handed to `sample_triangle(vs, ps, mesh.params.dd)`. Same
formula, finer sampling.

Neither shrinks on its exact-envelope path, because the shrink pays for the sampling and
nothing else — which is also why `use_exact` is unaffected here.

And internally: **our own two edge overloads already did this**. The triangle overload was the
only place that did not.

## Cost

The envelope is now honestly smaller, so the sampled path simplifies less far. Floors with the
corrected envelope:

| config | target was | floor now |
| --- | ---: | ---: |
| `shortest_edge_collapse_double_sphere` (575 v) | 287 | 430 |
| `shortest_edge_collapse_101633` (89,702 v) | 4,485 | 8,766 |
| `qslim_double_sphere` (575 v) | 172 | 264 |

Three configs asked for more than that and would now fail `throw_on_fail`. Those targets were
only reachable because the envelope was too permissive, so they are raised to 0.8, 0.12 and
0.55 in **data2 `7b25570`**, pinned here.

Note `qslim` holds a default-constructed `SampleEnvelope`, so it is *always* on the sampled
path and has no `use_sample_envelope` key to opt out — worth knowing when looking for what
this change touches, since grepping the configs does not find it.

I also tried fTetWild's finer sampling (`sampling_dist = eps/1.5`, giving `0.615 * eps` instead
of `0.4226 * eps`) to see whether it would preserve the old targets. It does not — it bottoms
out at 327 and 6,258, still short — so the targets were calibrated against the bug rather than
against the shrink factor. Went with the TetWild constants, which also match our edge
overloads.

## Verification

- Unit tests green: 24583 assertions in 54 test cases.
- All 35 integration configs run locally against this build; every one passes with the pinned data2.
- Containment re-measured independently after the fix: 0.43× eps on `model_101633`,
  0.39× on `double_sphere`.
- Everything on the exact-envelope path is untouched, which is every other integration config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
