### PR TITLE
determinism: give the remaining partial sort comparators a total order (resurrects #953)

### DIFF
--- a/components/tetwild/wmtk/components/tetwild/orig/EdgeSplitter.h
+++ b/components/tetwild/wmtk/components/tetwild/orig/EdgeSplitter.h
@@ -34,7 +34,12 @@ struct cmp_es
 {
     bool operator()(const ElementInQueue_es& e1, const ElementInQueue_es& e2)
     {
-        return e1.weight < e2.weight;
+        // Equal-length edges are everywhere on a symmetric mesh. On weight alone they compare
+        // equivalent and the heap pops them in an order that differs between libc++, libstdc++
+        // and MSVC -- and that order decides which edge gets split first, so the resulting mesh
+        // differs per platform. Break on the vertex ids for a total order, as cmp_ec/cmp_er do.
+        if (e1.weight == e2.weight) return e1.v_ids < e2.v_ids;
+        return e1.weight < e2.weight; ///choose longer edge for splitting
     }
 };
 

--- a/components/topological_offset/wmtk/components/topological_offset/TopoOffsetTetMesh.h
+++ b/components/topological_offset/wmtk/components/topological_offset/TopoOffsetTetMesh.h
@@ -368,7 +368,14 @@ private: // helpers
                 double len2 = (m_vertex_attribute[e2.vertices()[0]].m_posf -
                                m_vertex_attribute[e2.vertices()[1]].m_posf)
                                   .norm();
-                return len1 > len2;
+                // Symmetric inputs have many edges of exactly equal length. Length alone
+                // leaves those in an implementation-defined order (libc++ vs libstdc++ vs
+                // MSVC), and that order decides which edge marching splits first, so the
+                // offset mesh differs across platforms. simplex::Edge orders totally on
+                // its vertex pair, so use it to break the tie.
+                if (len1 > len2) return true;
+                if (len2 > len1) return false;
+                return e1 < e2;
             });
     }
 

--- a/components/topological_offset/wmtk/components/topological_offset/TopoOffsetTriMesh.h
+++ b/components/topological_offset/wmtk/components/topological_offset/TopoOffsetTriMesh.h
@@ -318,7 +318,14 @@ private: // helpers
                 double len2 = (m_vertex_attribute[e2.vertices()[0]].m_posf -
                                m_vertex_attribute[e2.vertices()[1]].m_posf)
                                   .squaredNorm();
-                return len1 > len2;
+                // Symmetric inputs have many edges of exactly equal length. Length alone
+                // leaves those in an implementation-defined order (libc++ vs libstdc++ vs
+                // MSVC), and that order decides which edge marching splits first, so the
+                // offset mesh differs across platforms. simplex::Edge orders totally on
+                // its vertex pair, so use it to break the tie.
+                if (len1 > len2) return true;
+                if (len2 > len1) return false;
+                return e1 < e2;
             });
     }
 

--- a/src/wmtk/TetMesh.cpp
+++ b/src/wmtk/TetMesh.cpp
@@ -192,8 +192,17 @@ std::vector<TetMesh::Tuple> TetMesh::get_edges() const
             edges.emplace_back(v0, v1, tup);
         }
     }
+    // std::unique below keeps the first tuple of each edge, and every tet incident to an
+    // edge contributes one, so comparing the endpoints alone leaves the survivor -- the tet
+    // the returned tuple lives in -- up to std::sort, which is not stable and orders
+    // equivalent elements differently on libc++, libstdc++ and MSVC. The Tuple tie-break
+    // makes this a total order, so the representative is the same everywhere.
     std::sort(edges.begin(), edges.end(), [](auto& a, auto& b) {
-        return std::tie(std::get<0>(a), std::get<1>(a)) < std::tie(std::get<0>(b), std::get<1>(b));
+        const auto ka = std::tie(std::get<0>(a), std::get<1>(a));
+        const auto kb = std::tie(std::get<0>(b), std::get<1>(b));
+        if (ka < kb) return true;
+        if (kb < ka) return false;
+        return std::get<2>(a) < std::get<2>(b);
     });
     edges.erase(
         std::unique(

--- a/src/wmtk/TetMeshTriangleInsertionConn.cpp
+++ b/src/wmtk/TetMeshTriangleInsertionConn.cpp
@@ -86,12 +86,15 @@ void wmtk::TetMesh::triangle_insertion(
         }
     }
     // unique old_face_vids
+    // A face shared by two tets is pushed once per tet, with the same vids but a different
+    // (tid, l_fid), and std::unique below keeps whichever came first. Ordering on the vids
+    // alone leaves that up to std::sort, which is not stable, so the tid that ends up in
+    // old_faces would differ between libc++, libstdc++ and MSVC. Comparing the whole array
+    // keeps the vid grouping and adds (tid, l_fid) as a tie-break, giving a total order.
     std::sort(
         old_face_vids.begin(),
         old_face_vids.end(),
-        [](const std::array<size_t, 5>& v1, const std::array<size_t, 5>& v2) {
-            return std::tie(v1[0], v1[1], v1[2]) < std::tie(v2[0], v2[1], v2[2]);
-        });
+        [](const std::array<size_t, 5>& v1, const std::array<size_t, 5>& v2) { return v1 < v2; });
     auto it = std::unique(
         old_face_vids.begin(),
         old_face_vids.end(),
@@ -396,11 +399,15 @@ void wmtk::TetMesh::subdivide_a_tet(
     }
 
     for (auto& info : new_face_vids) { // erase duplicates <-- must have duplicates
+        // Same as for old_face_vids above: the duplicates being erased carry different
+        // (tid, l_fid), and both the survivor and the order of what is left become the
+        // face tuples handed to triangle_insertion_after. Comparing the whole array adds
+        // (tid, l_fid) as a tie-break so the result does not depend on sort stability.
         std::sort(
             info.second.begin(),
             info.second.end(),
             [](const std::array<size_t, 5>& v1, const std::array<size_t, 5>& v2) {
-                return std::make_tuple(v1[0], v1[1], v1[2]) < std::make_tuple(v2[0], v2[1], v2[2]);
+                return v1 < v2;
             });
         auto it = std::unique(
             info.second.begin(),


### PR DESCRIPTION
Resurrects [#953](https://github.com/wildmeshing/wildmeshing-toolkit/pull/953), which is still OPEN but targets `danielepanozzo/concurrency-cleanup` — a branch whose own PR #952 was closed as superseded by #934. With the base orphaned, #953 has had no path to main since 2026-07-20. Same stranded stack as [#979](https://github.com/wildmeshing/wildmeshing-toolkit/pull/979).

Cherry-picked from `5671370bba`. **Applies to current main with no conflicts** — the commit is independent of the concurrency work beneath it in the original stack.

## What it fixes

A sweep of every `std::sort` / `std::unique` / priority-queue comparator in `src/wmtk` and the components, looking for comparators that treat two *distinct* elements as equivalent. `std::sort` is not stable, so the order it leaves such elements in is unspecified and differs between libc++, libstdc++ and MSVC — and in each of these sites that order reaches the output.

Six sites, four sharing one idiom: sort on a partial key, `std::unique` to collapse duplicates, then read the very fields the comparator ignored. It reads as correct because the grouping and the deduplication both work — only the choice of *which* duplicate survives is left to the standard library.

- `TetMesh::get_edges` — every tet incident to an edge contributes an entry, so which tet the returned tuple lives in was unspecified. `get_edges` feeds the operation queues.
- `TetMeshTriangleInsertionConn`, `old_face_vids` / `new_face_vids` — the survivor is consumed as `tuple_from_face(info[3], info[4])`, i.e. the discarded fields *are* the output.

Each is fixed by extending the comparator to a total order, keeping the existing grouping so the `unique` still collapses the same sets.

This is the same class of bug as the nondeterminism I hit while diagnosing the tetwild cap divergence, where the post-insertion mesh differed run to run and decided whether the model converged or timed out. This commit does not address that one (that is parallel operation ordering, not comparator order), but it removes a related source of cross-platform divergence.

## Verification

Full suite **96/96 in Release and Debug**, macOS/arm64. No formatting changes needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)