### PR TITLE
Fix resolve_path throwing on an empty root (Linux only)

### DIFF
--- a/src/wmtk/utils/resolve_path.cpp
+++ b/src/wmtk/utils/resolve_path.cpp
@@ -13,7 +13,15 @@ fs::path resolve_path(const fs::path& root, const fs::path& path)
         return path;
     }
 
-    const fs::path root_abs = fs::absolute(root);
+    // An empty root means "resolve against the current directory". Spelling that out
+    // rather than leaving it to fs::absolute() is not pedantry: fs::absolute("") is
+    // not portable -- libstdc++ throws filesystem_error(EINVAL), libc++ returns the
+    // current path. Components take root from json_params["input_dir"], which
+    // app/main.cpp derives from the config file's parent_path(), and that is empty
+    // for a bare relative config name (`wmtk_app -j config.json`). Without this,
+    // every component aborts on Linux for a config invoked that way, while the same
+    // command works on macOS.
+    const fs::path root_abs = root.empty() ? fs::current_path() : fs::absolute(root);
 
     const fs::path root_dir =
         fs::exists(root_abs) && !fs::is_directory(root_abs) ? root_abs.parent_path() : root_abs;

--- a/src/wmtk/utils/resolve_path.hpp
+++ b/src/wmtk/utils/resolve_path.hpp
@@ -23,9 +23,12 @@ namespace wmtk::utils {
  *      path = "/c/b.txt"
  *      returns: "/c/b.txt"
  *
+ * An empty `root` resolves `path` against the current working directory.
+ *
  * An exception is thrown if the root path does not exist.
  *
  * @param root The folder used as root. If it is a file the parent folder is used as root.
+ *             If it is empty the current working directory is used.
  * @param path The path that should be made absolute.
  *
  * @returns The absolute path.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -15,6 +15,7 @@ set(TEST_SOURCES
     test_nonmanifold.cpp
     test_operations.cpp
     test_raw_simplex_collection.cpp
+    test_resolve_path.cpp
     test_simplex_navigation.cpp
     test_tuple.cpp
     test_orient.cpp

--- a/tests/test_resolve_path.cpp
+++ b/tests/test_resolve_path.cpp
@@ -1,0 +1,36 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include <wmtk/utils/resolve_path.hpp>
+
+namespace fs = std::filesystem;
+using wmtk::utils::resolve_path;
+
+TEST_CASE("resolve_path_empty_root", "[utils][resolve_path]")
+{
+    // `wmtk_app -j config.json` leaves the components with input_dir == "", because
+    // app/main.cpp derives it from the config file's parent_path(). Resolving against
+    // an empty root has to mean "the current directory" rather than throw: fs::absolute("")
+    // throws on libstdc++ and does not on libc++, so this was a Linux-only abort --
+    // every component, every model, before any work was done.
+    fs::path resolved;
+    REQUIRE_NOTHROW(resolved = resolve_path("", "out.log"));
+    CHECK(resolved.is_absolute());
+    CHECK(resolved == fs::weakly_canonical(fs::current_path() / "out.log"));
+}
+
+TEST_CASE("resolve_path_relative_root", "[utils][resolve_path]")
+{
+    const fs::path resolved = resolve_path("a", "b.txt");
+    CHECK(resolved.is_absolute());
+    CHECK(resolved == fs::weakly_canonical(fs::current_path() / "a" / "b.txt"));
+}
+
+TEST_CASE("resolve_path_absolute_path_ignores_root", "[utils][resolve_path]")
+{
+    const fs::path absolute_input = fs::current_path() / "c" / "b.txt";
+
+    // An absolute path is returned untouched whatever the root is -- including the
+    // empty root, which must not reach fs::absolute() on the way.
+    CHECK(resolve_path("a", absolute_input) == absolute_input);
+    CHECK(resolve_path("", absolute_input) == absolute_input);
+}


### PR DESCRIPTION
`wmtk_app -j config.json` aborts on Linux before doing any work:

```
terminate called after throwing an instance of 'std::filesystem::__cxx11::filesystem_error'
  what():  filesystem error: cannot make absolute path: Invalid argument []
```

The same command works on macOS.

## Cause

[`app/main.cpp:47`](https://github.com/wildmeshing/wildmeshing-toolkit/blob/main/app/main.cpp#L47) derives `input_dir` from the config file's `parent_path()`, which is **empty** when the config is named by a bare relative path (`-j config.json`, the natural form when the config sits in the working directory). Every component then calls `resolve_path(root, ...)` with that empty root, and `resolve_path` passed it straight to `fs::absolute()`.

`fs::absolute("")` is not portable: **libstdc++ throws `filesystem_error(EINVAL)`, libc++ returns the current path.** Hence macOS fine, Linux dead — and dead for every component, not just tetwild, since they all resolve `input_dir` the same way.

Found while setting up a Thingi10K sweep on a Linux box, where it failed 100% of models with no output and no useful diagnostic.

## Fix

Resolve an empty root against the current working directory — what the caller means — instead of leaving the empty-path case to `fs::absolute()`. One line in `resolve_path`, so it fixes all seven components at once. Header doc updated to state the behaviour.

## Tests

`tests/test_resolve_path.cpp`, three cases: empty root resolves against the cwd without throwing; a relative root still composes; an absolute path is returned untouched for both a normal and an empty root.

Worth being explicit about their reach: **these are a genuine regression test only on libstdc++.** On libc++ they pass with or without the fix — that asymmetry is the bug. CI's Linux job is what actually guards this.

Verified independently on the Linux host that `fs::absolute("")` throws exactly the reported error there and that the guarded expression resolves correctly.

Local `ctest`: 93/93 (90 before, plus the 3 new), Release, macOS/arm64.

🤖 Generated with [Claude Code](https://claude.com/claude-code)