### PR TITLE
Run the component tests in ctest, and fix the two suites that were broken behind it

### DIFF
--- a/components/cmake/add_component_test.cmake
+++ b/components/cmake/add_component_test.cmake
@@ -43,4 +43,19 @@ function(add_component_test COMPONENT_NAME)
 
     set_target_properties(${COMPONENT_TEST_NAME} PROPERTIES FOLDER wmtk_components_tests)
 
+    # Register with ctest. Without this the executable is built and never run, by CI or by
+    # anyone typing `ctest` locally -- which is how two suites came to sit broken on main
+    # (tetwild's surface-swap case and three shortest_edge_collapse cases), each failing
+    # against behaviour that had changed underneath it while nothing was watching.
+    #
+    # One entry per component rather than catch_discover_tests: that helper lives in Catch2's
+    # `extras` and needs the module path set up, which is done in tests/ and is not visible in
+    # this directory scope. The whole set runs in a few seconds, so per-case granularity is
+    # not worth the extra plumbing here.
+    # --allow-running-no-tests because c1_simplification's two cases are currently commented
+    # out, so its executable holds nothing and Catch2 exits non-zero on an empty run. Without
+    # the flag that component alone would fail the moment these are registered.
+    add_test(NAME ${COMPONENT_TEST_NAME} COMMAND ${COMPONENT_TEST_NAME} --allow-running-no-tests)
+    wmtk_copy_dll(${COMPONENT_TEST_NAME})
+
 endfunction()

--- a/components/shortest_edge_collapse/wmtk/components/shortest_edge_collapse/tests/test_sec.cpp
+++ b/components/shortest_edge_collapse/wmtk/components/shortest_edge_collapse/tests/test_sec.cpp
@@ -13,7 +13,21 @@
 using namespace wmtk;
 using namespace components::shortest_edge_collapse;
 
-TEST_CASE("separate-manifold-patch", "[test_sec]")
+// Quarantined below: three cases that predate freeze_boundary().
+//
+// create_mesh() now ends with freeze_boundary(), and collapse_edge_before() refuses any
+// collapse with a frozen endpoint. The meshes these three build are small open patches in
+// which every vertex lies on a boundary edge, so every vertex is frozen and no collapse can
+// succeed -- the logs show "success / fail: 0 / N". Their expectations (collapse down to 3
+// vertices / 1 face) are unreachable, and separate-manifold-patch additionally asserts
+// out_v.size() == 9 over a 5-vertex input, so it could never have passed as written.
+//
+// freeze_boundary() arrived in b640ec5f, the same commit that last touched this file; the
+// suite was built but never registered with ctest, so nothing noticed. Tagged [.] (skipped
+// by default) rather than deleted: the scenarios are worth keeping, but they need rebuilding
+// on closed meshes, or an opt-out from boundary freezing, to say anything again.
+
+TEST_CASE("separate-manifold-patch", "[test_sec][.stale_pre_freeze_boundary]")
 {
     std::vector<Eigen::Vector3d> v = {
         {Eigen::Vector3d(0, 0, 0),
@@ -56,7 +70,7 @@ TEST_CASE("separate-manifold-patch", "[test_sec]")
 }
 
 
-TEST_CASE("shortest_edge_collapse", "[test_sec]")
+TEST_CASE("shortest_edge_collapse", "[test_sec][.stale_pre_freeze_boundary]")
 {
     // 0___1___2                *
     // \  /\  /                 *
@@ -97,7 +111,7 @@ TEST_CASE("shortest_edge_collapse", "[test_sec]")
     REQUIRE(m.get_faces().size() == 1);
 }
 
-TEST_CASE("shortest_edge_collapse_boundary_edge", "[test_sec]")
+TEST_CASE("shortest_edge_collapse_boundary_edge", "[test_sec][.stale_pre_freeze_boundary]")
 {
     // 0___1___2    0 __1___2      0 __1
     // \  /\  /      \  |  /         \ |

--- a/components/tetwild/wmtk/components/tetwild/EdgeSwapping.cpp
+++ b/components/tetwild/wmtk/components/tetwild/EdgeSwapping.cpp
@@ -244,9 +244,17 @@ bool TetWildMesh::prepare_surface_flip_32(const Tuple& t, const std::vector<size
 
     // The flip adds two surface faces (a,c,d),(b,c,d) on edge (c,d). If any
     // surface face is already incident to edge (c,d), the result is a
-    // non-manifold surface edge (> 2 surface faces) -> reject. This counts the
-    // incident surface faces directly and does NOT rely on the m_is_on_surface
-    // vertex flags (which can be stale), unlike is_edge_on_surface().
+    // non-manifold surface edge (> 2 surface faces) -> reject.
+    //
+    // get_surface_faces_for_edge() opens with
+    //     if (!vertex_is_on_surface(v0) || !vertex_is_on_surface(v1)) return {};
+    // so this answer does depend on the m_is_on_surface vertex flags being in step with
+    // the face tags. They are: the flag is written in only four places and the collapse
+    // rule ORs it, so a vertex cannot silently lose it, and instrumenting this guard to
+    // compare against a direct count over (c,d)'s incident faces finds no disagreement on
+    // any tetwild or simwild integration config. If that ever stops holding, this guard is
+    // one of the places that would silently start passing bad flips, so prefer fixing the
+    // flag over working around it here.
     {
         std::array<size_t, 2> cd{{c, d}};
         assert(tuple_from_edge(cd).is_valid(*this));

--- a/components/tetwild/wmtk/components/tetwild/tests/test_surface_swap.cpp
+++ b/components/tetwild/wmtk/components/tetwild/tests/test_surface_swap.cpp
@@ -265,15 +265,23 @@ TEST_CASE("surface-flip-rejected", "[tetwild_operation][surface_swap]")
         CHECK(count_valid_tets(mesh) == 3);
     }
 
-    SECTION("edge (c,d) already a surface edge (stale vertex flag) -> rejected")
+    SECTION("edge (c,d) already a surface edge -> rejected")
     {
         // Six-vertex, four-tet mesh: the ring (a,b,c,d,e) plus a vertex f=5 with
         // tet T3=(b,c,d,f) sharing face (b,c,d), so edge (c,d) carries a surface
         // face (c,d,f). Flipping (a,b) would give edge (c,d) a 3rd/4th surface
-        // face -> non-manifold, and must be rejected. Crucially we clear c's
-        // m_is_on_surface flag (a stale state that occurs in real runs): the old
-        // is_edge_on_surface()-based guard short-circuits and MISSES this; the
-        // direct surface-face count on edge (c,d) still catches it.
+        // face -> non-manifold, and must be rejected.
+        //
+        // This used to also clear c's m_is_on_surface flag, on the theory that the
+        // flag goes stale in real runs and the guard must not trust it. It does not:
+        // instrumenting prepare_surface_flip_32 to compare the flag-based lookup
+        // against a direct count over (c,d)'s incident faces reports zero
+        // disagreements across every tetwild and simwild integration config, and a
+        // full scan after optimization finds the flagged and genuinely-on-surface
+        // vertex sets identical on sphere, double_sphere, octocat and crown. The
+        // flag is only written in four places and the collapse rule ORs it, so it
+        // cannot silently drop. Poking the attribute by hand therefore built a state
+        // the code cannot reach, and the test failed against correct behaviour.
         SampleEnvelope env;
         init_loose_envelope(env);
         TetWildMesh mesh(params, env, 1);
@@ -300,7 +308,6 @@ TEST_CASE("surface-flip-rejected", "[tetwild_operation][surface_swap]")
         }
         va[E].m_is_on_surface = false;
         va[E].m_order = 0;
-        va[C].m_is_on_surface = false; // STALE flag: c is on surface faces but flag is false
         std::vector<TetAttributes> ta(4);
         mesh.create_mesh_attributes(va, ta);
 


### PR DESCRIPTION
`add_component_test()` built `wmtk_test_<component>` and stopped there — no `catch_discover_tests`,
no `add_test`. **Eight suites were compiled by every CI job and run by none of them.**

That is how two of them came to sit broken on `main`, each failing against behaviour that had
changed underneath it while nothing was watching. This PR registers them and fixes both.

Registering costs **1.34 s for all eight**, so the only reason not to was that nobody had.

## 1. tetwild's surface-swap case

The failing case cleared `c`'s `m_is_on_surface` by hand:

```cpp
va[C].m_is_on_surface = false; // STALE flag: c is on surface faces but flag is false
```

on the theory that this is "a stale state that occurs in real runs", so the guard in
`prepare_surface_flip_32` must not trust the flag.

**It does not occur.** Two independent measurements:

1. **At the point the guard runs.** Instrumented `prepare_surface_flip_32` to compare the
   flag-based `get_surface_faces_for_edge()` against a direct count over `(c,d)`'s incident
   faces. Across all four `tetwild_*` and all fourteen `simwild_*` integration configs:
   **zero disagreements**. The only hit anywhere is this test, poking the attribute directly.

2. **After optimization.** Flagged vertices vs vertices genuinely incident to a surface face:

   | model | surface faces | flagged | truly on surface | false neg | false pos |
   | --- | ---: | ---: | ---: | ---: | ---: |
   | sphere | 1282 | 643 | 643 | 0 | 0 |
   | double_sphere | 1584 | 760 | 760 | 0 | 0 |
   | octocat | 5732 | 2867 | 2867 | 0 | 0 |
   | crown | 4643 | 2303 | 2303 | 0 | 0 |

Consistent with how the flag is written — four sites, and the collapse rule ORs it
(`VA[v2] = VA[v1] || VA[v2]`), so a vertex cannot silently lose it.

So the test built a state the code cannot reach and failed against correct behaviour.
**Fix: delete the fabricated line. No production change.** The scenario it exists to cover —
`(c,d)` already carries a surface face, so the flip would make it non-manifold — is reachable
without it and still checked. Disabling the guard makes the case fail (6 assertions), so it
still has teeth.

## 2. Three shortest_edge_collapse cases

These predate `freeze_boundary()`. `create_mesh()` now ends with it, and
`collapse_edge_before()` refuses any collapse with a frozen endpoint. The meshes these build
are small open patches where *every* vertex lies on a boundary edge — so everything freezes and
nothing collapses (`success / fail: 0 / N`). Their expectations (collapse to 3 vertices / 1
face) are unreachable, and `separate-manifold-patch` additionally asserts `out_v.size() == 9`
over a 5-vertex input, so it could never have passed as written.

`freeze_boundary()` arrived in `b640ec5f` — the same commit that last touched that file.

Tagged `[.]` with the reasoning rather than deleted: the scenarios are worth keeping, but they
need rebuilding on closed meshes, or an opt-out from boundary freezing, to say anything again.

## Also

- **The comment above the `(c,d)` guard was false.** It claimed the guard "does NOT rely on the
  m_is_on_surface vertex flags (which can be stale)". It does — `get_surface_faces_for_edge()`
  opens with `if (!vertex_is_on_surface(v0) || !vertex_is_on_surface(v1)) return {};`. That
  claim is what led the test to fabricate a stale flag in the first place. Replaced with what
  is true: the guard depends on the flags, the flags are consistent (measured above), and if
  that ever changes this guard is one of the places that would quietly start passing bad flips.
- **`c1_simplification`'s two cases are commented out**, so its executable holds nothing and
  Catch2 exits non-zero on an empty run. Registered with `--allow-running-no-tests`.
- One `add_test` per component rather than `catch_discover_tests`: that helper lives in Catch2's
  `extras` and needs a module path set up in `tests/`, not visible in this directory scope. At a
  few seconds for the whole set, per-case granularity is not worth the plumbing.

## Result

**62 of 62 ctest entries pass**, component suites included, in 1.77 s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
