### PR TITLE
io: keep edge orientation when merging duplicate vertices

### DIFF
--- a/components/triwild/wmtk/components/triwild/tests/CMakeLists.txt
+++ b/components/triwild/wmtk/components/triwild/tests/CMakeLists.txt
@@ -10,6 +10,7 @@ add_component_test(${COMPONENT_NAME})
 set(SRC_FILES
     test_sizing_refine.cpp
     test_simplify_segments.cpp
+    test_winding_tags.cpp
     )
 
 target_sources(wmtk_test_${COMPONENT_NAME} PRIVATE ${SRC_FILES})

--- a/components/triwild/wmtk/components/triwild/tests/test_winding_tags.cpp
+++ b/components/triwild/wmtk/components/triwild/tests/test_winding_tags.cpp
@@ -1,0 +1,141 @@
+#include <wmtk/TriMesh.h>
+#include <wmtk/components/triwild/TriWildMesh.h>
+#include <wmtk/Types.hpp>
+#include <wmtk/io/read_edge_mesh.hpp>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <array>
+#include <cmath>
+#include <filesystem>
+#include <fstream>
+#include <vector>
+
+using namespace wmtk;
+using namespace wmtk::components::triwild;
+
+// The per-input tags come from the winding number of that input's curve, which is a sum of
+// SIGNED subtended angles. Anything that loses a curve's orientation -- reordering its
+// segments, normalizing their endpoints -- leaves the loop closed and every structural
+// check intact while turning the tags into noise, so the invariant worth testing is
+// geometric, not structural: the area tagged for an input must equal the area its polygon
+// encloses.
+namespace {
+
+// A uniform grid over [0,1]^2, split into triangles. Fine enough that the boundary
+// triangles of the shapes below contribute a small fraction of their area.
+void build_grid(TriWildMesh& mesh, int n)
+{
+    const int nv = (n + 1) * (n + 1);
+    std::vector<std::array<size_t, 3>> tris;
+    tris.reserve(2 * n * n);
+    auto vid = [n](int i, int j) { return static_cast<size_t>(j * (n + 1) + i); };
+    for (int j = 0; j < n; ++j) {
+        for (int i = 0; i < n; ++i) {
+            tris.push_back({{vid(i, j), vid(i + 1, j), vid(i + 1, j + 1)}});
+            tris.push_back({{vid(i, j), vid(i + 1, j + 1), vid(i, j + 1)}});
+        }
+    }
+    mesh.init(nv, tris);
+    mesh.m_vertex_attribute.resize(nv);
+    mesh.m_edge_attribute.resize(3 * tris.size());
+    mesh.m_face_attribute.resize(tris.size());
+    for (int j = 0; j <= n; ++j) {
+        for (int i = 0; i <= n; ++i) {
+            auto& va = mesh.m_vertex_attribute[vid(i, j)];
+            va.m_posf = Vector2d(double(i) / n, double(j) / n);
+            va.m_is_rounded = true;
+            va.m_pos = to_rational(va.m_posf);
+        }
+    }
+}
+
+/// Closed rectangle [x0,x1]x[y0,y1] as (V, E). `ccw` picks the traversal direction; the
+/// tags must not depend on it.
+void rect(double x0, double y0, double x1, double y1, bool ccw, MatrixXd& V, MatrixXi& E)
+{
+    V.resize(4, 2);
+    V << x0, y0, x1, y0, x1, y1, x0, y1;
+    E.resize(4, 2);
+    for (int i = 0; i < 4; ++i) {
+        const int a = i, b = (i + 1) % 4;
+        E.row(i) = ccw ? Eigen::Vector2i(a, b) : Eigen::Vector2i(b, a);
+    }
+}
+
+double tagged_area(const TriWildMesh& mesh, int64_t tag)
+{
+    double area = 0;
+    for (const auto& f : mesh.get_faces()) {
+        const size_t fid = f.fid(mesh);
+        if (mesh.m_face_attribute[fid].tags.count(tag) == 0) {
+            continue;
+        }
+        const auto vs = mesh.oriented_tri_vids(f);
+        const Vector2d& a = mesh.m_vertex_attribute[vs[0]].m_posf;
+        const Vector2d& b = mesh.m_vertex_attribute[vs[1]].m_posf;
+        const Vector2d& c = mesh.m_vertex_attribute[vs[2]].m_posf;
+        area += 0.5 * std::abs((b - a).x() * (c - a).y() - (b - a).y() * (c - a).x());
+    }
+    return area;
+}
+
+} // namespace
+
+TEST_CASE("winding-tags-match-input-area", "[triwild][winding]")
+{
+    // Three disjoint rectangles of known area, one of them wound clockwise.
+    const double tol = 2e-2; // boundary triangles straddle the outline
+    Parameters params;
+    TriWildMesh mesh(params, params.eps, 0);
+    build_grid(mesh, 60);
+
+    std::vector<MatrixXd> Vs(3);
+    std::vector<MatrixXi> Es(3);
+    rect(0.10, 0.10, 0.40, 0.30, true, Vs[0], Es[0]); // area 0.06
+    rect(0.55, 0.20, 0.95, 0.50, false, Vs[1], Es[1]); // area 0.12, clockwise
+    rect(0.30, 0.60, 0.50, 0.90, true, Vs[2], Es[2]); // area 0.06
+    const std::array<double, 3> expected = {0.06, 0.12, 0.06};
+
+    mesh.compute_winding_numbers(Vs, Es);
+
+    for (int64_t k = 0; k < 3; ++k) {
+        const double got = tagged_area(mesh, k);
+        INFO("input " << k << ": tagged area " << got << ", expected " << expected[k]);
+        CHECK(std::abs(got - expected[k]) < tol);
+    }
+
+    // Disjoint inputs must not share faces.
+    for (const auto& f : mesh.get_faces()) {
+        CHECK(mesh.m_face_attribute[f.fid(mesh)].tags.size() <= 1);
+    }
+}
+
+TEST_CASE("winding-tags-survive-vertex-merge", "[triwild][winding]")
+{
+    // Same check, but the curves go through the reader that merges duplicate vertices --
+    // the step that used to normalize edge endpoints and destroy the orientation. The
+    // rectangle is written with a duplicated corner so the merge actually runs.
+    namespace fs = std::filesystem;
+    const fs::path path = fs::temp_directory_path() / "wmtk_winding_tag_test.obj";
+    {
+        std::ofstream f(path);
+        f << "v 0.2 0.2 0\nv 0.7 0.2 0\nv 0.7 0.7 0\nv 0.2 0.7 0\nv 0.2 0.7 0\n";
+        f << "l 1 2\nl 2 3\nl 3 4\nl 4 5\nl 5 1\n";
+    }
+
+    MatrixXd V;
+    MatrixXi E;
+    wmtk::io::read_edge_mesh(path.string(), V, E, 1e-8);
+    fs::remove(path);
+    V = V.block(0, 0, V.rows(), 2).eval();
+
+    Parameters params;
+    TriWildMesh mesh(params, params.eps, 0);
+    build_grid(mesh, 60);
+    mesh.compute_winding_numbers({V}, {E});
+
+    const double got = tagged_area(mesh, 0);
+    INFO("tagged area " << got << ", expected 0.25");
+    CHECK(std::abs(got - 0.25) < 2e-2);
+}

--- a/src/wmtk/io/read_edge_mesh.cpp
+++ b/src/wmtk/io/read_edge_mesh.cpp
@@ -24,9 +24,13 @@ namespace {
 /**
  * @brief Merge vertices closer than `tol` and remap the edges onto the survivors.
  *
- * Degenerate edges (both endpoints merged together) and duplicated edges are dropped;
- * the surviving edge order follows the sorted endpoint pairs, so the result does not
- * depend on the input order of coincident edges.
+ * Degenerate edges (both endpoints merged together) and duplicated edges are dropped.
+ * Duplicates are detected on the sorted endpoint pair, so a segment and its reverse
+ * count as one, but each surviving edge keeps the ORIENTATION IT WAS GIVEN and the
+ * edges keep their input order. Both matter: a curve's orientation is what makes the
+ * winding number +/-1 inside it, and normalizing endpoints to (min, max) silently
+ * turns every closed loop into an inconsistently oriented one, so the winding-number
+ * tagging that decides which faces belong to an input degenerates into noise.
  */
 void merge_duplicate_vertices(MatrixXd& V, MatrixXi& E, double tol)
 {
@@ -43,20 +47,21 @@ void merge_duplicate_vertices(MatrixXd& V, MatrixXi& E, double tol)
         return;
     }
 
-    std::set<std::pair<int, int>> unique_edges;
+    std::set<std::pair<int, int>> seen; // keyed on the sorted pair, for dedup only
+    std::vector<std::pair<int, int>> kept; // the edges themselves, as oriented
+    kept.reserve(static_cast<size_t>(E.rows()));
     for (int i = 0; i < E.rows(); ++i) {
-        int a = SVJ(E(i, 0));
-        int b = SVJ(E(i, 1));
+        const int a = SVJ(E(i, 0));
+        const int b = SVJ(E(i, 1));
         if (a == b) {
             continue; // collapsed to a point
         }
-        if (a > b) {
-            std::swap(a, b);
+        if (seen.insert(std::minmax(a, b)).second) {
+            kept.emplace_back(a, b);
         }
-        unique_edges.insert({a, b});
     }
 
-    const int n_dropped = static_cast<int>(E.rows()) - static_cast<int>(unique_edges.size());
+    const int n_dropped = static_cast<int>(E.rows()) - static_cast<int>(kept.size());
     if (V.rows() != SV.rows() || n_dropped > 0) {
         logger().info(
             "Merged {} duplicate vertices and dropped {} degenerate/duplicate edges",
@@ -65,9 +70,9 @@ void merge_duplicate_vertices(MatrixXd& V, MatrixXi& E, double tol)
     }
 
     V = SV;
-    E.resize(unique_edges.size(), 2);
+    E.resize(kept.size(), 2);
     int idx = 0;
-    for (const auto& [a, b] : unique_edges) {
+    for (const auto& [a, b] : kept) {
         E(idx, 0) = a;
         E(idx, 1) = b;
         ++idx;

--- a/tests/test_io.cpp
+++ b/tests/test_io.cpp
@@ -4,6 +4,7 @@
 #include <wmtk/TriMesh.h>
 #include <wmtk/io/TetVTUWriter.hpp>
 #include <wmtk/io/TriVTUWriter.hpp>
+#include <wmtk/io/read_edge_mesh.hpp>
 #include <wmtk/utils/Delaunay.hpp>
 #include <wmtk/utils/examples/TetMesh_examples.hpp>
 #include <wmtk/utils/examples/TriMesh_examples.hpp>
@@ -12,6 +13,8 @@
 
 #include <catch2/catch_test_macros.hpp>
 
+#include <filesystem>
+#include <fstream>
 #include <sstream>
 
 using namespace wmtk;
@@ -172,4 +175,43 @@ TEST_CASE("io-pysical-groups", "[io][mshio][.]")
     msh.add_physical_group("testgroup"); // does not work with binary for now
 
     msh.save("test-io-pysical-groups.msh", true);
+}
+TEST_CASE("read-edge-mesh-orientation", "[io][edge_mesh]")
+{
+    // A closed loop read with a merge tolerance must come back closed AND
+    // consistently oriented: the winding number that decides which faces belong
+    // to an input is a sum of SIGNED angles, so normalizing endpoints to
+    // (min, max) turns every region into noise.
+    namespace fs = std::filesystem;
+    const fs::path path = fs::temp_directory_path() / "wmtk_edge_loop_test.obj";
+    {
+        std::ofstream f(path);
+        f << "v 0 0 0\nv 1 0 0\nv 1 1 0\nv 0 1 0\n";
+        // deliberately traversed so that the closing segment runs high -> low
+        f << "l 1 2\nl 2 3\nl 3 4\nl 4 1\n";
+    }
+
+    Eigen::MatrixXd V;
+    Eigen::MatrixXi E;
+    wmtk::io::read_edge_mesh(path.string(), V, E, 1e-10);
+    fs::remove(path);
+
+    REQUIRE(V.rows() == 4);
+    REQUIRE(E.rows() == 4);
+
+    // every vertex is entered once and left once
+    Eigen::VectorXi out_deg = Eigen::VectorXi::Zero(V.rows());
+    Eigen::VectorXi in_deg = Eigen::VectorXi::Zero(V.rows());
+    Eigen::Vector3d closure = Eigen::Vector3d::Zero();
+    for (int i = 0; i < E.rows(); ++i) {
+        ++out_deg(E(i, 0));
+        ++in_deg(E(i, 1));
+        closure += (V.row(E(i, 1)) - V.row(E(i, 0))).transpose();
+    }
+    CHECK(out_deg.minCoeff() == 1);
+    CHECK(out_deg.maxCoeff() == 1);
+    CHECK(in_deg.minCoeff() == 1);
+    CHECK(in_deg.maxCoeff() == 1);
+    // a consistently oriented closed loop's edge vectors sum to zero
+    CHECK(closure.norm() < 1e-12);
 }


### PR DESCRIPTION
merge_duplicate_vertices normalized every edge to (min, max) before inserting it into a std::set, then re-emitted the set in sorted order. The loop stays topologically closed -- every vertex keeps degree 2, so structural checks pass -- but its orientation is gone, and a winding number is a sum of SIGNED subtended angles. triwild tags faces per input by testing winding > 0.5, so the tagging degenerated into noise.

Measured on a 7-input 2D scene (dragon_2d), interior winding numbers came back as 1.97, 0.49, 0.62, 0.94, 1.06, 0.85, 0.84 where every one of them must be exactly +/-1. Every region was mis-tagged: floor over-tagged 4x, dragon 2.7x, weight under-tagged 4x. One input landed at 0.4919, just under the threshold, and vanished from the output entirely -- which is how this was noticed. With the fix all seven read exactly +/-1.0 and the per-tag areas match the pre-regression reference to four decimals.

Duplicates are still detected on the sorted pair, so a segment and its reverse still count as one; only the emitted edge keeps the direction it was given, and the edges keep their input order.

This path went live for triwild when it started passing remove_duplicate_eps to the reader; before that the dedup never ran. tetwild and simwild also use this reader, but for closed surfaces, where orientation rides on the faces.