### PR TITLE
tetwild: optional interleaved smoothing between the topology passes

### DIFF
--- a/components/tetwild/wmtk/components/tetwild/Parameters.h
+++ b/components/tetwild/wmtk/components/tetwild/Parameters.h
@@ -117,6 +117,18 @@ struct Parameters
      */
     int num_smoothing_passes = 10;
 
+    // Interleave smoothing between the topology passes instead of running it all at the end
+    // of the iteration. With this on, one iteration is
+    //     split   + interleaved_smoothing_passes smoothing passes
+    //     collapse + ...
+    //     swaps    + ...
+    // rather than split, collapse, swaps, then num_smoothing_passes passes. Smoothing is the
+    // only phase that improves quality without changing connectivity, so giving each topology
+    // pass a chance to be relaxed before the next one runs may keep the optimizer off the
+    // plateaus where split, collapse and swap simply undo each other.
+    bool interleaved_smoothing = false;
+    int interleaved_smoothing_passes = 2;
+
     bool debug_output = false;
     bool perform_sanity_checks = false;
 

--- a/components/tetwild/wmtk/components/tetwild/TetWildMesh.cpp
+++ b/components/tetwild/wmtk/components/tetwild/TetWildMesh.cpp
@@ -76,8 +76,18 @@ void TetWildMesh::mesh_improvement(int max_its)
     for (int it = 0; it < max_its; it++) {
         ///ops
         logger().info("\n========it {}========", it);
-        auto [max_energy, avg_energy] =
-            local_operations({{1, 1, 1, m_params.num_smoothing_passes}});
+        // One iteration is either split/collapse/swaps followed by all the smoothing, or --
+        // with interleaved_smoothing -- each topology pass followed by its own smoothing, so
+        // the next pass sees a relaxed mesh rather than the raw output of the previous one.
+        auto [max_energy, avg_energy] = [&]() -> std::tuple<double, double> {
+            if (!m_params.interleaved_smoothing) {
+                return local_operations({{1, 1, 1, m_params.num_smoothing_passes}});
+            }
+            const int k = m_params.interleaved_smoothing_passes;
+            local_operations({{1, 0, 0, k}});
+            local_operations({{0, 1, 0, k}});
+            return local_operations({{0, 0, 1, k}});
+        }();
 
         ///energy check
         logger().info("max energy {:.6} | stop {:.6}", max_energy, m_params.stop_energy);

--- a/components/tetwild/wmtk/components/tetwild/tetwild.cpp
+++ b/components/tetwild/wmtk/components/tetwild/tetwild.cpp
@@ -131,6 +131,8 @@ TetWildMesh::ExportStruct tetwild_with_export(nlohmann::json json_params)
     params.stop_energy = json_params["stop_energy"];
     params.split_high_valence_threshold = json_params["split_high_valence_threshold"];
     params.num_smoothing_passes = json_params["num_smoothing_passes"];
+    params.interleaved_smoothing = json_params["interleaved_smoothing"];
+    params.interleaved_smoothing_passes = json_params["interleaved_smoothing_passes"];
     params.w_amips = json_params["w_amips"];
 
     params.preserve_topology = json_params["preserve_topology"];

--- a/components/tetwild/wmtk/components/tetwild/tetwild_spec.json
+++ b/components/tetwild/wmtk/components/tetwild/tetwild_spec.json
@@ -25,6 +25,8 @@
       "split_high_valence_threshold",
       "w_amips",
       "num_smoothing_passes",
+      "interleaved_smoothing",
+      "interleaved_smoothing_passes",
       "preserve_topology",
       "remove_duplicate_eps",
       "allow_surface_swap",
@@ -200,6 +202,18 @@
     "type": "int",
     "default": 10,
     "doc": "Number of smoothing passes per optimization iteration. Smoothing is the only phase that improves quality without changing connectivity, so when split, collapse and swap have run out of useful moves it is the only thing that can still lower the energy."
+  },
+  {
+    "pointer": "/interleaved_smoothing",
+    "type": "bool",
+    "default": false,
+    "doc": "Interleave smoothing between the topology passes: split + smoothing, collapse + smoothing, swaps + smoothing, instead of split, collapse, swaps followed by num_smoothing_passes smoothing passes."
+  },
+  {
+    "pointer": "/interleaved_smoothing_passes",
+    "type": "int",
+    "default": 2,
+    "doc": "Smoothing passes to run after each topology pass when interleaved_smoothing is set."
   },
   {
     "pointer": "/preserve_topology",


### PR DESCRIPTION
**Draft — parked for later.** The idea works on one model and not on another; the measurements are below so this can be picked up without redoing them.

## What it does

An iteration currently runs split, collapse and swaps back to back, then smooths `num_smoothing_passes` times. With `interleaved_smoothing` set it instead runs

```
split    + interleaved_smoothing_passes smoothing passes
collapse + ...
swaps    + ...
```

so each topology pass hands the next one a relaxed mesh rather than its raw output. Smoothing is the only phase that improves quality without changing connectivity, so the hypothesis is that it keeps the optimizer off the plateaus where split, collapse and swap simply undo each other — a pattern visible in the stalled sweep models, where `after swap == start` exactly, iteration after iteration.

**Off by default.** The scheduler already runs op types in order, so this is three `local_operations` calls rather than a change to the pass machinery.

## Measurements

| model | baseline | interleaved | |
| --- | --- | --- | --- |
| 240280 (stalled) | 18 iterations, 219 s | **13 iterations, 178 s** | clear gain |
| 562343 (stalled) | 13 iterations | **15 iterations**, mesh identical | mild loss |
| octocat | max E 87.4 | **81.3** | gain |
| crown | max E 89.3, avg 7.061 | max E 97.3, avg **6.841** | mixed |
| sphere | max E 6.7505 | 6.7505 | identical |
| double_sphere | max E 7.5491 | 7.5491 | identical |

One clear win, one mild loss, one gain, one mixed, two neutral.

## Why it is not on by default

- **The 240280 result does not generalise.** That single model was the case for the idea; 562343, the other stalled model tested, got slightly worse.
- **sphere's Hausdorff distance moves 4.2e-07 → 6.5e-04.** Small in absolute terms — both are well inside an `eps_rel` of 1e-3 — but three orders of magnitude, and the only number that moved that far. Worth understanding before this becomes a default.
- The two stalled models it was aimed at turned out to be stalled for a different reason: `simplify_envelope_ratio` leaving the optimizer no envelope headroom. Both converge once that is addressed, with or without this change.

## If picked up again

The useful experiment is a larger sample of *stalled* models rather than more single cases, plus an explanation for the sphere Hausdorff shift. `interleaved_smoothing_passes` (default 2) is the other knob worth sweeping.

97/97 including `Integration_Tests`, Release, macOS/arm64.

🤖 Generated with [Claude Code](https://claude.com/claude-code)