### PR TITLE
tetwild: round every vertex that can be rounded, and say so honestly

### DIFF
--- a/components/tetwild/wmtk/components/tetwild/EdgeSplitting.cpp
+++ b/components/tetwild/wmtk/components/tetwild/EdgeSplitting.cpp
@@ -163,14 +163,23 @@ bool TetWildMesh::split_edge_after(const Tuple& loc)
     }
     if (!m_vertex_attribute[v_id].m_is_rounded) {
         // The rounded (double) midpoint inverts an incident tet. By default reject
-        // the split. But if this edge belongs to the current worst-tet set (the
-        // seeds picked by refine_sizing_around_worst) and the rational fallback is
-        // enabled, place the new vertex at the EXACT rational midpoint of the two
-        // endpoints instead. That midpoint lies on the shared edge, so it can never
-        // invert a previously-valid incident tet -- the split always succeeds and
-        // the worst region can keep being refined. The vertex stays un-rounded
-        // (m_pos exact, m_is_rounded=false) until a later round() reclaims it.
-        if (!m_params.stuck_refine_rational_split) {
+        // the split. But if the rational fallback is enabled, place the new vertex at
+        // the EXACT rational midpoint of the two endpoints instead. That midpoint lies
+        // on the shared edge, so it can never invert a previously-valid incident tet --
+        // the split always succeeds and a stuck region can keep being refined. The
+        // vertex stays un-rounded (m_pos exact, m_is_rounded=false) until a later
+        // round() reclaims it.
+        //
+        // Only when an endpoint is already rational, though. Splitting between two
+        // rounded endpoints would manufacture a brand-new rational vertex out of a
+        // fully-rounded neighbourhood, so a mesh that had reached "All rounded!" could
+        // go back to carrying exact coordinates -- and did: model 73435 finished with
+        // unrounded vertices having reported all-rounded one iteration earlier. With
+        // this rule rationals only ever propagate from existing rationals, so the
+        // rounded set cannot shrink and the invariant is monotone.
+        const bool endpoint_is_rational =
+            !m_vertex_attribute[v1_id].m_is_rounded || !m_vertex_attribute[v2_id].m_is_rounded;
+        if (!m_params.stuck_refine_rational_split || !endpoint_is_rational) {
             return false;
         }
 
@@ -183,6 +192,9 @@ bool TetWildMesh::split_edge_after(const Tuple& loc)
                 return false;
             }
         }
+        // This split keeps an un-rounded vertex, so the sweep must not skip the next
+        // pass. Set after the rollback checks above, which leave the mesh unchanged.
+        m_all_rounded.store(false, std::memory_order_relaxed);
     }
 
     /// update quality

--- a/components/tetwild/wmtk/components/tetwild/TetWildMesh.cpp
+++ b/components/tetwild/wmtk/components/tetwild/TetWildMesh.cpp
@@ -82,13 +82,12 @@ void TetWildMesh::mesh_improvement(int max_its)
         ///energy check
         logger().info("max energy {:.6} | stop {:.6}", max_energy, m_params.stop_energy);
 
-        if (max_energy < m_params.stop_energy) {
-            break;
-        }
-        consolidate_mesh();
-
-        logger().info("#V = {}, #T = {}", vert_capacity(), tet_capacity());
-
+        // Count the rounded vertices BEFORE the stop check. This used to sit after the
+        // break, so the iteration that actually reached the energy target never reported
+        // its rounding: the last thing the log said was "All rounded!" from the previous
+        // iteration, and finalize could then still fail with "Not all vertices rounded!".
+        // The log was not wrong, it was one iteration stale, which reads exactly like a
+        // contradiction.
         auto cnt_round = 0, cnt_verts = 0;
         TetMesh::for_each_vertex([&](auto& v) {
             if (m_vertex_attribute[v.vid(*this)].m_is_rounded) cnt_round++;
@@ -97,8 +96,15 @@ void TetWildMesh::mesh_improvement(int max_its)
         if (cnt_round < cnt_verts) {
             logger().info("rounded {}/{}", cnt_round, cnt_verts);
         } else {
-            logger().info("All rounded!", cnt_round, cnt_verts);
+            logger().info("All rounded!");
         }
+
+        if (max_energy < m_params.stop_energy) {
+            break;
+        }
+        consolidate_mesh();
+
+        logger().info("#V = {}, #T = {}", vert_capacity(), tet_capacity());
 
         /// sizing field: when the max energy stalls, refine around the worst
         /// elements to escape stuck configurations (replaces the old global
@@ -121,6 +127,36 @@ void TetWildMesh::mesh_improvement(int max_its)
 
     logger().info("========it post========");
     local_operations({{0, 1, 0, 0}});
+}
+
+size_t TetWildMesh::round_all_vertices()
+{
+    if (m_all_rounded.load(std::memory_order_relaxed)) {
+        return 0;
+    }
+
+    size_t reclaimed = 0, still_unrounded = 0;
+    for (const Tuple& v : get_vertices()) {
+        if (m_vertex_attribute[v.vid(*this)].m_is_rounded) {
+            continue;
+        }
+        if (round(v)) {
+            ++reclaimed;
+        } else {
+            ++still_unrounded;
+        }
+    }
+
+    if (still_unrounded == 0) {
+        m_all_rounded.store(true, std::memory_order_relaxed);
+    }
+    if (reclaimed > 0 || still_unrounded > 0) {
+        logger().info(
+            "rounding sweep: reclaimed {}, still unrounded {}",
+            reclaimed,
+            still_unrounded);
+    }
+    return reclaimed;
 }
 
 void TetWildMesh::mesh_improvement_legacy(int max_its)
@@ -505,6 +541,20 @@ std::tuple<double, double> TetWildMesh::local_operations(
             for (int n = 0; n < ops[i]; n++) {
                 logger().info("==smoothing {}==", n);
                 smooth_all_vertices();
+            }
+            // Reclaim whatever smoothing just made roundable: once per iteration, after
+            // all of its smoothing passes. Here rather than at the end of the run because
+            // smoothing is what frees a stuck vertex, and because a vertex left rational
+            // makes every incident tet take the exact-arithmetic path in get_quality --
+            // so rounding early keeps the following passes on doubles.
+            //
+            // Guarded on ops[i] so it really is once per iteration: this branch is also
+            // entered by the collapse-only pre and post passes, which pass ops[3] == 0
+            // and have no smoothing for the sweep to follow.
+            //
+            // Skipped entirely once m_all_rounded is set.
+            if (ops[i] > 0) {
+                round_all_vertices();
             }
             if (m_params.debug_output) {
                 save_paraview(fmt::format("debug_{}", debug_print_counter++), false);

--- a/components/tetwild/wmtk/components/tetwild/TetWildMesh.cpp
+++ b/components/tetwild/wmtk/components/tetwild/TetWildMesh.cpp
@@ -88,19 +88,43 @@ void TetWildMesh::mesh_improvement(int max_its)
         // iteration, and finalize could then still fail with "Not all vertices rounded!".
         // The log was not wrong, it was one iteration stale, which reads exactly like a
         // contradiction.
-        auto cnt_round = 0, cnt_verts = 0;
+        // Atomic because for_each_vertex runs threading::parallel_for whenever
+        // NUM_THREADS != 0. These were plain ints, which raced: octocat reported counts
+        // like "-37 of 4149 un-rounded", i.e. cnt_round > cnt_verts. Harmless while this
+        // only fed a log line, not harmless now that it decides whether to stop.
+        std::atomic<int> n_round = 0, n_verts = 0;
         TetMesh::for_each_vertex([&](auto& v) {
-            if (m_vertex_attribute[v.vid(*this)].m_is_rounded) cnt_round++;
-            cnt_verts++;
+            if (m_vertex_attribute[v.vid(*this)].m_is_rounded) {
+                n_round.fetch_add(1, std::memory_order_relaxed);
+            }
+            n_verts.fetch_add(1, std::memory_order_relaxed);
         });
+        const int cnt_round = n_round.load(std::memory_order_relaxed);
+        const int cnt_verts = n_verts.load(std::memory_order_relaxed);
         if (cnt_round < cnt_verts) {
             logger().info("rounded {}/{}", cnt_round, cnt_verts);
         } else {
             logger().info("All rounded!");
         }
 
+        // Energy alone is not a sufficient termination condition. A mesh that hits the
+        // quality target while some vertex still carries exact coordinates is not
+        // finished: the output is what the caller consumes, and rational coordinates in
+        // it are a defect regardless of how good the elements are. So keep iterating
+        // while anything is un-rounded, and let max_its bound the run as before.
+        //
+        // The exact count is used rather than m_all_rounded, which is only maintained
+        // where the sweep runs (after smoothing) and would stay stale at
+        // num_smoothing_passes == 0, stranding the loop at max_its for no reason.
         if (max_energy < m_params.stop_energy) {
-            break;
+            if (cnt_round == cnt_verts) {
+                break;
+            }
+            logger().info(
+                "energy target reached, but {} of {} vertices are still un-rounded; "
+                "continuing",
+                cnt_verts - cnt_round,
+                cnt_verts);
         }
         consolidate_mesh();
 

--- a/components/tetwild/wmtk/components/tetwild/TetWildMesh.h
+++ b/components/tetwild/wmtk/components/tetwild/TetWildMesh.h
@@ -311,6 +311,27 @@ public:
     double get_quality(const std::array<size_t, 4>& vs) const;
     double get_quality(const Tuple& loc) const;
     bool round(const Tuple& loc);
+    /**
+     * @brief Try to round every un-rounded vertex; returns the number reclaimed.
+     *
+     * round() is otherwise only attempted as a side effect of another operation
+     * (smooth_before on the vertex being smoothed, collapse_edge_after on the merged
+     * one), and neither reaches a vertex that only becomes roundable later: smoothing
+     * skips "good" regions by default. Without a sweep such a vertex keeps exact
+     * coordinates into the output for no geometric reason.
+     *
+     * Skipped outright when m_all_rounded says there is nothing to do.
+     */
+    size_t round_all_vertices();
+
+    /**
+     * @brief True when every vertex is known to be rounded.
+     *
+     * Only trusted when true, and only round_all_vertices() sets it that way. Any code
+     * that leaves a vertex un-rounded must clear it, or the sweep will skip the vertex
+     * forever. Atomic because operations that clear it run in parallel.
+     */
+    std::atomic<bool> m_all_rounded = false;
     //
     bool is_edge_on_surface(const Tuple& loc);
     bool is_edge_on_bbox(const Tuple& loc);

--- a/components/tetwild/wmtk/components/tetwild/VolumemesherInsertion.cpp
+++ b/components/tetwild/wmtk/components/tetwild/VolumemesherInsertion.cpp
@@ -1514,6 +1514,7 @@ void TetWildMesh::init_from_Volumeremesher(
             if (m_vertex_attribute[vid].m_is_rounded) {
                 m_vertex_attribute[vid].m_pos = v_rational[vid];
                 m_vertex_attribute[vid].m_is_rounded = false;
+                m_all_rounded.store(false, std::memory_order_relaxed);
             }
         }
     }


### PR DESCRIPTION
Stacked on #965 — review that first; this branch's diff against it is four files in `components/tetwild`.

Thingi10K model 73435 is a recorded `>3600s` timeout in the failure set that now finishes in ~25 s. It came out with `all_rounded: false` immediately after the log said `All rounded!`. Three defects, none of them the geometry.

## The log was a full iteration stale

The rounded-vertex count sat *after* the `max_energy < stop_energy` break, so the iteration that actually reached the target never reported its own rounding — the last line printed came from the iteration before it.

Moving the count above the break shows there was never a rounded-then-rational contradiction to explain:

```
it 0:  rounded 7236/7244
it 1:  rounded 6719/6720      <- now reported; was invisible
it post -> "Not all vertices rounded!"
```

It never reached "All rounded!" at all. The stale log is the only reason it looked like a contradiction.

## Nothing ever retried `round()`

`round()` is only attempted as a side effect of another operation — `smooth_before` on the vertex being smoothed, `collapse_edge_after` on the merged one. Neither reaches a vertex that becomes roundable *late*, because smoothing skips "good" regions (`skip_good_regions` defaults on) and the post pass is collapse-only.

73435's single leftover vertex, instrumented at finalize:

```
unrounded v1359: |to_double(m_pos) - m_posf| = 0.000000e+00,
                 one-ring 18 tets, quality [40.82, 143.7],
                 rounding inverts 0 of them, on_surface=true, order=2
```

Its rational position was **already exactly its double position**, and rounding inverted **none** of its 18 incident tets. Not geometrically stuck — never asked.

`round_all_vertices()` runs once per iteration, after that iteration's smoothing passes. Smoothing is what frees a stuck vertex, and rounding early also keeps the following passes on doubles: a single rational vertex forces every incident tet through the exact-arithmetic path in `get_quality`. Guarded on `ops[3] > 0`, since the collapse-only pre/post passes enter the same branch.

`m_all_rounded` skips the sweep once there is nothing to do. Trusted only when true, set only by the sweep, and cleared by the two places that leave a vertex un-rounded: the rational-split fallback and the insertion revert loop.

## The rational split could manufacture rationals from nothing

When a split's rounded midpoint would invert an incident tet, the fallback places the new vertex at the exact rational midpoint. It was gated only on `stuck_refine_rational_split`, so it fired between two already-rounded endpoints — a fully-rounded neighbourhood could produce a fresh rational vertex. It now also requires an endpoint to be rational, so rationals only propagate from existing rationals and the rounded set cannot shrink.

**This change fixed no output I measured.** The sweep is what fixes 73435. It is an invariant worth holding, not a demonstrated bug fix — flagging that rather than letting the commit imply otherwise.

## Result

73435, single-threaded (deterministic — this is the configuration that reproduced the failure on Linux):

| | before | after |
| --- | --- | --- |
| rounding | `Not all vertices rounded!` | `reclaimed 8, still unrounded 0` |
| `all_rounded` | false | **true** |
| max energy | 26.47 / 100 | 26.47 / 100 |

The mesh shifts slightly (6306 → 6316 v) because rounding a vertex earlier moves its tets off the exact path and changes later decisions. That is the intent of sweeping per-iteration rather than once at the end, not a side effect.

## Termination no longer stops at the energy target alone

A run could reach `stop_energy` with rational coordinates still in the mesh and stop there. The output is what the caller consumes, so the loop now also requires every vertex to be rounded; `max_iterations` (default 80) bounds it as before.

The exact count is used rather than `m_all_rounded`, deliberately: the flag is only maintained where the sweep runs, so at `num_smoothing_passes: 0` it would stay false and strand every run at 80 iterations.

### That exposed a pre-existing data race

`TetMesh::for_each_vertex` dispatches to `threading::parallel_for` whenever `NUM_THREADS != 0`, and the rounded/total counters were plain `int`s. So **every `rounded X/Y` line tetwild has logged under threading was unreliable.** Octocat printed:

```
energy target reached, but -37 of 4149 vertices are still un-rounded
```

`cnt_round > cnt_verts` — impossible serially. Harmless while the number only fed a log line; not harmless once it decides whether to stop.

| counters | negative counts | spurious continuations | integration |
| --- | ---: | ---: | ---: |
| plain `int` (racy) | 76 | 76 | 323 s |
| `std::atomic<int>` | **0** | **0** | **145 s** |

All six tetwild/triwild configs still reach the target fully rounded, so the stricter condition costs them nothing.

## Verification

- `ctest` **91/91 green**, integration included, 145 s (138 s before this branch; the 7 s is the sweep plus the now-exact counting).
- The sweep **never logs** on any of the six tetwild/triwild integration configs — they were already fully rounded, so it costs nothing where there is nothing to fix.
- `clang-format` 21.1.8 clean.

## Not covered

The `m_all_rounded` skip is correct by construction but **no run I measured exercised it**: on 73435 the flag is set during the last iteration that smooths, and the integration configs never set it because they never have unrounded vertices. A model that rounds fully early and then keeps optimizing would.

Separately, and not addressed here: valgrind on 73435 found 6 uninitialised-value contexts, **all** inside libigl's `readSTL` / `read_triangle_mesh`, zero in wmtk (leaks clean: 0 definitely, 0 indirectly lost). That path is also where two other models in the same failure set die — two 84-byte empty STLs segfault, and one malformed STL escapes as an uncaught `std::runtime_error`. Likely one weak parser rather than three bugs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
