### PR TITLE
tetwild: Thingi10K sweep defaults, plus the two fixes the sweep needed

### DIFF
--- a/components/simwild/wmtk/components/simwild/EdgeSplitting.cpp
+++ b/components/simwild/wmtk/components/simwild/EdgeSplitting.cpp
@@ -75,7 +75,7 @@ void SimWildMesh::split_all_edges()
             "[force-split] {} worst-tet longest edges force-split",
             m_force_split_count);
     }
-    // Consumed: the queued force-split edges no longer exist after this pass.
+    // Consumed: the queued force-split edges no longer exist after this pass
     m_force_split_edges.clear();
 }
 

--- a/components/simwild/wmtk/components/simwild/EdgeSplitting.cpp
+++ b/components/simwild/wmtk/components/simwild/EdgeSplitting.cpp
@@ -172,10 +172,6 @@ bool SimWildMesh::split_edge_after(const Tuple& loc)
         std::atomic_ref<size_t>(m_force_split_count).fetch_add(1, std::memory_order_relaxed);
     }
     if (!m_vertex_attribute[v_id].m_is_rounded) {
-        if (!m_params.stuck_refine_rational_split) {
-            return false;
-        }
-
         m_vertex_attribute[v_id].m_pos =
             (m_vertex_attribute[v1_id].m_pos + m_vertex_attribute[v2_id].m_pos) / 2;
         p = to_double(m_vertex_attribute[v_id].m_pos);

--- a/components/simwild/wmtk/components/simwild/Parameters.h
+++ b/components/simwild/wmtk/components/simwild/Parameters.h
@@ -58,7 +58,6 @@ struct Parameters
     // the current worst-tet set (the seeds used by refine_sizing_around_worst)
     // instead fall back to the EXACT rational midpoint (never inverts) and keep
     // the new vertex un-rounded, so the worst region can still be refined.
-    bool stuck_refine_rational_split = true;
 
     // ---- Skip good regions ----------------------------------------------
     // Only smooth vertices incident to a tet whose energy is >=
@@ -144,7 +143,6 @@ struct Parameters
         stuck_refine_force_split = json_params["stuck_refine_force_split"];
         stuck_refine_min_scalar = json_params["stuck_refine_min_scalar"];
         stuck_refine_gradation = json_params["stuck_refine_gradation"];
-        stuck_refine_rational_split = json_params["stuck_refine_rational_split"];
 
         // Skip good regions.
         skip_good_regions = json_params["skip_good_regions"];

--- a/components/simwild/wmtk/components/simwild/simwild_spec.json
+++ b/components/simwild/wmtk/components/simwild/simwild_spec.json
@@ -42,7 +42,6 @@
       "stuck_refine_min_scalar",
       "stuck_refine_gradation",
       "stuck_refine_force_split",
-      "stuck_refine_rational_split",
       "skip_good_regions",
       "skip_good_regions_margin",
       "fill_holes_tags",
@@ -371,12 +370,6 @@
     "type": "bool",
     "default": true,
     "doc": "When the max energy stalls, split each worst tet's longest edge once, bypassing the split length gate, to unstick a sliver without changing the sizing field. Adds at most one split per worst tet per stall."
-  },
-  {
-    "pointer": "/stuck_refine_rational_split",
-    "type": "bool",
-    "default": true,
-    "doc": "When a split's rounded (double) midpoint would invert an incident tet, allow edges of the current worst-tet set to fall back to the exact rational midpoint (never inverts, keeps the new vertex un-rounded) instead of rejecting the split."
   },
   {
     "pointer": "/skip_good_regions",

--- a/components/tetwild/wmtk/components/tetwild/EdgeSplitting.cpp
+++ b/components/tetwild/wmtk/components/tetwild/EdgeSplitting.cpp
@@ -221,27 +221,26 @@ bool TetWildMesh::split_edge_after(const Tuple& loc)
         std::atomic_ref<size_t>(m_force_split_count).fetch_add(1, std::memory_order_relaxed);
     }
     if (!m_vertex_attribute[v_id].m_is_rounded) {
-        // The rounded (double) midpoint inverts an incident tet. By default reject
-        // the split. But if the rational fallback is enabled, place the new vertex at
-        // the EXACT rational midpoint of the two endpoints instead. That midpoint lies
-        // on the shared edge, so it can never invert a previously-valid incident tet --
-        // the split always succeeds and a stuck region can keep being refined. The
-        // vertex stays un-rounded (m_pos exact, m_is_rounded=false) until a later
-        // round() reclaims it.
+        // The rounded (double) midpoint inverts an incident tet, so place the new vertex at
+        // the EXACT rational midpoint of the two endpoints instead. That midpoint lies on the
+        // shared edge, so it can never invert a previously-valid incident tet: the split
+        // always succeeds and a stuck region can keep being refined. The vertex stays
+        // un-rounded (m_pos exact, m_is_rounded = false) until a later round() reclaims it.
         //
-        // Only when an endpoint is already rational, though. Splitting between two
-        // rounded endpoints would manufacture a brand-new rational vertex out of a
-        // fully-rounded neighbourhood, so a mesh that had reached "All rounded!" could
-        // go back to carrying exact coordinates -- and did: model 73435 finished with
-        // unrounded vertices having reported all-rounded one iteration earlier. With
-        // this rule rationals only ever propagate from existing rationals, so the
-        // rounded set cannot shrink and the invariant is monotone.
-        const bool endpoint_is_rational =
-            !m_vertex_attribute[v1_id].m_is_rounded || !m_vertex_attribute[v2_id].m_is_rounded;
-        if (!m_params.stuck_refine_rational_split || !endpoint_is_rational) {
-            return false;
-        }
-
+        // This used to apply only when an endpoint was already rational, to stop a split
+        // between two rounded endpoints from reintroducing exact coordinates into a
+        // fully-rounded mesh. That restriction is what stalled the optimizer: it rejected the
+        // split outright exactly where the mesh is degenerate, which is where refinement is
+        // needed, and the stuck-refine machinery then hammered the region from outside,
+        // driving the max energy up by orders of magnitude per pass. On Thingi10K 509315 the
+        // restriction cost 5 of 8 runs, which diverged to 1e16..1e20 and hit the sweep's
+        // one-hour timeout; without it 8 of 8 converge, in 2-5 iterations, and healthy models
+        // are unchanged in both time and quality.
+        //
+        // Exact coordinates reaching the output is prevented by the iteration, not here: a
+        // split is the only operation that can un-round a vertex (collapse, all four swaps
+        // and smoothing never do), the post-optimization pass is collapse-only, and the loop
+        // does not stop until every vertex is rounded as well as the energy target being met.
         m_vertex_attribute[v_id].m_pos =
             (m_vertex_attribute[v1_id].m_pos + m_vertex_attribute[v2_id].m_pos) / 2;
         // Guard against a pre-existing inverted incident tet: re-check in exact

--- a/components/tetwild/wmtk/components/tetwild/EdgeSplitting.cpp
+++ b/components/tetwild/wmtk/components/tetwild/EdgeSplitting.cpp
@@ -20,7 +20,15 @@ void TetWildMesh::split_all_edges()
     // has an id below it (same invariant run_localized_to_convergence relies on for
     // vertex_epoch). make_unique value-initialises, so every slot starts at 0.
     if (m_params.split_high_valence_threshold > 0) {
-        m_high_valence_claim_size = vert_capacity();
+        // Size to the preallocated capacity, not vert_capacity(). vert_capacity() returns
+        // current_vert_size -- the live vertex count -- so every vertex a split creates during
+        // this pass gets an id at or above it, trips the `vid >= m_high_valence_claim_size`
+        // guard below, and is exempted from the gate entirely. Those exempt vertices are
+        // exactly the ones that run away: on Thingi10K 509315 v15601 absorbed 1792
+        // valence-increasing splits in a single pass, where the gate allows one, reaching
+        // valence ~700 while the max energy climbed with it. The attribute collections are
+        // resized to the reservation, so their size is the capacity to use.
+        m_high_valence_claim_size = std::max(vert_capacity(), m_vertex_attribute.size());
         m_high_valence_claim = std::make_unique<std::atomic<int>[]>(m_high_valence_claim_size);
     }
     m_high_valence_rejects = 0;

--- a/components/tetwild/wmtk/components/tetwild/Parameters.h
+++ b/components/tetwild/wmtk/components/tetwild/Parameters.h
@@ -61,7 +61,6 @@ struct Parameters
     // the current worst-tet set (the seeds used by refine_sizing_around_worst)
     // instead fall back to the EXACT rational midpoint (never inverts) and keep
     // the new vertex un-rounded, so the worst region can still be refined.
-    bool stuck_refine_rational_split = true;
 
     // ---- Skip good regions ----------------------------------------------
     // Only smooth vertices incident to a tet whose energy is >=

--- a/components/tetwild/wmtk/components/tetwild/tetwild.cpp
+++ b/components/tetwild/wmtk/components/tetwild/tetwild.cpp
@@ -150,7 +150,6 @@ TetWildMesh::ExportStruct tetwild_with_export(nlohmann::json json_params)
     params.stuck_refine_force_split = json_params["stuck_refine_force_split"];
     params.stuck_refine_min_scalar = json_params["stuck_refine_min_scalar"];
     params.stuck_refine_gradation = json_params["stuck_refine_gradation"];
-    params.stuck_refine_rational_split = json_params["stuck_refine_rational_split"];
 
     // Skip good regions.
     params.skip_good_regions = json_params["skip_good_regions"];

--- a/components/tetwild/wmtk/components/tetwild/tetwild_spec.json
+++ b/components/tetwild/wmtk/components/tetwild/tetwild_spec.json
@@ -45,7 +45,6 @@
       "stuck_refine_min_scalar",
       "stuck_refine_gradation",
       "stuck_refine_force_split",
-      "stuck_refine_rational_split",
       "skip_good_regions",
       "skip_good_regions_margin",
       "skip_winding_number"
@@ -322,12 +321,6 @@
     "type": "bool",
     "default": true,
     "doc": "When the max energy stalls, split each worst tet's longest edge once, bypassing the split length gate, to unstick a sliver without changing the sizing field. Adds at most one split per worst tet per stall."
-  },
-  {
-    "pointer": "/stuck_refine_rational_split",
-    "type": "bool",
-    "default": true,
-    "doc": "When a split's rounded (double) midpoint would invert an incident tet, allow edges of the current worst-tet set to fall back to the exact rational midpoint (never inverts, keeps the new vertex un-rounded) instead of rejecting the split."
   },
   {
     "pointer": "/skip_good_regions",

--- a/components/tetwild/wmtk/components/tetwild/tetwild_spec.json
+++ b/components/tetwild/wmtk/components/tetwild/tetwild_spec.json
@@ -168,7 +168,7 @@
   {
     "pointer": "/eps_rel",
     "type": "float",
-    "default": 2e-3,
+    "default": 1e-3,
     "doc": "Envelope thickness relative to the bounding box"
   },
   {

--- a/components/tetwild/wmtk/components/tetwild/tetwild_spec.json
+++ b/components/tetwild/wmtk/components/tetwild/tetwild_spec.json
@@ -124,7 +124,7 @@
   {
     "pointer": "/simplify_envelope_ratio",
     "type": "float",
-    "default": 0.9,
+    "default": 0.5,
     "doc": "Envelope thickness used for the input simplification, as a fraction of the one used for the tetrahedralisation. Simplifying inside a tighter envelope reserves the remainder as headroom: if the simplification is allowed to place vertices at the full limit, the optimizer starts with a mesh where almost every move already lies outside and most operations are vetoed. 1.0 restores the old behaviour of sharing a single envelope."
   },
   {

--- a/components/tetwild/wmtk/components/tetwild/tetwild_spec.json
+++ b/components/tetwild/wmtk/components/tetwild/tetwild_spec.json
@@ -113,19 +113,19 @@
   {
     "pointer": "/simplify_use_link_condition",
     "type": "bool",
-    "default": true,
+    "default": false,
     "doc": "Require the link condition when simplifying the input surface. When true the simplification cannot change the topology of the input, which also means it cannot create non-manifold edges or vertices. When false those collapses are allowed, so the input simplifies further, but the surface handed to the arrangement may differ topologically from the input."
   },
   {
     "pointer": "/simplify_use_sample_envelope",
     "type": "bool",
-    "default": false,
+    "default": true,
     "doc": "Use the sampled envelope instead of the exact one for the input simplification only; the tetrahedralisation keeps whatever use_sample_envelope selects. The exact envelope dominates the cost of simplifying a large input. Note the toolkit itself warns that the sampled envelope is unreliable, and on thin lattice geometry it has been observed to over-collapse badly."
   },
   {
     "pointer": "/simplify_envelope_ratio",
     "type": "float",
-    "default": 0.5,
+    "default": 0.9,
     "doc": "Envelope thickness used for the input simplification, as a fraction of the one used for the tetrahedralisation. Simplifying inside a tighter envelope reserves the remainder as headroom: if the simplification is allowed to place vertices at the full limit, the optimizer starts with a mesh where almost every move already lies outside and most operations are vetoed. 1.0 restores the old behaviour of sharing a single envelope."
   },
   {
@@ -180,7 +180,7 @@
   {
     "pointer": "/stop_energy",
     "type": "float",
-    "default": 10,
+    "default": 100,
     "doc": "Target energy. If all tets have an energy below this, tetwild will stop."
   },
   {
@@ -210,8 +210,8 @@
   {
     "pointer": "/remove_duplicate_eps",
     "type": "float",
-    "default": 2e-3,
-    "doc": "Remove duplicate vertices in the input meshes that are closer than this fraction of the bounding box diagonal. This is applied to each input mesh separately."
+    "default": 0,
+    "doc": "Remove duplicate vertices in the input meshes that are closer than this fraction of the bounding box diagonal. This is applied to each input mesh separately. 0 merges only exactly coincident vertices, which is still needed to build the surface connectivity; negative skips the pass entirely."
   },
   {
     "pointer": "/allow_surface_swap",

--- a/components/triwild/wmtk/components/triwild/EdgeSplitting.cpp
+++ b/components/triwild/wmtk/components/triwild/EdgeSplitting.cpp
@@ -164,16 +164,12 @@ bool TriWildMesh::split_edge_after(const Tuple& loc)
     }
     if (!m_vertex_attribute[v_id].m_is_rounded) {
         // The rounded (double) midpoint inverts an incident triangle. By default reject
-        // the split. If the rational fallback is enabled, place the new vertex at the
+        // the split. Place the new vertex at the
         // EXACT rational midpoint of the two endpoints instead. That midpoint lies on the
         // shared edge, so it can never invert a previously-valid incident triangle -- the
         // split always succeeds and the worst region can keep being refined. The vertex
         // stays un-rounded (m_pos exact, m_is_rounded = false) until a later round()
         // reclaims it.
-        if (!m_params.stuck_refine_rational_split) {
-            return false;
-        }
-
         m_vertex_attribute[v_id].m_pos =
             (m_vertex_attribute[v1_id].m_pos + m_vertex_attribute[v2_id].m_pos) / 2;
         // Unlike tetwild, keep m_posf in step with the exact position: when an endpoint is

--- a/components/triwild/wmtk/components/triwild/Parameters.h
+++ b/components/triwild/wmtk/components/triwild/Parameters.h
@@ -66,7 +66,6 @@ struct Parameters
     // current worst-triangle set instead fall back to the EXACT rational midpoint
     // (never inverts) and keep the new vertex un-rounded, so the worst region can
     // still be refined.
-    bool stuck_refine_rational_split = true;
 
     // ---- Skip good regions ----------------------------------------------
     // Only smooth vertices incident to a triangle whose energy is >=
@@ -109,7 +108,6 @@ struct Parameters
         stuck_refine_min_scalar = json_params["stuck_refine_min_scalar"];
         stuck_refine_gradation = json_params["stuck_refine_gradation"];
         stuck_refine_force_split = json_params["stuck_refine_force_split"];
-        stuck_refine_rational_split = json_params["stuck_refine_rational_split"];
 
         // Skip good regions.
         skip_good_regions = json_params["skip_good_regions"];

--- a/components/triwild/wmtk/components/triwild/triwild_spec.json
+++ b/components/triwild/wmtk/components/triwild/triwild_spec.json
@@ -34,7 +34,6 @@
       "stuck_refine_min_scalar",
       "stuck_refine_gradation",
       "stuck_refine_force_split",
-      "stuck_refine_rational_split",
       "skip_good_regions",
       "skip_good_regions_margin"
     ]
@@ -238,12 +237,6 @@
     "type": "bool",
     "default": true,
     "doc": "When the max energy stalls, split each worst triangle's longest edge once, bypassing the split length gate, to unstick a sliver without changing the sizing field. Adds at most one split per worst triangle per stall -- but 'worst' means every triangle above the filter energy when stuck_refine_num_worst is 0, so on a mesh whose stop_energy sits close to the AMIPS2D floor of 2 this can force thousands of splits in one pass and blow up the element count. Bound stuck_refine_num_worst or turn this off in that regime."
-  },
-  {
-    "pointer": "/stuck_refine_rational_split",
-    "type": "bool",
-    "default": true,
-    "doc": "When a split's rounded (double) midpoint would invert an incident triangle, allow edges of the current worst-triangle set to fall back to the exact rational midpoint (never inverts, keeps the new vertex un-rounded) instead of rejecting the split."
   },
   {
     "pointer": "/skip_good_regions",


### PR DESCRIPTION
 Two things, both driven by running tetwild over Thingi10K: the retuned defaults the sweep runs with, and the two defects the sweep exposed. The fixes are here rather than in separate PRs because the sweep cannot complete without them.

## 1. Retuned defaults

Biased toward getting through a large heterogeneous input set rather than toward the best mesh for any one model.

| parameter | old | new | why |
| --- | --- | --- | --- |
| `eps_rel` | `2e-3` | `1e-3` | the value the sweep runs at; no reason for every config to restate it |
| `remove_duplicate_eps` | `2e-3` | `0` | merge only exactly coincident input vertices. A tolerance relative to the bbox diagonal silently welds real features on models whose detail sits below it. `0` still runs the dedup pass (needed for valid connectivity); negative would skip it |
| `stop_energy` | `10` | `100` | the tail of the optimization is where a sweep spends its time, and the interesting question is whether a model completes at all |
| `simplify_use_sample_envelope` | `false` | `true` | the exact envelope dominates the cost of simplifying a large input. The doc's caveat stands — this is a throughput tradeoff, not a claim it is safe everywhere |
| `simplify_envelope_ratio` | `0.5` | `0.5` (unchanged) | **was raised to 0.9, then reverted** — 0.9 left the optimizer no envelope headroom and two sweep models stopped converging. See below. |
| `simplify_use_link_condition` | `true` | `false` | let the input simplify past topology-preserving collapses. The surface handed to the arrangement may then differ topologically from the input |

`Parameters.h` keeps `stop_energy = 10` as the C++ struct default — that is what the unit tests construct against, and `tetwild.cpp` overwrites it from the JSON on every run through the component entry point.

### Why `simplify_envelope_ratio` went back to 0.5

Raising it to 0.9 is what the parameter's own doc warns against — "if the simplification is allowed to place vertices at the full limit, the optimizer starts with a mesh where almost every move already lies outside and most operations are vetoed". Two sweep models stalled on exactly that: 240280 plateaued at max energy 4891 with smoothing at **17 accepted / 825 envelope-rejected**, and 562343 ran 60 iterations without reaching the target.

Running 240280 with `DEBUG_disable_envelope` confirmed the envelope was the binding constraint — energy **1.69e12 → 10.05 in two iterations**, against a plateau at ~4900 with it on. At ratio 0.5 both converge: 240280 in 18 iterations (rejections 825 → 60), 562343 in 13.

## 2. Fix: the high-valence split gate never applied to new vertices

`split_all_edges` sized its claim array with `vert_capacity()`, which returns `current_vert_size` — the **live vertex count**, not the reservation. Every vertex created during the pass therefore lands at an id at or above that size, trips

```cpp
if (vid >= m_high_valence_claim_size) continue;
```

and is silently exempt from the gate. The comment there asserts the opposite invariant.

Those exempt vertices are the ones that run away: on 509315, `v15601` — created mid-pass — absorbed **1792 valence-increasing splits in a single pass**, where the gate permits one, reaching valence ~700.

Sized to the preallocated capacity instead. Note this does not by itself stop the divergence (see below); it is a real defect regardless, since the gate is inoperative for exactly the vertices it most needs to cover.

## 3. Fix: a split that would invert now always takes the exact-rational midpoint

**This is the one that fixes the sweep timeouts.**

When a split's rounded midpoint inverts an incident tet, the split fell back to the exact rational midpoint — which lies on the shared edge and so cannot invert a previously-valid tet — but **only when an endpoint was already rational**. Between two rounded endpoints the split was rejected outright.

That restriction refuses the split *exactly where the mesh is degenerate*, which is where refinement is needed to break the configuration apart. The region cannot be repaired, stuck-refine then hammers it from outside, and the max energy climbs by orders of magnitude per split pass.

On Thingi10K 509315, 8 runs of the sweep configuration:

| | converged | diverged |
| --- | --- | --- |
| before | 3 | 5, to 1e16–1e20, hitting the 1 h timeout |
| after | **8** | **0** — 2–5 iterations, 85–98 s |

Healthy models are unchanged or better: 100026 4 s → 3 s (max energy 51.2 → 18.2), 213888 38 s → 32 s (91.573 both), 39925 and 229958 unchanged.

### Why the rounding guard is not needed

It existed to stop a fully-rounded mesh reacquiring exact coordinates, with model 73435 as the counter-example. The iteration already prevents that, and more reliably:

- a split is the **only** operation that can un-round a vertex — collapse, all four swaps and smoothing never do (`m_is_rounded = false` appears once in `EdgeSplitting.cpp`);
- the post-optimization pass is `local_operations({{0,1,0,0}})`, collapse-only, so no rational vertex can appear after the loop;
- the loop does not stop until every vertex is rounded **and** the energy target is met.

73435 now finishes `all_rounded` in 3 of 3 runs (max energy 11.7 / 13.7 / 15.2, no "Not all vertices rounded").

`stuck_refine_rational_split` is removed with it, from tetwild, triwild and simwild. In triwild and simwild it only ever gated this same fallback and defaulted to `true`, so their behaviour is unchanged — it just removes the off switch.

**Breaking:** a config still setting `stuck_refine_rational_split` will now fail JSE validation.

## Verification

`ctest` **97/97 including `Integration_Tests`**, Release, macOS/arm64 — which covers triwild and simwild as well.

The sweep itself is at ~9,300 of 10,000 with 8 failures on the pre-fix binary; the 4 remaining non-input failures are the divergence class this addresses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
