### PR TITLE
tetwild: extend 4-4 and 5-6 edge swaps to the tracked surface (resurrects #954)

### DIFF
--- a/components/tetwild/wmtk/components/tetwild/EdgeSwapping.cpp
+++ b/components/tetwild/wmtk/components/tetwild/EdgeSwapping.cpp
@@ -11,6 +11,7 @@
 #include "wmtk/utils/TupleUtils.hpp"
 
 #include <cassert>
+#include <limits>
 
 namespace wmtk::components::tetwild {
 
@@ -140,16 +141,14 @@ bool TetWildMesh::swap_edge_before(const Tuple& t)
     if (is_edge_on_bbox(t)) {
         return false;
     }
-    // Surface edges are allowed only as a topology-preserving surface diagonal
-    // flip (see prepare_surface_flip_32). If disabled, keep the old behavior of
-    // rejecting all surface-edge swaps.
-    if (is_edge_on_surface(t)) {
-        if (!m_params.allow_surface_swap) {
-            return false;
-        }
-        if (!prepare_surface_flip_32(t, incident_tets)) {
-            return false;
-        }
+    // Surface edges are allowed only as a topology-preserving surface diagonal flip (see
+    // prepare_surface_flip). If disabled, keep the old behavior of rejecting all surface-edge
+    // swaps. Route on the direct incident-surface-face count so a genuine surface edge is never
+    // mistaken for interior because of stale m_is_on_surface flags (which would tear the surface).
+    const int n_surf_faces = edge_incident_surface_face_count(t);
+    if (n_surf_faces > 0) {
+        if (!m_params.allow_surface_swap) return false;
+        if (!prepare_surface_flip(t, incident_tets)) return false;
     }
 
     double max_energy = -1.0;
@@ -163,9 +162,10 @@ bool TetWildMesh::swap_edge_before(const Tuple& t)
     return true;
 }
 
-bool TetWildMesh::prepare_surface_flip_32(const Tuple& t, const std::vector<size_t>& incident_tets)
+bool TetWildMesh::prepare_surface_flip(const Tuple& t, const std::vector<size_t>& incident_tets)
 {
     auto& cache = swap_cache.local();
+    cache.is_surface_flip = false;
 
     const size_t a = t.vid(*this);
     const size_t b = t.switch_vertex(*this).vid(*this);
@@ -175,94 +175,82 @@ bool TetWildMesh::prepare_surface_flip_32(const Tuple& t, const std::vector<size
         return false;
     }
 
-    // The three "ring" vertices are the incident-tet vertices other than a,b.
-    std::array<size_t, 3> ring{};
-    int nr = 0;
+    // The "ring" vertices are the incident-tet vertices other than a,b (deduplicated). This works
+    // for any ring size (3->2, 4-4, 5-6); the specific retetrahedralization that realizes the flip
+    // is selected later by swap_edge_44_accept_case / swap_edge_56_accept_case.
+    std::vector<size_t> ring;
+    ring.reserve(incident_tets.size() + 1);
     for (const size_t tid : incident_tets) {
-        const auto vs = oriented_tet_vids(tid);
-        for (const size_t v : vs) {
-            if (v == a || v == b) {
-                continue;
-            }
-            bool seen = false;
-            for (int k = 0; k < nr; ++k) {
-                if (ring[k] == v) {
-                    seen = true;
-                    break;
+        for (const size_t v : oriented_tet_vids(tid)) {
+            if (v == a || v == b) continue;
+            if (std::find(ring.begin(), ring.end(), v) == ring.end()) ring.push_back(v);
+        }
+    }
+
+    // Exactly two of the ring faces (a,b,r) must be surface faces (manifold surface edge). Their
+    // apexes are the endpoints (c,d) of the new surface edge.
+    int n_surf = 0;
+    size_t c = 0, d = 0;
+    for (const size_t r : ring) {
+        auto [ftup, fid] = tuple_from_face(std::array<size_t, 3>{{a, b, r}});
+        (void)ftup;
+        if (fid == static_cast<size_t>(-1)) continue;
+        if (!m_face_attribute[fid].m_is_surface_fs) continue;
+        if (n_surf == 0) {
+            c = r;
+            cache.sf_face_attr = m_face_attribute[fid];
+        } else if (n_surf == 1) {
+            d = r;
+        } else {
+            return false; // > 2 surface faces: non-manifold edge
+        }
+        ++n_surf;
+    }
+    if (n_surf != 2) return false;
+
+    // The flip adds two surface faces (a,c,d),(b,c,d) on edge (c,d). If any surface face is
+    // already incident to edge (c,d), the result is a non-manifold surface edge (> 2 surface
+    // faces) -> reject. This counts the incident surface faces directly and does NOT rely on the
+    // m_is_on_surface vertex flags (which can be stale), unlike is_edge_on_surface().
+    //
+    // (c,d) need not exist yet: for a 3->2 flip the two apexes are adjacent, but for 4-4 / 5-6
+    // they are not, so the edge is created by the flip. Hence the validity check rather than an
+    // assert -- asserting here is a 3->2-only invariant and aborts a Debug build on 4-4.
+    {
+        const Tuple cd = tuple_from_edge(std::array<size_t, 2>{{c, d}});
+        if (cd.is_valid(*this)) {
+            const auto cd_tets = get_incident_tets_for_edge(cd);
+            for (const auto& ct : cd_tets) {
+                const auto vs = oriented_tet_vids(ct.tid(*this));
+                for (const size_t w : vs) {
+                    if (w == c || w == d) continue;
+                    auto [wf, wfid] = tuple_from_face(std::array<size_t, 3>{{c, d, w}});
+                    (void)wf;
+                    if (wfid != static_cast<size_t>(-1) && m_face_attribute[wfid].m_is_surface_fs)
+                        return false;
                 }
             }
-            if (seen) {
-                continue;
-            }
-            if (nr > 2) {
-                log_and_throw_error("prepare_surface_flip_32: more than 3 ring vertices");
-                // return false; // not a clean 3->2 ring
-            }
-            ring[nr++] = v;
         }
     }
-    if (nr != 3) {
-        log_and_throw_error("prepare_surface_flip_32: not exactly 3 ring vertices");
-        // return false;
-    }
 
-    // Of the three ring faces (a,b,ring[k]), exactly two must be surface faces
-    // (manifold surface edge). Their apexes are the new surface edge (c,d); the
-    // remaining apex is the other one (e).
-    int n_surf = 0;
-    size_t c = 0, d = 0, e = 0; // vertex ids; c/d on surface, e not
-    bool e_set = false;
-    for (int k = 0; k < 3; ++k) {
-        const auto [_, fid] = tuple_from_face(std::array<size_t, 3>{{a, b, ring[k]}});
-        (void)_; // tell compiler this variable is not needed
-        if (m_face_attribute[fid].m_is_surface_fs) {
-            if (n_surf == 0) {
-                c = ring[k];
-                cache.sf_face_attr = m_face_attribute[fid];
-            } else if (n_surf == 1) {
-                d = ring[k];
-            } else {
-                return false; // > 2 surface faces: non-manifold edge
-            }
-            ++n_surf;
-        } else {
-            if (e_set) {
-                return false; // > 1 non-surface face
-            }
-            e = ring[k];
-            e_set = true;
-        }
-    }
-    if (n_surf != 2 || !e_set) {
-        /**
-         * This statement should never be reached because the previous loop already checks for the
-         * number of surface faces and non-surface faces. If this statement is reached, it indicates
-         * a logical error in the code or an unexpected input configuration.
-         */
-        log_and_throw_error("prepare_surface_flip_32: invalid surface face configuration");
-    }
-
-    // The flip adds two surface faces (a,c,d),(b,c,d) on edge (c,d). If any
-    // surface face is already incident to edge (c,d), the result is a
-    // non-manifold surface edge (> 2 surface faces) -> reject.
-    //
-    // get_surface_faces_for_edge() opens with
-    //     if (!vertex_is_on_surface(v0) || !vertex_is_on_surface(v1)) return {};
-    // so this answer does depend on the m_is_on_surface vertex flags being in step with
-    // the face tags. They are: the flag is written in only four places and the collapse
-    // rule ORs it, so a vertex cannot silently lose it, and instrumenting this guard to
-    // compare against a direct count over (c,d)'s incident faces finds no disagreement on
-    // any tetwild or simwild integration config. If that ever stops holding, this guard is
-    // one of the places that would silently start passing bad flips, so prefer fixing the
-    // flag over working around it here.
+    // The two would-be new surface faces (a,c,d),(b,c,d) must not already be tagged surface,
+    // otherwise the flip corrupts manifoldness / boundaries.
     {
-        std::array<size_t, 2> cd{{c, d}};
-        assert(tuple_from_edge(cd).is_valid(*this));
-        const auto sf_edge = get_surface_faces_for_edge(cd);
-        if (sf_edge.size() > 0) {
-            // (c,d) already has a surface face incident
-            return false;
-        }
+        // These are the faces the flip is about to create, so on the normal path they do not
+        // exist yet. tuple_from_face treats that as a programming error -- it asserts, and only
+        // returns the -1 sentinel once asserts are compiled out -- so ask whether the three
+        // vertices share a tet before querying, rather than letting a Debug build abort on
+        // every 4-4 flip.
+        const auto face_is_surface = [&](size_t x, size_t y, size_t z) {
+            if (lowest_common_tet(x, y, z) == std::numeric_limits<size_t>::max()) {
+                return false; // no such face yet, so it cannot already be tagged surface
+            }
+            const auto [ftup, fid] = tuple_from_face(std::array<size_t, 3>{{x, y, z}});
+            (void)ftup;
+            return fid != static_cast<size_t>(-1) && m_face_attribute[fid].m_is_surface_fs;
+        };
+        if (face_is_surface(a, c, d)) return false;
+        if (face_is_surface(b, c, d)) return false;
     }
 
     cache.is_surface_flip = true;
@@ -270,8 +258,35 @@ bool TetWildMesh::prepare_surface_flip_32(const Tuple& t, const std::vector<size
     cache.sf_b = b;
     cache.sf_c = c;
     cache.sf_d = d;
-    cache.sf_e = e;
     return true;
+}
+
+bool TetWildMesh::swap_edge_44_accept_case(const std::array<size_t, 2>& new_edge)
+{
+    const auto& cache = swap_cache.local();
+    if (!cache.is_surface_flip) return true; // interior edge: keep pure min-energy behavior
+    // Surface flip: accept only the diagonal that creates the new surface edge (c,d).
+    return (new_edge[0] == cache.sf_c && new_edge[1] == cache.sf_d) ||
+           (new_edge[0] == cache.sf_d && new_edge[1] == cache.sf_c);
+}
+
+bool TetWildMesh::swap_edge_56_accept_case(const std::array<size_t, 3>& new_face)
+{
+    const auto& cache = swap_cache.local();
+    if (!cache.is_surface_flip) return true; // interior edge: keep pure min-energy behavior
+    // Surface flip: the fan apex (new_face[0]) must be one surface apex and the other surface apex
+    // must be one of the two fan tips, so the created diagonal is exactly (c,d). Keying on the apex
+    // (not "the face contains edge (c,d)") rejects the spurious case where (c,d) is a pre-existing
+    // link edge of the fan face rather than a newly created diagonal.
+    const size_t apex = new_face[0];
+    size_t other;
+    if (apex == cache.sf_c)
+        other = cache.sf_d;
+    else if (apex == cache.sf_d)
+        other = cache.sf_c;
+    else
+        return false;
+    return new_face[1] == other || new_face[2] == other;
 }
 
 bool TetWildMesh::swap_edge_after(const Tuple& t)
@@ -334,6 +349,7 @@ bool TetWildMesh::swap_edge_after(const Tuple& t)
         // m_face_attribute[fid1].m_is_surface_fs = true;
         // m_face_attribute[fid2].m_is_surface_fs = true;
         cnt_surface_swap++;
+        cnt_surface_swap_32++;
     }
 
     cnt_swap++;
@@ -528,6 +544,8 @@ size_t TetWildMesh::swap_all_edges_44()
     time = timer.getElapsedTime();
     logger().info("edge swap 44 prepare time: {:.4}s", time);
     size_t total_success = 0;
+    SurfaceTopoSignature sig_before;
+    if (m_params.check_surface_topology) sig_before = surface_topology_signature();
     auto setup_and_execute = [&](auto& executor) {
         executor.renew_neighbor_tuples = wmtk::renewal_edges;
         executor.priority = [&](auto& m, auto op, auto& t) { return m.get_length2(t); };
@@ -543,15 +561,16 @@ size_t TetWildMesh::swap_all_edges_44()
         setup_and_execute(executor);
         time = timer.getElapsedTime();
         logger().info("edge swap 44 operation time parallel: {:.4}s", time);
-        return total_success;
     } else {
         timer.start();
         auto executor = wmtk::ExecutePass<TetWildMesh>(wmtk::ExecutionPolicy::kSeq);
         setup_and_execute(executor);
         time = timer.getElapsedTime();
         logger().info("edge swap 44 operation time serial: {:.4}s", time);
-        return total_success;
     }
+    if (m_params.check_surface_topology)
+        warn_if_surface_topology_changed(sig_before, "swap_all_edges_44");
+    return total_success;
 }
 
 bool TetWildMesh::swap_edge_44_before(const Tuple& t)
@@ -559,28 +578,36 @@ bool TetWildMesh::swap_edge_44_before(const Tuple& t)
     if (!TetMesh::swap_edge_44_before(t)) {
         return false;
     }
-    // if (m_params.preserve_global_topology) return false;
+
+    auto& cache = swap_cache.local();
+    cache.is_surface_flip = false;
 
     auto incident_tets = get_incident_tids_for_edge(t);
     if (incident_tets.size() != 4) {
         return false;
     }
 
-    if (is_edge_on_surface(t) || is_edge_on_bbox(t)) {
+    // bbox edges are never swapped.
+    if (is_edge_on_bbox(t)) {
         return false;
+    }
+    // Surface edges are allowed only as a topology-preserving surface diagonal flip. The base 4-4
+    // swap is steered to the case that creates the new surface edge (c,d) by
+    // swap_edge_44_accept_case; if no 4-4 diagonal yields (c,d) the swap is rejected. Route on the
+    // direct incident-surface-face count so a genuine surface edge is never mistaken for interior.
+    const int n_surf_faces = edge_incident_surface_face_count(t);
+    if (n_surf_faces > 0) {
+        if (!m_params.allow_surface_swap) return false;
+        if (!prepare_surface_flip(t, incident_tets)) return false;
     }
 
     auto max_energy = -1.0;
     for (auto& l : incident_tets) {
         max_energy = std::max(m_tet_attribute[l].m_quality, max_energy);
     }
-    swap_cache.local().max_energy = max_energy;
+    cache.max_energy = max_energy;
 
-    face_attribute_tracker(
-        *this,
-        incident_tets,
-        m_face_attribute,
-        swap_cache.local().changed_faces);
+    face_attribute_tracker(*this, incident_tets, m_face_attribute, cache.changed_faces);
 
     return true;
 }
@@ -606,6 +633,7 @@ bool TetWildMesh::swap_edge_44_after(const Tuple& t)
 
     auto incident_tets = get_incident_tets_for_edge(t);
 
+    auto& cache = swap_cache.local();
     auto max_energy = -1.0;
     for (auto& l : incident_tets) {
         if (is_inverted(l)) return false;
@@ -614,11 +642,40 @@ bool TetWildMesh::swap_edge_44_after(const Tuple& t)
         max_energy = std::max(q, max_energy);
     }
 
-    if (max_energy >= swap_cache.local().max_energy) {
+    if (max_energy >= cache.max_energy) {
         return false;
     }
 
-    tracker_assign_after(*this, incident_tets, swap_cache.local().changed_faces, m_face_attribute);
+    if (cache.is_surface_flip) {
+        // The two new surface faces (a,c,d),(b,c,d) must stay within the Hausdorff envelope,
+        // exactly like a surface-edge collapse / the 3->2 surface flip.
+        const auto& VA = m_vertex_attribute;
+        if (m_envelope->is_outside(
+                {{VA[cache.sf_a].m_posf, VA[cache.sf_c].m_posf, VA[cache.sf_d].m_posf}}))
+            return false;
+        if (m_envelope->is_outside(
+                {{VA[cache.sf_b].m_posf, VA[cache.sf_c].m_posf, VA[cache.sf_d].m_posf}}))
+            return false;
+    }
+
+    tracker_assign_after(*this, incident_tets, cache.changed_faces, m_face_attribute);
+
+    if (cache.is_surface_flip) {
+        // Re-tag the two new surface faces (the generic tracker reset them to interior). Net
+        // surface change: -(a,b,c) -(a,b,d) +(a,c,d) +(b,c,d).
+        auto [ft1, fid1] =
+            tuple_from_face(std::array<size_t, 3>{{cache.sf_a, cache.sf_c, cache.sf_d}});
+        auto [ft2, fid2] =
+            tuple_from_face(std::array<size_t, 3>{{cache.sf_b, cache.sf_c, cache.sf_d}});
+        (void)ft1;
+        (void)ft2;
+        m_face_attribute[fid1] = cache.sf_face_attr;
+        m_face_attribute[fid2] = cache.sf_face_attr;
+        m_face_attribute[fid1].m_is_surface_fs = true;
+        m_face_attribute[fid2].m_is_surface_fs = true;
+        cnt_surface_swap++;
+        cnt_surface_swap_44++;
+    }
 
     cnt_swap++;
     return true;
@@ -636,6 +693,8 @@ size_t TetWildMesh::swap_all_edges_56()
     time = timer.getElapsedTime();
     logger().info("edge swap 56 prepare time: {:.4}s", time);
     size_t total_success = 0;
+    SurfaceTopoSignature sig_before;
+    if (m_params.check_surface_topology) sig_before = surface_topology_signature();
     auto setup_and_execute = [&](auto& executor) {
         executor.renew_neighbor_tuples = wmtk::renewal_edges;
         executor.priority = [&](auto& m, auto op, auto& t) { return m.get_length2(t); };
@@ -651,15 +710,16 @@ size_t TetWildMesh::swap_all_edges_56()
         setup_and_execute(executor);
         time = timer.getElapsedTime();
         logger().info("edge swap 56 operation time parallel: {:.4}s", time);
-        return total_success;
     } else {
         timer.start();
         auto executor = wmtk::ExecutePass<TetWildMesh>(wmtk::ExecutionPolicy::kSeq);
         setup_and_execute(executor);
         time = timer.getElapsedTime();
         logger().info("edge swap 56 operation time serial: {:.4}s", time);
-        return total_success;
     }
+    if (m_params.check_surface_topology)
+        warn_if_surface_topology_changed(sig_before, "swap_all_edges_56");
+    return total_success;
 }
 
 bool TetWildMesh::swap_edge_56_before(const Tuple& t)
@@ -668,25 +728,34 @@ bool TetWildMesh::swap_edge_56_before(const Tuple& t)
         return false;
     }
 
+    auto& cache = swap_cache.local();
+    cache.is_surface_flip = false;
+
     const auto incident_tets = get_incident_tids_for_edge(t);
     if (incident_tets.size() != 5) {
         return false;
     }
-    if (is_edge_on_surface(t) || is_edge_on_bbox(t)) {
+    // bbox edges are never swapped.
+    if (is_edge_on_bbox(t)) {
         return false;
+    }
+    // Surface edges are allowed only as a topology-preserving surface diagonal flip. The base 5-6
+    // swap is steered to the fan that creates the new surface edge (c,d) by
+    // swap_edge_56_accept_case; if no fan yields (c,d) the swap is rejected. Route on the direct
+    // incident-surface-face count so a genuine surface edge is never mistaken for interior.
+    const int n_surf_faces = edge_incident_surface_face_count(t);
+    if (n_surf_faces > 0) {
+        if (!m_params.allow_surface_swap) return false;
+        if (!prepare_surface_flip(t, incident_tets)) return false;
     }
 
     double max_energy = -1.0;
     for (const size_t l : incident_tets) {
         max_energy = std::max(m_tet_attribute[l].m_quality, max_energy);
     }
-    swap_cache.local().max_energy = max_energy;
+    cache.max_energy = max_energy;
 
-    face_attribute_tracker(
-        *this,
-        incident_tets,
-        m_face_attribute,
-        swap_cache.local().changed_faces);
+    face_attribute_tracker(*this, incident_tets, m_face_attribute, cache.changed_faces);
 
     return true;
 }
@@ -721,6 +790,7 @@ bool TetWildMesh::swap_edge_56_after(const Tuple& t)
     const auto e2 = get_incident_tids_for_edge(t.switch_edge(*this));
     const auto tids = wmtk::set_union(e1, e2);
 
+    auto& cache = swap_cache.local();
     double max_energy = -1.0;
     for (const size_t tid : tids) {
         const Tuple tet = tuple_from_tet(tid);
@@ -729,7 +799,35 @@ bool TetWildMesh::swap_edge_56_after(const Tuple& t)
         max_energy = std::max(q, max_energy);
     }
 
-    tracker_assign_after(*this, tids, swap_cache.local().changed_faces, m_face_attribute);
+    if (cache.is_surface_flip) {
+        // The two new surface faces (a,c,d),(b,c,d) must stay within the Hausdorff envelope.
+        const auto& VA = m_vertex_attribute;
+        if (m_envelope->is_outside(
+                {{VA[cache.sf_a].m_posf, VA[cache.sf_c].m_posf, VA[cache.sf_d].m_posf}}))
+            return false;
+        if (m_envelope->is_outside(
+                {{VA[cache.sf_b].m_posf, VA[cache.sf_c].m_posf, VA[cache.sf_d].m_posf}}))
+            return false;
+    }
+
+    tracker_assign_after(*this, tids, cache.changed_faces, m_face_attribute);
+
+    if (cache.is_surface_flip) {
+        // Re-tag the two new surface faces (the generic tracker reset them to interior). Net
+        // surface change: -(a,b,c) -(a,b,d) +(a,c,d) +(b,c,d).
+        auto [ft1, fid1] =
+            tuple_from_face(std::array<size_t, 3>{{cache.sf_a, cache.sf_c, cache.sf_d}});
+        auto [ft2, fid2] =
+            tuple_from_face(std::array<size_t, 3>{{cache.sf_b, cache.sf_c, cache.sf_d}});
+        (void)ft1;
+        (void)ft2;
+        m_face_attribute[fid1] = cache.sf_face_attr;
+        m_face_attribute[fid2] = cache.sf_face_attr;
+        m_face_attribute[fid1].m_is_surface_fs = true;
+        m_face_attribute[fid2].m_is_surface_fs = true;
+        cnt_surface_swap++;
+        cnt_surface_swap_56++;
+    }
 
     cnt_swap++;
     return true;

--- a/components/tetwild/wmtk/components/tetwild/Parameters.h
+++ b/components/tetwild/wmtk/components/tetwild/Parameters.h
@@ -16,9 +16,10 @@ struct Parameters
     bool preserve_topology = false;
     std::string output_path;
 
-    // Allow the 3->2 edge swap to operate on surface edges (a surface diagonal
-    // flip) instead of forbidding them outright. Enabled by default; can be
-    // turned off to reproduce the old surface-frozen behavior for A/B testing.
+    // Allow the edge swaps (3->2, 4-4, 5-6) to operate on surface edges as a
+    // topology-preserving surface diagonal flip, instead of forbidding them
+    // outright. Enabled by default; can be turned off to reproduce the old
+    // surface-frozen behavior for A/B testing.
     bool allow_surface_swap = true;
     // Expensive debug check: verify the global surface topology signature
     // (connected components, Euler characteristic, boundary loops) is unchanged

--- a/components/tetwild/wmtk/components/tetwild/TetWildMesh.cpp
+++ b/components/tetwild/wmtk/components/tetwild/TetWildMesh.cpp
@@ -559,7 +559,12 @@ std::tuple<double, double> TetWildMesh::local_operations(
             }
             auto [max_energy, avg_energy] = get_max_avg_energy();
             logger().info("swap max energy = {:.6} avg = {:.6}", max_energy, avg_energy);
-            logger().info("cnt_surface_swap (cumulative) = {}", cnt_surface_swap.load());
+            logger().info(
+                "cnt_surface_swap (cumulative) = {} [3-2: {}, 4-4: {}, 5-6: {}]",
+                cnt_surface_swap.load(),
+                cnt_surface_swap_32.load(),
+                cnt_surface_swap_44.load(),
+                cnt_surface_swap_56.load());
             sanity_checks();
         } else if (i == 3) {
             for (int n = 0; n < ops[i]; n++) {
@@ -1384,6 +1389,31 @@ bool TetWildMesh::is_edge_on_surface(const Tuple& loc)
     }
 
     return false;
+}
+
+int TetWildMesh::edge_incident_surface_face_count(const Tuple& e)
+{
+    const size_t v1_id = e.vid(*this);
+    const size_t v2_id = e.switch_vertex(*this).vid(*this);
+
+    const auto tets = get_incident_tets_for_edge(e);
+    std::vector<size_t> n_vids;
+    for (const auto& t : tets) {
+        const auto vs = oriented_tet_vertices(t);
+        for (int j = 0; j < 4; ++j) {
+            const size_t v = vs[j].vid(*this);
+            if (v != v1_id && v != v2_id) n_vids.push_back(v);
+        }
+    }
+    wmtk::vector_unique(n_vids);
+
+    int count = 0;
+    for (const size_t vid : n_vids) {
+        auto [ftup, fid] = tuple_from_face({{v1_id, v2_id, vid}});
+        (void)ftup;
+        if (fid != static_cast<size_t>(-1) && m_face_attribute[fid].m_is_surface_fs) ++count;
+    }
+    return count;
 }
 
 

--- a/components/tetwild/wmtk/components/tetwild/TetWildMesh.h
+++ b/components/tetwild/wmtk/components/tetwild/TetWildMesh.h
@@ -3,6 +3,7 @@
 #include <igl/Timer.h>
 #include <wmtk/TetMesh.h>
 #include <wmtk/utils/PartitionMesh.h>
+#include <algorithm>
 #include <wmtk/envelope/Envelope.hpp>
 #include <wmtk/optimization/SmoothVertex.hpp>
 #include <wmtk/threading/concurrent_map.hpp>
@@ -167,7 +168,7 @@ public:
         const std::vector<VertexAttributes>& _vertex_attribute,
         const std::vector<TetAttributes>& _tet_attribute)
     {
-        auto n_tet = _tet_attribute.size();
+        const size_t n_tet = _tet_attribute.size();
         m_vertex_attribute.resize(_vertex_attribute.size());
         m_face_attribute.resize(4 * n_tet);
         m_tet_attribute.resize(n_tet);
@@ -175,11 +176,22 @@ public:
         // new for edge
         // m_edge_attribute.resize(6 * n_tet);
 
-        for (auto i = 0; i < _vertex_attribute.size(); i++)
+        for (size_t i = 0; i < _vertex_attribute.size(); i++)
             m_vertex_attribute[i] = _vertex_attribute[i];
-        m_tet_attribute.m_attributes = std::vector<TetAttributes>(_tet_attribute.size());
-        for (auto i = 0; i < _tet_attribute.size(); i++) m_tet_attribute[i] = _tet_attribute[i];
-        for (auto i = 0; i < _tet_attribute.size(); i++)
+
+        // Keep whatever init() reserved. AttributeCollection::resize only ever grows, so the
+        // calls above cannot shrink a collection -- but assigning m_attributes directly does,
+        // and it used to drop the tet attributes to exactly n_tet. The attributes have to stay
+        // at least as large as the connectivity: an operation that creates a new element
+        // indexes them by its id, and a 5->6 swap creates one. That left m_tet_attribute one
+        // short of the tet the swap adds, and AttributeCollection::operator[] read past the end
+        // of it -- ASan reports a heap-buffer-overflow reached from swap_edge_56_after, and
+        // libstdc++ then aborts on the corrupted heap a few allocations later, while libc++
+        // carries on and the tests pass.
+        const size_t tcap = std::max(n_tet, m_tet_attribute.size());
+        m_tet_attribute.m_attributes = std::vector<TetAttributes>(tcap);
+        for (size_t i = 0; i < n_tet; i++) m_tet_attribute[i] = _tet_attribute[i];
+        for (size_t i = 0; i < n_tet; i++)
             m_tet_attribute[i].m_quality = get_quality(tuple_from_tet(i));
     }
 

--- a/components/tetwild/wmtk/components/tetwild/TetWildMesh.h
+++ b/components/tetwild/wmtk/components/tetwild/TetWildMesh.h
@@ -249,12 +249,14 @@ public:
     bool swap_edge_44_before(const Tuple& t) override;
     double swap_edge_44_energy(const std::vector<std::array<size_t, 4>>& tets, const int op_case)
         override;
+    bool swap_edge_44_accept_case(const std::array<size_t, 2>& new_edge) override;
     bool swap_edge_44_after(const Tuple& t) override;
 
     size_t swap_all_edges_56();
     bool swap_edge_56_before(const Tuple& t) override;
     double swap_edge_56_energy(const std::vector<std::array<size_t, 4>>& tets, const int op_case)
         override;
+    bool swap_edge_56_accept_case(const std::array<size_t, 3>& new_face) override;
     bool swap_edge_56_after(const Tuple& t) override;
 
     size_t swap_all_edges_32();
@@ -262,17 +264,29 @@ public:
     bool swap_edge_after(const Tuple& t) override;
 
     /**
-     * @brief Prepare a surface 3->2 edge swap (a surface diagonal flip).
+     * @brief Prepare a surface edge swap (a surface diagonal flip), any ring size.
      *
-     * Called from swap_edge_before when the swapped edge (a,b) is on the surface
-     * and has exactly 3 incident tets. Verifies the local guards that guarantee
-     * the flip preserves surface manifoldness / topology, and fills the
-     * surface-flip fields of swap_cache. Returns false (rejecting the swap) if
-     * any guard fails: open-boundary edge, non-manifold edge (!= 2 surface
-     * faces), or one of the two would-be new surface faces already tagged
-     * surface. The tets sharing (a,b) are passed in to avoid recomputation.
+     * Called from swap_edge_before / swap_edge_44_before / swap_edge_56_before when the swapped
+     * edge (a,b) is on the surface. Regardless of how many tets share (a,b), the surface change is
+     * always the 2D diagonal flip of the two incident surface faces (a,b,c),(a,b,d) into
+     * (a,c,d),(b,c,d). This verifies the ring-size-independent guards that guarantee the flip
+     * preserves surface manifoldness / topology and fills the surface-flip fields of swap_cache.
+     * The specific retetrahedralization that realizes (c,d) is selected later by
+     * swap_edge_44_accept_case / swap_edge_56_accept_case (the 3->2 path always realizes it).
+     * Returns false (rejecting the swap) if any guard fails: open-boundary edge, non-manifold edge
+     * (!= 2 surface faces incident to (a,b)), the target edge (c,d) already carries a surface face,
+     * or one of the two would-be new surface faces (a,c,d),(b,c,d) is already tagged surface. The
+     * tets sharing (a,b) are passed in to avoid recomputation.
      */
-    bool prepare_surface_flip_32(const Tuple& t, const std::vector<size_t>& incident_tets);
+    bool prepare_surface_flip(const Tuple& t, const std::vector<size_t>& incident_tets);
+
+    /**
+     * @brief Number of surface faces incident to edge (a,b), counted directly over the edge's
+     * incident tets. Unlike is_edge_on_surface(), this does NOT short-circuit on the (possibly
+     * stale) m_is_on_surface vertex flags, so a genuine manifold surface edge is never mistaken
+     * for an interior edge (== 2) nor a non-manifold one (> 2). Used to route swaps.
+     */
+    int edge_incident_surface_face_count(const Tuple& e);
 
     /// A topological fingerprint of the tracked surface (m_is_surface_fs). See
     /// wmtk/utils/SurfaceTopology.hpp.
@@ -413,7 +427,10 @@ public:
     // debug use
     std::atomic<int> cnt_split = 0, cnt_collapse = 0, cnt_swap = 0;
     // Successful surface diagonal flips (subset of cnt_swap). Diagnostic.
+    // cnt_surface_swap is the grand total; the per-type counters break it down by the swap that
+    // realized the flip (3->2, 4-4, 5-6).
     std::atomic<int> cnt_surface_swap = 0;
+    std::atomic<int> cnt_surface_swap_32 = 0, cnt_surface_swap_44 = 0, cnt_surface_swap_56 = 0;
 
 private:
     // tags: correspondence map from new tet-face node indices to in-triangle ids.
@@ -484,13 +501,14 @@ private:
         double max_energy;
         std::map<std::array<size_t, 3>, FaceAttributes> changed_faces;
 
-        // Surface 3->2 flip bookkeeping (filled by swap_edge_before when the
-        // swapped edge (a,b) lies on the surface). a,b are the removed-edge
-        // endpoints, c,d are the new surface-edge endpoints, e is the interior
-        // apex. sf_face_attr is copied onto the two new surface faces (a,c,d),
-        // (b,c,d). is_surface_flip gates the extra handling in swap_edge_after.
+        // Surface diagonal-flip bookkeeping (filled by prepare_surface_flip from
+        // swap_edge_before / swap_edge_44_before / swap_edge_56_before when the swapped edge (a,b)
+        // lies on the surface). a,b are the removed-edge endpoints, c,d are the new surface-edge
+        // endpoints (the apexes of the two incident surface faces). sf_face_attr is copied onto the
+        // two new surface faces (a,c,d),(b,c,d). is_surface_flip gates the accept-case case-forcing
+        // and the extra retag/envelope handling in the swap *_after callbacks.
         bool is_surface_flip = false;
-        size_t sf_a = 0, sf_b = 0, sf_c = 0, sf_d = 0, sf_e = 0;
+        size_t sf_a = 0, sf_b = 0, sf_c = 0, sf_d = 0;
         FaceAttributes sf_face_attr;
     };
     wmtk::threading::enumerable_thread_specific<SwapInfoCache> swap_cache;

--- a/components/tetwild/wmtk/components/tetwild/tests/test_surface_swap.cpp
+++ b/components/tetwild/wmtk/components/tetwild/tests/test_surface_swap.cpp
@@ -6,6 +6,7 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include <array>
+#include <cmath>
 #include <vector>
 
 using namespace wmtk;
@@ -350,4 +351,349 @@ TEST_CASE("surface-flip-rejected", "[tetwild_operation][surface_swap]")
         CHECK(is_surface(mesh, A, B, D));
         CHECK(count_valid_tets(mesh) == 3);
     }
+}
+
+// ---------------------------------------------------------------------------
+// Extended surface swaps: 4-4 and 5-6 edge flips.
+//
+// The surface change is always the 2D diagonal flip of the two incident surface
+// faces (a,b,c),(a,b,d) -> (a,c,d),(b,c,d). The volumetric operation that realizes
+// it depends on the ring size: 3->2 (done above), 4-4, or 5-6. These fixtures build
+// an N-tet ring around edge (a=0,b=1) whose ring vertices lie on a regular N-gon in
+// z=0, with a,b far apart on the z-axis so edge (a,b) is a bad sliver and the
+// diagonal flip strictly lowers the AMIPS energy (mirrors tet_mesh_swap56_with_position).
+// ---------------------------------------------------------------------------
+namespace {
+
+constexpr double kPi = 3.14159265358979323846;
+
+// vids: a=0, b=1, ring i -> 2+i. Ring is CCW so the tets (a,b,r_i,r_{i+1}) are
+// positively oriented. `half` is the |z| of a,b; a large value makes (a,b) a sliver.
+void build_ring_n(TetWildMesh& mesh, int N, double half, double radius)
+{
+    std::vector<std::array<size_t, 4>> tets;
+    for (int i = 0; i < N; ++i) tets.push_back({{0, 1, size_t(2 + i), size_t(2 + (i + 1) % N)}});
+    mesh.init(N + 2, tets);
+
+    std::vector<VertexAttributes> va(N + 2);
+    va[0].m_posf = Vector3d(0, 0, -half);
+    va[1].m_posf = Vector3d(0, 0, half);
+    for (int i = 0; i < N; ++i) {
+        const double ang = 2.0 * kPi * i / N;
+        va[2 + i].m_posf = Vector3d(radius * std::cos(ang), radius * std::sin(ang), 0);
+    }
+    for (int i = 0; i < N + 2; ++i) {
+        va[i].m_is_rounded = true;
+        va[i].m_pos = to_rational(va[i].m_posf);
+        va[i].m_is_on_surface = false;
+        va[i].m_is_on_open_boundary = false;
+        va[i].m_order = 0;
+    }
+    std::vector<TetAttributes> ta(N);
+    mesh.create_mesh_attributes(va, ta);
+}
+
+void mark_surface_vertex(TetWildMesh& mesh, size_t v)
+{
+    mesh.m_vertex_attribute[v].m_is_on_surface = true;
+    mesh.m_vertex_attribute[v].m_order = 1;
+}
+
+// Build an envelope around the current tracked-surface faces of `mesh` (eps in world
+// units). `env` must outlive the swap (the mesh holds a reference).
+void init_env_from_surface(SampleEnvelope& env, const TetWildMesh& mesh, double eps)
+{
+    std::vector<Vector3d> v(mesh.vert_capacity());
+    for (size_t i = 0; i < mesh.vert_capacity(); ++i) v[i] = mesh.m_vertex_attribute[i].m_posf;
+    std::vector<Eigen::Vector3i> f;
+    for (size_t i = 0; i < mesh.tet_capacity(); ++i) {
+        const auto tt = mesh.tuple_from_tet(i);
+        if (!tt.is_valid(mesh)) continue;
+        for (int j = 0; j < 4; ++j) {
+            const auto ft = mesh.tuple_from_face(i, j);
+            const size_t fid = ft.fid(mesh);
+            if (fid != 4 * i + j) continue; // canonical: visit each face once
+            if (!mesh.m_face_attribute[fid].m_is_surface_fs) continue;
+            const auto vs = mesh.get_face_vids(ft);
+            f.emplace_back(int(vs[0]), int(vs[1]), int(vs[2]));
+        }
+    }
+    env.init(v, f, eps);
+}
+
+int count_valid_tets_n(TetWildMesh& mesh)
+{
+    int n = 0;
+    for (size_t i = 0; i < mesh.tet_capacity(); ++i)
+        if (mesh.tuple_from_tet(i).is_valid(mesh)) ++n;
+    return n;
+}
+
+bool any_inverted_n(TetWildMesh& mesh)
+{
+    for (size_t i = 0; i < mesh.tet_capacity(); ++i) {
+        const auto tt = mesh.tuple_from_tet(i);
+        if (tt.is_valid(mesh) && mesh.is_inverted(tt)) return true;
+    }
+    return false;
+}
+
+} // namespace
+
+TEST_CASE("surface-flip-44-correctness", "[tetwild_operation][surface_swap]")
+{
+    // 4-tet ring; the two surface apexes are OPPOSITE in the ring (vids 2 and 4), so
+    // exactly one 4-4 diagonal is (2,4) and the flip is realizable.
+    Parameters params;
+    params.init(Vector3d(-2, -2, -2000), Vector3d(2, 2, 2000));
+    auto env = std::make_shared<SampleEnvelope>();
+    TetWildMesh mesh(params, env, 1);
+    build_ring_n(mesh, 4, 1000.0, 1.0);
+    for (size_t v : {size_t(0), size_t(1), size_t(2), size_t(4)}) mark_surface_vertex(mesh, v);
+    set_surface(mesh, 0, 1, 2, true); // (a,b,c)
+    set_surface(mesh, 0, 1, 4, true); // (a,b,d)
+    init_env_from_surface(*env, mesh, 50.0); // permissive (the surface stays planar here)
+
+    const auto sig_before = mesh.surface_topology_signature();
+    CHECK(sig_before.F == 2);
+
+    auto t = mesh.tuple_from_edge(std::array<size_t, 2>{{0, 1}});
+    REQUIRE(t.is_valid(mesh));
+    std::vector<TetMesh::Tuple> ret;
+    const bool ok = mesh.swap_edge_44(t, ret);
+
+    REQUIRE(ok);
+    CHECK(count_valid_tets_n(mesh) == 4); // 4-4: tet count unchanged
+    CHECK(mesh.check_mesh_connectivity_validity());
+    CHECK_FALSE(any_inverted_n(mesh));
+
+    // Surface diagonal flipped (a,b) -> (c,d) == (2,4).
+    CHECK(is_surface(mesh, 0, 2, 4)); // (a,c,d)
+    CHECK(is_surface(mesh, 1, 2, 4)); // (b,c,d)
+
+    const auto sig_after = mesh.surface_topology_signature();
+    CHECK(sig_after.F == 2);
+    CHECK(sig_after == sig_before); // surface topology invariant
+
+    CHECK(mesh.cnt_surface_swap_44.load() == 1);
+    CHECK(mesh.cnt_surface_swap.load() == 1);
+    // Vertex surface membership is invariant under a pure diagonal flip.
+    for (size_t v : {size_t(0), size_t(1), size_t(2), size_t(4)})
+        CHECK(mesh.m_vertex_attribute[v].m_is_on_surface);
+}
+
+TEST_CASE("surface-flip-44-rejected", "[tetwild_operation][surface_swap]")
+{
+    Parameters params;
+    params.init(Vector3d(-2, -2, -2000), Vector3d(2, 2, 2000));
+
+    SECTION("adjacent surface apexes -> no matching diagonal -> rejected")
+    {
+        // Surface apexes vids 2 and 3 are ADJACENT in the ring, so neither 4-4
+        // diagonal ((2,4) or (3,5)) equals (2,3): the accept-case vetoes both cases.
+        auto env = std::make_shared<SampleEnvelope>();
+        TetWildMesh mesh(params, env, 1);
+        build_ring_n(mesh, 4, 1000.0, 1.0);
+        for (size_t v : {size_t(0), size_t(1), size_t(2), size_t(3)}) mark_surface_vertex(mesh, v);
+        set_surface(mesh, 0, 1, 2, true);
+        set_surface(mesh, 0, 1, 3, true);
+        init_env_from_surface(*env, mesh, 50.0);
+
+        const auto sig_before = mesh.surface_topology_signature();
+        auto t = mesh.tuple_from_edge(std::array<size_t, 2>{{0, 1}});
+        std::vector<TetMesh::Tuple> ret;
+        CHECK_FALSE(mesh.swap_edge_44(t, ret));
+        CHECK(count_valid_tets_n(mesh) == 4);
+        CHECK(mesh.cnt_surface_swap_44.load() == 0);
+        CHECK(mesh.surface_topology_signature() == sig_before);
+    }
+
+    SECTION("disabled by param -> rejected")
+    {
+        params.allow_surface_swap = false;
+        auto env = std::make_shared<SampleEnvelope>();
+        TetWildMesh mesh(params, env, 1);
+        build_ring_n(mesh, 4, 1000.0, 1.0);
+        for (size_t v : {size_t(0), size_t(1), size_t(2), size_t(4)}) mark_surface_vertex(mesh, v);
+        set_surface(mesh, 0, 1, 2, true);
+        set_surface(mesh, 0, 1, 4, true);
+        init_env_from_surface(*env, mesh, 50.0);
+
+        auto t = mesh.tuple_from_edge(std::array<size_t, 2>{{0, 1}});
+        std::vector<TetMesh::Tuple> ret;
+        CHECK_FALSE(mesh.swap_edge_44(t, ret));
+        CHECK(count_valid_tets_n(mesh) == 4);
+        CHECK(mesh.cnt_surface_swap_44.load() == 0);
+    }
+
+    SECTION("non-manifold edge (3 surface faces) -> rejected")
+    {
+        auto env = std::make_shared<SampleEnvelope>();
+        TetWildMesh mesh(params, env, 1);
+        build_ring_n(mesh, 4, 1000.0, 1.0);
+        for (size_t v : {size_t(0), size_t(1), size_t(2), size_t(3), size_t(4)})
+            mark_surface_vertex(mesh, v);
+        set_surface(mesh, 0, 1, 2, true);
+        set_surface(mesh, 0, 1, 3, true);
+        set_surface(mesh, 0, 1, 4, true); // 3rd surface face on edge (a,b)
+        init_env_from_surface(*env, mesh, 50.0);
+
+        auto t = mesh.tuple_from_edge(std::array<size_t, 2>{{0, 1}});
+        std::vector<TetMesh::Tuple> ret;
+        CHECK_FALSE(mesh.swap_edge_44(t, ret));
+        CHECK(count_valid_tets_n(mesh) == 4);
+        CHECK(mesh.cnt_surface_swap_44.load() == 0);
+    }
+}
+
+TEST_CASE("surface-flip-44-routing-stale-flag", "[tetwild_operation][surface_swap]")
+{
+    // A genuine surface edge whose endpoint vertex flags are stale-false must still be
+    // routed through the surface flip (edge_incident_surface_face_count is face-based),
+    // so the surface is not silently torn by the interior path.
+    Parameters params;
+    params.init(Vector3d(-2, -2, -2000), Vector3d(2, 2, 2000));
+    auto env = std::make_shared<SampleEnvelope>();
+    TetWildMesh mesh(params, env, 1);
+    build_ring_n(mesh, 4, 1000.0, 1.0);
+    // Deliberately DO NOT mark any vertex on-surface (all m_is_on_surface stay false),
+    // even though (0,1,2),(0,1,4) are surface faces.
+    set_surface(mesh, 0, 1, 2, true);
+    set_surface(mesh, 0, 1, 4, true);
+    init_env_from_surface(*env, mesh, 50.0);
+
+    const auto sig_before = mesh.surface_topology_signature();
+    auto t = mesh.tuple_from_edge(std::array<size_t, 2>{{0, 1}});
+    std::vector<TetMesh::Tuple> ret;
+    const bool ok = mesh.swap_edge_44(t, ret);
+    REQUIRE(ok);
+    // The flip ran through the surface path: surface retagged and topology preserved.
+    CHECK(is_surface(mesh, 0, 2, 4));
+    CHECK(is_surface(mesh, 1, 2, 4));
+    CHECK(mesh.cnt_surface_swap_44.load() == 1);
+    CHECK(mesh.surface_topology_signature() == sig_before);
+}
+
+TEST_CASE("surface-flip-56-correctness", "[tetwild_operation][surface_swap]")
+{
+    // 5-tet ring; the two surface apexes (vids 2 and 4) are separated by ONE ring vertex
+    // (distance 2 in the pentagon), so a fan from vertex 2 (or 4) creates the diagonal
+    // (2,4) and realizes the surface flip.
+    Parameters params;
+    params.init(Vector3d(-2, -2, -2000), Vector3d(2, 2, 2000));
+    auto env = std::make_shared<SampleEnvelope>();
+    TetWildMesh mesh(params, env, 1);
+    build_ring_n(mesh, 5, 1000.0, 1.0);
+    for (size_t v : {size_t(0), size_t(1), size_t(2), size_t(4)}) mark_surface_vertex(mesh, v);
+    set_surface(mesh, 0, 1, 2, true); // (a,b,c)
+    set_surface(mesh, 0, 1, 4, true); // (a,b,d)
+    init_env_from_surface(*env, mesh, 50.0); // permissive: the surface is folded here
+
+    const auto sig_before = mesh.surface_topology_signature();
+    CHECK(sig_before.F == 2);
+
+    auto t = mesh.tuple_from_edge(std::array<size_t, 2>{{0, 1}});
+    REQUIRE(t.is_valid(mesh));
+    std::vector<TetMesh::Tuple> ret;
+    const bool ok = mesh.swap_edge_56(t, ret);
+
+    REQUIRE(ok);
+    CHECK(count_valid_tets_n(mesh) == 6); // 5-6: 5 tets -> 6 tets
+    CHECK(mesh.check_mesh_connectivity_validity());
+    CHECK_FALSE(any_inverted_n(mesh));
+
+    CHECK(is_surface(mesh, 0, 2, 4)); // (a,c,d)
+    CHECK(is_surface(mesh, 1, 2, 4)); // (b,c,d)
+
+    const auto sig_after = mesh.surface_topology_signature();
+    CHECK(sig_after.F == 2);
+    CHECK(sig_after == sig_before);
+
+    CHECK(mesh.cnt_surface_swap_56.load() == 1);
+    CHECK(mesh.cnt_surface_swap.load() == 1);
+}
+
+TEST_CASE("surface-flip-56-rejected", "[tetwild_operation][surface_swap]")
+{
+    // Surface apexes vids 2,3 are ADJACENT. For the fan at vertex 5 the new face is
+    // (5,2,3) whose edge (2,3) is a pre-existing link edge -- a naive "face contains
+    // (c,d)" test would wrongly accept it; the apex-keyed accept-case (apex 5 not in
+    // {2,3}) correctly rejects, so no flip happens.
+    // (Envelope-based rejection is identical code to the 3->2 path and is covered by the
+    // "new surface outside envelope" section of surface-flip-rejected.)
+    Parameters params;
+    params.init(Vector3d(-2, -2, -2000), Vector3d(2, 2, 2000));
+    auto env = std::make_shared<SampleEnvelope>();
+    TetWildMesh mesh(params, env, 1);
+    build_ring_n(mesh, 5, 1000.0, 1.0);
+    for (size_t v : {size_t(0), size_t(1), size_t(2), size_t(3)}) mark_surface_vertex(mesh, v);
+    set_surface(mesh, 0, 1, 2, true);
+    set_surface(mesh, 0, 1, 3, true);
+    init_env_from_surface(*env, mesh, 50.0);
+
+    const auto sig_before = mesh.surface_topology_signature();
+    auto t = mesh.tuple_from_edge(std::array<size_t, 2>{{0, 1}});
+    std::vector<TetMesh::Tuple> ret;
+    CHECK_FALSE(mesh.swap_edge_56(t, ret));
+    CHECK(count_valid_tets_n(mesh) == 5);
+    CHECK(mesh.cnt_surface_swap_56.load() == 0);
+    CHECK(mesh.surface_topology_signature() == sig_before);
+}
+
+TEST_CASE("surface-flip-interior-unchanged", "[tetwild_operation][surface_swap]")
+{
+    // With no surface faces, the 4-4 and 5-6 swaps must behave exactly as before: the
+    // accept-case predicate defaults to accepting every case (is_surface_flip == false),
+    // and no surface retag occurs.
+    Parameters params;
+    params.init(Vector3d(-2, -2, -2000), Vector3d(2, 2, 2000));
+
+    SECTION("interior 4-4")
+    {
+        auto env = std::make_shared<SampleEnvelope>();
+        TetWildMesh mesh(params, env, 1);
+        build_ring_n(mesh, 4, 1000.0, 1.0); // no surface faces tagged
+        auto t = mesh.tuple_from_edge(std::array<size_t, 2>{{0, 1}});
+        std::vector<TetMesh::Tuple> ret;
+        CHECK(mesh.swap_edge_44(t, ret));
+        CHECK(count_valid_tets_n(mesh) == 4);
+        CHECK(mesh.check_mesh_connectivity_validity());
+        CHECK(mesh.cnt_surface_swap_44.load() == 0);
+    }
+
+    SECTION("interior 5-6")
+    {
+        auto env = std::make_shared<SampleEnvelope>();
+        TetWildMesh mesh(params, env, 1);
+        build_ring_n(mesh, 5, 1000.0, 1.0);
+        auto t = mesh.tuple_from_edge(std::array<size_t, 2>{{0, 1}});
+        std::vector<TetMesh::Tuple> ret;
+        CHECK(mesh.swap_edge_56(t, ret));
+        CHECK(count_valid_tets_n(mesh) == 6);
+        CHECK(mesh.check_mesh_connectivity_validity());
+        CHECK(mesh.cnt_surface_swap_56.load() == 0);
+    }
+}
+
+TEST_CASE("surface-face-swap-excluded", "[tetwild_operation][surface_swap]")
+{
+    // The 2->3 face swap must never touch a surface face (it would tear a hole in the
+    // tracked surface). Confirm it is rejected and the surface is unchanged.
+    Parameters params;
+    params.init(Vector3d(-2, -2, -2), Vector3d(2, 2, 2));
+    auto env = std::make_shared<SampleEnvelope>();
+    init_loose_envelope(*env);
+    TetWildMesh mesh(params, env, 1);
+    build_ring(mesh);
+    set_surface(mesh, A, B, C, true);
+    set_surface(mesh, A, B, D, true);
+
+    const auto sig_before = mesh.surface_topology_signature();
+    auto [ftup, fid] = mesh.tuple_from_face(std::array<size_t, 3>{{A, B, C}});
+    (void)fid;
+    REQUIRE(ftup.is_valid(mesh));
+    std::vector<TetMesh::Tuple> ret;
+    CHECK_FALSE(mesh.swap_face(ftup, ret)); // surface face: rejected
+    CHECK(is_surface(mesh, A, B, C));
+    CHECK(mesh.surface_topology_signature() == sig_before);
 }

--- a/components/tetwild/wmtk/components/tetwild/tetwild_spec.json
+++ b/components/tetwild/wmtk/components/tetwild/tetwild_spec.json
@@ -217,7 +217,7 @@
     "pointer": "/allow_surface_swap",
     "type": "bool",
     "default": true,
-    "doc": "Allow surface edge swapping."
+    "doc": "Allow the edge swaps (3-2, 4-4, 5-6) to operate on surface edges, as a topology-preserving surface diagonal flip. When false, every surface edge is left alone."
   },
   {
     "pointer": "/check_surface_topology",

--- a/src/wmtk/TetMesh.h
+++ b/src/wmtk/TetMesh.h
@@ -814,6 +814,19 @@ protected:
      */
     virtual bool swap_edge_44_after(const Tuple& t) { return true; }
     /**
+     * @brief Filter which of the 4-4 orientations may be chosen.
+     *
+     * Called for every candidate 4-4 case (identified by its new edge) BEFORE the energy-based
+     * selection; a candidate whose new edge is rejected here is not considered. The default
+     * accepts everything, so interior edges keep the pure min-energy behavior. A derived mesh can
+     * override this to force a specific retetrahedralization (e.g. tetwild forces the case that
+     * realizes a surface diagonal flip).
+     *
+     * @param new_edge The two vertices of the candidate's new edge. The ordering is
+     * implementation-defined (currently new_edge[0] is the case-selector vertex).
+     */
+    virtual bool swap_edge_44_accept_case(const std::array<size_t, 2>& new_edge) { return true; }
+    /**
      * @brief User specified preparations and desideratas for a 5-6 edge swap before changing the
      * connectivity
      *
@@ -844,6 +857,19 @@ protected:
      * @return true if the modification succeed
      */
     virtual bool swap_edge_56_after(const Tuple& t) { return true; }
+    /**
+     * @brief Filter which of the 5-6 orientations may be chosen.
+     *
+     * Called for every candidate 5-6 case (identified by its new fan face) BEFORE the energy-based
+     * selection; a candidate whose new face is rejected here is not considered. The default accepts
+     * everything, so interior edges keep the pure min-energy behavior. `new_face[0]` is the fan
+     * apex. A derived mesh can override this to force a specific retetrahedralization (e.g. tetwild
+     * forces the fan that realizes a surface diagonal flip).
+     *
+     * @param new_face The candidate's new fan face; new_face[0] is the fan apex.
+     * @return true if this candidate case is allowed.
+     */
+    virtual bool swap_edge_56_accept_case(const std::array<size_t, 3>& new_face) { return true; }
     /**
      * @brief User specified preparations and desideratas for an 3-2 edge swap before changing the
      * conenctivity

--- a/src/wmtk/TetMeshSwapMeshConnectivity.cpp
+++ b/src/wmtk/TetMeshSwapMeshConnectivity.cpp
@@ -540,6 +540,13 @@ bool TetMesh::swap_edge_44(const Tuple& t, std::vector<Tuple>& new_tet_tuples)
         auto tets = swap_4_4(old_tets_conn, v1_id, v2_id, v0, edge_vids);
         assert(v0 == edge_vids[0]);
 
+        // Let the app veto a candidate case (e.g. tetwild forces the diagonal that
+        // realizes a surface flip). Default accepts all, so interior edges are unchanged.
+        if (!swap_edge_44_accept_case(edge_vids)) {
+            ++op_case;
+            continue;
+        }
+
         double energy = swap_edge_44_energy(tets, op_case);
         if (energy < min_energy) {
             min_energy = energy;
@@ -754,6 +761,13 @@ bool TetMesh::swap_edge_56(const Tuple& t, std::vector<Tuple>& new_tet_tuples)
         std::array<size_t, 3> edge_vids;
         auto tets = swap_5_6(old_tets_conn, v1_id, v2_id, v0, edge_vids);
         assert(v0 == edge_vids[0]);
+
+        // Let the app veto a candidate case (e.g. tetwild forces the fan that
+        // realizes a surface flip). Default accepts all, so interior edges are unchanged.
+        if (!swap_edge_56_accept_case(edge_vids)) {
+            ++op_case;
+            continue;
+        }
 
         double energy = swap_edge_56_energy(tets, op_case);
         if (energy < min_energy) {


### PR DESCRIPTION
Resurrects [#954](https://github.com/wildmeshing/wildmeshing-toolkit/pull/954), which reports MERGED but whose code is **not in main**:

```
$ git show origin/main:.../EdgeSwapping.cpp | grep prepare_surface_flip
(nothing)
```

## Why it went missing

```
#951  MERGED → main    Drop geogram (and TBB) from the build
 └─ #952  CLOSED       Concurrency cleanup          ← "This was integrated in #934"
     └─ #953  OPEN     Total order for sort comparators
         └─ #954  merged into #953's branch   ← this work
             └─ #955  merged into #954's branch
```

#952 was closed as superseded (correctly — #934 took its content to main another way), but closing the foundation orphaned everything stacked above. #954 and #955 show MERGED because they merged into intermediate branches that themselves never reached main. `danielepanozzo/sort-total-order` still sits on origin at #954's merge commit.

## What it fixes

Until now the only surface swap was the 3→2 diagonal flip; 4-4 and 5-6 rejected every surface edge outright. That leaves a **flat tet embedded in the surface** unrepairable whenever its edges have ring size 4 or 5 — all 4 vertices, all 6 edges and 3–4 of 4 faces on the surface, volume 1.8e-14 with edge lengths 3.5–17. Face swaps refuse surface faces; the 3→2 flip needs *exactly* 3 incident tets and these have 8, 8, 4, 5, 3, 8; collapse and smoothing are envelope-bound.

So max energy stalls at exactly one value, stuck-refine force-splits the tet, and splitting a cap yields flatter caps — volume 1.8e-14 → **1.65e-28**, energy → 2.5e20, worst-tet count 4 → 244, iterations 3 s → 10 min, timeout.

## Verification

8 runs of the configuration that timed out on the Thingi10K sweep, on the model that timed out (229958.stl):

| start energy | before | after |
| --- | --- | --- |
| 2.10e11 *(the sweep's timeout)* | 3.66e17 → timeout | **99.1** |
| 1.61e11 | 3.80e20 → timeout | **95.9** |
| 4.43e11 | — | **89.6** |

All 8/8 converge (86–292 against `stop_energy` 100). The counters show the restored cases doing the work:

```
cnt_surface_swap (cumulative) = 1741  [3-2: 107,  4-4: 1223,  5-6: 411]
```

~94% of surface repair comes from the swaps this brings back.

`test_surface_swap.cpp`: 149 assertions in 10 cases. Full suite **94/94 in Release and Debug**.

## Adaptations (the branch was 182 commits behind)

Three are API drift; the fourth was a latent bug that only Debug exposes.

- `m_envelope` is a `shared_ptr` now → four envelope checks use `->`, and the added test sections build it with `make_shared`.
- main already carries `allow_surface_swap` / `check_surface_topology` (landed separately). Kept main's entries, only widened the doc to name all three swap types.
- Kept main's unqualified `logger()`, and took #954's removal of the early `return total_success` in the 44/56 passes — without it the `check_surface_topology` net below never runs.
- **main's 3→2 code asserts edge (c,d) exists before testing it.** That's a 3→2-only invariant: the two surface apexes are adjacent in a 3-ring but *opposite* in a 4-4/5-6 ring, so there the flip **creates** (c,d). Same for `tuple_from_face` on the would-be-new faces (a,c,d),(b,c,d), which by definition don't exist yet. Both aborted every 4-4 flip in Debug while passing in Release; now guarded by `is_valid` / `lowest_common_tet`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)