### PR TITLE
Bump VolumeRemesher and fast-envelope onto a shared exact-arithmetic kernel

### DIFF
--- a/cmake/recipes/fenvelope.cmake
+++ b/cmake/recipes/fenvelope.cmake
@@ -43,7 +43,8 @@ CPMAddPackage(
     # and reintroduces none of the duplicate expansion definitions that #2 existed to
     # remove.
     GITHUB_REPOSITORY wildmeshing/fast-envelope
-    GIT_TAG eda933b6fab8e89e5f43271ebafc397761da1563
+    # master. A commit rather than the branch name, so the build stays reproducible.
+    GIT_TAG a9f488f81cda91fe3e3099aa4f98b9ee90d4502d
     OPTIONS
     "FAST_ENVELOPE_WITH_UNIT_TESTS OFF"
     "FAST_ENVELOPE_ENABLE_TBB OFF"

--- a/cmake/recipes/fenvelope.cmake
+++ b/cmake/recipes/fenvelope.cmake
@@ -44,7 +44,7 @@ CPMAddPackage(
     # remove.
     GITHUB_REPOSITORY wildmeshing/fast-envelope
     # master. A commit rather than the branch name, so the build stays reproducible.
-    GIT_TAG a9f488f81cda91fe3e3099aa4f98b9ee90d4502d
+    GIT_TAG 8381a02dbb8bb01846d3e8d08ec0854d62c762b4
     OPTIONS
     "FAST_ENVELOPE_WITH_UNIT_TESTS OFF"
     "FAST_ENVELOPE_ENABLE_TBB OFF"

--- a/cmake/recipes/fenvelope.cmake
+++ b/cmake/recipes/fenvelope.cmake
@@ -19,10 +19,22 @@ message(STATUS "Third-party: creating target 'FastEnvelope::FastEnvelope'")
 include(CPM)
 CPMAddPackage(
     NAME FastEnvelope
-    # wildmeshing fork tracking PR #1 (perf: hoist per-node box-cut work).
-    # Forked from daniel-zint/fast-envelope @ 0a7a6c8; GIT_TAG is the PR branch tip.
+    # wildmeshing fork, forked from daniel-zint/fast-envelope @ 0a7a6c8.
+    # Carries PR #1 (perf: hoist per-node box-cut work) and PR #2, which drops the
+    # vendored expansion arithmetic for MarcoAttene's NFG + Indirect_Predicates -- the
+    # same pair VolumeRemesher uses. Two copies of those cannot share a binary: both put
+    # `expansionObject` in the global namespace and disagree on whether its members are
+    # static, which the Itanium ABI mangles identically, so calls through the wrong
+    # convention have their arguments shifted by a register.
+    #
+    # Plus PR #3, which is required with #2: `genericPoint::orient3D` returns the opposite
+    # sign from the predicates #2 replaced, and FastEnvelope reads those predicates as the
+    # height of the implicit point over an oriented plane -- a point is in a prism when it
+    # is below every outward face, i.e. every face NEGATIVE. Forwarding the raw sign makes
+    # containment fail everywhere, so the envelope silently grows far more conservative
+    # than the requested epsilon rather than erroring out.
     GITHUB_REPOSITORY wildmeshing/fast-envelope
-    GIT_TAG 9a0b16eae615b9c7a20affd4a890e2c9fe69e683
+    GIT_TAG 7d615a9c578087dab899cd370cb225464908dcf4
     OPTIONS
     "FAST_ENVELOPE_WITH_UNIT_TESTS OFF"
     "FAST_ENVELOPE_ENABLE_TBB OFF"

--- a/cmake/recipes/fenvelope.cmake
+++ b/cmake/recipes/fenvelope.cmake
@@ -33,8 +33,17 @@ CPMAddPackage(
     # is below every outward face, i.e. every face NEGATIVE. Forwarding the raw sign makes
     # containment fail everywhere, so the envelope silently grows far more conservative
     # than the requested epsilon rather than erroring out.
+    #
+    # PR #3 also puts back the graded cascade that #2 removed along with the arithmetic it
+    # fronted: the vendored semi-static double filter, then Indirect_Predicates' interval
+    # stage, then its exact one. Indirect_Predicates has no double-precision tier of its
+    # own, so without the first every query went straight to interval arithmetic, which on
+    # arm64 switches the FPU rounding mode twice per predicate -- 48% of samples in
+    # `fesetround` and 2.5-3.4x the runtime here. The filter is self-contained double code
+    # and reintroduces none of the duplicate expansion definitions that #2 existed to
+    # remove.
     GITHUB_REPOSITORY wildmeshing/fast-envelope
-    GIT_TAG 7d615a9c578087dab899cd370cb225464908dcf4
+    GIT_TAG eda933b6fab8e89e5f43271ebafc397761da1563
     OPTIONS
     "FAST_ENVELOPE_WITH_UNIT_TESTS OFF"
     "FAST_ENVELOPE_ENABLE_TBB OFF"

--- a/cmake/recipes/volumeremesher.cmake
+++ b/cmake/recipes/volumeremesher.cmake
@@ -25,7 +25,7 @@ include(CPM)
 CPMAddPackage(
     NAME VolumeRemesher
     GITHUB_REPOSITORY wildmeshing/VolumeRemesher
-    GIT_TAG cdf56d43d9c8929de338c186125236c593a3fd1c
+    GIT_TAG dcf40546f9c71c82c72eb4c29527c30ac40f640b
     OPTIONS
     "VOLUMEREMESHER_BUILD_TESTS OFF"
 )

--- a/cmake/recipes/volumeremesher.cmake
+++ b/cmake/recipes/volumeremesher.cmake
@@ -6,9 +6,14 @@ endif()
 
 message(STATUS "Third-party: creating target 'VolumeRemesher::VolumeRemesher'")
 
-# PR #15 (branch `2d`), a descendant of the previous pin, which adds the 2D pipeline:
-# vol_rem::embed_seg_in_tri_mesh in VolumeRemesher/2d/embed2d.h, used by triwild to
-# insert its input segments. The 3D entry point is unchanged.
+# wildmeshing/VolumeRemesher main. Carries the 2D pipeline
+# (vol_rem::embed_seg_in_tri_mesh in VolumeRemesher/2d/embed2d.h, used by triwild to
+# insert its input segments) plus, since PR #19, an externalized exact-arithmetic
+# kernel: numerics.h and the predicate headers are now thin shims over NFG and
+# Indirect_Predicates, fetched and pinned by VolumeRemesher itself. Those upstream
+# headers live in the global namespace; the shims re-export the public types into
+# `vol_rem` with using-declarations, so the include paths and the API this project
+# depends on are unchanged. Note the build now fetches two more repositories.
 #
 # Exact-arithmetic backend: VOLUMEREMESHER_WITH_GMP defaults to OFF, so
 # `vol_rem::bigrational` is upstream's built-in bignum rather than mpq_class and
@@ -20,7 +25,7 @@ include(CPM)
 CPMAddPackage(
     NAME VolumeRemesher
     GITHUB_REPOSITORY wildmeshing/VolumeRemesher
-    GIT_TAG 39884cecf50464fc618257faa15aca7e702534ac
+    GIT_TAG cdf56d43d9c8929de338c186125236c593a3fd1c
     OPTIONS
     "VOLUMEREMESHER_BUILD_TESTS OFF"
 )


### PR DESCRIPTION
Stacked on #971.

VolumeRemesher main externalized its exact-arithmetic kernel (its PR #19): `numerics.h` and the predicate headers are now thin shims over MarcoAttene's NFG and Indirect_Predicates, which VolumeRemesher fetches and pins itself.

fast-envelope carried its own vendored copy of that same code, and **the two cannot share a binary**: both put `expansionObject` in the global namespace and disagree on whether its members are static, which the Itanium ABI mangles identically — so calls through the wrong convention have their arguments shifted by a register. fast-envelope PR #2 drops the vendored copy so both dependencies build against the one upstream.

## Four defects found on the way

Each silently changed output or performance rather than failing.

**1. Missing homogeneous divide** — `implicitPoint3D_LNC/_BPT/_TBC::getExactXYZCoordinates` returned the homogeneous numerators without dividing by the denominator, so exact coordinates came back scaled. Fixed in `wildmeshing/Indirect_Predicates` (upstream PRs #13, #14), which VolumeRemesher pins.

**2. Inverted orientation sign** ([fast-envelope#3](https://github.com/wildmeshing/fast-envelope/pull/3)) — `genericPoint::orient3D` returns the opposite sign from the predicates PR #2 replaced:

```
plane <(0,0,0), (1,0,0), (0,1,0)>, whose (b-a)x(c-a) normal is +z
  point (0,0,+1), above the plane -> -1
  point (0,0,-1), below the plane -> +1
```

fast-envelope reads these as the height of the implicit point over an oriented plane, and calls a point inside a prism when it is below every outward-oriented face — every face NEGATIVE (`tot == halfspace[prismindex[i]].size()`). Forwarding the raw sign makes containment fail everywhere: every prism is skipped, every point looks outside, and the envelope becomes far more conservative than the requested epsilon. `tetwild_octocat` gained 4.4x the vertices and Hausdorff distance collapsed, with no error anywhere.

**3. The predicate filter cascade went missing** ([fast-envelope#3](https://github.com/wildmeshing/fast-envelope/pull/3)) — PR #2 took the semi-static double filter away along with the arithmetic it fronted, and Indirect_Predicates has no double-precision tier to replace it. Every query went straight to interval arithmetic, which on arm64 switches the FPU rounding mode twice per predicate: 48% of `tetwild_octocat`'s samples in `fesetround`, for 2.5–3.4x the runtime. Restored as a graded cascade (semi-static filter → interval → exact), with the implicit point built only when a query escalates and `_pre_exact` no longer computing exact coordinates just to test for a non-zero denominator.

**4. ODR hardening** (VolumeRemesher PR #21) — keeps NFG and Indirect_Predicates inside `namespace vol_rem`, so the two consumers cannot collide again.

## Verification

Integration suite run **serially** against a pre-bump build, comparing max/avg energy, vertex and tet counts, rounding state, Hausdorff distance, epsilon and coverage. Every configuration matches, and every configuration that exercises the exact envelope is now at runtime parity:

| config | max energy (ref = new) | runtime vs pre-bump |
| --- | --- | --- |
| tetwild_octocat | 9.993 | 1.00x |
| tetwild_crown | 88.72 | 1.02x |
| tetwild_sphere | 5.953 | 0.99x |
| tetwild_double_sphere | 8.544 | 1.01x |
| simwild_double_sphere_3d | 7.883 | 1.05x |
| simwild_double_sphere_notop_3d | 8.968 | 0.91x |

`ctest` is **91/91**, Integration_Tests included, in 147s — against 337s before the cascade was restored.

Predicate soundness was checked directly rather than inferred: every definite answer the restored cascade gives was cross-checked against the exact predicate over a full `tetwild_sphere` run — 1,873,918 calls, 225 UNCERTAIN, **0 disagreements**.