### PR TITLE
tetwild: stop split cascades from running a vertex to 10k incident tets

### DIFF
--- a/components/tetwild/wmtk/components/tetwild/EdgeSplitting.cpp
+++ b/components/tetwild/wmtk/components/tetwild/EdgeSplitting.cpp
@@ -14,6 +14,17 @@ void TetWildMesh::split_all_edges()
     igl::Timer timer;
     double time;
     m_force_split_count = 0;
+
+    // Reset the high-valence claims for this pass. Sized at vert_capacity() now: storage
+    // is preallocated per phase, so any vertex a split creates during this pass already
+    // has an id below it (same invariant run_localized_to_convergence relies on for
+    // vertex_epoch). make_unique value-initialises, so every slot starts at 0.
+    if (m_params.split_high_valence_threshold > 0) {
+        m_high_valence_claim_size = vert_capacity();
+        m_high_valence_claim = std::make_unique<std::atomic<int>[]>(m_high_valence_claim_size);
+    }
+    m_high_valence_rejects = 0;
+
     timer.start();
     auto collect_all_ops = wmtk::parallel_collect_edge_ops(
         *this,
@@ -72,6 +83,12 @@ void TetWildMesh::split_all_edges()
             "[force-split] {} worst-tet longest edges force-split",
             m_force_split_count);
     }
+    if (const size_t n = m_high_valence_rejects.load(); n > 0) {
+        wmtk::logger().info(
+            "[high-valence] {} splits refused to avoid growing a vertex past {} incident tets",
+            n,
+            m_params.split_high_valence_threshold);
+    }
     // Consumed: the queued force-split edges no longer exist after this pass.
     m_force_split_edges.clear();
 }
@@ -111,6 +128,40 @@ bool TetWildMesh::split_edge_before(const Tuple& loc0)
     };
 
     auto tets = get_incident_tets_for_edge(loc0);
+
+    // High-valence gate. Splitting (v1,v2) leaves the endpoints' own incident-tet counts
+    // unchanged -- each keeps one child of every tet it was in -- and adds one to every
+    // vertex in the edge's link, since those sit in both children. So the gate applies to
+    // the link.
+    //
+    // A vertex past the threshold accepts one such split per pass and refuses the rest,
+    // which spreads the refinement instead of letting it pile onto the same vertex. Done
+    // here, before the face caching below, so a refusal is cheap.
+    if (m_params.split_high_valence_threshold > 0 && m_high_valence_claim) {
+        const size_t threshold = static_cast<size_t>(m_params.split_high_valence_threshold);
+        std::vector<size_t> to_claim;
+        for (const Tuple& t : tets) {
+            const auto vs = oriented_tet_vertices(t);
+            for (int j = 0; j < 4; j++) {
+                const size_t vid = vs[j].vid(*this);
+                if (vid == v1_id || vid == v2_id) continue;
+                if (vid >= m_high_valence_claim_size) continue;
+                if (vertex_valence(vid) <= threshold) continue;
+                if (m_high_valence_claim[vid].load(std::memory_order_relaxed) != 0) {
+                    // Already spent this pass. Refuse rather than grow it further.
+                    m_high_valence_rejects.fetch_add(1, std::memory_order_relaxed);
+                    return false;
+                }
+                to_claim.push_back(vid);
+            }
+        }
+        // Claim only once the whole link is known to be free, so a refusal late in the
+        // loop does not burn the budget of a vertex found earlier.
+        for (const size_t vid : to_claim) {
+            m_high_valence_claim[vid].store(1, std::memory_order_relaxed);
+        }
+    }
+
     for (auto& t : tets) {
         auto vs = oriented_tet_vertices(t);
         for (int j = 0; j < 4; j++) {

--- a/components/tetwild/wmtk/components/tetwild/Parameters.h
+++ b/components/tetwild/wmtk/components/tetwild/Parameters.h
@@ -82,6 +82,22 @@ struct Parameters
     double stop_energy = 10;
 
     /**
+     * Incident-tet count above which a vertex is treated as pathological, or 0 to
+     * disable the gate.
+     *
+     * A well-shaped tet mesh has vertex valence around 20-30. When a split cascade
+     * concentrates on one vertex the valence runs away -- Thingi10K model 71263 reached
+     * 10896 -- and every operation touching it becomes O(valence): the one-ring walks in
+     * split_edge_after alone stall the pass. Above this threshold a vertex accepts only
+     * one valence-increasing split per split pass, which lets the refinement spread out
+     * instead of piling onto the same vertex.
+     *
+     * Splitting edge (a,b) leaves a's and b's own counts unchanged and adds one to every
+     * vertex in the edge's link, so the gate is applied to the link, not the endpoints.
+     */
+    int split_high_valence_threshold = 200;
+
+    /**
      * Relative weight of the AMIPS (quality) term against the envelope (stay-on-surface)
      * term during smoothing. w_envelope is derived as 1 - w_amips in the TetWildMesh
      * constructor, so the small default means the envelope dominates and AMIPS acts as a

--- a/components/tetwild/wmtk/components/tetwild/TetWildMesh.h
+++ b/components/tetwild/wmtk/components/tetwild/TetWildMesh.h
@@ -597,6 +597,16 @@ public:
     /// parallel split; reset + logged by split_all_edges). Diagnostic only.
     size_t m_force_split_count = 0;
 
+    /// Per-pass claim for the high-valence split gate: one slot per vertex, reset at the
+    /// start of every split pass. A high-valence vertex accepts the first
+    /// valence-increasing split of the pass and refuses the rest, so refinement spreads
+    /// instead of piling onto the same vertex. Atomic because splits run in parallel; a
+    /// plain array of unique_ptr rather than a vector because std::atomic is not movable.
+    std::unique_ptr<std::atomic<int>[]> m_high_valence_claim;
+    size_t m_high_valence_claim_size = 0;
+    /// Splits refused by that gate in the current pass, reported once per pass.
+    std::atomic<size_t> m_high_valence_rejects = 0;
+
     /// True iff edge (v1,v2) is a worst tet's longest edge queued for force-split.
     bool is_force_split_edge(size_t v1, size_t v2) const
     {

--- a/components/tetwild/wmtk/components/tetwild/tetwild.cpp
+++ b/components/tetwild/wmtk/components/tetwild/tetwild.cpp
@@ -129,6 +129,7 @@ TetWildMesh::ExportStruct tetwild_with_export(nlohmann::json json_params)
     params.epsr = json_params["eps_rel"];
     params.lr = json_params["length_rel"];
     params.stop_energy = json_params["stop_energy"];
+    params.split_high_valence_threshold = json_params["split_high_valence_threshold"];
     params.num_smoothing_passes = json_params["num_smoothing_passes"];
     params.w_amips = json_params["w_amips"];
 

--- a/components/tetwild/wmtk/components/tetwild/tetwild_spec.json
+++ b/components/tetwild/wmtk/components/tetwild/tetwild_spec.json
@@ -22,6 +22,7 @@
       "eps_rel",
       "length_rel",
       "stop_energy",
+      "split_high_valence_threshold",
       "w_amips",
       "num_smoothing_passes",
       "preserve_topology",
@@ -181,6 +182,12 @@
     "type": "float",
     "default": 10,
     "doc": "Target energy. If all tets have an energy below this, tetwild will stop."
+  },
+  {
+    "pointer": "/split_high_valence_threshold",
+    "type": "int",
+    "default": 200,
+    "doc": "Incident-tet count above which a vertex accepts only one valence-increasing split per split pass, or 0 to disable. A well-shaped tet mesh has valence around 20-30; a split cascade can drive one vertex into the thousands, at which point every operation touching it is O(valence) and the pass stalls. Splitting an edge leaves its endpoints' counts unchanged and adds one to each vertex in the edge's link, so the gate applies to the link."
   },
   {
     "pointer": "/w_amips",

--- a/src/wmtk/TetMesh.cpp
+++ b/src/wmtk/TetMesh.cpp
@@ -389,6 +389,54 @@ TetMesh::Tuple TetMesh::tuple_from_face(size_t tid, int local_fid) const
     return Tuple(*this, vid, eid, local_fid, tid);
 }
 
+size_t TetMesh::lowest_common_tet(const size_t v0_id, const size_t v1_id, const size_t v2_id) const
+{
+    const auto& t0 = m_vertex_connectivity[v0_id].m_conn_tets;
+    const auto& t1 = m_vertex_connectivity[v1_id].m_conn_tets;
+    const auto& t2 = m_vertex_connectivity[v2_id].m_conn_tets;
+
+    // Scan the SMALLEST of the three fans and test the other two vertices against each
+    // candidate tet, rather than merging all three in lockstep.
+    //
+    // The lockstep merge advances every pointer, so it costs O(|t0| + |t1| + |t2|) --
+    // set by the LARGEST fan. That is fine when the fans are all ~20-30, which is the
+    // valence of a well-shaped tet mesh, and it is why the merge was written that way.
+    // It collapses when the fans are skewed. On Thingi10K model 71263 a split cascade
+    // drove two vertices to 5494 and 10896 incident tets while the third had 10: the
+    // merge walked ~16k entries to find a tet that 10 candidates would have located.
+    // split_edge_before calls this four times per incident tet, so the pass stopped
+    // making visible progress -- 98.5% of samples sat in this function.
+    //
+    // Scanning the smallest fan costs O(min fan) with a four-element check per candidate,
+    // so it is comparable at normal valence and bounded by the *best* vertex rather than
+    // the worst when the mesh degenerates.
+    //
+    // m_conn_tets is sorted, so scanning upward returns the lowest common tet id -- the
+    // canonicalisation the global face id depends on, since a face shared by two tets
+    // must get the same id from either side.
+    const std::vector<size_t>* fan = &t0;
+    size_t other_a = v1_id;
+    size_t other_b = v2_id;
+    if (t1.size() < fan->size()) {
+        fan = &t1;
+        other_a = v0_id;
+        other_b = v2_id;
+    }
+    if (t2.size() < fan->size()) {
+        fan = &t2;
+        other_a = v0_id;
+        other_b = v1_id;
+    }
+
+    for (const size_t tid : *fan) {
+        const auto& conn = m_tet_connectivity[tid];
+        if (conn.find(other_a) >= 0 && conn.find(other_b) >= 0) {
+            return tid;
+        }
+    }
+    return std::numeric_limits<size_t>::max();
+}
+
 std::tuple<TetMesh::Tuple, size_t> TetMesh::tuple_from_face(const std::array<size_t, 3>& vids) const
 {
     size_t v0_id = vids[0];
@@ -402,41 +450,16 @@ std::tuple<TetMesh::Tuple, size_t> TetMesh::tuple_from_face(const std::array<siz
         const auto& t0 = m_vertex_connectivity[v0_id].m_conn_tets;
         const auto& t1 = m_vertex_connectivity[v1_id].m_conn_tets;
         const auto& t2 = m_vertex_connectivity[v2_id].m_conn_tets;
-        size_t i0 = 0;
-        size_t i1 = 0;
-        size_t i2 = 0;
 
         if (t0.empty() || t1.empty() || t2.empty()) {
             assert(false && "tuple_from_face: one of the vertices has no incident tets");
             return {Tuple(), -1};
         }
 
-        while (true) {
-            if (t0[i0] < t1[i1] || t0[i0] < t2[i2]) {
-                i0++;
-                if (i0 == t0.size()) {
-                    assert(false && "tuple_from_face: no common tet found for the three vertices");
-                    return {Tuple(), -1};
-                }
-            }
-            if (t1[i1] < t2[i2] || t1[i1] < t0[i0]) {
-                i1++;
-                if (i1 == t1.size()) {
-                    assert(false && "tuple_from_face: no common tet found for the three vertices");
-                    return {Tuple(), -1};
-                }
-            }
-            if (t2[i2] < t0[i0] || t2[i2] < t1[i1]) {
-                i2++;
-                if (i2 == t2.size()) {
-                    assert(false && "tuple_from_face: no common tet found for the three vertices");
-                    return {Tuple(), -1};
-                }
-            }
-            if (t0[i0] == t1[i1] && t0[i0] == t2[i2]) {
-                global_tid = t0[i0];
-                break;
-            }
+        global_tid = lowest_common_tet(v0_id, v1_id, v2_id);
+        if (global_tid == std::numeric_limits<size_t>::max()) {
+            assert(false && "tuple_from_face: no common tet found for the three vertices");
+            return {Tuple(), -1};
         }
     }
 

--- a/src/wmtk/TetMesh.h
+++ b/src/wmtk/TetMesh.h
@@ -954,6 +954,25 @@ public:
      * @param vids Global vertex index of the face
      */
     std::tuple<Tuple, size_t> tuple_from_face(const std::array<size_t, 3>& vids) const;
+
+    /**
+     * @brief Lowest tet id incident to all three vertices, or size_t(-1) if there is none.
+     *
+     * Costs O(smallest incident-tet fan) rather than O(largest), which matters when the
+     * fans are skewed -- see the implementation for the case that motivated it.
+     */
+    size_t lowest_common_tet(size_t v0_id, size_t v1_id, size_t v2_id) const;
+
+    /**
+     * @brief Number of tets incident to a vertex, in O(1).
+     *
+     * Around 20-30 on a well-shaped mesh. Worth checking before anything that walks the
+     * one ring, since a degenerate mesh can push it into the thousands.
+     */
+    size_t vertex_valence(const size_t vid) const
+    {
+        return m_vertex_connectivity[vid].m_conn_tets.size();
+    }
     std::tuple<Tuple, size_t> tuple_from_face(const simplex::Face& f) const;
 
     /**

--- a/src/wmtk/TetMeshTuple.cpp
+++ b/src/wmtk/TetMeshTuple.cpp
@@ -216,43 +216,21 @@ size_t TetMesh::Tuple::fid(const TetMesh& m) const
 
     size_t tid = std::numeric_limits<size_t>::max();
 
-    // find lowest common tet id
+    // find lowest common tet id -- see TetMesh::lowest_common_tet for why it scans the
+    // smallest fan rather than merging all three.
     {
         const auto& t0 = m.m_vertex_connectivity[v0_id].m_conn_tets;
         const auto& t1 = m.m_vertex_connectivity[v1_id].m_conn_tets;
         const auto& t2 = m.m_vertex_connectivity[v2_id].m_conn_tets;
-        size_t i0 = 0;
-        size_t i1 = 0;
-        size_t i2 = 0;
 
         if (t0.empty() || t1.empty() || t2.empty()) {
             log_and_throw_error(
                 "Tuple::fid(*this) error: One of the vertices has an empty tet vector");
         }
 
-        while (true) {
-            if (t0[i0] < t1[i1] || t0[i0] < t2[i2]) {
-                i0++;
-                if (i0 == t0.size()) {
-                    log_and_throw_error("Tuple::fid(*this) error");
-                }
-            }
-            if (t1[i1] < t2[i2] || t1[i1] < t0[i0]) {
-                i1++;
-                if (i1 == t1.size()) {
-                    log_and_throw_error("Tuple::fid(*this) error");
-                }
-            }
-            if (t2[i2] < t0[i0] || t2[i2] < t1[i1]) {
-                i2++;
-                if (i2 == t2.size()) {
-                    log_and_throw_error("Tuple::fid(*this) error");
-                }
-            }
-            if (t0[i0] == t1[i1] && t0[i0] == t2[i2]) {
-                tid = t0[i0];
-                break;
-            }
+        tid = m.lowest_common_tet(v0_id, v1_id, v2_id);
+        if (tid == std::numeric_limits<size_t>::max()) {
+            log_and_throw_error("Tuple::fid(*this) error");
         }
     }
 


### PR DESCRIPTION
Stacked on #970, which is stacked on #965. Review those first.

Thingi10K model **71263** is a recorded `>3600s` timeout. It now finishes in **57 s**.

## Diagnosis

Not a deadlock. Attaching lldb showed the main thread parked in `task_group::wait` and one worker at 100% CPU, RSS flat, with register state changing between samples — so it was doing work and getting nowhere. `sample` was unambiguous:

```
6797 / 6905 samples (98.5%)  TetMesh::tuple_from_face(array<size_t,3>)
                             <- TetWildMesh::split_edge_before
```

Reading the loop bounds out of the registers gave the reason. The three incident-tet fans of the face being looked up were

```
5494, 10896, 10
```

and those two large numbers were **identical across samples taken seconds apart**, so the same pathological vertices were being hit face after face. A well-shaped tet mesh has vertex valence around 20–30.

## 1. `tuple_from_face` cost O(largest fan) when O(smallest) suffices

The lockstep three-way merge advances all three pointers, so its cost is set by the **worst** vertex. Both places that carried it — `tuple_from_face(vids)` and `Tuple::fid()` — now call a shared `TetMesh::lowest_common_tet`, which scans the **smallest** fan and tests the other two vertices against each candidate tet. Ten candidates instead of ~16k entries.

`m_conn_tets` is sorted, so scanning upward still returns the *lowest* common tet id — the canonicalisation the global face id depends on, since a face shared by two tets must get the same id from either side.

This is close to the `// alternative implementation but slower` that sat commented out in that function. It *is* slower at normal valence, which is presumably why it was abandoned, but that judgement does not survive skewed fans.

**No regression at normal valence** (this is on the hot path for every mesh, so it was measured rather than assumed):

| | integration suite |
| --- | ---: |
| before | 138 s / 145 s |
| after | **131.6 s / 140.4 s** |

**This alone did not fix the model.** The profile simply moved to `split_edge_after`, which walks the one ring for inversion and quality checks — O(valence) whatever the lookup costs.

## 2. Nothing bounded the valence

Above `split_high_valence_threshold` (default **200**, `0` disables) a vertex accepts **one valence-increasing split per split pass** and refuses the rest, so refinement spreads instead of piling onto one vertex.

Splitting `(a,b)` leaves the endpoints' own counts unchanged — each keeps one child of every tet it was in — and adds one to each vertex in the edge's **link**, so the gate applies to the link, not the endpoints. Claims are taken only once the whole link is known to be free, so a late refusal does not burn an earlier vertex's budget.

Also adds `TetMesh::vertex_valence`, an O(1) accessor, since the gate needs the count without materialising the ring.

## Result on 71263

| | |
| --- | --- |
| wall | **57 s** (was `>3600 s`) |
| iterations | 9 (previously stuck inside iteration 1) |
| max energy | **88.46 / 100** |
| all rounded | yes |
| containment / eps | 0.0125 / 0.0435 = **0.29×**, inside |

The gate fired **once**, refusing **14,555 splits** in a single pass. That pass was the entire cascade; the run proceeded normally afterwards.

**Valence in the output mesh** (15,665 tets, 3,076 vertices), parsed from the binary gmsh:

| max | mean | median | above threshold |
| ---: | ---: | ---: | ---: |
| **92** | 20.4 | 18 | **0** |

Down from 10,896 — a factor of ~118 — and nothing near the 200 cap. So the refusals *redirected* the refinement rather than merely capping it; the neighbourhood resolved to normal valence on its own.

**Both changes are needed.** The lookup fix alone leaves it stuck in `split_edge_after`; the gate alone still pays O(largest fan) in `tuple_from_face`.

## Verification

- `ctest` **91/91 green**, integration included.
- The navigation change was benchmarked against baseline (above) because it is on the hot path for every mesh.
- **The gate is not a no-op on the integration set.** It fires 12 times on `tetwild_crown`, which *improves*: max energy 97.79 → **92.07**, containment 0.1182 → **0.1053**, still fully rounded and inside the envelope. Worth a look, since it means this changes tetwild output for existing users.
- `clang-format` 21.1.8 clean.

## Not addressed

Why the cascade concentrates on one vertex in the first place. The gate contains the symptom well enough that the model converges to a healthy mesh, but the underlying refinement behaviour that drove a vertex toward 10⁴ incident tets is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
