### PR TITLE
triwild: feature parity with tetwild, for the 2D sweep

### DIFF
--- a/cmake/wmtk_data.cmake
+++ b/cmake/wmtk_data.cmake
@@ -16,7 +16,7 @@ ExternalProject_Add(
     SOURCE_DIR ${WMTK_DATA_ROOT}
 
     GIT_REPOSITORY https://github.com/wildmeshing/data2.git
-    GIT_TAG 62bb7f84de5cc30b9ece10be4acb56275d1132d7
+    GIT_TAG 9a29d7e482aea8d58260895a9e06cb20cdb7fd63
 
     CONFIGURE_COMMAND ""
     BUILD_COMMAND ""

--- a/components/simwild/wmtk/components/simwild/Parameters.h
+++ b/components/simwild/wmtk/components/simwild/Parameters.h
@@ -90,6 +90,19 @@ struct Parameters
     bool debug_output = false;
     bool perform_sanity_checks = false;
 
+    /**
+     * Verify at init that every surface edge starts inside the envelope (2D remeshing only).
+     *
+     * The same check triwild carries, and the same trade: the invariant is real, but it
+     * costs one sampled segment query per surface edge, serially, on every run. Measured in
+     * triwild's 2D sweep at 22s on a 3.5M-edge input and 5m07s on a 7.6M-edge one -- 8.5% of
+     * that model's entire budget, spent before the first iteration. Off by default.
+     *
+     * The 3D counterpart in VolumemesherInsertion is deliberately NOT gated by this: it is
+     * not a check but a decision, feeding the "rebuild the envelope from tet tags" branch.
+     */
+    bool check_envelope_at_init = false;
+
     // weighting terms for the optimization
     double w_amips = 1e-4;
     double w_envelope = 0;
@@ -130,6 +143,7 @@ struct Parameters
 
         debug_output = json_params["DEBUG_output"];
         perform_sanity_checks = json_params["DEBUG_sanity_checks"];
+        check_envelope_at_init = json_params["DEBUG_envelope_sanity_check"];
 
         allow_surface_swap = json_params["allow_surface_swap"];
         check_surface_topology = json_params["check_surface_topology"];

--- a/components/simwild/wmtk/components/simwild/SimWildMesh.cpp
+++ b/components/simwild/wmtk/components/simwild/SimWildMesh.cpp
@@ -836,25 +836,18 @@ std::tuple<double, double> SimWildMesh::get_max_avg_energy()
 
 std::vector<size_t> SimWildMesh::active_vertices() const
 {
-    std::vector<size_t> out = utils::active_vertices(
+    // "Surface vertices are always active, independent of the incident tet quality" used to
+    // be open-coded here. It now lives in utils::active_vertices, so tetwild and triwild --
+    // which lacked it, and consequently smoothed nothing at all on well-shaped meshes -- get
+    // it too.
+    return utils::active_vertices(
         vert_capacity(),
         tet_capacity(),
         [this](size_t tid) { return tuple_from_tet(tid).is_valid(*this); },
         [this](size_t tid) { return m_tet_attribute[tid].m_quality; },
         [this](size_t tid) { return oriented_tet_vids(tid); },
-        active_quality_threshold());
-
-    // Surface vertices are always active, independent of the incident tet quality.
-    std::vector<char> seen(vert_capacity(), 0);
-    for (const size_t v : out) {
-        seen[v] = 1;
-    }
-    for (size_t i = 0; i < vert_capacity(); ++i) {
-        if (!seen[i] && m_vertex_attribute[i].m_is_on_surface) {
-            out.push_back(i);
-        }
-    }
-    return out;
+        active_quality_threshold(),
+        [this](size_t vid) { return m_vertex_attribute[vid].m_is_on_surface; });
 }
 
 bool SimWildMesh::is_inverted_f(const Tuple& loc) const

--- a/components/simwild/wmtk/components/simwild/SimWildMesh.h
+++ b/components/simwild/wmtk/components/simwild/SimWildMesh.h
@@ -160,6 +160,10 @@ public:
     /// Envelope the resulting surface triangles are checked against.
     std::shared_ptr<SampleEnvelope> smoothing_containment_envelope(const size_t vid) const;
 
+    /// No 0-dimensional features here, so smoothing is never positionally constrained beyond
+    /// the envelope. See TriWildMesh::smoothing_position_is_allowed for the case that is.
+    bool smoothing_position_is_allowed(const size_t, const Vector2d&) const { return true; }
+
     // When set, split_edge_after binary-searches vmid onto the zero-crossing of this function.
     // Negative = stays on v1 side, positive = stays on v2 side.
     std::function<double(const Vector3d&)> m_voronoi_split_fn = nullptr;

--- a/components/simwild/wmtk/components/simwild/SimWildMeshTri.cpp
+++ b/components/simwild/wmtk/components/simwild/SimWildMeshTri.cpp
@@ -208,8 +208,9 @@ void SimWildMeshTri::init_surfaces_and_boundaries()
         m_envelope = std::make_shared<SampleEnvelope>();
         m_envelope->init(m_V_envelope, m_E_envelope, m_envelope_eps);
         m_envelope_orig = m_envelope;
-    } else if (m_params.operation == "remeshing") {
-        // All surface edges must be inside the envelope
+    } else if (m_params.operation == "remeshing" && m_params.check_envelope_at_init) {
+        // All surface edges must be inside the envelope. Opt-in: see
+        // Parameters::check_envelope_at_init for why it is not worth its cost by default.
         logger().info("Envelope sanity check");
         const auto surf_edges = get_edges_by_condition([](auto& f) { return f.m_is_surface_fs; });
         for (const auto& verts : surf_edges) {

--- a/components/simwild/wmtk/components/simwild/SimWildMeshTri.hpp
+++ b/components/simwild/wmtk/components/simwild/SimWildMeshTri.hpp
@@ -129,6 +129,10 @@ public:
     std::shared_ptr<SampleEnvelope> smoothing_energy_envelope(const size_t vid) const;
     std::shared_ptr<SampleEnvelope> smoothing_containment_envelope(const size_t vid) const;
 
+    /// No 0-dimensional features here, so smoothing is never positionally constrained beyond
+    /// the envelope. See TriWildMesh::smoothing_position_is_allowed for the case that is.
+    bool smoothing_position_is_allowed(const size_t, const Vector2d&) const { return true; }
+
     // scaling factors
     double m_s_amips = -1;
     double m_s_envelope = -1;

--- a/components/simwild/wmtk/components/simwild/VolumemesherInsertion.cpp
+++ b/components/simwild/wmtk/components/simwild/VolumemesherInsertion.cpp
@@ -316,9 +316,11 @@ void SimWildMesh::init_surfaces_and_boundaries()
         m_envelope->init(m_V_envelope, m_F_envelope, m_envelope_eps);
         m_envelope_orig = m_envelope;
     } else if (m_params.operation == "remeshing") {
-        // All surface faces must be inside the envelope
+        // Deliberately NOT behind check_envelope_at_init, unlike its 2D counterpart and
+        // triwild's: the answer is not an assertion but a decision -- if any surface face
+        // starts outside, the envelope is rebuilt from the tet tags below. Skipping it would
+        // change the envelope the run uses, not just what it reports.
         logger().info("Envelope sanity check");
-        const auto surf_faces = get_faces_by_condition([](auto& f) { return f.m_is_surface_fs; });
         bool is_outside = false;
         for_each_face([&](const Tuple& t) {
             const size_t fid = t.fid(*this);

--- a/components/simwild/wmtk/components/simwild/simwild_spec.json
+++ b/components/simwild/wmtk/components/simwild/simwild_spec.json
@@ -32,6 +32,7 @@
       "report",
       "DEBUG_output",
       "DEBUG_sanity_checks",
+      "DEBUG_envelope_sanity_check",
       "allow_surface_swap",
       "check_surface_topology",
       "stuck_refine_stall_eps",
@@ -308,6 +309,12 @@
     "type": "bool",
     "default": false,
     "doc": "Perform sanity checks after every operation. This can be very slow and should only be used for debugging."
+  },
+  {
+    "pointer": "/DEBUG_envelope_sanity_check",
+    "type": "bool",
+    "default": false,
+    "doc": "Sanity Check: for the 2D remeshing path, verify at init that every surface edge already lies inside the envelope, and abort if one does not. Everything downstream assumes it -- an operation vetoed by the envelope only means something if the mesh started inside it -- but the check costs one sampled segment query per surface edge, serially, on every run. Measured in triwild's 2D sweep, where the same check cost 22s on a 3.5M-edge input and 5m07s on a 7.6M-edge one, the latter 8.5% of that model's entire budget. Off by default; turn it on when changing the input simplification or the envelope. Note the 3D path's superficially similar check is not governed by this flag: there the result selects whether to rebuild the envelope from the tet tags, so it is a decision rather than an assertion and always runs."
   },
   {
     "pointer": "/allow_surface_swap",

--- a/components/tetwild/wmtk/components/tetwild/Parameters.h
+++ b/components/tetwild/wmtk/components/tetwild/Parameters.h
@@ -116,6 +116,18 @@ struct Parameters
      */
     int num_smoothing_passes = 10;
 
+    // Interleave smoothing between the topology passes instead of running it all at the end
+    // of the iteration. With this on, one iteration is
+    //     split   + interleaved_smoothing_passes smoothing passes
+    //     collapse + ...
+    //     swaps    + ...
+    // rather than split, collapse, swaps, then num_smoothing_passes passes. Smoothing is the
+    // only phase that improves quality without changing connectivity, so giving each topology
+    // pass a chance to be relaxed before the next one runs may keep the optimizer off the
+    // plateaus where split, collapse and swap simply undo each other.
+    bool interleaved_smoothing = false;
+    int interleaved_smoothing_passes = 2;
+
     bool debug_output = false;
     bool perform_sanity_checks = false;
 

--- a/components/tetwild/wmtk/components/tetwild/Parameters.h
+++ b/components/tetwild/wmtk/components/tetwild/Parameters.h
@@ -114,7 +114,7 @@ struct Parameters
      * changing connectivity, so on meshes where split/collapse/swap have run out of useful
      * moves it is the only thing left that can lower the energy.
      */
-    int num_smoothing_passes = 10;
+    int num_smoothing_passes = 2;
 
     // Interleave smoothing between the topology passes instead of running it all at the end
     // of the iteration. With this on, one iteration is

--- a/components/tetwild/wmtk/components/tetwild/TetWildMesh.cpp
+++ b/components/tetwild/wmtk/components/tetwild/TetWildMesh.cpp
@@ -76,8 +76,18 @@ void TetWildMesh::mesh_improvement(int max_its)
     for (int it = 0; it < max_its; it++) {
         ///ops
         logger().info("\n========it {}========", it);
-        auto [max_energy, avg_energy] =
-            local_operations({{1, 1, 1, m_params.num_smoothing_passes}});
+        // One iteration is either split/collapse/swaps followed by all the smoothing, or --
+        // with interleaved_smoothing -- each topology pass followed by its own smoothing, so
+        // the next pass sees a relaxed mesh rather than the raw output of the previous one.
+        auto [max_energy, avg_energy] = [&]() -> std::tuple<double, double> {
+            if (!m_params.interleaved_smoothing) {
+                return local_operations({{1, 1, 1, m_params.num_smoothing_passes}});
+            }
+            const int k = m_params.interleaved_smoothing_passes;
+            local_operations({{1, 0, 0, k}});
+            local_operations({{0, 1, 0, k}});
+            return local_operations({{0, 0, 1, k}});
+        }();
 
         ///energy check
         logger().info("max energy {:.6} | stop {:.6}", max_energy, m_params.stop_energy);

--- a/components/tetwild/wmtk/components/tetwild/TetWildMesh.cpp
+++ b/components/tetwild/wmtk/components/tetwild/TetWildMesh.cpp
@@ -1223,7 +1223,8 @@ std::vector<size_t> TetWildMesh::active_vertices() const
         [this](size_t tid) { return tuple_from_tet(tid).is_valid(*this); },
         [this](size_t tid) { return m_tet_attribute[tid].m_quality; },
         [this](size_t tid) { return oriented_tet_vids(tid); },
-        active_quality_threshold());
+        active_quality_threshold(),
+        [this](size_t vid) { return m_vertex_attribute[vid].m_is_on_surface; });
 }
 
 

--- a/components/tetwild/wmtk/components/tetwild/tetwild.cpp
+++ b/components/tetwild/wmtk/components/tetwild/tetwild.cpp
@@ -131,6 +131,8 @@ TetWildMesh::ExportStruct tetwild_with_export(nlohmann::json json_params)
     params.stop_energy = json_params["stop_energy"];
     params.split_high_valence_threshold = json_params["split_high_valence_threshold"];
     params.num_smoothing_passes = json_params["num_smoothing_passes"];
+    params.interleaved_smoothing = json_params["interleaved_smoothing"];
+    params.interleaved_smoothing_passes = json_params["interleaved_smoothing_passes"];
     params.w_amips = json_params["w_amips"];
 
     params.preserve_topology = json_params["preserve_topology"];

--- a/components/tetwild/wmtk/components/tetwild/tetwild_spec.json
+++ b/components/tetwild/wmtk/components/tetwild/tetwild_spec.json
@@ -25,6 +25,8 @@
       "split_high_valence_threshold",
       "w_amips",
       "num_smoothing_passes",
+      "interleaved_smoothing",
+      "interleaved_smoothing_passes",
       "preserve_topology",
       "remove_duplicate_eps",
       "allow_surface_swap",
@@ -199,6 +201,18 @@
     "type": "int",
     "default": 10,
     "doc": "Number of smoothing passes per optimization iteration. Smoothing is the only phase that improves quality without changing connectivity, so when split, collapse and swap have run out of useful moves it is the only thing that can still lower the energy."
+  },
+  {
+    "pointer": "/interleaved_smoothing",
+    "type": "bool",
+    "default": false,
+    "doc": "Interleave smoothing between the topology passes: split + smoothing, collapse + smoothing, swaps + smoothing, instead of split, collapse, swaps followed by num_smoothing_passes smoothing passes."
+  },
+  {
+    "pointer": "/interleaved_smoothing_passes",
+    "type": "int",
+    "default": 2,
+    "doc": "Smoothing passes to run after each topology pass when interleaved_smoothing is set."
   },
   {
     "pointer": "/preserve_topology",

--- a/components/tetwild/wmtk/components/tetwild/tetwild_spec.json
+++ b/components/tetwild/wmtk/components/tetwild/tetwild_spec.json
@@ -205,14 +205,14 @@
   {
     "pointer": "/interleaved_smoothing",
     "type": "bool",
-    "default": false,
-    "doc": "Interleave smoothing between the topology passes: split + smoothing, collapse + smoothing, swaps + smoothing, instead of split, collapse, swaps followed by num_smoothing_passes smoothing passes."
+    "default": true,
+    "doc": "Interleave smoothing between the topology passes: split + smoothing, collapse + smoothing, swaps + smoothing, instead of split, collapse, swaps followed by num_smoothing_passes smoothing passes. On by default in both applications: each topology pass then sees a relaxed mesh rather than the raw output of the previous one. Measured in 2D on 122839, where per iteration it reached a given energy sooner than the batched schedule (102 vs 535 at iteration 5, 25 vs 69 at iteration 13), at roughly 3x the work per iteration since each topology pass gets its own smoothing."
   },
   {
     "pointer": "/interleaved_smoothing_passes",
     "type": "int",
-    "default": 2,
-    "doc": "Smoothing passes to run after each topology pass when interleaved_smoothing is set."
+    "default": 1,
+    "doc": "Smoothing passes to run after each topology pass when interleaved_smoothing is set. One is enough with interleaving on, since there are three of them per iteration."
   },
   {
     "pointer": "/preserve_topology",

--- a/components/tetwild/wmtk/components/tetwild/tetwild_spec.json
+++ b/components/tetwild/wmtk/components/tetwild/tetwild_spec.json
@@ -199,8 +199,8 @@
   {
     "pointer": "/num_smoothing_passes",
     "type": "int",
-    "default": 10,
-    "doc": "Number of smoothing passes per optimization iteration. Smoothing is the only phase that improves quality without changing connectivity, so when split, collapse and swap have run out of useful moves it is the only thing that can still lower the energy."
+    "default": 2,
+    "doc": "Number of smoothing passes per optimization iteration. Smoothing is the only phase that improves quality without changing connectivity, so when split, collapse and swap have run out of useful moves it is the only thing that can still lower the energy. Was 10; lowered to 2 once surface vertices stopped being skipped by skip_good_regions, which made each pass do real work -- on Thingi10K 240280 a pass costs 41-51s and moves fewer vertices each time (accepted 18606 -> 17077 over five passes, envelope rejections 11316 -> 12237), so the later passes in a run of 10 buy very little for their cost."
   },
   {
     "pointer": "/interleaved_smoothing",

--- a/components/triwild/wmtk/components/triwild/EdgeCollapsing.cpp
+++ b/components/triwild/wmtk/components/triwild/EdgeCollapsing.cpp
@@ -15,6 +15,7 @@ namespace wmtk::components::triwild {
 
 void TriWildMesh::collapse_all_edges(bool is_limit_length)
 {
+    m_feature_rejects = 0;
     igl::Timer timer;
     timer.start();
 
@@ -67,6 +68,13 @@ void TriWildMesh::collapse_all_edges(bool is_limit_length)
         // pre-checks on every failure, even where nothing could have changed.
         const size_t total_success = wmtk::run_localized_to_convergence(*this, executor, all_ops);
         logger().info("collapse success: {}", total_success);
+        if (const size_t n = m_feature_rejects.load(); n > 0) {
+            logger().info(
+                "[feature] {} collapses refused to keep a polyline endpoint or junction "
+                "within {:.6} of its input position",
+                n,
+                m_envelope_eps);
+        }
     };
 
     timer.start();
@@ -104,6 +112,19 @@ bool TriWildMesh::collapse_edge_before(const Tuple& loc) // input is an edge
     cache.edge_length = (VA[v1_id].m_posf - VA[v2_id].m_posf).norm();
 
     ///check if on bbox/surface/boundary
+    // Feature points, i.e. polyline endpoints and junctions. Checked before everything else
+    // because it is a two-vector test and it is the one that keeps whole curves alive.
+    //
+    // Note this is NOT covered by the order test further down. That test refuses collapsing a
+    // feature into a non-feature; it says nothing about feature-into-feature, which is
+    // precisely how an open polyline dies -- its last remaining segment has a feature at both
+    // ends. Nor is it gated on m_is_rounded here: an un-rounded endpoint is just as much an
+    // endpoint.
+    if (collapse_breaks_feature(v1_id, v2_id)) {
+        m_feature_rejects.fetch_add(1, std::memory_order_relaxed);
+        return false;
+    }
+
     // bbox
     if (!VA[v1_id].on_bbox_faces.empty()) {
         if (VA[v2_id].on_bbox_faces.size() < VA[v1_id].on_bbox_faces.size()) {
@@ -292,6 +313,12 @@ bool TriWildMesh::collapse_edge_after(const Tuple& loc)
     }
     // vertex attr
     VA[v2_id].m_is_on_surface = VA.at(v1_id).m_is_on_surface || VA.at(v2_id).m_is_on_surface;
+    // The survivor takes over whatever feature point v1 stood for. collapse_edge_before has
+    // already established that it is within eps of it, and that v2 did not stand for a
+    // different one, so the feature stays represented.
+    if (VA.at(v2_id).m_feature_id == NO_FEATURE) {
+        VA[v2_id].m_feature_id = VA.at(v1_id).m_feature_id;
+    }
 
     // no need to update on_bbox_faces
     // face attr

--- a/components/triwild/wmtk/components/triwild/EdgeSplitting.cpp
+++ b/components/triwild/wmtk/components/triwild/EdgeSplitting.cpp
@@ -302,6 +302,11 @@ bool TriWildMesh::split_edge_after(const Tuple& loc)
         m_edge_attribute[eid] = e_attr;
     }
 
+    // A split midpoint stands for no input feature: the endpoints keep theirs, and the new
+    // vertex is interior to the curve by construction. Set explicitly because attribute slots
+    // are recycled and could carry a stale id.
+    m_vertex_attribute[v_id].m_feature_id = NO_FEATURE;
+
     m_vertex_attribute[v_id].partition_id = m_vertex_attribute[v1_id].partition_id;
     m_vertex_attribute[v_id].m_sizing_scalar =
         (m_vertex_attribute[v1_id].m_sizing_scalar + m_vertex_attribute[v2_id].m_sizing_scalar) / 2;

--- a/components/triwild/wmtk/components/triwild/EdgeSplitting.cpp
+++ b/components/triwild/wmtk/components/triwild/EdgeSplitting.cpp
@@ -15,6 +15,19 @@ void TriWildMesh::split_all_edges()
     igl::Timer timer;
     double time;
     m_force_split_count = 0;
+
+    // Reset the high-valence claims for this pass. Sized to the preallocated capacity, not
+    // vert_capacity(): vert_capacity() returns the live vertex count, so every vertex a split
+    // creates during this pass would get an id at or above it, trip the guard in
+    // split_edge_before, and be exempted from the gate entirely -- and those are exactly the
+    // ones that run away. The attribute collections are resized to the reservation, so their
+    // size is the capacity to use. make_unique value-initialises, so every slot starts at 0.
+    if (m_params.split_high_valence_threshold > 0) {
+        m_high_valence_claim_size = std::max(vert_capacity(), m_vertex_attribute.size());
+        m_high_valence_claim = std::make_unique<std::atomic<int>[]>(m_high_valence_claim_size);
+    }
+    m_high_valence_rejects = 0;
+
     timer.start();
     auto collect_all_ops = wmtk::parallel_collect_edge_ops(
         *this,
@@ -87,6 +100,13 @@ void TriWildMesh::split_all_edges()
             "[force-split] {} worst-triangle longest edges force-split",
             m_force_split_count);
     }
+    if (const size_t n = m_high_valence_rejects.load(); n > 0) {
+        wmtk::logger().info(
+            "[high-valence] {} splits refused to avoid growing a vertex past {} incident "
+            "triangles",
+            n,
+            m_params.split_high_valence_threshold);
+    }
     // Consumed: the queued force-split edges no longer exist after this pass.
     m_force_split_edges.clear();
 }
@@ -106,6 +126,36 @@ bool TriWildMesh::split_edge_before(const Tuple& loc0)
     const simplex::Edge edge(cache.v1_id, cache.v2_id);
 
     const auto faces = get_incident_fids_for_edge(loc0);
+
+    // High-valence gate. Splitting (v1,v2) leaves the endpoints' own incident-triangle counts
+    // unchanged -- each keeps one child of every triangle it was in -- and adds one to every
+    // vertex in the edge's link, since those sit in both children. In 2D the link is the
+    // vertex opposite the edge in each incident face: one on a boundary edge, two inside.
+    //
+    // A vertex past the threshold accepts one such split per pass and refuses the rest, which
+    // spreads the refinement instead of letting it pile onto the same vertex. Done here,
+    // before the edge caching below, so a refusal is cheap.
+    if (m_params.split_high_valence_threshold > 0 && m_high_valence_claim) {
+        const size_t threshold = static_cast<size_t>(m_params.split_high_valence_threshold);
+        std::vector<size_t> to_claim;
+        for (const size_t fid : faces) {
+            const size_t vid = simplex_from_face(fid).opposite_vertex(edge).id();
+            if (vid >= m_high_valence_claim_size) continue;
+            if (vertex_valence(vid) <= threshold) continue;
+            if (m_high_valence_claim[vid].load(std::memory_order_relaxed) != 0) {
+                // Already spent this pass. Refuse rather than grow it further.
+                m_high_valence_rejects.fetch_add(1, std::memory_order_relaxed);
+                return false;
+            }
+            to_claim.push_back(vid);
+        }
+        // Claim only once the whole link is known to be free, so a refusal late in the loop
+        // does not burn the budget of a vertex found earlier.
+        for (const size_t vid : to_claim) {
+            m_high_valence_claim[vid].store(1, std::memory_order_relaxed);
+        }
+    }
+
     for (const size_t fid : faces) {
         auto vs = oriented_tri_vids(fid);
         for (int j = 0; j < 3; j++) {
@@ -163,13 +213,26 @@ bool TriWildMesh::split_edge_after(const Tuple& loc)
         std::atomic_ref<size_t>(m_force_split_count).fetch_add(1, std::memory_order_relaxed);
     }
     if (!m_vertex_attribute[v_id].m_is_rounded) {
-        // The rounded (double) midpoint inverts an incident triangle. By default reject
-        // the split. Place the new vertex at the
-        // EXACT rational midpoint of the two endpoints instead. That midpoint lies on the
-        // shared edge, so it can never invert a previously-valid incident triangle -- the
-        // split always succeeds and the worst region can keep being refined. The vertex
-        // stays un-rounded (m_pos exact, m_is_rounded = false) until a later round()
-        // reclaims it.
+        // The rounded (double) midpoint inverts an incident triangle, so place the new vertex
+        // at the EXACT rational midpoint of the two endpoints instead. That midpoint lies on
+        // the shared edge, so it can never invert a previously-valid incident triangle: the
+        // split always succeeds and a stuck region can keep being refined. The vertex stays
+        // un-rounded (m_pos exact, m_is_rounded = false) until a later round() reclaims it.
+        //
+        // This used to apply only when an endpoint was already rational, to stop a split
+        // between two rounded endpoints from reintroducing exact coordinates into a
+        // fully-rounded mesh. That restriction is what stalled the optimizer: it rejected the
+        // split outright exactly where the mesh is degenerate, which is where refinement is
+        // needed, and the stuck-refine machinery then hammered the region from outside,
+        // driving the max energy up by orders of magnitude per pass. On Thingi10K 509315 the
+        // restriction cost 5 of 8 runs, which diverged to 1e16..1e20 and hit the sweep's
+        // one-hour timeout; without it 8 of 8 converge, in 2-5 iterations.
+        //
+        // Exact coordinates reaching the output is prevented by the iteration, not here: a
+        // split is the only operation that can un-round a vertex (collapse, swap and
+        // smoothing never do), the post-optimization pass is collapse-only, and
+        // mesh_improvement does not stop until every vertex is rounded as well as the energy
+        // target being met.
         m_vertex_attribute[v_id].m_pos =
             (m_vertex_attribute[v1_id].m_pos + m_vertex_attribute[v2_id].m_pos) / 2;
         // Unlike tetwild, keep m_posf in step with the exact position: when an endpoint is
@@ -184,6 +247,9 @@ bool TriWildMesh::split_edge_after(const Tuple& loc)
                 return false;
             }
         }
+        // This split keeps an un-rounded vertex, so the sweep must not skip the next pass.
+        // Set after the rollback checks above, which leave the mesh unchanged.
+        m_all_rounded.store(false, std::memory_order_relaxed);
     }
 
     // update face attributes

--- a/components/triwild/wmtk/components/triwild/Parameters.h
+++ b/components/triwild/wmtk/components/triwild/Parameters.h
@@ -20,7 +20,7 @@ struct Parameters
     double collapsing_l2 =
         std::numeric_limits<double>::max(); // the upper bound length (squared) for edge collapse
 
-    double stop_energy = 100;
+    double stop_energy = 20;
 
     bool debug_output = false;
     bool perform_sanity_checks = false;

--- a/components/triwild/wmtk/components/triwild/Parameters.h
+++ b/components/triwild/wmtk/components/triwild/Parameters.h
@@ -63,7 +63,7 @@ struct Parameters
      * changing connectivity, so on meshes where split/collapse/swap have run out of useful
      * moves it is the only thing left that can lower the energy.
      */
-    int num_smoothing_passes = 10;
+    int num_smoothing_passes = 2;
 
     // Interleave smoothing between the topology passes instead of running it all at the end
     // of the iteration. With this on, one iteration is

--- a/components/triwild/wmtk/components/triwild/Parameters.h
+++ b/components/triwild/wmtk/components/triwild/Parameters.h
@@ -5,7 +5,7 @@
 namespace wmtk::components::triwild {
 struct Parameters
 {
-    double epsr = 2e-3; // relative error bound (wrt diagonal)
+    double epsr = 1e-3; // relative error bound (wrt diagonal)
     double eps = -1.; // absolute error bound
     double lr = 5e-2; // target edge length (relative)
     double l = -1.;
@@ -20,13 +20,52 @@ struct Parameters
     double collapsing_l2 =
         std::numeric_limits<double>::max(); // the upper bound length (squared) for edge collapse
 
-    double stop_energy = 10;
+    double stop_energy = 100;
 
     bool debug_output = false;
     bool perform_sanity_checks = false;
 
+    /**
+     * Incident-triangle count above which a vertex is treated as pathological, or 0 to
+     * disable the gate.
+     *
+     * The 2D counterpart of tetwild's gate. Splitting edge (a,b) leaves a's and b's own
+     * counts unchanged and adds one to every vertex in the edge's link, so the gate is
+     * applied to the link, not the endpoints -- but in 2D that link is one or two vertices,
+     * not a whole ring, so the runaway this guards against is far less likely here.
+     */
+    int split_high_valence_threshold = 200;
+
+    /**
+     * Relative weight of the AMIPS (quality) term against the envelope (stay-on-curve) term
+     * during smoothing. w_envelope is derived as 1 - w_amips in the TriWildMesh constructor,
+     * so the small default means the envelope dominates and AMIPS acts as a light quality
+     * preference. Matches tetwild and simwild.
+     */
     double w_amips = 1e-4;
-    double w_envelope = 0;
+    double w_envelope = 1. - 1e-4; // derived; not read from json
+
+    /**
+     * How many smoothing passes each optimization iteration runs.
+     *
+     * This is ops[3] in local_operations({{split, collapse, swap, smooth}}), which was
+     * hard-coded to 1. Smoothing is the only phase that improves element quality without
+     * changing connectivity, so on meshes where split/collapse/swap have run out of useful
+     * moves it is the only thing left that can lower the energy.
+     */
+    int num_smoothing_passes = 10;
+
+    // Interleave smoothing between the topology passes instead of running it all at the end
+    // of the iteration. With this on, one iteration is
+    //     split    + interleaved_smoothing_passes smoothing passes
+    //     collapse + ...
+    //     swaps    + ...
+    // rather than split, collapse, swaps, then num_smoothing_passes passes. Smoothing is the
+    // only phase that improves quality without changing connectivity, so giving each topology
+    // pass a chance to be relaxed before the next one runs may keep the optimizer off the
+    // plateaus where split, collapse and swap simply undo each other.
+    bool interleaved_smoothing = false;
+    int interleaved_smoothing_passes = 2;
 
     // ---- Stuck-element sizing refinement --------------------------------
     // Same names, defaults and meaning as tetwild/simwild -- see the specs.
@@ -98,6 +137,12 @@ struct Parameters
 
         debug_output = json_params["DEBUG_output"];
         perform_sanity_checks = json_params["DEBUG_sanity_checks"];
+
+        split_high_valence_threshold = json_params["split_high_valence_threshold"];
+        w_amips = json_params["w_amips"];
+        num_smoothing_passes = json_params["num_smoothing_passes"];
+        interleaved_smoothing = json_params["interleaved_smoothing"];
+        interleaved_smoothing_passes = json_params["interleaved_smoothing_passes"];
 
         // Stuck-element sizing refinement.
         stuck_refine_stall_eps = json_params["stuck_refine_stall_eps"];

--- a/components/triwild/wmtk/components/triwild/Parameters.h
+++ b/components/triwild/wmtk/components/triwild/Parameters.h
@@ -36,6 +36,18 @@ struct Parameters
     bool perform_sanity_checks = false;
 
     /**
+     * Verify at init that every constrained edge starts inside the envelope.
+     *
+     * The invariant is real -- the envelope is built around the *input* curves while the
+     * constrained edges come from the simplified ones, so it checks that the simplification
+     * stayed inside its share of eps -- but it costs one sampled segment query per
+     * constrained edge, serially. On a 3.5M-edge input that is 22s locally and 63s on a
+     * slower machine, paid on every run to catch something that has fired once in 15665
+     * models. Off by default; turn it on when changing the simplification or the envelope.
+     */
+    bool check_envelope_at_init = false;
+
+    /**
      * Incident-triangle count above which a vertex is treated as pathological, or 0 to
      * disable the gate.
      *
@@ -154,6 +166,7 @@ struct Parameters
 
         debug_output = json_params["DEBUG_output"];
         perform_sanity_checks = json_params["DEBUG_sanity_checks"];
+        check_envelope_at_init = json_params["DEBUG_envelope_sanity_check"];
 
         split_high_valence_threshold = json_params["split_high_valence_threshold"];
         w_amips = json_params["w_amips"];

--- a/components/triwild/wmtk/components/triwild/Parameters.h
+++ b/components/triwild/wmtk/components/triwild/Parameters.h
@@ -14,6 +14,16 @@ struct Parameters
     Vector2d box_min = Vector2d::Zero();
     Vector2d box_max = Vector2d::Ones();
     bool preserve_topology = false;
+
+    /**
+     * Keep the curve network's 0-dimensional features -- open polyline endpoints and
+     * junctions -- within eps of where the arrangement put them.
+     *
+     * Without it the collapse pass deletes open polylines outright: a polyline erodes into
+     * its own tip until one segment is left, and that segment has a feature at both ends,
+     * which nothing else refuses. Off only for A/B against the old behaviour.
+     */
+    bool preserve_feature_points = true;
     std::string output_path;
 
     double splitting_l2 = -1.; // the lower bound length (squared) for edge split
@@ -134,6 +144,7 @@ struct Parameters
         lr = json_params["length_rel"];
         stop_energy = json_params["stop_energy"];
         preserve_topology = json_params["preserve_topology"];
+        preserve_feature_points = json_params["preserve_feature_points"];
 
         debug_output = json_params["DEBUG_output"];
         perform_sanity_checks = json_params["DEBUG_sanity_checks"];

--- a/components/triwild/wmtk/components/triwild/Parameters.h
+++ b/components/triwild/wmtk/components/triwild/Parameters.h
@@ -74,8 +74,8 @@ struct Parameters
     // only phase that improves quality without changing connectivity, so giving each topology
     // pass a chance to be relaxed before the next one runs may keep the optimizer off the
     // plateaus where split, collapse and swap simply undo each other.
-    bool interleaved_smoothing = false;
-    int interleaved_smoothing_passes = 2;
+    bool interleaved_smoothing = true;
+    int interleaved_smoothing_passes = 1;
 
     // ---- Stuck-element sizing refinement --------------------------------
     // Same names, defaults and meaning as tetwild/simwild -- see the specs.
@@ -123,7 +123,13 @@ struct Parameters
     // gated: gating the topology/sizing ops (split/collapse/swap) starves the
     // optimizer and blows up the element count, so those always run over the
     // whole mesh.
-    bool skip_good_regions = true;
+    // Off: gating on element quality also skips SURFACE vertices, whose smoothing is driven
+    // almost entirely by the envelope term (w_amips 1e-4), not by the quality of the elements
+    // around them. On 122839 the filtered run exhausted 60 iterations at max energy 21.03
+    // while the unfiltered one converged to 19.9998 in 54 -- and did so in LESS wall time
+    // (875s vs 947s), because needing fewer iterations more than paid for the extra vertices
+    // per pass.
+    bool skip_good_regions = false;
     // Safety margin on the "active" threshold: a triangle is active when its
     // energy is >= this fraction of stop_energy, so vertices near triangles
     // sitting just below the target are still smoothed.

--- a/components/triwild/wmtk/components/triwild/TriWildMesh.cpp
+++ b/components/triwild/wmtk/components/triwild/TriWildMesh.cpp
@@ -445,8 +445,8 @@ void TriWildMesh::init_mesh(
 
     // Around the original input curves, not around the arrangement's constrained edges:
     // after simplification those are the coarsened curves, and the optimizer must stay near
-    // what the user gave us. The sanity check below then genuinely verifies that the
-    // simplified curves are still inside the envelope.
+    // what the user gave us. That is what makes the (opt-in) sanity check below a real
+    // check rather than a tautology: it asks whether the simplified curves are still inside.
     m_V_envelope.resize(V_env.rows());
     for (size_t i = 0; i < m_V_envelope.size(); ++i) {
         m_V_envelope[i] = V_env.row(i);
@@ -459,8 +459,9 @@ void TriWildMesh::init_mesh(
     m_envelope = std::make_shared<SampleEnvelope>();
     m_envelope->init(m_V_envelope, m_E_envelope, m_envelope_eps);
 
-    // Sanity check: All surface edges must be inside the envelope
-    {
+    // Sanity check: All surface edges must be inside the envelope. Opt-in: see
+    // Parameters::check_envelope_at_init for why it is not worth its cost by default.
+    if (m_params.check_envelope_at_init) {
         logger().info("Envelope sanity check");
         const auto surf_edges = get_edges_by_condition([](auto& f) { return f.m_is_surface_fs; });
         for (const auto& verts : surf_edges) {

--- a/components/triwild/wmtk/components/triwild/TriWildMesh.cpp
+++ b/components/triwild/wmtk/components/triwild/TriWildMesh.cpp
@@ -261,6 +261,7 @@ std::tuple<double, double> TriWildMesh::local_operations(
 
 void TriWildMesh::init_mesh(
     const MatrixXd& V,
+    const std::vector<Vector2r>& V_rational,
     const MatrixXi& F,
     const MatrixXi& E,
     const std::vector<std::string>& tag_names,
@@ -278,27 +279,110 @@ void TriWildMesh::init_mesh(
     m_vertex_attribute.resize(V.rows());
     m_edge_attribute.resize(F.rows() * 3);
 
+    // Take the arrangement's EXACT positions, and round separately -- the 2D counterpart of
+    // what VolumemesherInsertion does with v_rational. m_pos used to be to_rational(V.row(i)),
+    // i.e. the rounded double converted back, which silently threw the arrangement's
+    // exactness away before anything could use it.
+    //
+    // A vertex whose coordinates happen to have an exact double representation ("direct")
+    // rounds for free: snapping it changes nothing, so it cannot invert a triangle. The rest
+    // start un-rounded and the sweep below reclaims whichever ones can be rounded without
+    // inverting anything.
+    assert(V_rational.empty() || V_rational.size() == size_t(V.rows()));
+    size_t n_indirect = 0;
     for (int i = 0; i < vert_capacity(); i++) {
-        m_vertex_attribute[i].m_pos = to_rational(Vector2d(V.row(i)));
-        m_vertex_attribute[i].m_posf = V.row(i);
+        auto& va = m_vertex_attribute[i];
+        if (V_rational.empty()) {
+            // No exact input available (a caller that only has doubles, e.g. a unit test).
+            va.m_pos = to_rational(Vector2d(V.row(i)));
+            va.m_posf = V.row(i);
+            va.m_is_rounded = true;
+            continue;
+        }
+        va.m_pos = V_rational[i];
+        va.m_posf = Vector2d(V_rational[i][0].to_double(), V_rational[i][1].to_double());
+        va.m_is_rounded =
+            (Rational(va.m_posf[0]) == va.m_pos[0]) && (Rational(va.m_posf[1]) == va.m_pos[1]);
+        if (!va.m_is_rounded) {
+            ++n_indirect;
+            m_all_rounded.store(false, std::memory_order_relaxed);
+        }
+    }
+    if (n_indirect > 0) {
+        logger().info(
+            "{} of {} arrangement vertices have no exact double representation; rounding "
+            "them where it does not invert a triangle",
+            n_indirect,
+            vert_capacity());
+        round_all_vertices();
     }
 
-    // init quality and check for inverted mesh
-    bool is_mesh_inverted = false;
+    // Init quality, and check that the arrangement handed over a uniformly, positively
+    // oriented triangulation.
+    //
+    // This used to trip on the first anomaly and report "Tets with different orientations in
+    // the input!", which named neither of the two things it actually catches and, because
+    // the old state machine took the first bad face as evidence that the WHOLE mesh was
+    // inverted, reported "fully inverted" whenever the only bad face happened to be the last
+    // one. Count instead, and say what was found. Same acceptance -- an all-positive mesh
+    // passes, anything else throws -- only the message changed.
+    //
+    // The orientation is judged in EXACT arithmetic, on m_pos, not on the rounded m_posf.
+    // Judging it on doubles is what used to make about a third of the 20k 2D dataset
+    // unusable: two arrangement vertices that are exactly distinct can round to the same
+    // double, and any triangle using both then looks exactly degenerate even though the
+    // arrangement is perfectly valid. With the rationals kept and only the safely-roundable
+    // vertices rounded (above), a triangle that is still degenerate here is a real one.
+    size_t n_degenerate = 0, n_negative = 0, n_total = 0;
+    size_t first_bad_fid = std::numeric_limits<size_t>::max();
+    std::array<size_t, 3> first_bad_vids = {{0, 0, 0}};
     for (const Tuple& t : get_faces()) {
-        if (is_mesh_inverted ^ is_inverted(t)) {
-            if (!is_mesh_inverted) {
-                is_mesh_inverted = true;
+        const size_t fid = t.fid(*this);
+        const auto vs = oriented_tri_vids(fid);
+        const Vector2r& p0 = m_vertex_attribute[vs[0]].m_pos;
+        const Vector2r& p1 = m_vertex_attribute[vs[1]].m_pos;
+        const Vector2r& p2 = m_vertex_attribute[vs[2]].m_pos;
+        const Rational d = (p1[0] - p0[0]) * (p2[1] - p0[1]) - (p1[1] - p0[1]) * (p2[0] - p0[0]);
+        if (!(d > 0)) {
+            if (d == 0) {
+                ++n_degenerate;
             } else {
-                log_and_throw_error("Tets with different orientations in the input!");
+                ++n_negative;
+            }
+            if (first_bad_fid == std::numeric_limits<size_t>::max()) {
+                first_bad_fid = fid;
+                first_bad_vids = vs;
             }
         }
-        m_face_attribute[t.fid(*this)].m_quality = get_quality(t);
+        ++n_total;
+        m_face_attribute[fid].m_quality = get_quality(t);
     }
 
-    if (is_mesh_inverted) {
+    if (n_degenerate + n_negative > 0) {
+        if (n_degenerate + n_negative == n_total) {
+            log_and_throw_error(
+                "Input mesh is fully inverted! This should not happen... Might be a bug.");
+        }
+        const auto& p0 = m_vertex_attribute[first_bad_vids[0]].m_posf;
+        const auto& p1 = m_vertex_attribute[first_bad_vids[1]].m_posf;
+        const auto& p2 = m_vertex_attribute[first_bad_vids[2]].m_posf;
         log_and_throw_error(
-            "Input mesh is fully inverted! This should not happen... Might be a bug.");
+            "The arrangement produced {} zero-area and {} negatively oriented triangles out "
+            "of {} (measured exactly, on the arrangement's rational coordinates). First is "
+            "face {} = ({}, {}, {}) at ({}, {}), ({}, {}), ({}, {}).",
+            n_degenerate,
+            n_negative,
+            n_total,
+            first_bad_fid,
+            first_bad_vids[0],
+            first_bad_vids[1],
+            first_bad_vids[2],
+            p0[0],
+            p0[1],
+            p1[0],
+            p1[1],
+            p2[0],
+            p2[1]);
     }
 
     // mark edges as on surface if they are in E

--- a/components/triwild/wmtk/components/triwild/TriWildMesh.cpp
+++ b/components/triwild/wmtk/components/triwild/TriWildMesh.cpp
@@ -1178,42 +1178,44 @@ std::pair<size_t, size_t> TriWildMesh::feature_retention(double* worst_ratio) co
     if (m_feature_points.empty()) {
         return {0, 0};
     }
-    // Measured geometrically, not from the ids: the invariant is "every input feature point
-    // still has a mesh vertex within eps of it", and that is true whether or not the vertex
-    // in question is the one carrying the id. Ids drive the per-collapse policy because they
-    // are local and cheap; they are not the thing being promised, and counting them would
-    // under-report exactly the legitimate merge case the policy now allows.
-    std::vector<char> seen(m_feature_points.size(), 0);
-    const double eps2 = m_envelope_eps * m_envelope_eps;
+
+    // One nearest-neighbour query per feature against a kd-tree of the live vertices.
+    //
+    // The first version of this walked every vertex for every feature, and called
+    // get_vertices() -- which BUILDS AND RETURNS A FRESH VECTOR each time -- from inside that
+    // loop. On 2D model 177574 (573k triangles, thousands of features) it was 100% of the
+    // process's samples and burned the entire 1800 s sweep timeout on a mesh that had already
+    // converged to 19.91 and finished rounding. It turned four converged models into
+    // "failures". Diagnostics do not get to cost more than the thing they measure.
+    std::vector<Vector3d> pts;
+    pts.reserve(vert_capacity());
     for (const Tuple& v : get_vertices()) {
         const Vector2d& p = m_vertex_attribute[v.vid(*this)].m_posf;
-        for (size_t f = 0; f < m_feature_points.size(); ++f) {
-            if (!seen[f] && (p - m_feature_points[f]).squaredNorm() <= eps2) {
-                seen[f] = 1;
-            }
+        pts.emplace_back(p[0], p[1], 0);
+    }
+    if (pts.empty()) {
+        return {0, m_feature_points.size()};
+    }
+    const KNN knn(pts);
+
+    size_t kept = 0;
+    for (const Vector2d& anchor : m_feature_points) {
+        uint32_t idx = 0;
+        double sq = 0;
+        knn.nearest_neighbor(Vector3d(anchor[0], anchor[1], 0), idx, sq);
+        // Retention is geometric on purpose: the invariant is "some vertex is still within
+        // eps of this anchor", true whether or not that vertex carries the id. Ids drive the
+        // per-collapse policy because they are local and cheap; counting them here would
+        // under-report the legitimate merge the policy allows.
+        if (sq <= m_envelope_eps * m_envelope_eps) {
+            ++kept;
+        } else if (worst_ratio) {
+            // How far the nearest vertex actually is, in units of eps -- what separates an
+            // anchor that drifted just past the ball from a curve that was deleted.
+            *worst_ratio = std::max(*worst_ratio, std::sqrt(sq) / m_envelope_eps);
         }
     }
-    // For anything not retained, how far the nearest live vertex actually is, in units of
-    // eps. This is what separates "the anchor drifted just past the ball" from "the curve was
-    // deleted": the first is a bookkeeping artefact of a legitimate merge, the second is the
-    // bug this whole mechanism exists to stop.
-    if (worst_ratio) {
-        for (size_t f = 0; f < m_feature_points.size(); ++f) {
-            if (seen[f]) {
-                continue;
-            }
-            double best = std::numeric_limits<double>::max();
-            for (const Tuple& v : get_vertices()) {
-                best = std::min(
-                    best,
-                    (m_vertex_attribute[v.vid(*this)].m_posf - m_feature_points[f]).squaredNorm());
-            }
-            if (best < std::numeric_limits<double>::max()) {
-                *worst_ratio = std::max(*worst_ratio, std::sqrt(best) / m_envelope_eps);
-            }
-        }
-    }
-    return {size_t(std::count(seen.begin(), seen.end(), char(1))), m_feature_points.size()};
+    return {kept, m_feature_points.size()};
 }
 
 bool TriWildMesh::smoothing_position_is_allowed(const size_t vid, const Vector2d& p) const

--- a/components/triwild/wmtk/components/triwild/TriWildMesh.cpp
+++ b/components/triwild/wmtk/components/triwild/TriWildMesh.cpp
@@ -1170,8 +1170,11 @@ bool TriWildMesh::is_inverted(const size_t fid) const
     return is_inverted(vs);
 }
 
-std::pair<size_t, size_t> TriWildMesh::feature_retention() const
+std::pair<size_t, size_t> TriWildMesh::feature_retention(double* worst_ratio) const
 {
+    if (worst_ratio) {
+        *worst_ratio = 0;
+    }
     if (m_feature_points.empty()) {
         return {0, 0};
     }
@@ -1187,6 +1190,26 @@ std::pair<size_t, size_t> TriWildMesh::feature_retention() const
         for (size_t f = 0; f < m_feature_points.size(); ++f) {
             if (!seen[f] && (p - m_feature_points[f]).squaredNorm() <= eps2) {
                 seen[f] = 1;
+            }
+        }
+    }
+    // For anything not retained, how far the nearest live vertex actually is, in units of
+    // eps. This is what separates "the anchor drifted just past the ball" from "the curve was
+    // deleted": the first is a bookkeeping artefact of a legitimate merge, the second is the
+    // bug this whole mechanism exists to stop.
+    if (worst_ratio) {
+        for (size_t f = 0; f < m_feature_points.size(); ++f) {
+            if (seen[f]) {
+                continue;
+            }
+            double best = std::numeric_limits<double>::max();
+            for (const Tuple& v : get_vertices()) {
+                best = std::min(
+                    best,
+                    (m_vertex_attribute[v.vid(*this)].m_posf - m_feature_points[f]).squaredNorm());
+            }
+            if (best < std::numeric_limits<double>::max()) {
+                *worst_ratio = std::max(*worst_ratio, std::sqrt(best) / m_envelope_eps);
             }
         }
     }

--- a/components/triwild/wmtk/components/triwild/TriWildMesh.cpp
+++ b/components/triwild/wmtk/components/triwild/TriWildMesh.cpp
@@ -1102,7 +1102,8 @@ std::vector<size_t> TriWildMesh::active_vertices() const
         [this](size_t fid) { return tuple_from_tri(fid).is_valid(*this); },
         [this](size_t fid) { return m_face_attribute[fid].m_quality; },
         [this](size_t fid) { return oriented_tri_vids(fid); },
-        active_quality_threshold());
+        active_quality_threshold(),
+        [this](size_t vid) { return m_vertex_attribute[vid].m_is_on_surface; });
 }
 
 bool TriWildMesh::is_inverted_f(const Tuple& loc) const

--- a/components/triwild/wmtk/components/triwild/TriWildMesh.cpp
+++ b/components/triwild/wmtk/components/triwild/TriWildMesh.cpp
@@ -63,27 +63,66 @@ void TriWildMesh::mesh_improvement(int max_its)
     for (int it = 0; it < max_its; it++) {
         ///ops
         logger().info("\n========it {}========", it);
-        auto [max_energy, avg_energy] = local_operations({{1, 1, 1, 1}});
+        // One iteration is either split/collapse/swaps followed by all the smoothing, or --
+        // with interleaved_smoothing -- each topology pass followed by its own smoothing, so
+        // the next pass sees a relaxed mesh rather than the raw output of the previous one.
+        auto [max_energy, avg_energy] = [&]() -> std::tuple<double, double> {
+            if (!m_params.interleaved_smoothing) {
+                return local_operations({{1, 1, 1, m_params.num_smoothing_passes}});
+            }
+            const int k = m_params.interleaved_smoothing_passes;
+            local_operations({{1, 0, 0, k}});
+            local_operations({{0, 1, 0, k}});
+            return local_operations({{0, 0, 1, k}});
+        }();
 
         ///energy check
         logger().info("max energy {:.6} | stop {:.6}", max_energy, m_params.stop_energy);
+
+        // Counted BEFORE the stop check, because it decides whether to stop. Atomic because
+        // for_each_vertex runs threading::parallel_for whenever NUM_THREADS != 0; plain ints
+        // race and can report cnt_round > cnt_verts. Same as tetwild.
+        std::atomic<int> n_round = 0, n_verts = 0;
+        TriMesh::for_each_vertex([&](auto& v) {
+            if (m_vertex_attribute[v.vid(*this)].m_is_rounded) {
+                n_round.fetch_add(1, std::memory_order_relaxed);
+            }
+            n_verts.fetch_add(1, std::memory_order_relaxed);
+        });
+        const int cnt_round = n_round.load(std::memory_order_relaxed);
+        const int cnt_verts = n_verts.load(std::memory_order_relaxed);
+        if (cnt_round < cnt_verts) {
+            logger().info("rounded {}/{}", cnt_round, cnt_verts);
+        } else {
+            logger().info("All rounded!");
+        }
+
+        // Energy alone is not a sufficient termination condition. A mesh that hits the
+        // quality target while some vertex still carries exact coordinates is not finished:
+        // the output is what the caller consumes, and rational coordinates in it are a defect
+        // regardless of how good the elements are. So keep iterating while anything is
+        // un-rounded, and let max_its bound the run as before.
+        //
+        // This is what makes the unconditional exact-rational split in split_edge_after safe:
+        // a split is the only operation that can un-round a vertex, and the loop does not
+        // stop until the rounding sweep has reclaimed every one it introduced.
+        //
+        // The exact count is used rather than m_all_rounded, which is only maintained where
+        // the sweep runs (after smoothing) and would stay stale at num_smoothing_passes == 0,
+        // stranding the loop at max_its for no reason.
         if (max_energy < m_params.stop_energy) {
-            break;
+            if (cnt_round == cnt_verts) {
+                break;
+            }
+            logger().info(
+                "energy target reached, but {} of {} vertices are still un-rounded; "
+                "continuing",
+                cnt_verts - cnt_round,
+                cnt_verts);
         }
         consolidate_mesh();
 
         logger().info("#V = {}, #T = {}", vert_capacity(), tri_capacity());
-
-        auto cnt_round = 0, cnt_verts = 0;
-        TriMesh::for_each_vertex([&](auto& v) {
-            if (m_vertex_attribute[v.vid(*this)].m_is_rounded) cnt_round++;
-            cnt_verts++;
-        });
-        if (cnt_round < cnt_verts) {
-            logger().info("rounded {}/{}", cnt_round, cnt_verts);
-        } else {
-            logger().info("All rounded!", cnt_round, cnt_verts);
-        }
 
         /// sizing field: when the max energy stalls, refine around the worst
         /// elements to escape stuck configurations (replaces the old global
@@ -192,6 +231,20 @@ std::tuple<double, double> TriWildMesh::local_operations(
         } else if (i == 3) {
             logger().info("==smoothing ==");
             smooth_all_vertices(ops[i]);
+            // Reclaim whatever smoothing just made roundable: once per iteration, after all
+            // of its smoothing passes. Here rather than at the end of the run because
+            // smoothing is what frees a stuck vertex, and because a vertex left rational
+            // makes every incident triangle take the exact-arithmetic path in is_inverted --
+            // so rounding early keeps the following passes on doubles.
+            //
+            // Guarded on ops[i] so it really is once per iteration: this branch is also
+            // entered by the collapse-only pre and post passes, which pass ops[3] == 0 and
+            // have no smoothing for the sweep to follow.
+            //
+            // Skipped entirely once m_all_rounded is set.
+            if (ops[i] > 0) {
+                round_all_vertices();
+            }
             auto [max_energy, avg_energy] = get_max_avg_energy();
             logger().info("smooth max energy = {:.6} avg = {:.6}", max_energy, avg_energy);
             sanity_checks();
@@ -991,6 +1044,36 @@ bool TriWildMesh::is_inverted(const size_t fid) const
 {
     auto vs = oriented_tri_vids(fid);
     return is_inverted(vs);
+}
+
+size_t TriWildMesh::round_all_vertices()
+{
+    if (m_all_rounded.load(std::memory_order_relaxed)) {
+        return 0;
+    }
+
+    size_t reclaimed = 0, still_unrounded = 0;
+    for (const Tuple& v : get_vertices()) {
+        if (m_vertex_attribute[v.vid(*this)].m_is_rounded) {
+            continue;
+        }
+        if (round(v)) {
+            ++reclaimed;
+        } else {
+            ++still_unrounded;
+        }
+    }
+
+    if (still_unrounded == 0) {
+        m_all_rounded.store(true, std::memory_order_relaxed);
+    }
+    if (reclaimed > 0 || still_unrounded > 0) {
+        logger().info(
+            "rounding sweep: reclaimed {}, still unrounded {}",
+            reclaimed,
+            still_unrounded);
+    }
+    return reclaimed;
 }
 
 bool TriWildMesh::round(const Tuple& v)

--- a/components/triwild/wmtk/components/triwild/TriWildMesh.cpp
+++ b/components/triwild/wmtk/components/triwild/TriWildMesh.cpp
@@ -397,6 +397,46 @@ void TriWildMesh::init_mesh(
         m_vertex_attribute[vids[1]].m_is_on_surface = true;
     }
 
+    // Feature points: the 0-dimensional features of the curve network, taken from the
+    // constrained edges E. Valence 1 is an open polyline's endpoint, valence >= 3 a junction;
+    // valence 2 is the interior of a curve and valence 0 is not on it at all.
+    //
+    // Without these, the collapse pass deletes open polylines outright. A polyline erodes by
+    // legal collapses of its interior into its tip until one segment is left, and that
+    // segment has a feature at BOTH ends -- which the existing order test permits, because it
+    // only refuses collapsing a feature into a non-feature. Measured on the 2D dataset:
+    // 215292 went from 28 open components after the arrangement to 0 in the output, and
+    // 134005 from 18 to 15, entirely in the collapse passes.
+    {
+        std::vector<int> surf_valence(vert_capacity(), 0);
+        for (int i = 0; i < E.rows(); ++i) {
+            ++surf_valence[E(i, 0)];
+            ++surf_valence[E(i, 1)];
+        }
+        size_t n_endpoints = 0, n_junctions = 0;
+        for (size_t v = 0; v < vert_capacity(); ++v) {
+            const int val = surf_valence[v];
+            if (val == 0 || val == 2) {
+                continue;
+            }
+            m_vertex_attribute[v].m_feature_id = m_feature_points.size();
+            m_feature_points.push_back(m_vertex_attribute[v].m_posf);
+            if (val == 1) {
+                ++n_endpoints;
+            } else {
+                ++n_junctions;
+            }
+        }
+        if (!m_feature_points.empty()) {
+            logger().info(
+                "feature points: {} polyline endpoints, {} junctions (kept within {:.6} of "
+                "their input positions)",
+                n_endpoints,
+                n_junctions,
+                m_envelope_eps);
+        }
+    }
+
     // init envelope
     if (m_envelope) {
         log_and_throw_error("Envelope was already initialized once.");
@@ -1128,6 +1168,65 @@ bool TriWildMesh::is_inverted(const size_t fid) const
 {
     auto vs = oriented_tri_vids(fid);
     return is_inverted(vs);
+}
+
+std::pair<size_t, size_t> TriWildMesh::feature_retention() const
+{
+    if (m_feature_points.empty()) {
+        return {0, 0};
+    }
+    // Measured geometrically, not from the ids: the invariant is "every input feature point
+    // still has a mesh vertex within eps of it", and that is true whether or not the vertex
+    // in question is the one carrying the id. Ids drive the per-collapse policy because they
+    // are local and cheap; they are not the thing being promised, and counting them would
+    // under-report exactly the legitimate merge case the policy now allows.
+    std::vector<char> seen(m_feature_points.size(), 0);
+    const double eps2 = m_envelope_eps * m_envelope_eps;
+    for (const Tuple& v : get_vertices()) {
+        const Vector2d& p = m_vertex_attribute[v.vid(*this)].m_posf;
+        for (size_t f = 0; f < m_feature_points.size(); ++f) {
+            if (!seen[f] && (p - m_feature_points[f]).squaredNorm() <= eps2) {
+                seen[f] = 1;
+            }
+        }
+    }
+    return {size_t(std::count(seen.begin(), seen.end(), char(1))), m_feature_points.size()};
+}
+
+bool TriWildMesh::smoothing_position_is_allowed(const size_t vid, const Vector2d& p) const
+{
+    const size_t f = m_vertex_attribute[vid].m_feature_id;
+    if (f == NO_FEATURE || !m_params.preserve_feature_points) {
+        return true;
+    }
+    // A ball, not a pin. The vertex may move anywhere within eps of the feature it stands
+    // for, which is exactly the guarantee the envelope gives everywhere else.
+    return (p - m_feature_points[f]).squaredNorm() <= m_envelope_eps * m_envelope_eps;
+}
+
+bool TriWildMesh::collapse_breaks_feature(const size_t v1_id, const size_t v2_id) const
+{
+    if (!m_params.preserve_feature_points) {
+        return false;
+    }
+    // v1 disappears into v2, and v2 does not move. So the question is only whether the
+    // feature v1 stood for is still represented afterwards, by v2.
+    const size_t f1 = m_vertex_attribute[v1_id].m_feature_id;
+    if (f1 == NO_FEATURE) {
+        return false;
+    }
+    // Distance is the whole test. An earlier version also refused outright when v2 already
+    // stood for a DIFFERENT feature, on the theory that one of the two would be lost. That
+    // is wrong, and expensively so: when two anchors sit within eps of each other the
+    // survivor covers both, and forbidding the merge deadlocks the mesh. On the puzzle
+    // integration model it left a degenerate triangle that the collapse pass exists to
+    // remove, and the max energy sat at 1e50 -- MAX_ENERGY -- for all 82 iterations instead
+    // of converging to 4.99 in 3.
+    //
+    // Two anchors further apart than eps are still protected, because then v2 -- sitting on
+    // one of them -- is more than eps from the other and fails this same test.
+    return (m_vertex_attribute[v2_id].m_posf - m_feature_points[f1]).squaredNorm() >
+           m_envelope_eps * m_envelope_eps;
 }
 
 size_t TriWildMesh::round_all_vertices()

--- a/components/triwild/wmtk/components/triwild/TriWildMesh.h
+++ b/components/triwild/wmtk/components/triwild/TriWildMesh.h
@@ -169,6 +169,11 @@ public:
      * @param F #Fx3 vertex IDs for all faces
      * @param E #Ex2 vertex IDs for all constraint edges
      * @param tag_names Names for each tag.
+     * @param V_rational the arrangement's EXACT vertex positions, matching V row for row.
+     *        V is only their rounding, and two exactly distinct vertices can round to the
+     *        same double, so V alone cannot tell a genuine degeneracy from a rounding
+     *        collision. Pass an empty vector when no exact positions exist (unit tests
+     *        building a mesh from doubles); every vertex is then taken as rounded.
      * @param V_env,E_env the curves the envelope is built around. These are the *original*
      *        input curves, not the arrangement's constrained edges: the optimizer has to
      *        stay near what the user gave us, not near the simplified version of it. Same
@@ -177,6 +182,7 @@ public:
      */
     void init_mesh(
         const MatrixXd& V,
+        const std::vector<Vector2r>& V_rational,
         const MatrixXi& F,
         const MatrixXi& E,
         const std::vector<std::string>& tag_names,

--- a/components/triwild/wmtk/components/triwild/TriWildMesh.h
+++ b/components/triwild/wmtk/components/triwild/TriWildMesh.h
@@ -24,6 +24,9 @@
 
 namespace wmtk::components::triwild {
 
+/// A vertex that stands for no input feature point. See VertexAttributes::m_feature_id.
+inline constexpr size_t NO_FEATURE = std::numeric_limits<size_t>::max();
+
 // TODO: missing comments on what these attributes are
 class VertexAttributes
 {
@@ -34,6 +37,24 @@ public:
 
     bool m_is_on_surface = false;
     std::vector<int> on_bbox_faces;
+
+    /**
+     * Index into TriWildMesh::m_feature_points, or NO_FEATURE.
+     *
+     * A feature point is a 0-dimensional feature of the curve network: an open polyline's
+     * endpoint, or a junction. This is the 2D counterpart of tetwild's m_is_on_open_boundary,
+     * with one deliberate difference -- it names WHICH feature the vertex stands for, not
+     * merely that it stands for one.
+     *
+     * That difference is the whole point. tetwild asks "is the survivor inside the envelope
+     * of the boundary?", a containment question, and in 3D a boundary is a curve with many
+     * edges so collapsing one shortens it rather than deleting it. In 2D the feature is a
+     * single point, and a containment test passes trivially when one endpoint is collapsed
+     * onto another -- the target IS a feature point, distance zero -- while the first
+     * endpoint quietly stops being represented. Preserving features is a COVERAGE property,
+     * so the constraint has to bind a vertex to a specific point.
+     */
+    size_t m_feature_id = NO_FEATURE;
 
     double m_sizing_scalar = 1;
 
@@ -96,6 +117,47 @@ public:
     std::vector<Vector2i> m_E_envelope;
     std::shared_ptr<SampleEnvelope> m_envelope;
     double m_envelope_eps = -1;
+
+    /**
+     * Anchor positions of the curve network's 0-dimensional features, indexed by
+     * VertexAttributes::m_feature_id.
+     *
+     * Filled in init_mesh from the arrangement's constrained edges: a vertex whose valence in
+     * that edge set is neither 0 nor 2 is a feature -- valence 1 is an open polyline's
+     * endpoint, valence >= 3 a junction. Reading it off the arrangement rather than the raw
+     * input is deliberate: it is the network the optimizer actually starts from, so a
+     * junction the simplification was allowed to merge (which it may, with
+     * simplify_use_link_condition off) is correctly absent, and no provenance or
+     * position-matching plumbing is needed.
+     *
+     * A vertex carrying feature f may never end up further than m_envelope_eps from
+     * m_feature_points[f]. Since the anchor never moves, no spatial index is required: the
+     * feature id is a direct lookup.
+     */
+    std::vector<Vector2d> m_feature_points;
+    /// Collapses refused because they would drop or displace a feature point. Diagnostic.
+    std::atomic<size_t> m_feature_rejects = 0;
+
+    /**
+     * @brief May vertex `vid` sit at `p`?
+     *
+     * False only when the vertex stands for a feature point and `p` is more than
+     * m_envelope_eps away from it. Smoothing is free to move a feature vertex inside that
+     * ball -- it is a containment test, not a freeze, so the optimizer keeps the quality it
+     * can get near features.
+     */
+    bool smoothing_position_is_allowed(const size_t vid, const Vector2d& p) const;
+
+    /**
+     * @brief {feature points still represented within eps, total feature points}.
+     *
+     * The invariant preserve_feature_points maintains, measured on the finished mesh rather
+     * than assumed from the per-operation checks.
+     */
+    std::pair<size_t, size_t> feature_retention() const;
+
+    /// True iff collapsing v1 into v2 would drop or displace a feature point.
+    bool collapse_breaks_feature(const size_t v1_id, const size_t v2_id) const;
 
     using VertAttCol = wmtk::AttributeCollection<VertexAttributes>;
     using EdgeAttCol = wmtk::AttributeCollection<EdgeAttributes>;

--- a/components/triwild/wmtk/components/triwild/TriWildMesh.h
+++ b/components/triwild/wmtk/components/triwild/TriWildMesh.h
@@ -18,6 +18,8 @@
 
 #include "Parameters.h"
 
+#include <atomic>
+#include <memory>
 #include <set>
 
 namespace wmtk::components::triwild {
@@ -228,6 +230,16 @@ public:
     /// split; reset + logged by split_all_edges). Diagnostic only.
     size_t m_force_split_count = 0;
 
+    /// Per-pass claim for the high-valence split gate: one slot per vertex, reset at the
+    /// start of every split pass. A high-valence vertex accepts the first valence-increasing
+    /// split of the pass and refuses the rest, so refinement spreads instead of piling onto
+    /// the same vertex. Atomic because splits run in parallel; a plain array of unique_ptr
+    /// rather than a vector because std::atomic is not movable.
+    std::unique_ptr<std::atomic<int>[]> m_high_valence_claim;
+    size_t m_high_valence_claim_size = 0;
+    /// Splits refused by that gate in the current pass, reported once per pass.
+    std::atomic<size_t> m_high_valence_rejects = 0;
+
     /// True iff edge (v1,v2) is a worst triangle's longest edge queued for force-split.
     bool is_force_split_edge(size_t v1, size_t v2) const
     {
@@ -283,6 +295,29 @@ public:
     double get_quality(const Tuple& loc) const;
     double get_quality(const size_t fid) const;
     bool round(const Tuple& loc);
+
+    /**
+     * @brief Try to round every un-rounded vertex; returns the number reclaimed.
+     *
+     * round() is otherwise only attempted as a side effect of another operation (smoothing
+     * the vertex, or the merged vertex of a collapse), and neither reaches a vertex that
+     * only becomes roundable later: smoothing skips "good" regions by default. Without a
+     * sweep such a vertex keeps exact coordinates into the output for no geometric reason --
+     * and split_edge_after now introduces them unconditionally whenever the rounded midpoint
+     * would invert, so the sweep is what keeps that from reaching the output.
+     *
+     * Skipped outright when m_all_rounded says there is nothing to do.
+     */
+    size_t round_all_vertices();
+
+    /**
+     * @brief True when every vertex is known to be rounded.
+     *
+     * Only trusted when true, and only round_all_vertices() sets it that way. Any code that
+     * leaves a vertex un-rounded must clear it, or the sweep will skip the vertex forever.
+     * Atomic because operations that clear it run in parallel.
+     */
+    std::atomic<bool> m_all_rounded = false;
     //
     bool is_edge_on_surface(const Tuple& loc) const;
     bool is_edge_on_surface(const std::array<size_t, 2>& vids) const;

--- a/components/triwild/wmtk/components/triwild/TriWildMesh.h
+++ b/components/triwild/wmtk/components/triwild/TriWildMesh.h
@@ -154,7 +154,7 @@ public:
      * The invariant preserve_feature_points maintains, measured on the finished mesh rather
      * than assumed from the per-operation checks.
      */
-    std::pair<size_t, size_t> feature_retention() const;
+    std::pair<size_t, size_t> feature_retention(double* worst_ratio = nullptr) const;
 
     /// True iff collapsing v1 into v2 would drop or displace a feature point.
     bool collapse_breaks_feature(const size_t v1_id, const size_t v2_id) const;

--- a/components/triwild/wmtk/components/triwild/init_from_delaunay.cpp
+++ b/components/triwild/wmtk/components/triwild/init_from_delaunay.cpp
@@ -20,8 +20,8 @@ namespace {
 // The remesher hands back exact coordinates; which concrete bignum type depends on
 // how VolumeRemesher was configured (see cmake/recipes/volumemesher.cmake). Go
 // through wmtk::Rational -- the same conversion the 3D insertion uses -- so both
-// backends are handled, then round once to double.
-double to_double(const vol_rem::bigrational& r)
+// backends are handled.
+Rational to_rational(const vol_rem::bigrational& r)
 {
     Rational q;
 #ifdef USE_GNU_GMP_CLASSES
@@ -29,7 +29,7 @@ double to_double(const vol_rem::bigrational& r)
 #else
     q.init_from_bin(r.get_str());
 #endif
-    return q.to_double();
+    return q;
 }
 
 /**
@@ -121,6 +121,7 @@ void init_from_delaunay_box_mesh(
     const MatrixXd& V,
     const MatrixXi& E,
     MatrixXd& V_out,
+    std::vector<Vector2r>& V_rational,
     MatrixXi& F_out,
     MatrixXi& E_out)
 {
@@ -172,11 +173,22 @@ void init_from_delaunay_box_mesh(
     }
     assert(vertices.size() % 2 == 0);
 
+    // Keep the exact coordinates and hand back the rounding alongside them. Rounding here
+    // and throwing the rationals away is what used to make distinct arrangement vertices
+    // collide on the same double -- see the header.
     const int nv = int(vertices.size() / 2);
+    V_rational.resize(nv);
     V_out.resize(nv, 2);
+    size_t n_indirect = 0;
     for (int v = 0; v < nv; ++v) {
-        V_out(v, 0) = to_double(vertices[2 * v + 0]);
-        V_out(v, 1) = to_double(vertices[2 * v + 1]);
+        V_rational[v][0] = to_rational(vertices[2 * v + 0]);
+        V_rational[v][1] = to_rational(vertices[2 * v + 1]);
+        V_out(v, 0) = V_rational[v][0].to_double();
+        V_out(v, 1) = V_rational[v][1].to_double();
+        if (Rational(V_out(v, 0)) != V_rational[v][0] ||
+            Rational(V_out(v, 1)) != V_rational[v][1]) {
+            ++n_indirect;
+        }
     }
 
     F_out.resize(tris.size(), 3);
@@ -213,10 +225,12 @@ void init_from_delaunay_box_mesh(
     }
 
     logger().info(
-        "2D arrangement: #V = {}, #F = {}, #E_constrained = {}",
+        "2D arrangement: #V = {}, #F = {}, #E_constrained = {} ({} vertices have no exact "
+        "double representation)",
         V_out.rows(),
         F_out.rows(),
-        E_out.rows());
+        E_out.rows(),
+        n_indirect);
 }
 
 void read_input_curves(

--- a/components/triwild/wmtk/components/triwild/init_from_delaunay.hpp
+++ b/components/triwild/wmtk/components/triwild/init_from_delaunay.hpp
@@ -12,9 +12,20 @@ namespace wmtk::components::triwild {
  * The input edges are a soup: they may cross, overlap, be duplicated or be degenerate. Crossings
  * become new output vertices, so E_out generally has more (and shorter) edges than E.
  *
+ * The arrangement's vertices are EXACT: a crossing between two segments generally has no
+ * double representation, and vol_rem::embed_seg_in_tri_mesh returns bigrationals for exactly
+ * that reason. They are handed back in V_rational, and V_out is only their rounding.
+ *
+ * Rounding alone is not enough to work with, which is why both are returned. Two vertices
+ * that are exactly distinct can round to the SAME double, and any triangle using both is
+ * then exactly degenerate -- on the 20k 2D dataset that made about a third of the models
+ * unusable. The 3D path has always kept the rationals (VolumemesherInsertion's v_rational);
+ * this is the 2D counterpart.
+ *
  * @param V input vertices (Nx2)
  * @param E input edges (Mx2)
- * @param V_out output vertices (Kx2)
+ * @param V_out output vertices (Kx2), the rounding of V_rational
+ * @param V_rational output vertices, exact (size K)
  * @param F_out output faces (Lx3)
  * @param E_out output edges (Px2) - the output edges tiling the input edges
  */
@@ -22,6 +33,7 @@ void init_from_delaunay_box_mesh(
     const MatrixXd& V,
     const MatrixXi& E,
     MatrixXd& V_out,
+    std::vector<Vector2r>& V_rational,
     MatrixXi& F_out,
     MatrixXi& E_out);
 

--- a/components/triwild/wmtk/components/triwild/scripts/README.md
+++ b/components/triwild/wmtk/components/triwild/scripts/README.md
@@ -1,0 +1,125 @@
+# triwild sweep scripts
+
+Batch-run triwild over a large 2D dataset, collect per-model results, and report.
+Written for the 20k 2D curve dataset on `kirby.cs.nyu.edu`, but nothing here is
+kirby-specific beyond the default paths.
+
+| file | what it is |
+|---|---|
+| `run_triwild_sweep.py` | the driver: one triwild run per model, capped in time and memory, then the report |
+| `sweep2d.sh` | tmux wrapper — start / stop / attach / status / report |
+| `failure_report.py` | post-hoc: where each failed model died, how far it got, at what energy |
+
+## Layout
+
+Everything hangs off one root, `TRIWILD_ROOT` (default `/u/3/daniele/triwild-sweep`):
+
+```
+<root>/build/app/wmtk_app     the binary under test
+<root>/data/*.obj             the dataset
+<root>/runs/<name>/           output: success/  failure/  .work/  report/
+```
+
+A model that exits 0 lands in `success/<id>/`, anything else in `failure/<id>/` with a
+`status.txt` recording the reason. Both keep the config, the log and the report.json.
+
+## Running
+
+```sh
+export TRIWILD_ROOT=/path/to/sweep
+./sweep2d.sh full          # every model, filename order
+./sweep2d.sh quick         # 300 models spread across the size range
+./sweep2d.sh status        # progress for every run
+./sweep2d.sh stop          # clean stop: drain, write the report, exit
+./sweep2d.sh attach        # attach to the tmux session
+./sweep2d.sh report [full] # regenerate the report without running anything
+```
+
+**Resuming is just re-running the same subcommand** — models already in `success/` or
+`failure/` are skipped. A clean `stop` abandons in-flight models *unpublished*, so they
+are reprocessed on resume rather than being recorded as spurious failures. To retry
+failures under new settings, move `failure/` aside first; anything left there is treated
+as already done.
+
+Or drive the runner directly:
+
+```sh
+TRIWILD_ROOT=... TRIWILD_OUT=.../runs/full TRIWILD_PARALLEL=13 TRIWILD_THREADS=8 \
+TRIWILD_JOB_TIMEOUT=21600 python3 run_triwild_sweep.py
+```
+
+### Environment
+
+| var | default | notes |
+|---|---|---|
+| `TRIWILD_ROOT` | the kirby path | `build/`, `data/`, `runs/` live here |
+| `TRIWILD_OUT` | `<root>/runs/full` | output directory |
+| `TRIWILD_PARALLEL` | 16 | models at once |
+| `TRIWILD_THREADS` | 8 | threads per model |
+| `TRIWILD_JOB_TIMEOUT` | 3600 | seconds per model |
+| `TRIWILD_MEM_GB` | 128 | per model, 0 disables |
+| `TRIWILD_LIMIT` | 0 | process at most N new models |
+| `TRIWILD_SAMPLE` | `name` | `name` \| `smallest` \| `spread` \| `random` |
+| `TRIWILD_SEED` | 0 | for `TRIWILD_SAMPLE=random` |
+| `TRIWILD_REPORT_ONLY` | unset | regenerate the report and exit |
+
+`TRIWILD_MEM_GB` is a cap **per model**, not a budget for the sweep — 16 × 128 G is far
+more than any machine has. It is a runaway-killer, and it binds harder in 2D than in 3D
+because the dataset's files span 2.7 KB to 1.6 GB and the large ones are read whole
+before anything else happens.
+
+`TRIWILD_PARALLEL × TRIWILD_THREADS` should be near the core count. The trade is not
+neutral: triwild's preprocessing (input simplification, then the 2D arrangement) is
+serial, so extra threads only help the optimization loop, while extra concurrent models
+contend for memory bandwidth and slow the serial phases for everyone. Measured on 228906,
+preprocessing took 32m16s at 32×4 and 23m19s at 13×8.
+
+## What the sweep fixes about the defaults
+
+Only the knobs the harness itself needs are pinned; everything else comes from the spec
+defaults of whatever branch `build/` was built from, which is the point — the sweep tests
+the defaults rather than a private configuration. Pinned:
+
+- `filter: none` and `skip_winding_number: true`. With `filter: none` the winding number
+  only feeds the MSH group tags, which the sweep does not read, and it is brute-force
+  O(#queries × #segments) in 2D: libigl has a hierarchical accelerator for 3D triangles
+  and none in 2D. It was **95% of one run's failures** — 232 of 245 timeouts died in that
+  phase with the mesh already converged.
+- `write_vtu: false`. The `.msh` is the real output; the `.vtu` would be written only to
+  be pruned.
+- `DEBUG_hausdorff: true`, because the two deviation directions are the point of the run.
+
+## Reports
+
+`report/` gets three files:
+
+- `summary.txt` — the same figures as the console output
+- `results.csv` — one row per model: time, iterations, energies, element counts, both
+  Hausdorff directions, input size, simplification ratio, failure reason
+- `index.html` — self-contained HTML: headline stats, the containment invariant,
+  distributions, run time vs input size, slowest models, failures. No CDN, no build step.
+
+### Reading the two Hausdorff numbers
+
+They are not interchangeable, and conflating them once made ~60% of models look like
+violations:
+
+- **containment**, d(output → input) — *the envelope invariant*. Every point of the output
+  must lie within eps of the input. Anything above 1.0 × eps is a real violation.
+- **coverage**, d(input → output) — *diagnostic, bounded by nothing*. The simplification is
+  allowed to remove detail and the arrangement may drop segments, so a large value means
+  the output no longer covers part of the input. Use `DEBUG_euler` to see which curves
+  were lost.
+
+Runs made before the direction was corrected stored coverage under the name `hausdorff`
+and have no `coverage` key. The report detects them by that absence, labels them
+`metric=legacy-coverage`, and keeps them out of the containment statistics rather than
+pooling two different quantities.
+
+## Caveat on comparing runs
+
+The report pools whatever is in `success/`, so a directory filled across several builds or
+several `stop_energy` targets yields statistics that mix them. The 19,686-model run of
+August 2026 is exactly that case: most of it ran at `stop_energy` 20 and the tail at 100,
+which is why its median max energy is 19.8. For a quotable dataset, run the whole corpus
+once on one build.

--- a/components/triwild/wmtk/components/triwild/scripts/failure_report.py
+++ b/components/triwild/wmtk/components/triwild/scripts/failure_report.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""Where did each timed-out model die, how far did it get, and at what energy."""
+import os
+import re
+import collections
+import statistics as st
+
+ROOT = os.environ.get("TRIWILD_ROOT", "/u/3/daniele/triwild-sweep")
+R = os.environ.get("TRIWILD_OUT", os.path.join(ROOT, "runs/full"))
+FD = os.path.join(R, "failure")
+DATA = os.path.join(ROOT, "data")
+
+# Milestones in the order triwild logs them. The last one present is how far it got.
+PHASES = [
+    ("Read edge mesh", "read input"),
+    ("input simplification:", "simplified"),
+    ("skip simplification", "simplified"),
+    ("2D arrangement:", "arrangement done"),
+    ("Envelope sanity check", "init_mesh done"),
+    ("========it pre========", "pre-collapse"),
+    ("========it 0========", "optimization"),
+    ("========it post========", "post-collapse"),
+    ("flood fill parts", "winding number"),
+    ("Hausdorff distance", "hausdorff check"),
+    ("final max energy", "writing output"),
+]
+
+rows = []
+for m in sorted(os.listdir(FD)):
+    d = os.path.join(FD, m)
+    log = ""
+    for f in ("out.log", "console.log"):
+        p = os.path.join(d, f)
+        if os.path.exists(p):
+            log += open(p, errors="ignore").read()
+    try:
+        size = os.path.getsize(os.path.join(DATA, m + ".obj"))
+    except OSError:
+        size = 0
+
+    phase = "before reading"
+    for needle, name in PHASES:
+        if needle in log:
+            phase = name
+
+    its = len(re.findall(r"========it (\d+)========", log))
+    en = re.findall(r"max energy ([0-9.e+]+) \| stop", log)
+    first = float(en[0]) if en else None
+    last = float(en[-1]) if en else None
+    nt = re.findall(r"#V = \d+, #T = (\d+)", log)
+    ne = re.search(r"Read edge mesh \S+: #V = (\d+), #E = (\d+)", log)
+    simp = re.search(r"#E (\d+) -> (\d+)", log)
+    arr = re.search(r"2D arrangement: #V = (\d+), #F = (\d+)", log)
+    rows.append(
+        dict(m=m, size=size, phase=phase, its=its, first=first, last=last,
+             nt=int(nt[-1]) if nt else None,
+             in_e=int(ne.group(2)) if ne else None,
+             simp_e=int(simp.group(2)) if simp else None,
+             arr_f=int(arr.group(2)) if arr else None))
+
+print("%d failures\n" % len(rows))
+
+# A sweep that finished cleanly has none, which is the good case, not an error.
+if not rows:
+    print("nothing to report: %s holds no failed models." % FD)
+    raise SystemExit(0)
+
+print("=== how far each got ===")
+order = [n for _, n in PHASES]
+counts = collections.Counter(r["phase"] for r in rows)
+for name in ["before reading"] + list(dict.fromkeys(order)):
+    if counts.get(name):
+        print("  %5d  %s" % (counts[name], name))
+
+print("\n=== iterations of the optimization loop reached ===")
+its = [r["its"] for r in rows]
+buckets = [(0, 0), (1, 1), (2, 5), (6, 20), (21, 200)]
+for lo, hi in buckets:
+    c = sum(1 for i in its if lo <= i <= hi)
+    if c:
+        print("  %5d models: %s iterations" % (c, lo if lo == hi else "%d-%d" % (lo, hi)))
+print("  median %d, max %d" % (st.median(its), max(its)))
+
+print("\n=== input size ===")
+sz = sorted(r["size"] for r in rows)
+print("  median %.0f MB   min %.1f MB   max %.0f MB" % (
+    sz[len(sz) // 2] / 1e6, min(sz) / 1e6, max(sz) / 1e6))
+
+print("\n=== energy, for the ones that ran at least one iteration ===")
+run = [r for r in rows if r["its"] > 0 and r["last"] is not None]
+print("  %d of %d models" % (len(run), len(rows)))
+if run:
+    lasts = sorted(r["last"] for r in run)
+    print("  last max energy: median %.4g   min %.4g   max %.4g   (target 20)" % (
+        lasts[len(lasts) // 2], min(lasts), max(lasts)))
+    print("  still above target: %d of %d" % (sum(1 for v in lasts if v > 20), len(lasts)))
+    conv = sum(1 for r in run if r["first"] and r["last"] and r["last"] < r["first"])
+    print("  energy was still decreasing when killed: %d of %d" % (conv, len(run)))
+
+print("\n=== furthest into the optimization ===")
+hdr = "  %-9s %6s %6s %9s %12s %12s  %s"
+print(hdr % ("model", "MB", "iters", "#T", "first maxE", "last maxE", "phase"))
+for r in sorted(rows, key=lambda r: -r["its"])[:12]:
+    print(hdr % (r["m"], "%.0f" % (r["size"] / 1e6), r["its"],
+                 r["nt"] if r["nt"] else "-",
+                 "%.4g" % r["first"] if r["first"] else "-",
+                 "%.4g" % r["last"] if r["last"] else "-", r["phase"]))
+
+print("\n=== smallest inputs that still timed out ===")
+hdr2 = "  %-9s %6s %6s %10s %10s %9s  %s"
+print(hdr2 % ("model", "MB", "iters", "input #E", "simp #E", "arr #F", "phase"))
+for r in sorted(rows, key=lambda r: r["size"])[:10]:
+    print(hdr2 % (r["m"], "%.1f" % (r["size"] / 1e6), r["its"],
+                  r["in_e"] if r["in_e"] else "-",
+                  r["simp_e"] if r["simp_e"] else "-",
+                  r["arr_f"] if r["arr_f"] else "-", r["phase"]))

--- a/components/triwild/wmtk/components/triwild/scripts/run_triwild_sweep.py
+++ b/components/triwild/wmtk/components/triwild/scripts/run_triwild_sweep.py
@@ -1,0 +1,1157 @@
+#!/usr/bin/env python3
+"""
+Batch-run triwild over a large 2D curve dataset. See README.md.
+
+Written for the 20k 2D dataset on kirby.cs.nyu.edu, whose layout is the default for
+TRIWILD_ROOT; set that variable to run it anywhere. The 2D counterpart of the
+Thingi10K tetwild runner, and deliberately the same contract: run it with no
+arguments to start (or resume) the sweep; it skips every model already in success/
+or failure/. Stop it cleanly with:
+
+    run_triwild_sweep.py stop
+
+which signals the running sweep to abandon whatever is in flight (those models are
+left unpublished, so a later resume reprocesses them -- no spurious failures), drain,
+write the report, and exit.
+
+What differs from the 3D runner:
+  * paths hang off TRIWILD_ROOT;
+  * the dataset is .obj only -- triwild reads segment networks ("v" + "l" lines), not
+    triangle soups, so the other extensions are not applicable;
+  * write_vtu is forced OFF. It defaults to true now (parity with tetwild), but the
+    sweep prunes .vtu anyway, and 20k of them would be written only to be deleted.
+    The .msh is the actual output;
+  * skip_winding_number is forced ON. With filter="none" the winding number only feeds
+    the MSH group tags, which this sweep does not read, and it is brute-force O(#queries
+    x #segments) in 2D -- it accounted for 95% of the timeouts in the previous run;
+  * DEBUG_hausdorff is forced ON, and the report separates its two directions:
+    CONTAINMENT d(output->input), the envelope invariant, which is the only one bounded
+    by eps, and COVERAGE d(input->output), which nothing promises and which is reported
+    without a threshold. Runs made before that direction was corrected stored coverage
+    under the name "hausdorff" and carry no "coverage" key; the report detects them by
+    that absence, labels them metric=legacy-coverage, and keeps them out of the
+    containment statistics rather than pooling two different quantities;
+  * the report buckets the two triwild-specific failures -- the arrangement orientation
+    error and the envelope sanity-check error -- instead of lumping them into
+    "nonzero exit";
+  * env vars are TRIWILD_*, not TETWILD_*, so a 2D and a 3D sweep can run side by side
+    on the same machine without one's settings leaking into the other.
+
+Per model:
+  * write a triwild JSON (defaults from whatever branch build/ was built from);
+  * run wmtk_app in a scratch dir under the output volume, capped in time and memory;
+  * exit 0                    -> move the run into  <OUT>/success/<id>/
+    nonzero / timeout / OOM   -> move the run into  <OUT>/failure/<id>/  (with a reason)
+
+Configuration -- environment variables:
+    TRIWILD_ROOT          sweep root: build/, data/, runs/  (default the kirby path)
+    TRIWILD_OUT           output directory            (default <root>/runs/full)
+    TRIWILD_PARALLEL      models to run concurrently  (default 16)
+    TRIWILD_THREADS       threads per model           (default 8)
+    TRIWILD_JOB_TIMEOUT   per-model seconds           (default 3600 = 1h)
+    TRIWILD_MEM_GB        per-model memory cap, GB    (default 128, 0 disables)
+    TRIWILD_LIMIT         process at most N new models (default 0 = all)
+    TRIWILD_SAMPLE        name | smallest | spread | random  (default name)
+    TRIWILD_SEED          seed for TRIWILD_SAMPLE=random  (default 0)
+    TRIWILD_REPORT_ONLY   if set, only regenerate the report and exit
+
+Memory note: the cap is PER MODEL, not a budget for the sweep. 16 x 128G is far more
+than kirby has, so the cap is a runaway-killer, not admission control -- it stops one
+pathological input from swapping the box, and does nothing in the normal case. It
+matters more here than in 3D: the dataset's file sizes span 2.7 KB to 1.6 GB, and the
+largest inputs are read whole before anything else happens.
+"""
+
+import csv
+import datetime
+import json
+import os
+import random
+import re
+import shutil
+import signal
+import subprocess
+import sys
+import threading
+import time
+from concurrent.futures import FIRST_COMPLETED, ThreadPoolExecutor
+from concurrent.futures import wait as futures_wait
+from pathlib import Path
+
+# --------------------------------------------------------------------------- #
+# Hardcoded configuration
+# --------------------------------------------------------------------------- #
+# Everything hangs off one root: build/ (the wmtk_app to test), data/ (the .obj
+# dataset) and runs/ (the outputs). Override with TRIWILD_ROOT to run this anywhere;
+# the default is the kirby layout it was written for.
+SWEEP_ROOT = Path(os.environ.get("TRIWILD_ROOT", "/u/3/daniele/triwild-sweep"))
+WMTK_APP = SWEEP_ROOT / "build/app/wmtk_app"
+DATASET_DIR = SWEEP_ROOT / "data"
+OUT_DIR = Path(os.environ.get("TRIWILD_OUT", str(SWEEP_ROOT / "runs/full")))
+
+# triwild input is a 2D segment network: an .obj carrying "v" and "l" lines. The
+# dataset is uniformly .obj, and every filename stem is unique, so the stem is a safe
+# per-model id.
+MESH_EXTENSIONS = ("*.obj",)
+
+PARALLEL = max(1, int(os.environ.get("TRIWILD_PARALLEL", "16")))
+THREADS = max(1, int(os.environ.get("TRIWILD_THREADS", "8")))
+JOB_TIMEOUT = int(os.environ.get("TRIWILD_JOB_TIMEOUT", "3600"))  # seconds, 1h
+MEM_GB = int(os.environ.get("TRIWILD_MEM_GB", "128"))  # 0 = no cap
+LIMIT = int(os.environ.get("TRIWILD_LIMIT", "0"))  # 0 = no limit
+SAMPLE = os.environ.get("TRIWILD_SAMPLE", "name")
+SEED = int(os.environ.get("TRIWILD_SEED", "0"))
+REPORT_ONLY = bool(os.environ.get("TRIWILD_REPORT_ONLY"))
+
+# Only the knobs the SWEEP needs, not the ones under test. Everything else comes from
+# the spec defaults of whatever branch build/ was built from -- which is the point of
+# running this on triwild-sweep, so do not pin eps_rel, stop_energy or the simplify_*
+# parameters here.
+PARAMS = {
+    "application": "triwild",
+    "filter": "none",
+    "num_threads": THREADS,
+    # Raised from the spec default of 20. Note this changes what "converged" MEANS, not just
+    # how long it takes: models processed before this point were held to 20 and later ones to
+    # 100, so max_energy is not comparable across the two halves of the run.
+    "stop_energy": 100,
+    "write_vtu": False,  # pruned anyway; do not spend the disk and the time
+    "DEBUG_hausdorff": True,  # the open 2D question -- collect it for every model
+    # The finalize-phase winding number, which with filter="none" only feeds the MSH group
+    # tags. It is not skipped automatically -- filter="none" is necessary but not sufficient,
+    # in 2D and 3D alike -- and it dominates the run on big inputs: libigl has a hierarchical
+    # accelerator for 3D triangles but none in 2D, so winding_number_2d is a brute-force
+    # O(#queries x #segments) sweep, ~2M faces x ~400k segments on the models that suffer.
+    #
+    # It was 95% of this sweep's failures: 232 of 245 timeouts died in that phase with the
+    # mesh ALREADY converged (median last max energy 19.99 against a target of 20, and 243 of
+    # 245 still improving when killed). Model 177011 finishes in 567s with this on and times
+    # out at 1800s without it.
+    #
+    # The cost is the group tags: every face lands in the untagged group. This sweep does not
+    # read them.
+    "skip_winding_number": True,
+    # Deliberately NOT enabled. It is a diagnostic on a property the pipeline does not
+    # guarantee, and the sweep is for throughput. Consequence: models processed before this
+    # was turned off carry features_retained / features_total / features_worst_ratio and
+    # later ones do not, so the report treats those columns as optional.
+}
+
+# Which of a run's output files to keep. The .msh is the actual mesh. Keep it, the
+# text (logs / report / config), and any .obj the run writes.
+KEEP_GLOBS = ["*.msh", "*.obj", "*.log", "*.json", "status.txt"]
+
+SUCCESS_DIR = OUT_DIR / "success"
+FAILURE_DIR = OUT_DIR / "failure"
+WORK_DIR = OUT_DIR / ".work"  # scratch, same filesystem as OUT so publish is atomic
+REPORT_DIR = OUT_DIR / "report"
+PIDFILE = OUT_DIR / "sweep.pid"
+
+# --------------------------------------------------------------------------- #
+# Stop handling.
+#
+# A stop must be clean under parallelism: kill every in-flight wmtk_app, and have
+# each worker ABANDON its model -- leave it unpublished so a resume reprocesses it --
+# rather than record the kill as a failure. _STOP is the flag; _children tracks the
+# live subprocesses so the signal handler can kill them all.
+# --------------------------------------------------------------------------- #
+_STOP = threading.Event()
+_children = {}  # model_id -> subprocess.Popen
+_children_lock = threading.Lock()
+
+
+def _kill(popen):
+    if popen and popen.poll() is None:
+        try:
+            os.killpg(os.getpgid(popen.pid), signal.SIGKILL)  # whole thread group
+        except (ProcessLookupError, PermissionError):
+            pass
+
+
+def _handle_signal(signum, _frame):
+    if not _STOP.is_set():
+        _STOP.set()
+        print(f"\n[signal] {signal.Signals(signum).name} received; abandoning in-flight "
+              f"models (they resume later), draining, and writing the report.", flush=True)
+    with _children_lock:
+        for popen in _children.values():
+            _kill(popen)
+
+
+signal.signal(signal.SIGINT, _handle_signal)
+signal.signal(signal.SIGTERM, _handle_signal)
+
+
+# --------------------------------------------------------------------------- #
+# Memory cap.
+#
+# cgroup v2 via a systemd transient scope, rather than RLIMIT_AS: the toolkit's
+# dependencies reserve large virtual ranges they never fault in, so an address-space
+# limit fires on models that are nowhere near the memory it is meant to bound.
+# MemoryMax is real usage. MemorySwapMax=0 keeps a bloated model from dragging the
+# whole machine into swap instead of dying.
+#
+# The scope is a child in our own process group, so the existing killpg path still
+# terminates it; the cap only changes how the kernel treats its memory.
+# --------------------------------------------------------------------------- #
+def _mem_wrapper(model_id):
+    if MEM_GB <= 0:
+        return []
+    return [
+        "systemd-run", "--user", "--scope", "--quiet",
+        f"--unit=trw-{model_id}-{os.getpid()}",
+        "-p", f"MemoryMax={MEM_GB}G",
+        "-p", "MemorySwapMax=0",
+        "--",
+    ]
+
+
+def _memory_capped_available():
+    """Probe once, so a broken systemd user manager fails loudly at startup."""
+    if MEM_GB <= 0:
+        return True
+    try:
+        r = subprocess.run(
+            ["systemd-run", "--user", "--scope", "--quiet",
+             "-p", f"MemoryMax={MEM_GB}G", "--", "/bin/true"],
+            capture_output=True, timeout=30)
+        return r.returncode == 0
+    except (OSError, subprocess.TimeoutExpired):
+        return False
+
+
+# --------------------------------------------------------------------------- #
+# Running one model
+# --------------------------------------------------------------------------- #
+def already_done(model_id):
+    return (SUCCESS_DIR / model_id).exists() or (FAILURE_DIR / model_id).exists()
+
+
+def run_one(mesh_path):
+    """Run triwild on one mesh. Returns 'success' / 'failure' / 'stopped'."""
+    model_id = mesh_path.stem
+    if _STOP.is_set():
+        return "stopped"  # never started
+
+    work = WORK_DIR / model_id
+    if work.exists():
+        shutil.rmtree(work, ignore_errors=True)
+    work.mkdir(parents=True)
+
+    cfg = dict(PARAMS)
+    cfg["input"] = [str(mesh_path)]
+    cfg["output"] = "out"
+    cfg["log_file"] = "out.log"
+    cfg["report"] = "report.json"
+    config_path = (work / "config.json").resolve()
+    config_path.write_text(json.dumps(cfg, indent=2))
+
+    print(f"  .. start {model_id} ({mesh_path.stat().st_size // 1024} KB)", flush=True)
+    reason = ""
+    started = time.time()
+    with open(work / "console.log", "wb") as console:
+        # start_new_session so the whole thread group can be killed as a unit.
+        popen = subprocess.Popen(
+            # Absolute config path, not "config.json": app/main.cpp sets input_dir to
+            # the config's parent_path(), and older builds threw on the empty path.
+            _mem_wrapper(model_id) + [str(WMTK_APP), "-j", str(config_path)],
+            cwd=str(work),
+            stdout=console,
+            stderr=subprocess.STDOUT,
+            start_new_session=True,
+        )
+        with _children_lock:
+            _children[model_id] = popen
+        try:
+            if _STOP.is_set():  # stop raced in just after Popen; kill immediately
+                _kill(popen)
+            code = popen.wait(timeout=JOB_TIMEOUT)
+        except subprocess.TimeoutExpired:
+            _kill(popen)
+            popen.wait()
+            code = None
+            reason = f"timeout (> {JOB_TIMEOUT}s)"
+        finally:
+            with _children_lock:
+                _children.pop(model_id, None)
+    elapsed = time.time() - started
+
+    # A stop in progress abandons whatever is in flight: drop the scratch, publish
+    # nothing, let the resume reprocess it. (A model genuinely crashing at stop time
+    # simply re-runs and is recorded on resume -- no harm.)
+    if _STOP.is_set():
+        shutil.rmtree(work, ignore_errors=True)
+        print(f"  .. abandoned (stop): {model_id}", flush=True)
+        return "stopped"
+
+    if code == 0:
+        status = "success"
+    else:
+        status = "failure"
+        if not reason:
+            reason = _describe_exit(code, work)
+
+    # status.txt: machine-parseable, one 'key: value' per line.
+    (work / "status.txt").write_text(
+        f"model: {model_id}\n"
+        f"input: {mesh_path}\n"
+        f"status: {status}\n"
+        f"reason: {reason}\n"
+        f"exit_code: {code}\n"
+        f"wall_seconds: {elapsed:.3f}\n"
+    )
+
+    _prune(work)
+    dest = (SUCCESS_DIR if status == "success" else FAILURE_DIR) / model_id
+    if dest.exists():
+        shutil.rmtree(dest, ignore_errors=True)
+    os.replace(work, dest)  # atomic rename within the same filesystem
+
+    print(f"  -> {status}: {model_id}  ({elapsed:.1f}s"
+          + (f", {reason}" if reason else "") + ")", flush=True)
+    return status
+
+
+# The toolkit reports a fatal condition by throwing std::runtime_error out of main, so
+# the useful part of a failure is that message, not the exit code (which is just
+# SIGABRT for every one of them). Pull it out of the console so the report can group by
+# cause. Three patterns, because the two standard libraries print differently:
+#
+#   libstdc++ (kirby):  terminate called after throwing an instance of 'std::runtime_error'
+#                         what():  Tets with different orientations in the input!
+#   libc++ (macOS):     libc++abi: terminating due to uncaught exception of type
+#                       std::runtime_error: Tets with different orientations in the input!
+#
+# and the wmtk logger's own [error] line, which precedes both and survives when the
+# abort message does not (a hard signal, a truncated console).
+_THROW_RES = [
+    re.compile(r"what\(\):\s*(.+)"),
+    re.compile(r"(?:runtime_error|logic_error|bad_alloc)\s*:\s*(.+)"),
+    re.compile(r"\[wmtk\]\s*\[error\]\s*(.+)"),
+]
+
+
+def _describe_exit(code, work):
+    """Human-readable reason for a nonzero exit, distinguishing the OOM kill."""
+    console = work / "console.log"
+    if console.exists():
+        text = console.read_text(errors="ignore")
+        tail = text[-8000:]
+        low = tail.lower()
+        if "oom" in low or "out of memory" in low:
+            return f"OOM (MemoryMax={MEM_GB}G)"
+        for rx in _THROW_RES:
+            hits = rx.findall(tail)
+            if hits:
+                # the last one is the message that actually terminated the run
+                return hits[-1].strip()
+    if code is not None and code < 0:
+        signame = signal.Signals(-code).name
+        if -code == signal.SIGKILL and MEM_GB > 0:
+            return f"killed by SIGKILL, no timeout -- OOM (MemoryMax={MEM_GB}G)"
+        return f"killed by signal {-code} ({signame})"
+    if code == 137 and MEM_GB > 0:
+        return f"exit 137 (SIGKILL) -- OOM (MemoryMax={MEM_GB}G)"
+    return f"nonzero exit ({code})"
+
+
+def _prune(work):
+    keep = set()
+    for pat in KEEP_GLOBS:
+        keep.update(work.glob(pat))
+    for f in work.iterdir():
+        if f.is_file() and f not in keep:
+            f.unlink()
+
+
+# --------------------------------------------------------------------------- #
+# Report generation
+# --------------------------------------------------------------------------- #
+IT_RE = re.compile(r"========it (\d+)========")
+SIMP_RE = re.compile(r"input simplification: #V (\d+) -> (\d+), #E (\d+) -> (\d+)")
+
+
+def _read_status(d):
+    info = {}
+    st = d / "status.txt"
+    if st.exists():
+        for line in st.read_text().splitlines():
+            if ":" in line:
+                k, _, v = line.partition(":")
+                info[k.strip()] = v.strip()
+    return info
+
+
+def _parse_success(d):
+    """time, iterations, energies, hausdorff for one successful model."""
+    row = {"id": d.name, "status": "success"}
+    rep = d / "report.json"
+    if rep.exists():
+        try:
+            j = json.loads(rep.read_text())
+            row["max_energy"] = j.get("max_energy")
+            row["avg_energy"] = j.get("avg_energy")
+            row["verts"] = j.get("#v")
+            row["tris"] = j.get("#t")
+            row["all_rounded"] = j.get("all_rounded")
+            # "hausdorff" is CONTAINMENT, d(output -> input): the envelope invariant, and
+            # the only direction bounded by eps. "coverage" is d(input -> output), which
+            # nothing promises -- simplification may remove detail and the arrangement may
+            # drop segments. Reporting coverage against eps is what made ~60% of models
+            # look like violations; see PR #982 and tetwild #967 for the same mistake in 3D.
+            h, cov, eps = j.get("hausdorff"), j.get("coverage"), j.get("eps")
+            # Legacy detection. Before the direction was corrected, "hausdorff" held
+            # COVERAGE and there was no "coverage" key. Those runs' meshes are unaffected
+            # (the change is diagnostic-only), but their number means something different,
+            # so it must not be pooled with the new one -- averaging the two would show
+            # phantom containment violations. Absence of "coverage" is the marker.
+            if cov is None:
+                row["metric"] = "legacy-coverage"
+                row["coverage"] = h
+                if isinstance(eps, (int, float)) and eps > 0 and isinstance(h, (int, float)) \
+                        and h >= 0:
+                    row["coverage_over_eps"] = h / eps
+                h = None  # no containment figure exists for this run
+            else:
+                row["metric"] = "both"
+                row["containment"] = h
+                row["coverage"] = cov
+            # Only the ratios are comparable across the dataset: the distances are in model
+            # units and eps scales with the bounding box. A negative value is the "output has
+            # no tracked edges" sentinel, not a distance.
+            if isinstance(eps, (int, float)) and eps > 0:
+                if isinstance(h, (int, float)) and h >= 0:
+                    row["containment_over_eps"] = h / eps
+                if isinstance(cov, (int, float)) and cov >= 0:
+                    row["coverage_over_eps"] = cov / eps
+        except json.JSONDecodeError:
+            pass
+    log = d / "out.log"
+    if log.exists():
+        text = log.read_text(errors="ignore")
+        row["iterations"] = len(IT_RE.findall(text))
+        m = SIMP_RE.search(text)
+        if m:
+            v0, v1 = int(m.group(1)), int(m.group(2))
+            row["input_verts"] = v0
+            row["simplify_ratio"] = (v1 / v0) if v0 else None
+    st = _read_status(d)
+    # triwild's report.json does not carry a runtime (tetwild's does), so the wall
+    # clock recorded here is the only timing available. It includes process startup
+    # and the read of what can be a 1.6 GB .obj, which is the honest number anyway.
+    if st.get("wall_seconds"):
+        row["time"] = float(st["wall_seconds"])
+    return row
+
+
+def _histogram(title, values, edges, fmt="{:g}"):
+    """ASCII histogram. edges is a list of bucket boundaries; last bucket is open."""
+    if not values:
+        return f"{title}: (no data)\n"
+    counts = [0] * (len(edges) + 1)
+    for v in values:
+        placed = False
+        for i, e in enumerate(edges):
+            if v < e:
+                counts[i] += 1
+                placed = True
+                break
+        if not placed:
+            counts[-1] += 1
+    labels = []
+    for i in range(len(edges) + 1):
+        if i == 0:
+            labels.append(f"< {fmt.format(edges[0])}")
+        elif i == len(edges):
+            labels.append(f">= {fmt.format(edges[-1])}")
+        else:
+            labels.append(f"{fmt.format(edges[i-1])} - {fmt.format(edges[i])}")
+    width = max(len(x) for x in labels)
+    peak = max(counts) or 1
+    lines = [title]
+    for lab, c in zip(labels, counts):
+        bar = "#" * int(round(50 * c / peak))
+        lines.append(f"  {lab:>{width}} | {bar} {c}")
+    return "\n".join(lines) + "\n"
+
+
+# --------------------------------------------------------------------------- #
+# HTML report
+# --------------------------------------------------------------------------- #
+
+# Slots 1-3 of the validated categorical palette, plus the status colors. Only three
+# categorical slots are used, which is the all-pairs-safe prefix; every chart here is
+# single-series anyway, so hue never carries meaning on its own.
+_CSS = """
+:root {
+  color-scheme: light;
+  --surface-1: #fcfcfb; --plane: #f9f9f7;
+  --ink-1: #0b0b0b; --ink-2: #52514e; --ink-muted: #898781;
+  --grid: #e1e0d9; --axis: #c3c2b7;
+  --series-1: #2a78d6; --series-2: #eb6834; --series-3: #1baf7a;
+  --good: #0ca30c; --critical: #d03b3b;
+  --ramp-100: #cde2fb; --ramp-450: #2a78d6; --ramp-600: #184f95;
+}
+@media (prefers-color-scheme: dark) {
+  :root:where(:not([data-theme="light"])) {
+    color-scheme: dark;
+    --surface-1: #1a1a19; --plane: #0d0d0d;
+    --ink-1: #ffffff; --ink-2: #c3c2b7; --ink-muted: #898781;
+    --grid: #2c2c2a; --axis: #383835;
+    --series-1: #3987e5; --series-2: #d95926; --series-3: #199e70;
+    --ramp-100: #184f95; --ramp-450: #3987e5; --ramp-600: #86b6ef;
+  }
+}
+:root[data-theme="dark"] {
+  color-scheme: dark;
+  --surface-1: #1a1a19; --plane: #0d0d0d;
+  --ink-1: #ffffff; --ink-2: #c3c2b7; --ink-muted: #898781;
+  --grid: #2c2c2a; --axis: #383835;
+  --series-1: #3987e5; --series-2: #d95926; --series-3: #199e70;
+  --ramp-100: #184f95; --ramp-450: #3987e5; --ramp-600: #86b6ef;
+}
+
+* { box-sizing: border-box; }
+body {
+  margin: 0; padding: 2rem 1.25rem 4rem;
+  background: var(--plane); color: var(--ink-1);
+  font: 15px/1.55 ui-sans-serif, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  -webkit-font-smoothing: antialiased;
+}
+.wrap { max-width: 1080px; margin: 0 auto; }
+h1 { font-size: 1.65rem; letter-spacing: -0.02em; margin: 0 0 0.2rem; }
+h2 {
+  font-size: 1.02rem; letter-spacing: -0.01em; margin: 2.4rem 0 0.85rem;
+  padding-bottom: 0.45rem; border-bottom: 1px solid var(--grid);
+}
+.sub { color: var(--ink-2); font-size: 0.9rem; margin: 0 0 1.6rem; }
+.sub code { font-size: 0.85em; color: var(--ink-muted); }
+.note {
+  color: var(--ink-2); font-size: 0.87rem; margin: 0.55rem 0 0;
+  max-width: 74ch;
+}
+
+/* hero stats */
+.stats { display: flex; flex-wrap: wrap; gap: 0.6rem; margin: 0 0 0.5rem; }
+.stat {
+  flex: 1 1 150px; background: var(--surface-1);
+  border: 1px solid var(--grid); border-radius: 10px; padding: 0.85rem 0.95rem;
+}
+.stat .k {
+  font-size: 0.72rem; text-transform: uppercase; letter-spacing: 0.055em;
+  color: var(--ink-muted); margin-bottom: 0.3rem;
+}
+.stat .v { font-size: 1.5rem; font-weight: 620; letter-spacing: -0.02em;
+           font-variant-numeric: tabular-nums; }
+.stat .u { font-size: 0.79rem; color: var(--ink-2); margin-top: 0.15rem; }
+.stat.ok .v { color: var(--good); }
+.stat.bad .v { color: var(--critical); }
+
+/* charts */
+.card {
+  background: var(--surface-1); border: 1px solid var(--grid);
+  border-radius: 10px; padding: 1.05rem 1.15rem 1.15rem;
+}
+.chart { display: grid; grid-template-columns: max-content 1fr; gap: 2px 0.7rem; }
+.chart .lab {
+  font-size: 0.79rem; color: var(--ink-2); text-align: right;
+  font-variant-numeric: tabular-nums; align-self: center; white-space: nowrap;
+}
+.track {
+  position: relative; height: 21px; display: flex; align-items: center;
+  border-left: 1px solid var(--axis);
+}
+.bar {
+  height: 15px; border-radius: 0 4px 4px 0; background: var(--series-1);
+  min-width: 2px; transition: filter .12s;
+}
+.track:hover .bar { filter: brightness(1.12); }
+.bar.zero { background: none; border: 1px dashed var(--axis); height: 13px; min-width: 12px; }
+.bar.warnzone { background: var(--critical); }
+.cnt {
+  font-size: 0.76rem; color: var(--ink-2); margin-left: 0.45rem;
+  font-variant-numeric: tabular-nums; white-space: nowrap;
+}
+.grid2 { display: grid; grid-template-columns: repeat(auto-fit, minmax(430px, 1fr)); gap: 0.9rem; }
+
+/* table */
+.tblwrap { overflow-x: auto; background: var(--surface-1);
+           border: 1px solid var(--grid); border-radius: 10px; }
+table { border-collapse: collapse; width: 100%; font-size: 0.86rem; }
+th, td { padding: 0.42rem 0.75rem; text-align: right; white-space: nowrap; }
+th {
+  font-size: 0.71rem; text-transform: uppercase; letter-spacing: 0.05em;
+  color: var(--ink-muted); font-weight: 600; border-bottom: 1px solid var(--grid);
+  position: sticky; top: 0; background: var(--surface-1);
+}
+td { border-bottom: 1px solid var(--grid); font-variant-numeric: tabular-nums; }
+tr:last-child td { border-bottom: none; }
+th:first-child, td:first-child { text-align: left; }
+details { margin-top: 0.7rem; }
+summary {
+  cursor: pointer; color: var(--ink-2); font-size: 0.85rem;
+  padding: 0.3rem 0; user-select: none;
+}
+summary:hover { color: var(--ink-1); }
+
+/* tooltip */
+#tip {
+  position: fixed; pointer-events: none; opacity: 0; transition: opacity .1s;
+  background: var(--ink-1); color: var(--surface-1);
+  padding: 0.35rem 0.55rem; border-radius: 6px; font-size: 0.78rem;
+  font-variant-numeric: tabular-nums; z-index: 50; max-width: 280px;
+}
+footer { color: var(--ink-muted); font-size: 0.8rem; margin-top: 2.5rem;
+         padding-top: 0.9rem; border-top: 1px solid var(--grid); }
+"""
+
+_JS = """
+(function () {
+  var tip = document.getElementById('tip');
+  document.querySelectorAll('[data-tip]').forEach(function (el) {
+    el.addEventListener('mousemove', function (e) {
+      tip.textContent = el.getAttribute('data-tip');
+      tip.style.opacity = '1';
+      var x = e.clientX + 14, y = e.clientY + 16;
+      var w = tip.offsetWidth, h = tip.offsetHeight;
+      if (x + w > window.innerWidth - 8) x = e.clientX - w - 14;
+      if (y + h > window.innerHeight - 8) y = e.clientY - h - 16;
+      tip.style.left = x + 'px';
+      tip.style.top = y + 'px';
+    });
+    el.addEventListener('mouseleave', function () { tip.style.opacity = '0'; });
+  });
+})();
+"""
+
+
+def _esc(s):
+    return (str(s).replace("&", "&amp;").replace("<", "&lt;")
+            .replace(">", "&gt;").replace('"', "&quot;"))
+
+
+def _fmt(v, nd=2):
+    if v is None:
+        return "-"
+    if isinstance(v, float):
+        if v != v:  # NaN
+            return "-"
+        if v >= 1e5 or (v and abs(v) < 1e-3):
+            return "{:.3g}".format(v)
+        return "{:.{}f}".format(v, nd)
+    return str(v)
+
+
+def _bucket(values, edges):
+    """Counts per bucket, plus the label for each. Last bucket is open-ended."""
+    counts = [0] * (len(edges) + 1)
+    for v in values:
+        for i, e in enumerate(edges):
+            if v < e:
+                counts[i] += 1
+                break
+        else:
+            counts[-1] += 1
+    labels = []
+    for i in range(len(edges) + 1):
+        if i == 0:
+            labels.append("< {:g}".format(edges[0]))
+        elif i == len(edges):
+            labels.append(">= {:g}".format(edges[-1]))
+        else:
+            labels.append("{:g} - {:g}".format(edges[i - 1], edges[i]))
+    return labels, counts
+
+
+def _html_hist(values, edges, unit, danger_from=None):
+    """Horizontal bar chart. danger_from marks buckets at/above that edge index red."""
+    if not values:
+        return '<p class="note">(no data)</p>'
+    labels, counts = _bucket(values, edges)
+    peak = max(counts) or 1
+    total = sum(counts) or 1
+    out = ['<div class="chart">']
+    for i, (lab, c) in enumerate(zip(labels, counts)):
+        pct = 100.0 * c / total
+        cls = "bar"
+        if c == 0:
+            cls += " zero"
+        elif danger_from is not None and i >= danger_from:
+            cls += " warnzone"
+        w = 100.0 * c / peak
+        tip = "{} {}: {} models ({:.1f}%)".format(lab, unit, c, pct)
+        out.append('<div class="lab">{}</div>'.format(_esc(lab)))
+        out.append(
+            '<div class="track" data-tip="{}">'
+            '<div class="{}" style="width:{:.2f}%"></div>'
+            '<span class="cnt">{}</span></div>'.format(
+                _esc(tip), cls, max(w, 0.0) if c else 0.0, "{:,}".format(c)))
+    out.append("</div>")
+    return "".join(out)
+
+
+def _stat(k, v, u="", cls=""):
+    return ('<div class="stat {}"><div class="k">{}</div><div class="v">{}</div>'
+            '<div class="u">{}</div></div>').format(cls, _esc(k), _esc(v), _esc(u))
+
+
+def _table(headers, rows, empty="(none)"):
+    if not rows:
+        return '<p class="note">{}</p>'.format(_esc(empty))
+    h = "".join("<th>{}</th>".format(_esc(x)) for x in headers)
+    body = []
+    for r in rows:
+        body.append("<tr>" + "".join("<td>{}</td>".format(_esc(c)) for c in r) + "</tr>")
+    return ('<div class="tblwrap"><table><thead><tr>{}</tr></thead>'
+            "<tbody>{}</tbody></table></div>").format(h, "".join(body))
+
+
+def generate_html_report(rows, stats, report_dir, out_dir):
+    """Write report/index.html. `rows` are the same dicts the CSV is built from."""
+    ok = [r for r in rows if r.get("status") == "success"]
+    bad = [r for r in rows if r.get("status") != "success"]
+    total = len(rows)
+
+    def col(key, src=None):
+        return [r[key] for r in (src if src is not None else ok)
+                if isinstance(r.get(key), (int, float))]
+
+    times, iters = col("time"), col("iterations")
+    contr, covr = col("containment_over_eps"), col("coverage_over_eps")
+    energies = col("max_energy")
+    unrounded = sum(1 for r in ok if r.get("all_rounded") is False)
+
+    def med(xs):
+        return sorted(xs)[len(xs) // 2] if xs else None
+
+    rate = (100.0 * len(ok) / total) if total else 0.0
+    over1 = sum(1 for v in contr if v > 1.0)
+
+    h = []
+    h.append("<!doctype html><html lang='en'><head><meta charset='utf-8'>")
+    h.append("<meta name='viewport' content='width=device-width,initial-scale=1'>")
+    h.append("<title>triwild 2D sweep report</title>")
+    h.append("<style>{}</style></head><body><div id='tip'></div><div class='wrap'>".format(_CSS))
+
+    h.append("<h1>triwild &mdash; 20k 2D curve sweep</h1>")
+    h.append("<p class='sub'>{} models &middot; <code>{}</code> &middot; generated {}</p>".format(
+        "{:,}".format(total), _esc(out_dir), _esc(stats.get("generated", ""))))
+
+    # ---- headline ----
+    h.append("<div class='stats'>")
+    h.append(_stat("Processed", "{:,}".format(total)))
+    h.append(_stat("Success rate", "{:.2f}%".format(rate),
+                   "{:,} succeeded".format(len(ok)), "ok" if not bad else ""))
+    h.append(_stat("Failures", "{:,}".format(len(bad)),
+                   "of {:,}".format(total), "bad" if bad else "ok"))
+    h.append(_stat("Un-rounded output", "{:,}".format(unrounded),
+                   "of {:,} successes".format(len(ok)), "ok" if not unrounded else "bad"))
+    h.append("</div><div class='stats'>")
+    h.append(_stat("Median run time", _fmt(med(times), 1), "seconds"))
+    h.append(_stat("Max run time", _fmt(max(times), 0) if times else "-", "seconds"))
+    h.append(_stat("Median iterations", _fmt(med(iters), 0), "per model"))
+    h.append(_stat("Max containment", _fmt(max(contr), 3) if contr else "-",
+                   "× eps — invariant is 1.0", "ok" if not over1 else "bad"))
+    h.append("</div>")
+
+    # ---- envelope invariant ----
+    h.append("<h2>Envelope containment &mdash; the invariant</h2>")
+    h.append("<div class='card'>")
+    h.append(_html_hist(contr, [0.1, 0.25, 0.5, 0.75, 1.0, 2.0], "× eps", danger_from=4))
+    h.append("</div>")
+    h.append("<p class='note'><strong>d(output &rarr; input) / eps.</strong> This is the one "
+             "quantity the pipeline actually promises: every point of the output lies within "
+             "eps of the input. Anything at or above 1.0 (shown red) is a real violation. "
+             "Measured: median {}, max {}, over 1.0: <strong>{} of {:,}</strong>.</p>".format(
+                 _fmt(med(contr), 3), _fmt(max(contr), 4) if contr else "-",
+                 over1, len(contr)))
+
+    # ---- distributions ----
+    h.append("<h2>Distributions</h2><div class='grid2'>")
+    h.append("<div class='card'><h3 style='margin:0 0 .7rem;font-size:.9rem;'>"
+             "Run time (seconds)</h3>{}</div>".format(
+                 _html_hist(times, [1, 2, 5, 10, 30, 60, 120, 300, 600, 1800, 3600], "s")))
+    h.append("<div class='card'><h3 style='margin:0 0 .7rem;font-size:.9rem;'>"
+             "Iterations</h3>{}</div>".format(
+                 _html_hist(iters, [1, 2, 3, 5, 8, 12, 20, 40, 80], "iterations")))
+    h.append("<div class='card'><h3 style='margin:0 0 .7rem;font-size:.9rem;'>"
+             "Final max energy <span style='color:var(--ink-muted);font-weight:400'>"
+             "(AMIPS2D floor is 2)</span></h3>{}</div>".format(
+                 _html_hist(energies, [5, 10, 20, 21, 50, 100, 101], "energy")))
+    h.append("<div class='card'><h3 style='margin:0 0 .7rem;font-size:.9rem;'>"
+             "Coverage d(input &rarr; output) / eps "
+             "<span style='color:var(--ink-muted);font-weight:400'>(diagnostic)</span>"
+             "</h3>{}</div>".format(
+                 _html_hist(covr, [0.5, 1, 2, 5, 10, 50, 100], "× eps")))
+    h.append("</div>")
+    h.append("<p class='note'>Coverage is <em>not</em> bounded by anything and a large value "
+             "is not a violation: the simplification is allowed to remove detail and the "
+             "arrangement may drop segments, so a high number means the output no longer "
+             "covers part of the input. Median {}, max {}. Use <code>DEBUG_euler</code> to see "
+             "which curves were lost.</p>".format(
+                 _fmt(med(covr), 3), _fmt(max(covr), 4) if covr else "-"))
+
+    # ---- scaling ----
+    sized = [r for r in ok if isinstance(r.get("input_verts"), (int, float))
+             and isinstance(r.get("time"), (int, float)) and r["input_verts"] > 0]
+    if sized:
+        h.append("<h2>Run time vs input size</h2>")
+        edges = [1e3, 1e4, 1e5, 3e5, 1e6, 3e6]
+        buckets = [[] for _ in range(len(edges) + 1)]
+        for r in sized:
+            for i, e in enumerate(edges):
+                if r["input_verts"] < e:
+                    buckets[i].append(r)
+                    break
+            else:
+                buckets[-1].append(r)
+        labels, _ = _bucket([r["input_verts"] for r in sized], edges)
+        trows = []
+        for lab, b in zip(labels, buckets):
+            if not b:
+                continue
+            ts = sorted(r["time"] for r in b)
+            p95 = ts[min(len(ts) - 1, int(0.95 * len(ts)))]
+            its = [r["iterations"] for r in b if isinstance(r.get("iterations"), int)]
+            trows.append([lab, "{:,}".format(len(b)), _fmt(ts[len(ts) // 2], 1),
+                          _fmt(p95, 1), _fmt(max(ts), 1),
+                          _fmt(sum(its) / len(its), 1) if its else "-"])
+        h.append(_table(["input vertices", "models", "median s", "p95 s", "max s",
+                         "mean iters"], trows))
+        h.append("<p class='note'>Wall clock includes process startup and reading the "
+                 "<code>.obj</code>, which for the largest inputs is over a gigabyte, so "
+                 "the smallest bucket is dominated by fixed cost rather than by the mesh.</p>")
+
+    # ---- slowest ----
+    slow = sorted([r for r in ok if isinstance(r.get("time"), (int, float))],
+                  key=lambda r: -r["time"])[:25]
+    if slow:
+        h.append("<h2>Slowest models</h2>")
+        h.append(_table(
+            ["id", "time s", "iters", "max energy", "#V out", "#T out",
+             "input #V", "containment/eps"],
+            [[r["id"], _fmt(r.get("time"), 1), r.get("iterations", "-"),
+              _fmt(r.get("max_energy"), 3), "{:,}".format(r["verts"]) if r.get("verts") else "-",
+              "{:,}".format(r["tris"]) if r.get("tris") else "-",
+              "{:,}".format(int(r["input_verts"])) if r.get("input_verts") else "-",
+              _fmt(r.get("containment_over_eps"), 3)] for r in slow]))
+
+    # ---- failures ----
+    h.append("<h2>Failures</h2>")
+    if bad:
+        h.append(_table(["id", "reason", "wall s"],
+                        [[r["id"], r.get("reason") or "unknown", _fmt(r.get("time"), 1)]
+                         for r in sorted(bad, key=lambda r: str(r["id"]))]))
+    else:
+        h.append("<div class='stats'>{}</div>".format(
+            _stat("Failures", "0", "every model produced an output", "ok")))
+
+    h.append("<details><summary>Full per-model data</summary>"
+             "<p class='note'>{:,} rows in <code>{}</code> &mdash; one line per model with "
+             "time, iterations, energies, element counts and both Hausdorff directions."
+             "</p></details>".format(total, _esc(str(report_dir / "results.csv"))))
+
+    h.append("<footer>triwild 2D sweep &middot; {} &middot; "
+             "containment is the invariant; coverage is diagnostic."
+             "</footer>".format(_esc(stats.get("generated", ""))))
+    h.append("</div><script>{}</script></body></html>".format(_JS))
+
+    path = report_dir / "index.html"
+    path.write_text("".join(h))
+    return path
+
+
+def generate_report():
+    REPORT_DIR.mkdir(parents=True, exist_ok=True)
+    successes = sorted(d for d in SUCCESS_DIR.glob("*") if d.is_dir()) \
+        if SUCCESS_DIR.exists() else []
+    failures = sorted(d for d in FAILURE_DIR.glob("*") if d.is_dir()) \
+        if FAILURE_DIR.exists() else []
+
+    rows = []
+    times, iters, contr, covr, energies = [], [], [], [], []
+    n_unrounded = 0
+    for d in successes:
+        r = _parse_success(d)
+        rows.append(r)
+        if isinstance(r.get("time"), (int, float)):
+            times.append(r["time"])
+        if isinstance(r.get("iterations"), int):
+            iters.append(r["iterations"])
+        if isinstance(r.get("containment_over_eps"), (int, float)):
+            contr.append(r["containment_over_eps"])
+        if isinstance(r.get("coverage_over_eps"), (int, float)):
+            covr.append(r["coverage_over_eps"])
+        if isinstance(r.get("max_energy"), (int, float)):
+            energies.append(r["max_energy"])
+        if r.get("all_rounded") is False:
+            n_unrounded += 1
+
+    reason_counts = {}
+    for d in failures:
+        st = _read_status(d)
+        reason = st.get("reason") or "unknown"
+        # Retroactive repair: a run recorded before the libstdc++ abort format was
+        # handled says only "killed by signal 6 (SIGABRT)", which buckets everything
+        # fatal together. console.log is kept, so the real message is still there --
+        # re-derive rather than make the user re-run 20k models for a report bug.
+        if "signal" in reason.lower() and (d / "console.log").exists():
+            better = _describe_exit(None, d)
+            if better and "signal" not in better.lower():
+                reason = better
+        key = _reason_bucket(reason)
+        reason_counts[key] = reason_counts.get(key, 0) + 1
+        rows.append({"id": d.name, "status": "failure", "reason": reason,
+                     "time": st.get("wall_seconds")})
+
+    csv_path = REPORT_DIR / "results.csv"
+    cols = ["id", "status", "time", "iterations", "max_energy", "avg_energy",
+            "verts", "tris", "all_rounded", "metric", "containment",
+            "containment_over_eps", "coverage", "coverage_over_eps", "input_verts",
+            "simplify_ratio", "reason"]
+    with open(csv_path, "w", newline="") as f:
+        w = csv.DictWriter(f, fieldnames=cols, extrasaction="ignore")
+        w.writeheader()
+        for r in sorted(rows, key=lambda x: x["id"]):
+            w.writerow(r)
+
+    total = len(successes) + len(failures)
+    lines = []
+    lines.append("=" * 64)
+    lines.append("triwild / 20k 2D batch report")
+    lines.append("=" * 64)
+    lines.append(f"output:     {OUT_DIR}")
+    lines.append(f"processed:  {total}")
+    lines.append(f"  success:  {len(successes)}")
+    lines.append(f"  failure:  {len(failures)}")
+    if total:
+        lines.append(f"  success rate: {100.0 * len(successes) / total:.1f}%")
+    lines.append("")
+    if times:
+        ts = sorted(times)
+        lines.append(f"run time (s): min {min(ts):.2f}  median {ts[len(ts)//2]:.2f}  "
+                     f"max {max(ts):.2f}  mean {sum(ts)/len(ts):.2f}")
+    if iters:
+        lines.append(f"iterations:   min {min(iters)}  max {max(iters)}  "
+                     f"mean {sum(iters)/len(iters):.1f}")
+    if energies:
+        es = sorted(energies)
+        lines.append(f"max energy:   median {es[len(es)//2]:.3f}  max {max(es):.4g}   "
+                     f"(AMIPS2D floor is 2)")
+    if successes:
+        lines.append(f"un-rounded output: {n_unrounded} of {len(successes)} successes")
+    if contr:
+        cs = sorted(contr)
+        over = sum(1 for v in contr if v > 1.0)
+        lines.append(f"containment d(out->in)/eps: median {cs[len(cs)//2]:.3f}  "
+                     f"max {max(cs):.4g}   OVER 1.0: {over}/{len(contr)}")
+        lines.append(f"  (the envelope invariant. Anything over 1.0 is a real violation. "
+                     f"Measured on {len(contr)} of {len(successes)} successes -- the rest "
+                     f"predate the direction fix and have no containment figure.)")
+    if covr:
+        vs = sorted(covr)
+        over = sum(1 for v in covr if v > 1.0)
+        lines.append(f"coverage    d(in->out)/eps: median {vs[len(vs)//2]:.3f}  "
+                     f"max {max(vs):.4g}   over 1.0: {over}/{len(covr)}")
+        lines.append("  (diagnostic only, bounded by nothing: simplification may remove "
+                     "detail and the arrangement may drop segments. Large means the output "
+                     "no longer covers part of the input. Use DEBUG_euler to see which "
+                     "curves were lost.)")
+    lines.append("")
+    lines.append(_histogram(
+        "Run time histogram (seconds, successful models):",
+        times, [1, 2, 5, 10, 30, 60, 120, 300, 600, 1800, 3600]))
+    lines.append(_histogram(
+        "Iteration-count histogram (successful models):",
+        iters, [1, 2, 3, 5, 8, 12, 20, 40, 80]))
+    lines.append(_histogram(
+        "Containment d(output->input) / eps histogram (successful models):",
+        contr, [0.1, 0.25, 0.5, 0.75, 1.0, 2.0]))
+    lines.append(_histogram(
+        "Coverage d(input->output) / eps histogram (successful models, diagnostic):",
+        covr, [0.5, 1, 2, 5, 10, 50, 100]))
+    lines.append("Failures by reason:")
+    if reason_counts:
+        for k in sorted(reason_counts, key=lambda x: -reason_counts[x]):
+            lines.append(f"  {reason_counts[k]:>6}  {k}")
+    else:
+        lines.append("  (none)")
+    lines.append("")
+    lines.append(f"per-model CSV: {csv_path}")
+
+    summary = "\n".join(lines) + "\n"
+    (REPORT_DIR / "summary.txt").write_text(summary)
+    print(summary, flush=True)
+
+    html_path = generate_html_report(
+        rows,
+        {"generated": datetime.datetime.now().strftime("%Y-%m-%d %H:%M")},
+        REPORT_DIR,
+        OUT_DIR,
+    )
+    print("HTML report:   {}".format(html_path), flush=True)
+
+
+def _reason_bucket(reason):
+    r = reason.lower()
+    if "timeout" in r:
+        return "timeout"
+    if "oom" in r:
+        return f"out of memory (MemoryMax={MEM_GB}G)"
+    # The two triwild-specific fatals, both known before the sweep started (PR #982).
+    if "different orientations" in r:
+        return "arrangement: tets with different orientations"
+    if "is outside" in r:
+        return "init: input edge outside the envelope"
+    if "empty output" in r:
+        return "empty output after filter"
+    if "sigsegv" in r or "signal 11" in r:
+        return "segfault"
+    if "signal" in r or "killed" in r:
+        return "killed by signal"
+    if "nonzero" in r:
+        return "nonzero exit (no message)"
+    return reason or "unknown"
+
+
+# --------------------------------------------------------------------------- #
+# Model selection
+# --------------------------------------------------------------------------- #
+def _order_models(meshes):
+    """Order the work list.
+
+    name:     lexicographic by filename. The default for the full sweep. File size is
+              uncorrelated with the name here, so the expensive models are spread evenly
+              through the run instead of arriving in one block at the end -- which keeps
+              throughput and the failure mix representative at every point, and means an
+              interrupted run is still a fair sample rather than "all the easy ones".
+    smallest: cheapest first. Maximises how many models a truncated run completes, but
+              back-loads every expensive model; with sizes spanning 2.7 KB to 1.6 GB that
+              makes the tail of the sweep look nothing like the head.
+    spread:   walk the size-sorted list at a stride, so a truncated run samples the whole
+              size range. That is what you want from a trial.
+    random:   uniform sample, seeded by TRIWILD_SEED.
+    """
+    if SAMPLE == "name":
+        return sorted(meshes, key=lambda p: p.name)
+    by_size = sorted(meshes, key=lambda p: p.stat().st_size)
+    if SAMPLE == "smallest":
+        return by_size
+    if SAMPLE == "random":
+        shuffled = list(by_size)
+        random.Random(SEED).shuffle(shuffled)
+        return shuffled
+    if SAMPLE == "spread":
+        n = len(by_size)
+        take = LIMIT if LIMIT else n
+        take = max(1, min(take, n))
+        stride = n / take
+        picked_idx = sorted({min(n - 1, int(i * stride)) for i in range(take)})
+        picked = [by_size[i] for i in picked_idx]
+        # keep the rest behind the sample so a resume still has work to do
+        rest = [m for i, m in enumerate(by_size) if i not in set(picked_idx)]
+        return picked + rest
+    sys.exit(f"unknown TRIWILD_SAMPLE: {SAMPLE!r} (name | smallest | spread | random)")
+
+
+# --------------------------------------------------------------------------- #
+# Main
+# --------------------------------------------------------------------------- #
+def run_sweep():
+    for d in (SUCCESS_DIR, FAILURE_DIR, WORK_DIR, REPORT_DIR):
+        d.mkdir(parents=True, exist_ok=True)
+
+    if REPORT_ONLY:
+        generate_report()
+        return
+
+    if not WMTK_APP.exists():
+        sys.exit(f"wmtk_app not found: {WMTK_APP}")
+    if not DATASET_DIR.exists():
+        sys.exit(f"dataset not found: {DATASET_DIR}")
+    if not _memory_capped_available():
+        sys.exit(f"cannot create a systemd scope with MemoryMax={MEM_GB}G -- the user "
+                 f"manager is not usable here. Set TRIWILD_MEM_GB=0 to run uncapped.")
+
+    # Clean any scratch left behind by a killed run.
+    for leftover in WORK_DIR.glob("*"):
+        shutil.rmtree(leftover, ignore_errors=True)
+
+    meshes = []
+    for pat in MESH_EXTENSIONS:
+        meshes.extend(DATASET_DIR.glob(pat))
+    ordered = _order_models(meshes)
+    todo = [m for m in ordered if not already_done(m.stem)]
+
+    cores = os.cpu_count() or 1
+    warn = "  (WARNING: parallel*threads exceeds cores; expect oversubscription)" \
+        if PARALLEL * THREADS > cores else ""
+    print(f"{len(meshes)} meshes, {len(meshes) - len(todo)} already done, "
+          f"{len(todo)} to process.\n"
+          f"parallel {PARALLEL} x threads {THREADS} (cores {cores}){warn}, "
+          f"timeout {JOB_TIMEOUT}s, "
+          f"memory {'uncapped' if MEM_GB <= 0 else str(MEM_GB) + 'G/model'}, "
+          f"limit {LIMIT or 'none'}, sample {SAMPLE}.\n"
+          f"output: {OUT_DIR}", flush=True)
+
+    PIDFILE.write_text(str(os.getpid()))
+    processed = 0
+    try:
+        # Bounded pool: keep PARALLEL models in flight, feeding a new one whenever a
+        # slot frees, and stop feeding once a stop is requested (or the limit is hit).
+        it = iter(todo)
+        inflight = {}
+        with ThreadPoolExecutor(max_workers=PARALLEL) as ex:
+            def submit_next():
+                nonlocal processed
+                if _STOP.is_set() or (LIMIT and processed >= LIMIT):
+                    return
+                mesh = next(it, None)
+                if mesh is None:
+                    return
+                inflight[ex.submit(run_one, mesh)] = mesh
+                processed += 1
+
+            for _ in range(PARALLEL):
+                submit_next()
+            while inflight:
+                done, _ = futures_wait(list(inflight), return_when=FIRST_COMPLETED)
+                for fut in done:
+                    inflight.pop(fut)
+                    try:
+                        fut.result()
+                    except Exception as e:  # a worker bug must not wedge the pool
+                        print(f"  !! worker error: {e}", flush=True)
+                    submit_next()
+    finally:
+        PIDFILE.unlink(missing_ok=True)
+        note = " (stopped)" if _STOP.is_set() else ""
+        print(f"\nsubmitted {processed} model(s) this run{note}. writing report...",
+              flush=True)
+        generate_report()
+
+
+def stop_sweep():
+    """Signal a running sweep to stop cleanly (via its pidfile)."""
+    if not PIDFILE.exists():
+        print("no sweep.pid found -- is a sweep running?")
+        return
+    try:
+        pid = int(PIDFILE.read_text().strip())
+    except ValueError:
+        print("sweep.pid is unreadable; remove it by hand.")
+        return
+    try:
+        os.kill(pid, signal.SIGTERM)
+        print(f"sent SIGTERM to sweep {pid}: it will abandon in-flight models "
+              f"(they resume later), write the report, and exit.")
+    except ProcessLookupError:
+        print(f"sweep {pid} is not running (stale pidfile); removing it.")
+        PIDFILE.unlink(missing_ok=True)
+
+
+if __name__ == "__main__":
+    if len(sys.argv) > 1 and sys.argv[1] == "stop":
+        stop_sweep()
+    else:
+        run_sweep()

--- a/components/triwild/wmtk/components/triwild/scripts/sweep2d.sh
+++ b/components/triwild/wmtk/components/triwild/scripts/sweep2d.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# Launch / control the triwild 2D sweep inside tmux, so it survives a dropped
+# connection. (On kirby lingering is enabled for this user, so the tmux server and the
+# per-model systemd scopes outlive the ssh session.) Set TRIWILD_ROOT to point at the
+# sweep root -- build/, data/ and runs/ hang off it; see README.md.
+#
+#   ./sweep2d.sh quick    300 models spread across the size range -> runs/quick300
+#   ./sweep2d.sh full     all ~19,700 models, in filename order  -> runs/full
+#   ./sweep2d.sh stop     clean stop: drain, report, exit (resumable)
+#   ./sweep2d.sh attach   attach to the running sweep's tmux session
+#   ./sweep2d.sh status   one-line progress for both runs
+#   ./sweep2d.sh report [quick|full]   regenerate the report without running anything
+#
+# Resume is just re-running the same subcommand: models already in success/ or
+# failure/ are skipped.
+#
+# Separate session name and separate TRIWILD_* variables from sweep.sh, so a 2D and a
+# 3D sweep can coexist on kirby without either one's settings leaking into the other.
+set -euo pipefail
+
+ROOT=${TRIWILD_ROOT:-/u/3/daniele/triwild-sweep}
+export TRIWILD_ROOT="$ROOT"
+RUNNER="$ROOT/scripts/run_triwild_sweep.py"
+SESSION=triwild-sweep
+
+export TRIWILD_PARALLEL=${TRIWILD_PARALLEL:-16}
+export TRIWILD_THREADS=${TRIWILD_THREADS:-8}              # 16 x 8 = 128 = kirby's core count
+export TRIWILD_JOB_TIMEOUT=${TRIWILD_JOB_TIMEOUT:-3600}   # 1 hour
+# Per model, not a sweep budget. 16 x 128G is far past kirby's 440G, so this is a
+# runaway-killer rather than admission control. It binds harder here than in 3D: the
+# dataset spans 2.7 KB to 1.6 GB per file, and the big ones are read whole up front.
+export TRIWILD_MEM_GB=${TRIWILD_MEM_GB:-128}              # per model
+
+out_for() { case "$1" in quick) echo "$ROOT/runs/quick300";; *) echo "$ROOT/runs/full";; esac; }
+
+start() {
+    local mode="$1" out; out="$(out_for "$mode")"
+    if tmux has-session -t "$SESSION" 2>/dev/null; then
+        echo "a 2D sweep session is already running -- './sweep2d.sh attach' or './sweep2d.sh stop' first."
+        exit 1
+    fi
+    mkdir -p "$out"
+    local env_extra=""
+    if [ "$mode" = quick ]; then
+        # 300 rather than 100: the 2D dataset is twice the size of Thingi10K and the
+        # known failure mode (arrangement orientation) hits roughly a third of models,
+        # so a 100-model trial would put a wide error bar on the number that matters.
+        env_extra="TRIWILD_LIMIT=300 TRIWILD_SAMPLE=spread"
+    else
+        # Filename order, not size order: size is uncorrelated with the name, so the
+        # expensive models are spread through the run rather than all landing at the end.
+        env_extra="TRIWILD_SAMPLE=name"
+    fi
+    # keep the pane alive after the run so the tail of the report stays readable.
+    # Every knob spelled out in the tmux command rather than relying on the tmux server
+    # inheriting our environment: a resume days later must run at the same settings as
+    # the run it is resuming, whatever the shell that launches it.
+    tmux new-session -d -s "$SESSION" -n "$mode" \
+        "TRIWILD_OUT='$out' TRIWILD_PARALLEL=$TRIWILD_PARALLEL TRIWILD_THREADS=$TRIWILD_THREADS \
+         TRIWILD_JOB_TIMEOUT=$TRIWILD_JOB_TIMEOUT TRIWILD_MEM_GB=$TRIWILD_MEM_GB \
+         $env_extra python3 '$RUNNER' 2>&1 | tee -a '$out/sweep.console.log'; \
+         echo; echo '[sweep finished -- pane kept open; ctrl-b d to detach]'; exec bash"
+    echo "started '$mode' 2D sweep in tmux session '$SESSION'"
+    echo "  output:  $out"
+    echo "  console: $out/sweep.console.log"
+    echo "  attach:  tmux attach -t $SESSION"
+}
+
+case "${1:-}" in
+    quick|full) start "$1" ;;
+    stop)
+        for m in quick full; do
+            out="$(out_for "$m")"
+            [ -f "$out/sweep.pid" ] && TRIWILD_OUT="$out" python3 "$RUNNER" stop
+        done
+        ;;
+    attach) tmux attach -t "$SESSION" ;;
+    report)
+        out="$(out_for "${2:-full}")"
+        TRIWILD_OUT="$out" TRIWILD_REPORT_ONLY=1 python3 "$RUNNER"
+        ;;
+    status)
+        for m in quick full; do
+            out="$(out_for "$m")"
+            [ -d "$out" ] || continue
+            s=$(find "$out/success" -maxdepth 1 -mindepth 1 -type d 2>/dev/null | wc -l)
+            f=$(find "$out/failure" -maxdepth 1 -mindepth 1 -type d 2>/dev/null | wc -l)
+            w=$(find "$out/.work"   -maxdepth 1 -mindepth 1 -type d 2>/dev/null | wc -l)
+            running=$([ -f "$out/sweep.pid" ] && echo "running" || echo "idle")
+            printf '%-6s %-8s success %-6s failure %-6s in-flight %s\n' "$m" "$running" "$s" "$f" "$w"
+        done
+        tmux has-session -t "$SESSION" 2>/dev/null && echo "tmux session '$SESSION' is up" || echo "no tmux session"
+        ;;
+    *)
+        sed -n '2,18p' "$0" | sed 's/^# \{0,1\}//'
+        exit 1
+        ;;
+esac

--- a/components/triwild/wmtk/components/triwild/tests/CMakeLists.txt
+++ b/components/triwild/wmtk/components/triwild/tests/CMakeLists.txt
@@ -11,6 +11,7 @@ set(SRC_FILES
     test_sizing_refine.cpp
     test_simplify_segments.cpp
     test_winding_tags.cpp
+    test_feature_points.cpp
     )
 
 target_sources(wmtk_test_${COMPONENT_NAME} PRIVATE ${SRC_FILES})

--- a/components/triwild/wmtk/components/triwild/tests/test_feature_points.cpp
+++ b/components/triwild/wmtk/components/triwild/tests/test_feature_points.cpp
@@ -1,0 +1,188 @@
+#include <wmtk/TriMesh.h>
+#include <wmtk/components/triwild/TriWildMesh.h>
+#include <wmtk/Types.hpp>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <array>
+#include <vector>
+
+using namespace wmtk;
+using namespace wmtk::components::triwild;
+
+// A feature point is a 0-dimensional feature of the curve network -- an open polyline's
+// endpoint, or a junction. collapse_breaks_feature is the policy that keeps one from being
+// dropped or displaced by an edge collapse, which is what used to delete open polylines
+// outright: a polyline erodes into its own tip until a single segment is left, and that
+// segment carries a feature at BOTH ends, which the surface order test does not refuse.
+//
+// The policy is a pure function of two vertices' attributes, so it is testable without
+// building a real curve network or running an operation.
+namespace {
+
+// One triangle is enough: the policy only reads m_feature_id and m_posf.
+void build_one_tri(TriWildMesh& mesh, const std::array<Vector2d, 3>& p)
+{
+    const std::vector<std::array<size_t, 3>> tris = {{{0, 1, 2}}};
+    mesh.init(3, tris);
+    mesh.m_vertex_attribute.resize(3);
+    mesh.m_edge_attribute.resize(3);
+    mesh.m_face_attribute.resize(1);
+    for (int i = 0; i < 3; ++i) {
+        auto& va = mesh.m_vertex_attribute[i];
+        va.m_posf = p[i];
+        va.m_pos = to_rational(p[i]);
+        va.m_is_rounded = true;
+    }
+}
+
+Parameters make_params()
+{
+    Parameters params;
+    params.init(Vector2d(0, 0), Vector2d(10, 10));
+    return params;
+}
+
+} // namespace
+
+TEST_CASE("triwild-feature-collapse-policy", "[triwild_operation][feature_points]")
+{
+    Parameters params = make_params();
+    const double eps = 1.0; // envelope_eps used directly, so the numbers below are readable
+
+    // v0 at the origin carries feature 0, anchored exactly where it sits.
+    // v1 sits 0.5 away (inside eps), v2 sits 5 away (well outside).
+    TriWildMesh mesh(params, eps, 0);
+    build_one_tri(mesh, {Vector2d(0, 0), Vector2d(0.5, 0), Vector2d(5, 0)});
+    mesh.m_feature_points = {Vector2d(0, 0)};
+    mesh.m_vertex_attribute[0].m_feature_id = 0;
+
+    SECTION("a vertex carrying no feature is never blocked")
+    {
+        CHECK_FALSE(mesh.collapse_breaks_feature(1, 2));
+        CHECK_FALSE(mesh.collapse_breaks_feature(2, 1));
+    }
+
+    SECTION("collapsing a feature into a nearby vertex is allowed")
+    {
+        // v1 is within eps of feature 0, so the feature stays represented.
+        CHECK_FALSE(mesh.collapse_breaks_feature(0, 1));
+    }
+
+    SECTION("collapsing a feature into a distant vertex is refused")
+    {
+        // This is the case that deletes a polyline: the anchor would be left behind.
+        CHECK(mesh.collapse_breaks_feature(0, 2));
+    }
+
+    SECTION("collapsing INTO a feature is always fine")
+    {
+        // v2 carries nothing; the feature on v0 is untouched by v2 disappearing.
+        CHECK_FALSE(mesh.collapse_breaks_feature(2, 0));
+    }
+
+    SECTION("two features closer than eps may merge -- the survivor covers both")
+    {
+        // v1 stands for its own anchor 0.5 away, inside eps. Collapsing either way leaves a
+        // vertex within eps of BOTH anchors, so nothing is lost and the merge is allowed.
+        // Refusing it outright (an earlier version did) deadlocks the mesh: on the puzzle
+        // integration model it stranded a degenerate triangle and the max energy stayed at
+        // 1e50 for all 82 iterations instead of converging in 3.
+        mesh.m_feature_points.push_back(Vector2d(0.5, 0));
+        mesh.m_vertex_attribute[1].m_feature_id = 1;
+        CHECK_FALSE(mesh.collapse_breaks_feature(0, 1));
+        CHECK_FALSE(mesh.collapse_breaks_feature(1, 0));
+    }
+
+    SECTION("two features further apart than eps still cannot merge")
+    {
+        // v2 stands for an anchor 5 away. Collapsing v0 into it would leave feature 0 with no
+        // vertex within eps, and the plain distance test catches that without needing a
+        // special case for "v2 already carries something".
+        mesh.m_feature_points.push_back(Vector2d(5, 0));
+        mesh.m_vertex_attribute[2].m_feature_id = 1;
+        CHECK(mesh.collapse_breaks_feature(0, 2));
+        CHECK(mesh.collapse_breaks_feature(2, 0));
+    }
+
+    SECTION("a vertex already carrying the SAME feature is fine")
+    {
+        mesh.m_vertex_attribute[1].m_feature_id = 0;
+        CHECK_FALSE(mesh.collapse_breaks_feature(0, 1));
+    }
+
+    SECTION("protection does not depend on rounding")
+    {
+        // The pre-existing order test is gated on m_is_rounded, so an un-rounded endpoint
+        // slipped through it. This rule is not.
+        mesh.m_vertex_attribute[0].m_is_rounded = false;
+        CHECK(mesh.collapse_breaks_feature(0, 2));
+    }
+
+    SECTION("preserve_feature_points off restores the old behaviour")
+    {
+        params.preserve_feature_points = false;
+        TriWildMesh off(params, eps, 0);
+        build_one_tri(off, {Vector2d(0, 0), Vector2d(0.5, 0), Vector2d(5, 0)});
+        off.m_feature_points = {Vector2d(0, 0)};
+        off.m_vertex_attribute[0].m_feature_id = 0;
+        CHECK_FALSE(off.collapse_breaks_feature(0, 2));
+    }
+}
+
+TEST_CASE("triwild-feature-smoothing-is-a-ball-not-a-pin", "[triwild_operation][feature_points]")
+{
+    Parameters params = make_params();
+    const double eps = 1.0;
+    TriWildMesh mesh(params, eps, 0);
+    build_one_tri(mesh, {Vector2d(0, 0), Vector2d(0.5, 0), Vector2d(5, 0)});
+    mesh.m_feature_points = {Vector2d(0, 0)};
+    mesh.m_vertex_attribute[0].m_feature_id = 0;
+
+    // A feature vertex is free to move, just not away: smoothing keeps whatever quality it
+    // can find inside the ball. Freezing it outright would be simpler and worse.
+    CHECK(mesh.smoothing_position_is_allowed(0, Vector2d(0, 0)));
+    CHECK(mesh.smoothing_position_is_allowed(0, Vector2d(0.9, 0)));
+    CHECK(mesh.smoothing_position_is_allowed(0, Vector2d(0, -0.9)));
+    CHECK(mesh.smoothing_position_is_allowed(0, Vector2d(0.7, 0.7))); // |.| = 0.99
+    CHECK_FALSE(mesh.smoothing_position_is_allowed(0, Vector2d(1.1, 0)));
+    CHECK_FALSE(mesh.smoothing_position_is_allowed(0, Vector2d(0.8, 0.8))); // |.| = 1.13
+
+    // A vertex with no feature is unconstrained by this rule.
+    CHECK(mesh.smoothing_position_is_allowed(1, Vector2d(100, 100)));
+}
+
+TEST_CASE("triwild-feature-retention-accounting", "[triwild_operation][feature_points]")
+{
+    Parameters params = make_params();
+    const double eps = 1.0;
+    TriWildMesh mesh(params, eps, 0);
+    build_one_tri(mesh, {Vector2d(0, 0), Vector2d(0.5, 0), Vector2d(5, 0)});
+    mesh.m_feature_points = {Vector2d(0, 0), Vector2d(5, 0)};
+
+    SECTION("anchors that still have a vertex on them are retained")
+    {
+        // v0 is at (0,0) = feature 0, v2 at (5,0) = feature 1.
+        const auto [kept, total] = mesh.feature_retention();
+        CHECK(total == 2);
+        CHECK(kept == 2);
+    }
+
+    SECTION("covered by a vertex that does not carry the id still counts")
+    {
+        // Retention is geometric on purpose: after a legitimate merge the surviving vertex
+        // carries one id but covers both anchors, and counting ids would under-report it.
+        // v0 sits exactly on feature 0 and v2 exactly on feature 1, carrying neither.
+        const auto [kept, total] = mesh.feature_retention();
+        CHECK(kept == 2);
+        CHECK(total == 2);
+    }
+
+    SECTION("an anchor with no vertex near it is not retained")
+    {
+        mesh.m_feature_points.push_back(Vector2d(50, 50)); // nothing is within eps of this
+        const auto [kept, total] = mesh.feature_retention();
+        CHECK(total == 3);
+        CHECK(kept == 2);
+    }
+}

--- a/components/triwild/wmtk/components/triwild/triwild.cpp
+++ b/components/triwild/wmtk/components/triwild/triwild.cpp
@@ -85,64 +85,79 @@ std::vector<int> compute_euler_characteristics(const MatrixXi& E)
 }
 
 /**
- * @brief One-sided Hausdorff distance from the input segments to the output's tracked
- * edges: the largest distance any point of the input has to travel to reach the output.
+ * @brief Largest distance from any point of the segments (V, E) to the geometry that
+ * `target` was built over, or -1 when there is nothing to sample.
  *
- * The 2D counterpart of tetwild's DEBUG_hausdorff check, which samples the input surface
- * and measures against an envelope built over the output surface. Here the samples are
- * spread along each input segment proportionally to its length (the input is a segment
- * soup, so there is no area to sample uniformly).
+ * Samples each segment uniformly with the budget spread by length: the input is a segment
+ * soup, so there is no area to sample, and there is no reason to sample a long segment as
+ * coarsely as a short one. Deterministic, unlike the 3D version's
+ * igl::random_points_on_mesh -- a diagnostic that changes between runs is hard to act on.
+ *
+ * A max over samples converges slowly, so the budget is deliberately large (tetwild raised
+ * its own from 10k to 100k after finding a 21x under-estimate). This is opt-in diagnostic
+ * code; a stable answer is worth the samples.
  */
-double hausdorff_to_output(
-    const TriWildMesh& mesh,
-    const std::vector<MatrixXd>& Vs,
-    const std::vector<MatrixXi>& Es)
+double
+max_deviation(const MatrixXd& V, const MatrixXi& E, const SampleEnvelope& target, int n_samples)
 {
-    // Envelope over the output's tracked edges.
-    std::vector<Vector2d> v_out;
-    std::vector<Vector2i> e_out;
-    v_out.reserve(mesh.vert_capacity());
-    for (size_t i = 0; i < mesh.vert_capacity(); ++i) {
-        v_out.push_back(mesh.m_vertex_attribute[i].m_posf);
-    }
-    for (const auto& vids :
-         mesh.get_edges_by_condition([](const auto& e) { return e.m_is_surface_fs; })) {
-        e_out.emplace_back(int(vids[0]), int(vids[1]));
-    }
-    if (e_out.empty()) {
-        logger().warn("Hausdorff check: the output has no tracked edges.");
-        return -1;
-    }
-    SampleEnvelope env;
-    env.init(v_out, e_out, 0);
-
-    // Total input length, so the sample budget can be spread by length.
-    constexpr int n_samples = 10000;
     double total_length = 0;
-    for (size_t k = 0; k < Es.size(); ++k) {
-        for (int i = 0; i < Es[k].rows(); ++i) {
-            total_length += (Vs[k].row(Es[k](i, 1)) - Vs[k].row(Es[k](i, 0))).norm();
-        }
+    for (int i = 0; i < E.rows(); ++i) {
+        total_length += (V.row(E(i, 1)) - V.row(E(i, 0))).norm();
     }
-    if (total_length <= 0) {
+    if (E.rows() == 0 || total_length <= 0) {
         return -1;
     }
 
     double sq_max = -1;
     Vector2d projection;
-    for (size_t k = 0; k < Es.size(); ++k) {
-        for (int i = 0; i < Es[k].rows(); ++i) {
-            const Vector2d a = Vs[k].row(Es[k](i, 0));
-            const Vector2d b = Vs[k].row(Es[k](i, 1));
-            const double len = (b - a).norm();
-            const int n = std::max(1, int(n_samples * len / total_length));
-            for (int s = 0; s <= n; ++s) {
-                const Vector2d p = a + (b - a) * (double(s) / double(n));
-                sq_max = std::max(sq_max, env.nearest_point(p, projection));
-            }
+    for (int i = 0; i < E.rows(); ++i) {
+        const Vector2d a = V.row(E(i, 0));
+        const Vector2d b = V.row(E(i, 1));
+        const double len = (b - a).norm();
+        const int n = std::max(1, int(n_samples * len / total_length));
+        for (int s = 0; s <= n; ++s) {
+            const Vector2d p = a + (b - a) * (double(s) / double(n));
+            sq_max = std::max(sq_max, target.nearest_point(p, projection));
         }
     }
     return sq_max < 0 ? -1 : std::sqrt(sq_max);
+}
+
+/**
+ * @brief The output's tracked (input-carrying) edges, as a standalone (V, E) pair.
+ */
+void tracked_edges(const TriWildMesh& mesh, MatrixXd& V, MatrixXi& E)
+{
+    V.resize(mesh.vert_capacity(), 2);
+    for (size_t i = 0; i < mesh.vert_capacity(); ++i) {
+        V.row(i) = mesh.m_vertex_attribute[i].m_posf;
+    }
+    const auto tracked =
+        mesh.get_edges_by_condition([](const auto& e) { return e.m_is_surface_fs; });
+    E.resize(tracked.size(), 2);
+    for (size_t i = 0; i < tracked.size(); ++i) {
+        E(i, 0) = int(tracked[i][0]);
+        E(i, 1) = int(tracked[i][1]);
+    }
+}
+
+/**
+ * @brief Build a 2D envelope over the segments (V, E). eps is irrelevant here: only
+ * nearest_point() is used, and that ignores the thickness.
+ */
+std::shared_ptr<SampleEnvelope> envelope_over(const MatrixXd& V, const MatrixXi& E)
+{
+    std::vector<Vector2d> v(V.rows());
+    for (int i = 0; i < V.rows(); ++i) {
+        v[i] = V.row(i);
+    }
+    std::vector<Vector2i> e(E.rows());
+    for (int i = 0; i < E.rows(); ++i) {
+        e[i] = E.row(i);
+    }
+    auto env = std::make_shared<SampleEnvelope>();
+    env->init(v, e, 0);
+    return env;
 }
 
 } // namespace
@@ -399,20 +414,51 @@ void triwild(nlohmann::json json_params)
     // double time = timer.getElapsedTime();
     // logger().info("total time {:.4}s", time);
 
-    // Sanity check: how far the input actually is from the output. The 2D counterpart of
-    // tetwild's DEBUG_hausdorff -- sample the input segments and measure each sample
-    // against an envelope built over the output's tracked (surface) edges.
-    double hausdorff_distance = -1;
+    // Surface deviation, both directions. The 2D counterpart of tetwild's DEBUG_hausdorff,
+    // including the correction from #967:
+    //
+    //   containment d(output -> input) is the envelope invariant. Every point of the output's
+    //       tracked edges stays within eps of the input; this is what the optimizer maintains
+    //       and the only direction worth comparing against eps.
+    //   coverage    d(input -> output) is NOT promised by anything. The simplification is
+    //       allowed to remove detail and the arrangement may drop segments, so this grows
+    //       while containment is untouched. Reported as a diagnostic only.
+    //
+    // This check used to compute coverage, call it "Hausdorff distance", and warn that it was
+    // "larger than the envelope" -- exactly the mistake #967 fixed in 3D, where a legitimate
+    // result read 50x eps on containment that was actually 0.34x. On the 2D sweep it made ~60%
+    // of successful models look like envelope violations.
+    double containment_distance = -1;
+    double coverage_distance = -1;
     if (json_params["DEBUG_hausdorff"]) {
-        hausdorff_distance = hausdorff_to_output(mesh, Vs, Es);
-        logger().info(
-            "Hausdorff distance = {:.4} | Envelope = {:.4}",
-            hausdorff_distance,
-            params.eps);
-        if (hausdorff_distance > params.eps) {
-            logger().warn("Hausdorff distance is larger than the envelope!");
+        const int n_samples = 100000;
+        MatrixXd V_track;
+        MatrixXi E_track;
+        tracked_edges(mesh, V_track, E_track);
+        if (E_track.rows() == 0) {
+            logger().warn("Hausdorff check: the output has no tracked edges.");
         } else {
-            logger().info("Hausdorff distance is smaller than envelope (as expected).");
+            const auto env_in = envelope_over(V_in, E_in);
+            const auto env_out = envelope_over(V_track, E_track);
+            containment_distance = max_deviation(V_track, E_track, *env_in, n_samples);
+            coverage_distance = max_deviation(V_in, E_in, *env_out, n_samples);
+
+            logger().info(
+                "curve deviation: containment d(output->input) = {:.4} | envelope = {:.4}",
+                containment_distance,
+                params.eps);
+            if (containment_distance > params.eps) {
+                logger().warn(
+                    "Output is outside the envelope; the containment invariant was "
+                    "violated.");
+            } else {
+                logger().info("Output is inside the envelope (as expected).");
+            }
+            // No comparison against eps: the pipeline does not promise this direction.
+            logger().info(
+                "curve deviation: coverage d(input->output) = {:.4} (diagnostic; large means "
+                "the output no longer covers part of the input)",
+                coverage_distance);
         }
     }
 
@@ -464,7 +510,10 @@ void triwild(nlohmann::json json_params)
         report["eps"] = params.eps;
         report["threads"] = NUM_THREADS;
         // report["time"] = time;
-        report["hausdorff"] = hausdorff_distance;
+        // "hausdorff" keeps its name and now holds containment, the invariant; "coverage" is
+        // the other direction. Same convention as the tetwild report.
+        report["hausdorff"] = containment_distance;
+        report["coverage"] = coverage_distance;
         report["all_rounded"] = all_rounded;
         // report["insertion_and_preprocessing"] = insertion_time;
         fout << std::setw(4) << report;

--- a/components/triwild/wmtk/components/triwild/triwild.cpp
+++ b/components/triwild/wmtk/components/triwild/triwild.cpp
@@ -508,17 +508,20 @@ void triwild(nlohmann::json json_params)
     }
 
     // The feature-point invariant, measured on the finished mesh.
-    const auto [feat_kept, feat_total] = mesh.feature_retention();
+    double feat_worst_ratio = 0;
+    const auto [feat_kept, feat_total] = mesh.feature_retention(&feat_worst_ratio);
     if (feat_total > 0) {
         if (feat_kept == feat_total) {
             logger().info("feature points retained: {}/{}", feat_kept, feat_total);
         } else {
             logger().warn(
                 "feature points retained: {}/{} -- {} polyline endpoints or junctions are no "
-                "longer represented within eps",
+                "longer represented within eps; the worst is {:.2f} x eps from the nearest "
+                "vertex",
                 feat_kept,
                 feat_total,
-                feat_total - feat_kept);
+                feat_total - feat_kept,
+                feat_worst_ratio);
         }
     }
 
@@ -543,6 +546,7 @@ void triwild(nlohmann::json json_params)
         report["coverage"] = coverage_distance;
         report["features_retained"] = feat_kept;
         report["features_total"] = feat_total;
+        report["features_worst_ratio"] = feat_worst_ratio;
         report["all_rounded"] = all_rounded;
         // report["insertion_and_preprocessing"] = insertion_time;
         fout << std::setw(4) << report;

--- a/components/triwild/wmtk/components/triwild/triwild.cpp
+++ b/components/triwild/wmtk/components/triwild/triwild.cpp
@@ -507,6 +507,21 @@ void triwild(nlohmann::json json_params)
         }
     }
 
+    // The feature-point invariant, measured on the finished mesh.
+    const auto [feat_kept, feat_total] = mesh.feature_retention();
+    if (feat_total > 0) {
+        if (feat_kept == feat_total) {
+            logger().info("feature points retained: {}/{}", feat_kept, feat_total);
+        } else {
+            logger().warn(
+                "feature points retained: {}/{} -- {} polyline endpoints or junctions are no "
+                "longer represented within eps",
+                feat_kept,
+                feat_total,
+                feat_total - feat_kept);
+        }
+    }
+
     /////////output
     auto [max_energy, avg_energy] = mesh.get_max_avg_energy();
     wmtk::logger().info("final max energy = {} avg = {}", max_energy, avg_energy);
@@ -526,6 +541,8 @@ void triwild(nlohmann::json json_params)
         // the other direction. Same convention as the tetwild report.
         report["hausdorff"] = containment_distance;
         report["coverage"] = coverage_distance;
+        report["features_retained"] = feat_kept;
+        report["features_total"] = feat_total;
         report["all_rounded"] = all_rounded;
         // report["insertion_and_preprocessing"] = insertion_time;
         fout << std::setw(4) << report;
@@ -539,6 +556,16 @@ void triwild(nlohmann::json json_params)
         }
         if (max_energy > params.stop_energy) {
             log_and_throw_error("Max energy is too large.");
+        }
+        // The feature-point invariant is a promise of the run, so it belongs here next to the
+        // other two. It is also what gives the polyline integration test teeth: the harness
+        // only checks that a config does not throw.
+        if (feat_kept < feat_total) {
+            log_and_throw_error(
+                "{} of {} feature points (polyline endpoints / junctions) are no longer "
+                "represented within eps.",
+                feat_total - feat_kept,
+                feat_total);
         }
     }
 

--- a/components/triwild/wmtk/components/triwild/triwild.cpp
+++ b/components/triwild/wmtk/components/triwild/triwild.cpp
@@ -242,6 +242,18 @@ void triwild(nlohmann::json json_params)
         simplify_eps,
         100 * simplify_envelope_ratio,
         envelope_eps);
+    // 0.5 is not an arbitrary ceiling. is_outside(edge) accepts when every sample is within
+    // eps/2 and the sampling guarantees the rest of the segment is within another eps/2, so
+    // the simplification can leave geometry up to simplify_eps from the input, while the
+    // triangulation's own check accepts samples only up to envelope_eps/2. Those meet exactly
+    // at ratio 0.5; above it the simplification may legally produce an input that the
+    // envelope sanity check below rejects, and the run dies before it starts.
+    if (simplify_envelope_ratio > 0.5) {
+        logger().warn(
+            "simplify_envelope_ratio {} exceeds 0.5; the simplification may produce curves "
+            "that the triangulation's envelope check rejects at init.",
+            simplify_envelope_ratio);
+    }
 
     MatrixXd V_simp = V_in;
     MatrixXi E_simp = E_in;

--- a/components/triwild/wmtk/components/triwild/triwild.cpp
+++ b/components/triwild/wmtk/components/triwild/triwild.cpp
@@ -14,9 +14,75 @@
 
 #include <triwild_spec.hpp>
 
+#include <algorithm>
+#include <map>
+#include <numeric>
+#include <vector>
+
 namespace wmtk::components::triwild {
 
 namespace {
+
+/**
+ * @brief Euler characteristic of each connected component of a 2D segment network, sorted.
+ *
+ * The 1D counterpart of tetwild's surface version. For a graph the Euler characteristic is
+ * V - E, which per connected component is 1 - (number of independent cycles): 1 for an open
+ * polyline or any other tree, 0 for a single closed loop, -1 for a figure eight. Comparing
+ * the sorted per-component values of the input curves against the output's tracked edges
+ * therefore catches exactly the topology changes that matter here -- components merged or
+ * split, loops opened or closed, whole curves lost.
+ *
+ * Vertices incident to no segment are ignored, mirroring the igl::remove_unreferenced call
+ * in the 3D version: they are free points the arrangement still triangulates, but they
+ * carry no curve topology and would otherwise swamp the result with one +1 component each.
+ */
+std::vector<int> compute_euler_characteristics(const MatrixXi& E)
+{
+    if (E.rows() == 0) {
+        return {};
+    }
+    const int n = E.maxCoeff() + 1;
+    std::vector<int> parent(n);
+    std::iota(parent.begin(), parent.end(), 0);
+    const auto find = [&parent](int x) {
+        while (parent[x] != x) {
+            parent[x] = parent[parent[x]]; // path halving
+            x = parent[x];
+        }
+        return x;
+    };
+    for (int i = 0; i < E.rows(); ++i) {
+        const int a = find(E(i, 0));
+        const int b = find(E(i, 1));
+        if (a != b) {
+            parent[a] = b;
+        }
+    }
+
+    std::vector<char> referenced(n, 0);
+    for (int i = 0; i < E.rows(); ++i) {
+        referenced[E(i, 0)] = 1;
+        referenced[E(i, 1)] = 1;
+    }
+    std::map<int, int> n_verts, n_edges;
+    for (int v = 0; v < n; ++v) {
+        if (referenced[v]) {
+            ++n_verts[find(v)];
+        }
+    }
+    for (int i = 0; i < E.rows(); ++i) {
+        ++n_edges[find(E(i, 0))];
+    }
+
+    std::vector<int> ecs;
+    ecs.reserve(n_verts.size());
+    for (const auto& [root, nv] : n_verts) {
+        ecs.push_back(nv - n_edges[root]);
+    }
+    std::sort(ecs.begin(), ecs.end());
+    return ecs;
+}
 
 /**
  * @brief One-sided Hausdorff distance from the input segments to the output's tracked
@@ -129,6 +195,15 @@ void triwild(nlohmann::json json_params)
     std::vector<MatrixXi> Es;
     read_input_curves(input_paths, json_params["remove_duplicate_eps"], V_in, E_in, Vs, Es);
 
+    // Informational input-topology report; gated behind DEBUG_euler because it is only
+    // meaningful next to the matching computations later in the run.
+    const bool debug_euler = json_params["DEBUG_euler"];
+    std::vector<int> ecs_input;
+    if (debug_euler) {
+        ecs_input = compute_euler_characteristics(E_in);
+        logger().info("Euler characteristic, input curves: {}", ecs_input);
+    }
+
     // The bounding box comes from the input curves, as in tetwild -- eps has to be known
     // before the arrangement runs, because the simplification happens first. (It used to be
     // taken from the arrangement output, which includes the background grid and is about
@@ -186,11 +261,43 @@ void triwild(nlohmann::json json_params)
             simplify_use_link_condition ? "on" : "off");
     }
 
+    // The simplification is the one stage whose topology is genuinely optional: with
+    // simplify_use_link_condition off it may merge junctions and separate curves. Compare
+    // here, while the curves are still the same kind of object.
+    std::vector<int> ecs_simplified;
+    if (debug_euler) {
+        ecs_simplified = compute_euler_characteristics(E_simp);
+        if (ecs_simplified != ecs_input) {
+            logger().warn(
+                "Euler characteristic, after simplification: {} -- changed from the input "
+                "{}. Expected when simplify_use_link_condition is off, which allows "
+                "junctions and separate curves to merge.",
+                ecs_simplified,
+                ecs_input);
+        } else {
+            logger().info("Euler characteristic, after simplification: unchanged.");
+        }
+    }
+
     // Exact arrangement of the (simplified) segment network.
     MatrixXd V;
+    std::vector<Vector2r> V_rational; // the same vertices, exact
     MatrixXi F;
     MatrixXi E; // constraint edges in the arrangement
-    init_from_delaunay_box_mesh(V_simp, E_simp, V, F, E);
+    init_from_delaunay_box_mesh(V_simp, E_simp, V, V_rational, F, E);
+
+    // The arrangement is the baseline for everything after it. It is EXPECTED to differ
+    // from the input: resolving a crossing inserts a vertex shared by both curves, which
+    // merges two components into one and adds a cycle. That is the arrangement doing its
+    // job, not a defect -- so this is reported, never warned about.
+    std::vector<int> ecs_arrangement;
+    if (debug_euler) {
+        ecs_arrangement = compute_euler_characteristics(E);
+        logger().info(
+            "Euler characteristic, arrangement constraints: {} ({} constrained edges)",
+            ecs_arrangement,
+            E.rows());
+    }
 
     if (params.debug_output) {
         MatrixXd V3(V.rows(), 3);
@@ -222,7 +329,7 @@ void triwild(nlohmann::json json_params)
 
     TriWildMesh mesh(params, envelope_eps, NUM_THREADS);
     wmtk::set_preallocation_factor_from_json(mesh, json_params);
-    mesh.init_mesh(V, F, E, tag_names, V_in, E_in);
+    mesh.init_mesh(V, V_rational, F, E, tag_names, V_in, E_in);
 
     // After init_mesh, which is what builds the envelope, and after the simplification, which
     // uses its own object -- so this only disables the checks the optimizer makes.
@@ -306,6 +413,39 @@ void triwild(nlohmann::json json_params)
             logger().warn("Hausdorff distance is larger than the envelope!");
         } else {
             logger().info("Hausdorff distance is smaller than envelope (as expected).");
+        }
+    }
+
+    // Output topology, compared against the ARRANGEMENT, not against the input. The
+    // arrangement is where a legitimate topology change happens -- resolving a crossing
+    // merges two components and adds a cycle -- so comparing to the input would warn on
+    // every self-intersecting drawing. Everything after the arrangement (split, collapse,
+    // swap) is supposed to leave the tracked network's topology alone, and a collapse is
+    // the one that could quietly not: the envelope only bounds output-inside-input, so it
+    // cannot see a curve eroding along itself.
+    std::vector<int> ecs_output;
+    if (debug_euler) {
+        const auto tracked =
+            mesh.get_edges_by_condition([](const auto& e) { return e.m_is_surface_fs; });
+        MatrixXi E_out(tracked.size(), 2);
+        for (size_t i = 0; i < tracked.size(); ++i) {
+            E_out(i, 0) = int(tracked[i][0]);
+            E_out(i, 1) = int(tracked[i][1]);
+        }
+        ecs_output = compute_euler_characteristics(E_out);
+        logger().info(
+            "Euler characteristic, output tracked edges: {} ({} edges)",
+            ecs_output,
+            E_out.rows());
+        if (ecs_output != ecs_arrangement) {
+            logger().warn(
+                "Euler characteristic changed across the optimization: arrangement {} -> "
+                "output {}. The operations altered the tracked curve network's topology; "
+                "only the arrangement is entitled to do that.",
+                ecs_arrangement,
+                ecs_output);
+        } else {
+            logger().info("Euler characteristic is unchanged across the optimization.");
         }
     }
 

--- a/components/triwild/wmtk/components/triwild/triwild.cpp
+++ b/components/triwild/wmtk/components/triwild/triwild.cpp
@@ -561,15 +561,30 @@ void triwild(nlohmann::json json_params)
         if (max_energy > params.stop_energy) {
             log_and_throw_error("Max energy is too large.");
         }
-        // The feature-point invariant is a promise of the run, so it belongs here next to the
-        // other two. It is also what gives the polyline integration test teeth: the harness
-        // only checks that a config does not throw.
-        if (feat_kept < feat_total) {
+        // The feature-point invariant, with the slack the merge rule makes unavoidable.
+        //
+        // Requiring every anchor to keep a vertex within exactly eps is too strict, because
+        // the collapse rule deliberately lets two anchors closer than eps merge -- the
+        // survivor covers both. It then carries only ONE feature id, so the other anchor
+        // stops constraining it. Bound on the result: at merge time the survivor is within
+        // eps of both anchors, so those anchors are at most 2 eps apart; afterwards it stays
+        // within eps of the one it carries, hence at most eps + 2 eps from the other.
+        //
+        // Measured across the 2D sweep, the worst unretained anchor lands at 1.02 to 2.22 x
+        // eps, comfortably inside that. Anything past 3 x eps is not this mechanism and is
+        // worth looking at -- a chain of merges could in principle compound further, and if
+        // that is what a model is doing the right answer is per-vertex feature SETS, not a
+        // larger constant here.
+        constexpr double feature_tolerance = 3.0;
+        if (feat_worst_ratio > feature_tolerance) {
             log_and_throw_error(
                 "{} of {} feature points (polyline endpoints / junctions) are no longer "
-                "represented within eps.",
+                "represented; the worst is {:.2f} x eps from the nearest vertex, past the "
+                "{:.0f} x eps the merge rule can account for.",
                 feat_total - feat_kept,
-                feat_total);
+                feat_total,
+                feat_worst_ratio,
+                feature_tolerance);
         }
     }
 

--- a/components/triwild/wmtk/components/triwild/triwild.cpp
+++ b/components/triwild/wmtk/components/triwild/triwild.cpp
@@ -561,31 +561,27 @@ void triwild(nlohmann::json json_params)
         if (max_energy > params.stop_energy) {
             log_and_throw_error("Max energy is too large.");
         }
-        // The feature-point invariant, with the slack the merge rule makes unavoidable.
+        // Feature-point retention is deliberately NOT asserted here, because "every anchor
+        // keeps a vertex within eps" is not actually an invariant of the pipeline.
         //
-        // Requiring every anchor to keep a vertex within exactly eps is too strict, because
-        // the collapse rule deliberately lets two anchors closer than eps merge -- the
-        // survivor covers both. It then carries only ONE feature id, so the other anchor
-        // stops constraining it. Bound on the result: at merge time the survivor is within
-        // eps of both anchors, so those anchors are at most 2 eps apart; afterwards it stays
-        // within eps of the one it carries, hence at most eps + 2 eps from the other.
+        // Two anchors closer than eps are allowed to merge: the survivor covers both, which
+        // is correct and is what keeps a mesh with sub-eps features from deadlocking. But the
+        // survivor carries only ONE feature id, so the anchor it did not keep stops
+        // constraining it, and it may then move a further eps away from that one.
         //
-        // Measured across the 2D sweep, the worst unretained anchor lands at 1.02 to 2.22 x
-        // eps, comfortably inside that. Anything past 3 x eps is not this mechanism and is
-        // worth looking at -- a chain of merges could in principle compound further, and if
-        // that is what a model is doing the right answer is per-vertex feature SETS, not a
-        // larger constant here.
-        constexpr double feature_tolerance = 3.0;
-        if (feat_worst_ratio > feature_tolerance) {
-            log_and_throw_error(
-                "{} of {} feature points (polyline endpoints / junctions) are no longer "
-                "represented; the worst is {:.2f} x eps from the nearest vertex, past the "
-                "{:.0f} x eps the merge rule can account for.",
-                feat_total - feat_kept,
-                feat_total,
-                feat_worst_ratio,
-                feature_tolerance);
-        }
+        // Those merges CASCADE. The survivor can merge again with a third anchor, and again
+        // with a fourth, each step re-anchoring the constraint on whichever id it happens to
+        // carry and letting the earliest anchors slip another eps. A chain of k merges walks
+        // the vertex O(k * eps) from where it started, so no fixed multiple of eps is a
+        // sound bound -- it depends on how many sub-eps features the input crowds together.
+        // Measured on the 2D sweep the worst case is 2.22 x eps, but that is an observation,
+        // not a guarantee, and throwing on any particular multiple would be dressing up a
+        // guess as an invariant.
+        //
+        // Making it exact needs per-vertex feature SETS, so a survivor stays constrained by
+        // every anchor it covers rather than the last id assigned to it. Until then this is
+        // reported and not enforced: the warning above, plus features_retained and
+        // features_worst_ratio in the report.
     }
 
     if (json_params["write_vtu"]) {

--- a/components/triwild/wmtk/components/triwild/triwild.cpp
+++ b/components/triwild/wmtk/components/triwild/triwild.cpp
@@ -17,6 +17,7 @@
 #include <algorithm>
 #include <map>
 #include <numeric>
+#include <tuple>
 #include <vector>
 
 namespace wmtk::components::triwild {
@@ -507,9 +508,14 @@ void triwild(nlohmann::json json_params)
         }
     }
 
-    // The feature-point invariant, measured on the finished mesh.
+    // The feature-point invariant, measured on the finished mesh. Opt-in: the cost scales
+    // with the input's feature count, which on a dense curve network runs to hundreds of
+    // thousands, and it tells you nothing the run depends on.
     double feat_worst_ratio = 0;
-    const auto [feat_kept, feat_total] = mesh.feature_retention(&feat_worst_ratio);
+    size_t feat_kept = 0, feat_total = 0;
+    if (json_params["DEBUG_feature_retention"]) {
+        std::tie(feat_kept, feat_total) = mesh.feature_retention(&feat_worst_ratio);
+    }
     if (feat_total > 0) {
         if (feat_kept == feat_total) {
             logger().info("feature points retained: {}/{}", feat_kept, feat_total);
@@ -544,9 +550,11 @@ void triwild(nlohmann::json json_params)
         // the other direction. Same convention as the tetwild report.
         report["hausdorff"] = containment_distance;
         report["coverage"] = coverage_distance;
-        report["features_retained"] = feat_kept;
-        report["features_total"] = feat_total;
-        report["features_worst_ratio"] = feat_worst_ratio;
+        if (json_params["DEBUG_feature_retention"]) {
+            report["features_retained"] = feat_kept;
+            report["features_total"] = feat_total;
+            report["features_worst_ratio"] = feat_worst_ratio;
+        }
         report["all_rounded"] = all_rounded;
         // report["insertion_and_preprocessing"] = insertion_time;
         fout << std::setw(4) << report;

--- a/components/triwild/wmtk/components/triwild/triwild.cpp
+++ b/components/triwild/wmtk/components/triwild/triwild.cpp
@@ -135,9 +135,23 @@ void triwild(nlohmann::json json_params)
     // 13% larger.)
     params.init(V_in.colwise().minCoeff(), V_in.colwise().maxCoeff());
 
-    // One envelope at eps/2 around the original input, shared by the simplification and by
-    // the optimizer -- tetwild's arrangement, which is what leaves room for both to move.
+    // Half of eps around the original input, as in tetwild -- the arrangement gets the other
+    // half, which is what leaves room for the optimizer to move.
     const double envelope_eps = params.eps / 2;
+    // The simplification and the triangulation used to share one envelope object at the same
+    // eps, which leaves the optimizer no room: a simplification free to place a vertex right
+    // at the limit hands the optimizer a mesh where almost every move is already outside.
+    // Simplifying inside a fraction of the envelope reserves the rest as headroom. Measured
+    // in 3D, where sharing one envelope put a third of the simplified vertices outside before
+    // the tet phase began and had ~94% of smoothing attempts vetoed.
+    const bool simplify_use_link_condition = json_params["simplify_use_link_condition"];
+    const double simplify_envelope_ratio = json_params["simplify_envelope_ratio"];
+    const double simplify_eps = envelope_eps * simplify_envelope_ratio;
+    logger().info(
+        "envelope eps: simplification {:.6} ({:.0f}% of triangulation {:.6})",
+        simplify_eps,
+        100 * simplify_envelope_ratio,
+        envelope_eps);
 
     MatrixXd V_simp = V_in;
     MatrixXi E_simp = E_in;
@@ -154,16 +168,22 @@ void triwild(nlohmann::json json_params)
             for (int i = 0; i < E_in.rows(); ++i) {
                 e[i] = E_in.row(i);
             }
-            simplify_envelope.init(v, e, envelope_eps);
+            simplify_envelope.init(v, e, simplify_eps);
         }
-        const size_t removed = wmtk::utils::simplify_segments(V_simp, E_simp, simplify_envelope);
+        const size_t removed = wmtk::utils::simplify_segments(
+            V_simp,
+            E_simp,
+            simplify_envelope,
+            simplify_use_link_condition);
         logger().info(
-            "input simplification: #V {} -> {}, #E {} -> {} ({} vertices removed)",
+            "input simplification: #V {} -> {}, #E {} -> {} ({} vertices removed). Link "
+            "condition {}.",
             V_in.rows(),
             V_simp.rows(),
             E_in.rows(),
             E_simp.rows(),
-            removed);
+            removed,
+            simplify_use_link_condition ? "on" : "off");
     }
 
     // Exact arrangement of the (simplified) segment network.
@@ -203,6 +223,15 @@ void triwild(nlohmann::json json_params)
     TriWildMesh mesh(params, envelope_eps, NUM_THREADS);
     wmtk::set_preallocation_factor_from_json(mesh, json_params);
     mesh.init_mesh(V, F, E, tag_names, V_in, E_in);
+
+    // After init_mesh, which is what builds the envelope, and after the simplification, which
+    // uses its own object -- so this only disables the checks the optimizer makes.
+    if (json_params["DEBUG_disable_envelope"]) {
+        logger().warn(
+            "DEBUG_disable_envelope: envelope checks are OFF for the triangulation. "
+            "The output has no containment guarantee and is for diagnosis only.");
+        mesh.m_envelope->disabled = true;
+    }
 
     if (params.debug_output) {
         mesh.write_vtu(output_path + "_initial");

--- a/components/triwild/wmtk/components/triwild/triwild_spec.json
+++ b/components/triwild/wmtk/components/triwild/triwild_spec.json
@@ -146,7 +146,7 @@
     "pointer": "/DEBUG_hausdorff",
     "type": "bool",
     "default": false,
-    "doc": "Sanity Check: Compute and report the Hausdorff distance of the input to the output. Should always be smaller than eps."
+    "doc": "Sanity Check: Compute and report the deviation between the input curves and the output's tracked edges, in both directions. Containment, d(output -> input), is the envelope invariant and should always be smaller than eps. Coverage, d(input -> output), is reported as a diagnostic and is NOT bounded by anything: the simplification is allowed to remove detail and the arrangement may drop segments, so a large value means the output no longer covers part of the input, not that the envelope was violated."
   },
   {
     "pointer": "/DEBUG_euler",

--- a/components/triwild/wmtk/components/triwild/triwild_spec.json
+++ b/components/triwild/wmtk/components/triwild/triwild_spec.json
@@ -24,6 +24,7 @@
       "interleaved_smoothing",
       "interleaved_smoothing_passes",
       "preserve_topology",
+      "preserve_feature_points",
       "remove_duplicate_eps",
       "throw_on_fail",
       "log_file",
@@ -201,6 +202,12 @@
     "type": "int",
     "default": 2,
     "doc": "Smoothing passes to run after each topology pass when interleaved_smoothing is set."
+  },
+  {
+    "pointer": "/preserve_feature_points",
+    "type": "bool",
+    "default": true,
+    "doc": "Keep the curve network's 0-dimensional features -- the endpoints of open polylines, and junctions -- within eps of where the arrangement placed them. Each such vertex is bound to a specific feature point, so a collapse is refused when it would leave that point unrepresented or move it further than eps, and smoothing may move the vertex anywhere inside that ball but no further. Without this the collapse pass deletes open polylines outright: a polyline erodes into its own tip until a single segment is left, and that segment carries a feature at BOTH ends, which the surface order test does not refuse (it only forbids collapsing a feature into a non-feature). Measured on the 2D dataset, model 215292 went from 28 open components after the arrangement to 0 in the output. Turn off only to reproduce the old behaviour."
   },
   {
     "pointer": "/preserve_topology",

--- a/components/triwild/wmtk/components/triwild/triwild_spec.json
+++ b/components/triwild/wmtk/components/triwild/triwild_spec.json
@@ -11,11 +11,18 @@
       "num_threads",
       "max_iterations",
       "skip_simplify",
+      "simplify_use_link_condition",
+      "simplify_envelope_ratio",
       "filter",
       "skip_winding_number",
       "eps_rel",
       "length_rel",
       "stop_energy",
+      "split_high_valence_threshold",
+      "w_amips",
+      "num_smoothing_passes",
+      "interleaved_smoothing",
+      "interleaved_smoothing_passes",
       "preserve_topology",
       "remove_duplicate_eps",
       "throw_on_fail",
@@ -26,6 +33,7 @@
       "DEBUG_output",
       "DEBUG_sanity_checks",
       "DEBUG_hausdorff",
+      "DEBUG_disable_envelope",
       "stuck_refine_stall_eps",
       "stuck_refine_cooldown",
       "stuck_refine_num_worst",
@@ -94,7 +102,19 @@
     "pointer": "/skip_simplify",
     "type": "bool",
     "default": false,
-    "doc": "If true, input simplification will be skipped. The input curves are otherwise coarsened first, by collapsing their shortest segments while staying inside half the envelope, so the exact arrangement and the initial mesh do not carry input detail far below the target edge length."
+    "doc": "If true, input simplification will be skipped. The input curves are otherwise coarsened first, by collapsing their shortest segments while staying inside the simplification envelope, so the exact arrangement and the initial mesh do not carry input detail far below the target edge length."
+  },
+  {
+    "pointer": "/simplify_use_link_condition",
+    "type": "bool",
+    "default": false,
+    "doc": "Require the link condition when simplifying the input curves. When true the simplification cannot change the topology of the curve network: junctions and vertices shared between two inputs are frozen, and any collapse that would leave a degenerate or duplicated segment is rejected. When false those collapses are allowed -- the segment that becomes degenerate or duplicated is dropped instead -- so a dirty input simplifies much further, at the cost of merging junctions and separate curves that pass within the envelope. Open endpoints stay frozen either way: the envelope is one-sided, so nothing would notice a curve eroding inwards from its own tip."
+  },
+  {
+    "pointer": "/simplify_envelope_ratio",
+    "type": "float",
+    "default": 0.5,
+    "doc": "Envelope thickness used for the input simplification, as a fraction of the one used for the triangulation. Simplifying inside a tighter envelope reserves the remainder as headroom: if the simplification is allowed to place vertices at the full limit, the optimizer starts with a mesh where almost every move already lies outside and most operations are vetoed. 1.0 restores the old behaviour of sharing a single envelope."
   },
   {
     "pointer": "/filter",
@@ -112,20 +132,26 @@
   {
     "pointer": "/eps_rel",
     "type": "float",
-    "default": 2e-3,
+    "default": 1e-3,
     "doc": "Envelope thickness relative to the bounding box"
   },
   {
     "pointer": "/remove_duplicate_eps",
     "type": "float",
-    "default": 2e-3,
-    "doc": "Merge vertices in the input meshes that are closer than this fraction of the bounding box diagonal, dropping the edges that become degenerate or duplicated. This is applied to each input mesh separately. Negative disables it."
+    "default": 0,
+    "doc": "Merge vertices in the input meshes that are closer than this fraction of the bounding box diagonal, dropping the edges that become degenerate or duplicated. This is applied to each input mesh separately. 0 merges only exactly coincident vertices, which is still needed to build the segment connectivity; negative skips the pass entirely."
   },
   {
     "pointer": "/DEBUG_hausdorff",
     "type": "bool",
     "default": false,
     "doc": "Sanity Check: Compute and report the Hausdorff distance of the input to the output. Should always be smaller than eps."
+  },
+  {
+    "pointer": "/DEBUG_disable_envelope",
+    "type": "bool",
+    "default": false,
+    "doc": "Diagnostic only. Disables every envelope containment check during the triangulation, after the input simplification has run. The envelope is the only thing that rejects an operation for geometric rather than combinatorial reasons, so this answers whether a stalled optimization is blocked by the envelope or by the mesh. The output has no containment guarantee and must not be used."
   },
   {
     "pointer": "/length_rel",
@@ -136,8 +162,38 @@
   {
     "pointer": "/stop_energy",
     "type": "float",
+    "default": 100,
+    "doc": "Target energy. If all triangles have an energy below this, triwild will stop. Note this is the raw AMIPS2D energy, whose floor (an equilateral triangle) is 2 -- tetwild's stop_energy is compared against the cube root of AMIPS3D, whose floor is 3, so the same number is a looser target here than there."
+  },
+  {
+    "pointer": "/split_high_valence_threshold",
+    "type": "int",
+    "default": 200,
+    "doc": "Incident-triangle count above which a vertex accepts only one valence-increasing split per split pass, or 0 to disable. A well-shaped triangle mesh has vertex valence around 6; a split cascade can drive one vertex much higher, at which point every operation touching it is O(valence) and the pass stalls. Splitting an edge leaves its endpoints' counts unchanged and adds one to each vertex opposite the edge, so the gate applies to those. Expect this to fire far less often than in 3D, where the edge's link is a whole ring rather than one or two vertices."
+  },
+  {
+    "pointer": "/w_amips",
+    "type": "float",
+    "default": 0.0001,
+    "doc": "Relative weight of the AMIPS quality term against the envelope term during smoothing; the envelope weight is 1 - w_amips. The small default makes smoothing primarily about staying on the input curves, with quality as a secondary preference."
+  },
+  {
+    "pointer": "/num_smoothing_passes",
+    "type": "int",
     "default": 10,
-    "doc": "Target energy. If all tets have an energy below this, triwild will stop."
+    "doc": "Number of smoothing passes per optimization iteration. Smoothing is the only phase that improves quality without changing connectivity, so when split, collapse and swap have run out of useful moves it is the only thing that can still lower the energy."
+  },
+  {
+    "pointer": "/interleaved_smoothing",
+    "type": "bool",
+    "default": false,
+    "doc": "Interleave smoothing between the topology passes: split + smoothing, collapse + smoothing, swaps + smoothing, instead of split, collapse, swaps followed by num_smoothing_passes smoothing passes."
+  },
+  {
+    "pointer": "/interleaved_smoothing_passes",
+    "type": "int",
+    "default": 2,
+    "doc": "Smoothing passes to run after each topology pass when interleaved_smoothing is set."
   },
   {
     "pointer": "/preserve_topology",
@@ -166,7 +222,7 @@
   {
     "pointer": "/write_vtu",
     "type": "bool",
-    "default": false,
+    "default": true,
     "doc": "Write not just MSH but also VTU output."
   },
   {

--- a/components/triwild/wmtk/components/triwild/triwild_spec.json
+++ b/components/triwild/wmtk/components/triwild/triwild_spec.json
@@ -201,14 +201,14 @@
   {
     "pointer": "/interleaved_smoothing",
     "type": "bool",
-    "default": false,
-    "doc": "Interleave smoothing between the topology passes: split + smoothing, collapse + smoothing, swaps + smoothing, instead of split, collapse, swaps followed by num_smoothing_passes smoothing passes."
+    "default": true,
+    "doc": "Interleave smoothing between the topology passes: split + smoothing, collapse + smoothing, swaps + smoothing, instead of split, collapse, swaps followed by num_smoothing_passes smoothing passes. On by default in triwild: per iteration it reaches a given energy sooner than the batched schedule (on 122839, 102 vs 535 at iteration 5 and 25 vs 69 at iteration 13), at the cost of roughly 3x the work per iteration since each topology pass gets its own smoothing. tetwild still defaults to off, pending the same measurement there."
   },
   {
     "pointer": "/interleaved_smoothing_passes",
     "type": "int",
-    "default": 2,
-    "doc": "Smoothing passes to run after each topology pass when interleaved_smoothing is set."
+    "default": 1,
+    "doc": "Smoothing passes to run after each topology pass when interleaved_smoothing is set. One is enough with interleaving on, since there are three of them per iteration."
   },
   {
     "pointer": "/preserve_feature_points",
@@ -318,8 +318,8 @@
   {
     "pointer": "/skip_good_regions",
     "type": "bool",
-    "default": true,
-    "doc": "Only smooth vertices incident to a triangle whose energy is at least skip_good_regions_margin * stop_energy; skip smoothing already-good regions."
+    "default": false,
+    "doc": "Only smooth vertices incident to a triangle whose energy is at least skip_good_regions_margin * stop_energy; skip smoothing already-good regions. OFF by default: the premise -- that smoothing a vertex surrounded by good triangles does nothing -- is false for surface vertices, whose smoothing is driven almost entirely by the envelope term rather than by element quality. Measured on 122839, filtering cost more than it saved: 60 iterations ending at max energy 21.03 with the filter on, against convergence to 19.9998 in 54 iterations and LESS wall time (875s vs 947s) with it off."
   },
   {
     "pointer": "/skip_good_regions_margin",

--- a/components/triwild/wmtk/components/triwild/triwild_spec.json
+++ b/components/triwild/wmtk/components/triwild/triwild_spec.json
@@ -184,8 +184,8 @@
   {
     "pointer": "/stop_energy",
     "type": "float",
-    "default": 20,
-    "doc": "Target energy. If all triangles have an energy below this, triwild will stop. Note this is the raw AMIPS2D energy, whose floor (an equilateral triangle) is 2 -- tetwild's stop_energy is compared against the cube root of AMIPS3D, whose floor is 3, so the same number would be a much looser target here than there. 20 is 10x the floor; tetwild's 100 is ~33x its own. At 100 a 300-model trial finished with a median max energy of 88.9 and a median iteration count of 1, i.e. one pass and stop."
+    "default": 100,
+    "doc": "Target energy. If all triangles have an energy below this, triwild will stop. Held numerically equal to tetwild's for parity, but note the two numbers are not the same quantity: this is the raw AMIPS2D energy, whose floor (an equilateral triangle) is 2, while tetwild compares the cube root of AMIPS3D, whose floor is 3. So 100 is 50x the floor here against ~33x there, i.e. a looser target in 2D than the same number buys in 3D. Making the two comparable would mean normalizing both energies by their dimension, which would change every logged figure and break comparison with existing runs; parity of the knob was chosen over parity of the target. At 100 a 300-model trial finished with a median max energy of 88.9 and a median iteration count of 1, i.e. one pass and stop; the 19686-model sweep converged 100% with a median max energy of 19.8 because most of it ran at the older target of 20."
   },
   {
     "pointer": "/split_high_valence_threshold",
@@ -325,8 +325,8 @@
   {
     "pointer": "/skip_good_regions",
     "type": "bool",
-    "default": false,
-    "doc": "Only smooth vertices incident to a triangle whose energy is at least skip_good_regions_margin * stop_energy; skip smoothing already-good regions. OFF by default: the premise -- that smoothing a vertex surrounded by good triangles does nothing -- is false for surface vertices, whose smoothing is driven almost entirely by the envelope term rather than by element quality. Measured on 122839, filtering cost more than it saved: 60 iterations ending at max energy 21.03 with the filter on, against convergence to 19.9998 in 54 iterations and LESS wall time (875s vs 947s) with it off."
+    "default": true,
+    "doc": "Only smooth vertices incident to a triangle whose energy is at least skip_good_regions_margin * stop_energy; skip smoothing already-good regions. The filter is safe for surface vertices only because active_vertices() appends every surface vertex unconditionally, whatever the quality threshold says -- their smoothing is driven by the envelope term rather than by element quality, so filtering them on quality would freeze them (it did: octocat smoothed nothing). It was briefly OFF here after an A/B on 122839 at stop_energy 20 showed filtering cost more than it saved (60 iterations ending at 21.03 with it on, against convergence to 19.9998 in 54 iterations and 875s vs 947s with it off). That measurement does not transfer to the current default: the threshold is skip_good_regions_margin * stop_energy, so at 20 it was 18 against an AMIPS2D floor of 2 and skipped almost nothing, while at 100 it is 90 and skips most of a converging mesh. Worth re-measuring in the new regime."
   },
   {
     "pointer": "/skip_good_regions_margin",

--- a/components/triwild/wmtk/components/triwild/triwild_spec.json
+++ b/components/triwild/wmtk/components/triwild/triwild_spec.json
@@ -35,6 +35,7 @@
       "DEBUG_sanity_checks",
       "DEBUG_hausdorff",
       "DEBUG_euler",
+      "DEBUG_feature_retention",
       "DEBUG_disable_envelope",
       "stuck_refine_stall_eps",
       "stuck_refine_cooldown",
@@ -154,6 +155,12 @@
     "type": "bool",
     "default": false,
     "doc": "Sanity Check: Compute and report the Euler characteristic of each connected component of the input curve network and of the output's tracked edges, and warn if they differ. For a graph this is V - E, i.e. 1 - (number of independent cycles) per component: 1 for an open polyline, 0 for a closed loop, -1 for a figure eight. It therefore detects curves merged or split, loops opened or closed, and whole components lost -- the changes the simplification is allowed to make with simplify_use_link_condition off, and the ones a collapse can make that the envelope cannot see (the envelope only bounds output-inside-input, so a curve eroding along itself is invisible to it). Off by default because on a network with many components it is a per-run cost with no effect on the result."
+  },
+  {
+    "pointer": "/DEBUG_feature_retention",
+    "type": "bool",
+    "default": false,
+    "doc": "Sanity Check: count how many of the curve network's 0-dimensional features -- open polyline endpoints and junctions -- still have a mesh vertex within eps of them, and how far the worst one that does not is. Reports features_retained, features_total and features_worst_ratio. Off by default because it is pure diagnosis and the count is proportional to the input's feature count, which can be enormous: model 177574 of the 2D dataset has 821,954 of them. It costs one kd-tree build over the live vertices plus one nearest-neighbour query per feature. Note this measures a property the pipeline does not guarantee -- two anchors closer than eps may legitimately merge, and such merges cascade -- so a value below 100% is information, not a failure."
   },
   {
     "pointer": "/DEBUG_disable_envelope",

--- a/components/triwild/wmtk/components/triwild/triwild_spec.json
+++ b/components/triwild/wmtk/components/triwild/triwild_spec.json
@@ -33,6 +33,7 @@
       "DEBUG_output",
       "DEBUG_sanity_checks",
       "DEBUG_hausdorff",
+      "DEBUG_euler",
       "DEBUG_disable_envelope",
       "stuck_refine_stall_eps",
       "stuck_refine_cooldown",
@@ -148,6 +149,12 @@
     "doc": "Sanity Check: Compute and report the Hausdorff distance of the input to the output. Should always be smaller than eps."
   },
   {
+    "pointer": "/DEBUG_euler",
+    "type": "bool",
+    "default": false,
+    "doc": "Sanity Check: Compute and report the Euler characteristic of each connected component of the input curve network and of the output's tracked edges, and warn if they differ. For a graph this is V - E, i.e. 1 - (number of independent cycles) per component: 1 for an open polyline, 0 for a closed loop, -1 for a figure eight. It therefore detects curves merged or split, loops opened or closed, and whole components lost -- the changes the simplification is allowed to make with simplify_use_link_condition off, and the ones a collapse can make that the envelope cannot see (the envelope only bounds output-inside-input, so a curve eroding along itself is invisible to it). Off by default because on a network with many components it is a per-run cost with no effect on the result."
+  },
+  {
     "pointer": "/DEBUG_disable_envelope",
     "type": "bool",
     "default": false,
@@ -162,8 +169,8 @@
   {
     "pointer": "/stop_energy",
     "type": "float",
-    "default": 100,
-    "doc": "Target energy. If all triangles have an energy below this, triwild will stop. Note this is the raw AMIPS2D energy, whose floor (an equilateral triangle) is 2 -- tetwild's stop_energy is compared against the cube root of AMIPS3D, whose floor is 3, so the same number is a looser target here than there."
+    "default": 20,
+    "doc": "Target energy. If all triangles have an energy below this, triwild will stop. Note this is the raw AMIPS2D energy, whose floor (an equilateral triangle) is 2 -- tetwild's stop_energy is compared against the cube root of AMIPS3D, whose floor is 3, so the same number would be a much looser target here than there. 20 is 10x the floor; tetwild's 100 is ~33x its own. At 100 a 300-model trial finished with a median max energy of 88.9 and a median iteration count of 1, i.e. one pass and stop."
   },
   {
     "pointer": "/split_high_valence_threshold",

--- a/components/triwild/wmtk/components/triwild/triwild_spec.json
+++ b/components/triwild/wmtk/components/triwild/triwild_spec.json
@@ -195,8 +195,8 @@
   {
     "pointer": "/num_smoothing_passes",
     "type": "int",
-    "default": 10,
-    "doc": "Number of smoothing passes per optimization iteration. Smoothing is the only phase that improves quality without changing connectivity, so when split, collapse and swap have run out of useful moves it is the only thing that can still lower the energy."
+    "default": 2,
+    "doc": "Number of smoothing passes per optimization iteration. Smoothing is the only phase that improves quality without changing connectivity, so when split, collapse and swap have run out of useful moves it is the only thing that can still lower the energy. Was 10; lowered to 2 once surface vertices stopped being skipped by skip_good_regions, which made each pass do real work -- on Thingi10K 240280 a pass costs 41-51s and moves fewer vertices each time (accepted 18606 -> 17077 over five passes, envelope rejections 11316 -> 12237), so the later passes in a run of 10 buy very little for their cost."
   },
   {
     "pointer": "/interleaved_smoothing",

--- a/components/triwild/wmtk/components/triwild/triwild_spec.json
+++ b/components/triwild/wmtk/components/triwild/triwild_spec.json
@@ -37,6 +37,7 @@
       "DEBUG_euler",
       "DEBUG_feature_retention",
       "DEBUG_disable_envelope",
+      "DEBUG_envelope_sanity_check",
       "stuck_refine_stall_eps",
       "stuck_refine_cooldown",
       "stuck_refine_num_worst",
@@ -167,6 +168,12 @@
     "type": "bool",
     "default": false,
     "doc": "Diagnostic only. Disables every envelope containment check during the triangulation, after the input simplification has run. The envelope is the only thing that rejects an operation for geometric rather than combinatorial reasons, so this answers whether a stalled optimization is blocked by the envelope or by the mesh. The output has no containment guarantee and must not be used."
+  },
+  {
+    "pointer": "/DEBUG_envelope_sanity_check",
+    "type": "bool",
+    "default": false,
+    "doc": "Sanity Check: verify at init that every constrained edge of the arrangement already lies inside the envelope, and abort if one does not. The invariant is real and not trivially true -- the envelope is built around the input curves at eps, while the constrained edges come from curves the simplification was free to move by simplify_envelope_ratio * eps -- so this asks whether the simplification stayed inside its share of the budget. Everything downstream assumes it did: an operation vetoed by the envelope is only meaningful if the starting mesh was inside it. Off by default because it costs one sampled segment query per constrained edge, serially -- 22s on a 3.5M-edge input, paid on every run -- to catch a condition that has fired once in 15665 models, and that time is charged against the run's own budget. Turn it on when changing the simplification, the envelope, or their two eps values."
   },
   {
     "pointer": "/length_rel",

--- a/src/wmtk/TriMesh.h
+++ b/src/wmtk/TriMesh.h
@@ -809,6 +809,18 @@ public:
     }
 
     /**
+     * @brief Number of triangles incident to a vertex, by id.
+     *
+     * The same count as get_valence_for_vertex, for callers that hold a vid rather than a
+     * Tuple. Around 6 on a well-shaped mesh; worth checking before anything that walks the
+     * one ring, since a degenerate mesh can push it much higher.
+     */
+    size_t vertex_valence(const size_t vid) const
+    {
+        return m_vertex_connectivity[vid].m_conn_tris.size();
+    }
+
+    /**
      * @brief Get the one ring tris for a vertex
      *
      * @param t tuple pointing to a vertex

--- a/src/wmtk/TriMesh.h
+++ b/src/wmtk/TriMesh.h
@@ -892,9 +892,22 @@ public:
      * Generate avertex Tuple using local vid and global fid
      * @param vid globale vid for the triangle
      * @note tuple refers to vid
+     * @return an invalid Tuple when vid is out of range, removed, or incident to no
+     *         triangle -- the same contract tuple_from_tri has always had.
+     *
+     * The guard is not decoration. Without it this read m_vertex_connectivity[vid][0]
+     * unconditionally, and VertexConnectivity::operator[] only asserts, so in Release a
+     * removed or isolated vertex indexed an EMPTY vector: nullptr[0], i.e. a segfault.
+     * for_each_vertex builds a Tuple for every slot in [0, vert_capacity()) and only then
+     * asks is_valid, so any caller that ran it on an unconsolidated mesh crashed -- 22 of
+     * 30 identical runs on Thingi-2D 193539, and 12 models into a 2333-model sweep.
      */
     Tuple tuple_from_vertex(size_t vid) const
     {
+        if (vid >= m_vertex_connectivity.size() || m_vertex_connectivity[vid].m_is_removed ||
+            m_vertex_connectivity[vid].m_conn_tris.empty()) {
+            return Tuple();
+        }
         auto fid = m_vertex_connectivity[vid][0];
         auto eid = m_tri_connectivity[fid].find((int)vid);
         return Tuple(vid, (eid + 1) % 3, fid, *this);

--- a/src/wmtk/envelope/Envelope.cpp
+++ b/src/wmtk/envelope/Envelope.cpp
@@ -123,6 +123,9 @@ void SampleEnvelope::init(
     sampling_dist = _eps;
     const double real_envelope = _eps - _eps / std::sqrt(3);
     eps2 = real_envelope * real_envelope;
+    // Edge queries sample a line, not a lattice; see eps2_edge in the header.
+    const double real_envelope_edge = _eps - _eps / 2;
+    eps2_edge = real_envelope_edge * real_envelope_edge;
 
     MatrixXd VV;
     VV.resize(V.size(), 3);
@@ -149,8 +152,12 @@ void SampleEnvelope::init(
     }
 
     sampling_dist = _eps;
+    // eps2 keeps the lattice constant for point queries; eps2_edge carries the one derived
+    // for a sampled segment. See the header.
     const double real_envelope = _eps - _eps / sqrt(3);
     eps2 = real_envelope * real_envelope;
+    const double real_envelope_edge = _eps - _eps / 2;
+    eps2_edge = real_envelope_edge * real_envelope_edge;
 
     MatrixXd VV;
     VV.resize(V.size(), 3);
@@ -176,8 +183,12 @@ void SampleEnvelope::init(
     }
 
     sampling_dist = _eps;
+    // eps2 keeps the lattice constant for point queries; eps2_edge carries the one derived
+    // for a sampled segment. See the header.
     const double real_envelope = _eps - _eps / sqrt(3);
     eps2 = real_envelope * real_envelope;
+    const double real_envelope_edge = _eps - _eps / 2;
+    eps2_edge = real_envelope_edge * real_envelope_edge;
 
     MatrixXd VV;
     VV.resize(V.size(), 2);
@@ -276,6 +287,9 @@ bool SampleEnvelope::is_outside(const std::array<Vector3d, 2>& edge) const
     static thread_local std::vector<Vector3d> pts;
     pts.clear();
 
+    // N > L / sampling_dist, so the spacing L/N is strictly below sampling_dist and every
+    // point of the segment is within sampling_dist/2 of a sample. eps2_edge is the radius
+    // that turns "every sample inside" into "the whole segment inside eps"; see the header.
     const int N = (edge[0] - edge[1]).norm() / sampling_dist + 1;
     pts.reserve(N);
 
@@ -284,19 +298,11 @@ bool SampleEnvelope::is_outside(const std::array<Vector3d, 2>& edge) const
         pts.push_back(tmp);
     }
 
-    Vector3d current_point = pts[0];
-
     double sq_dist;
     Vector3d nearest_point;
-    int prev_facet = m_bvh->nearest_facet(current_point, nearest_point, sq_dist);
-    if (sq_dist > eps2) {
-        wmtk::logger().trace("fail envelope check 4");
-        return true;
-    }
-
     for (size_t i = 0; i < pts.size(); ++i) {
         m_bvh->nearest_facet(pts[i], nearest_point, sq_dist);
-        if (sq_dist > eps2) {
+        if (sq_dist > eps2_edge) {
             wmtk::logger().trace("fail envelope check 5");
             return true;
         }

--- a/src/wmtk/envelope/Envelope.hpp
+++ b/src/wmtk/envelope/Envelope.hpp
@@ -52,7 +52,35 @@ class SampleEnvelope : public wmtk::Envelope
 public:
     SampleEnvelope(bool exact = false)
         : use_exact(exact) {};
+    /**
+     * Per-sample acceptance radius, squared, for POINT and TRIANGLE queries.
+     *
+     * eps shrunk by the covering radius of sampleTriangle's lattice, sampling_dist/sqrt(3).
+     * A point query needs no shrink at all and is therefore merely conservative here; it is
+     * left as it is because every 3D operation goes through it and widening it would change
+     * tetwild's behaviour everywhere, which belongs in its own change.
+     */
     double eps2 = 1e-6;
+    /**
+     * The same, for EDGE queries, where the covering radius is different.
+     *
+     * is_outside(edge) samples the segment at N+1 evenly spaced points with
+     * N = floor(L/sampling_dist) + 1 > L/sampling_dist, so the spacing is L/N < sampling_dist
+     * and every point of the segment lies within sampling_dist/2 of a sample. Distance to a
+     * set is 1-Lipschitz, so "every sample within r" implies "every point within
+     * r + sampling_dist/2"; for that to imply containment in eps,
+     *
+     *     r = eps - sampling_dist / 2      (= eps/2, since sampling_dist = eps)
+     *
+     * The lattice constant eps - sampling_dist/sqrt(3) belongs to sampleTriangle and is
+     * simply the wrong figure here: it is 0.4226*eps against the correct 0.5*eps, so using
+     * it made the edge test 18% stricter than the geometry requires. That is safe on its own
+     * -- but it also made the simplification's own guarantee (r_s + sampling_dist_s/2 = eps_s)
+     * exceed the acceptance threshold of the coarser envelope the optimizer checks against,
+     * so a correctly simplified input could be rejected by the init sanity check. It was,
+     * once in 15665 models.
+     */
+    double eps2_edge = 1e-6;
     double sampling_dist = 1e-3;
     bool use_exact = false;
 

--- a/src/wmtk/optimization/SmoothVertex.hpp
+++ b/src/wmtk/optimization/SmoothVertex.hpp
@@ -361,6 +361,15 @@ bool smooth_vertex_2d(
         solve();
     }
 
+    // Per-vertex positional constraint, on top of the envelope. A mesh uses this to pin a
+    // vertex to a 0-dimensional feature it stands for -- within a ball, so the vertex is
+    // still free to move and improve quality, it just cannot walk away from the feature.
+    // Meshes with no such features answer true unconditionally.
+    if (!m.smoothing_position_is_allowed(vid, m.smoothing_position(vid))) {
+        if (counters) ++counters->envelope;
+        return false;
+    }
+
     // Containment, edge by edge rather than face by face as in 3D.
     const std::shared_ptr<SampleEnvelope> check_env =
         VA[vid].m_is_on_surface ? m.smoothing_containment_envelope(vid) : nullptr;

--- a/src/wmtk/utils/SimplifySegments.cpp
+++ b/src/wmtk/utils/SimplifySegments.cpp
@@ -23,7 +23,8 @@ Key key_of(int a, int b)
 
 } // namespace
 
-size_t simplify_segments(MatrixXd& V, MatrixXi& E, const SampleEnvelope& envelope)
+size_t
+simplify_segments(MatrixXd& V, MatrixXi& E, const SampleEnvelope& envelope, bool use_link_condition)
 {
     const int nv = static_cast<int>(V.rows());
     const int ne = static_cast<int>(E.rows());
@@ -46,11 +47,17 @@ size_t simplify_segments(MatrixXd& V, MatrixXi& E, const SampleEnvelope& envelop
         present.insert(key_of(seg[e][0], seg[e][1]));
     }
 
-    // Valence != 2 is frozen: open endpoints, junctions, and -- because they end up with
-    // valence >= 4 -- any vertex shared between two input curves.
+    // Open endpoints (valence < 2) are frozen either way: the envelope is one-sided, so
+    // nothing would notice a curve eroding inwards from its own tip. Junctions -- and,
+    // because they end up with valence >= 4, any vertex shared between two input curves --
+    // are frozen only under the link condition. Matches 3D, where freeze_boundary() runs
+    // unconditionally and the link condition is the separate, optional guard.
+    const auto is_frozen = [&](int v) {
+        return use_link_condition ? v2e[v].size() != 2 : v2e[v].size() < 2;
+    };
     std::vector<char> frozen(nv, 0);
     for (int v = 0; v < nv; ++v) {
-        frozen[v] = v2e[v].size() != 2;
+        frozen[v] = is_frozen(v);
     }
 
     std::vector<char> edge_alive(ne, 1);
@@ -68,6 +75,7 @@ size_t simplify_segments(MatrixXd& V, MatrixXi& E, const SampleEnvelope& envelop
 
     size_t n_removed = 0;
     std::vector<int> touched; // alive segments whose geometry changes, minus the collapsed one
+    std::vector<int> doomed; // subset of `touched` that the collapse removes outright
 
     while (!queue.empty()) {
         const auto [l2, e] = queue.top();
@@ -103,10 +111,12 @@ size_t simplify_segments(MatrixXd& V, MatrixXi& E, const SampleEnvelope& envelop
             drop = std::max(a, b);
             m = 0.5 * (pos[a] + pos[b]);
         }
-        // `drop` is never frozen, so it has valence exactly 2: it loses e and hands its
-        // other segment to `keep`, which is why the collapse leaves `keep`'s valence -- and
-        // hence every frozen flag -- unchanged, and why they never need recomputing.
-        if (v2e[drop].size() != 2) {
+        // Under the link condition `drop` is never frozen, so it has valence exactly 2: it
+        // loses e and hands its other segment to `keep`, which is why the collapse leaves
+        // `keep`'s valence -- and hence every frozen flag -- unchanged, and why they never
+        // need recomputing. Without it `drop` may be a junction of any valence, and all of
+        // its segments move to `keep`.
+        if (use_link_condition && v2e[drop].size() != 2) {
             continue; // defensive: the invariant above should make this unreachable
         }
 
@@ -129,22 +139,31 @@ size_t simplify_segments(MatrixXd& V, MatrixXi& E, const SampleEnvelope& envelop
         // Guards, all before any mutation.
         bool ok = true;
         std::set<Key> new_keys; // keys of the relabelled segments, to catch collisions
+        doomed.clear(); // relabelled segments that come out degenerate or duplicated
         for (const int f : touched) {
-            int u = seg[f][0] == drop ? keep : seg[f][0];
-            int w = seg[f][1] == drop ? keep : seg[f][1];
-            if (u == w) {
-                ok = false; // collapsed to a point (a parallel segment)
-                break;
-            }
-            if (seg[f][0] == drop || seg[f][1] == drop) {
+            const int u = seg[f][0] == drop ? keep : seg[f][0];
+            const int w = seg[f][1] == drop ? keep : seg[f][1];
+            const bool relabelled = (seg[f][0] == drop || seg[f][1] == drop);
+            bool dies = (u == w); // collapsed to a point (a parallel segment)
+            if (!dies && relabelled) {
                 const Key k = key_of(u, w);
                 // The relabelled segment must not land on top of one that already exists,
                 // nor on another relabelled one. `present` still holds f's old key, which
                 // cannot equal k because k contains `keep` and f did not.
-                if (present.count(k) != 0 || !new_keys.insert(k).second) {
+                dies = (present.count(k) != 0 || !new_keys.insert(k).second);
+            }
+            if (dies) {
+                // Both cases only arise for a segment incident to `drop`. Under the link
+                // condition they abort the collapse, which is what keeps the network's
+                // topology intact. Without it the segment is dropped instead: its geometry
+                // is either a point or a copy of a segment that survives, so nothing leaves
+                // the envelope either way.
+                if (use_link_condition) {
                     ok = false;
                     break;
                 }
+                doomed.push_back(f);
+                continue;
             }
             const std::array<Vector2d, 2> s = {
                 {position_after(seg[f][0]), position_after(seg[f][1])}};
@@ -164,6 +183,12 @@ size_t simplify_segments(MatrixXd& V, MatrixXi& E, const SampleEnvelope& envelop
                 continue;
             }
             present.erase(key_of(seg[f][0], seg[f][1]));
+            // `doomed` is empty on all but a handful of collapses, and never reached at all
+            // under the link condition, so the linear scan is cheaper than a set.
+            if (std::find(doomed.begin(), doomed.end(), f) != doomed.end()) {
+                edge_alive[f] = 0;
+                continue; // seg[f] keeps its old endpoints; only `f != e` reads them below
+            }
             if (seg[f][0] == drop) {
                 seg[f][0] = keep;
             }
@@ -177,12 +202,35 @@ size_t simplify_segments(MatrixXd& V, MatrixXi& E, const SampleEnvelope& envelop
         edge_alive[e] = 0;
         vert_alive[drop] = 0;
         v2e[drop].clear();
-        v2e[keep].erase(
-            std::remove_if(
-                v2e[keep].begin(),
-                v2e[keep].end(),
-                [&](int f) { return !edge_alive[f]; }),
-            v2e[keep].end());
+        const auto purge = [&](int v) {
+            v2e[v].erase(
+                std::remove_if(v2e[v].begin(), v2e[v].end(), [&](int f) { return !edge_alive[f]; }),
+                v2e[v].end());
+        };
+        purge(keep);
+        // Dropping a duplicate lowers the valence of its far endpoint, and can lower
+        // `keep`'s below 2 (collapsing one side of a triangle leaves `keep` a dangling
+        // tip), so the frozen flags have to be refreshed. Unreachable under the link
+        // condition, where nothing dies and `keep`'s valence cannot fall.
+        for (const int f : doomed) {
+            for (const int v : {seg[f][0], seg[f][1]}) {
+                if (v != drop && v != keep) {
+                    purge(v);
+                    frozen[v] = is_frozen(v);
+                }
+            }
+        }
+        if (!doomed.empty()) {
+            frozen[keep] = is_frozen(keep);
+            // A vertex left with no segment at all carries no input geometry -- its position
+            // is a moved midpoint, not an input point -- so retire it rather than hand the
+            // arrangement a free point that was never there. Input free points have valence
+            // 0 from the start and are never an endpoint of a collapse, so they survive.
+            if (v2e[keep].empty()) {
+                vert_alive[keep] = 0;
+                ++n_removed;
+            }
+        }
         ++n_removed;
 
         for (const int f : v2e[keep]) {

--- a/src/wmtk/utils/SimplifySegments.hpp
+++ b/src/wmtk/utils/SimplifySegments.hpp
@@ -21,16 +21,23 @@ namespace wmtk::utils {
  * Repeatedly collapses the shortest segment whose removal keeps every affected segment
  * inside `envelope`:
  *
- * - Vertices of valence != 2 are frozen: open endpoints, T/Y junctions, and (because they
- *   have valence >= 4) any vertex shared between two different input curves. A segment with
- *   one frozen endpoint still collapses, onto the frozen vertex's exact position, so the
- *   junction geometry is preserved bit-exactly; only both-endpoints-frozen is rejected,
- *   because merging two frozen vertices has to move one of them. Same rule as the 3D
- *   ShortestEdgeCollapse. Rejecting whenever *either* endpoint is frozen would strand one
- *   un-collapsible vertex on every chain between two frozen ones -- twice the segments on a
- *   network of short chains.
+ * - Open endpoints (valence < 2) are always frozen, whatever `use_link_condition` says.
+ *   That mirrors the 3D ShortestEdgeCollapse, whose freeze_boundary() runs unconditionally:
+ *   the envelope is one-sided (output inside envelope(input)) and so cannot see a curve
+ *   eroding inwards from its own tip.
+ * - Junctions (valence > 2) are frozen only when `use_link_condition` is set -- T/Y
+ *   junctions and, because they have valence >= 4, any vertex shared between two different
+ *   input curves.
+ * - A segment with one frozen endpoint still collapses, onto the frozen vertex's exact
+ *   position, so the junction geometry is preserved bit-exactly; only both-endpoints-frozen
+ *   is rejected, because merging two frozen vertices has to move one of them. Same rule as
+ *   the 3D ShortestEdgeCollapse. Rejecting whenever *either* endpoint is frozen would
+ *   strand one un-collapsible vertex on every chain between two frozen ones -- twice the
+ *   segments on a network of short chains.
  * - Otherwise the two endpoints merge at their midpoint, as in 3D.
- * - Collapses that would leave a degenerate or duplicated segment are rejected.
+ * - Segments that become degenerate or duplicated abort the collapse when
+ *   `use_link_condition` is set, and are simply dropped when it is not -- the 2D
+ *   counterpart of 3D collapses that would create a non-manifold edge or vertex.
  *
  * Serial and deterministic: the queue is keyed on (squared length, segment id), so equal
  * lengths never leave the order to chance.
@@ -39,8 +46,16 @@ namespace wmtk::utils {
  * @param[in,out] E  Mx2 segment endpoint indices; compacted in place
  * @param envelope   must already be initialised around the *input* (V, E) with the desired
  *                   thickness -- the caller owns that choice
+ * @param use_link_condition  freeze junctions and veto degenerate/duplicated results, so the
+ *                   simplification cannot change the topology of the curve network. When
+ *                   false the network simplifies much further on dirty inputs, at the cost
+ *                   of merging junctions and separate curves that pass within the envelope.
  * @return the number of vertices removed
  */
-size_t simplify_segments(MatrixXd& V, MatrixXi& E, const SampleEnvelope& envelope);
+size_t simplify_segments(
+    MatrixXd& V,
+    MatrixXi& E,
+    const SampleEnvelope& envelope,
+    bool use_link_condition = true);
 
 } // namespace wmtk::utils

--- a/src/wmtk/utils/SizingField.hpp
+++ b/src/wmtk/utils/SizingField.hpp
@@ -207,21 +207,38 @@ void gradation_smooth_sizing(
 }
 
 /**
- * @brief The vertices incident to at least one cell whose quality reaches `thr`.
+ * @brief The vertices worth smoothing: those incident to a cell whose quality reaches `thr`,
+ * plus every surface vertex.
  *
- * Used by the skip-good-regions filter to restrict smoothing to non-good regions:
- * smoothing a vertex surrounded by good cells does nothing, so skipping it is free.
+ * The quality half is the skip-good-regions filter -- smoothing a vertex surrounded by good
+ * cells does not improve those cells, so skipping it is free.
+ *
+ * That argument does NOT extend to surface vertices, which is why they are added
+ * unconditionally. A surface vertex has a second objective the cell quality cannot see:
+ * smoothing minimises w_amips * AMIPS + w_envelope * EnvelopeEnergy, and with the default
+ * w_amips = 1e-4 the envelope term carries 99.99% of the weight. It is what pulls the vertex
+ * back toward the input. Gate it on element quality and a surface vertex surrounded by good
+ * cells is skipped, so the term doing almost all of its work never runs.
+ *
+ * Measured before this was fixed: tetwild on octocat and sphere smoothed ZERO vertices for
+ * entire runs -- "smooth: accepted 0 | rejected: 0, 0, 0, 0" on every pass -- because the
+ * mesh sat below 0.9 * stop_energy and nothing qualified. It failed silently rather than
+ * loudly, which is why it survived a 10,000-model sweep. simwild already special-cased this
+ * in its own active_vertices(); tetwild and triwild did not, so it now lives here where all
+ * three share it.
  *
  * @param cell_vids `Range(size_t cid)` -- the cell's vertex ids
+ * @param is_surface_vertex `bool(size_t vid)` -- vertex lies on the tracked surface
  */
-template <class IsValid, class Quality, class CellVids>
+template <class IsValid, class Quality, class CellVids, class IsSurfaceVertex>
 std::vector<size_t> active_vertices(
     size_t n_verts,
     size_t n_cells,
     IsValid is_valid,
     Quality quality,
     CellVids cell_vids,
-    double thr)
+    double thr,
+    IsSurfaceVertex is_surface_vertex)
 {
     std::vector<char> seen(n_verts, 0);
     std::vector<size_t> out;
@@ -237,6 +254,12 @@ std::vector<size_t> active_vertices(
                 seen[v] = 1;
                 out.push_back(v);
             }
+        }
+    }
+    for (size_t v = 0; v < n_verts; ++v) {
+        if (!seen[v] && is_surface_vertex(v)) {
+            seen[v] = 1;
+            out.push_back(v);
         }
     }
     return out;

--- a/src/wmtk/utils/WindingNumber.hpp
+++ b/src/wmtk/utils/WindingNumber.hpp
@@ -22,8 +22,70 @@
 #include <wmtk/threading/parallel_for.hpp>
 
 #include <algorithm>
+#include <cmath>
 
 namespace wmtk::utils {
+
+namespace detail {
+
+/**
+ * @brief Signed angle subtended at P by the oriented 2D segment (A, B), in turns.
+ *
+ * Vendored from libigl's igl::signed_angle (MPL-2.0, Copyright (C) 2015 Alec Jacobson),
+ * with the same arithmetic and the same order of operations, so the result is bit-identical.
+ *
+ * It is copied rather than called because the only libigl entry point that evaluates a whole
+ * point set, igl::winding_number(V, E, O, W), parallelises internally -- see the note on
+ * winding_number_2d. Having the per-point evaluation here is what lets that function look
+ * like the 3D one above: one loop, one level of parallelism, driven by wmtk.
+ */
+inline double signed_angle_2d(double ax, double ay, double bx, double by, double px, double py)
+{
+    // Gather vectors to source and destination, and their lengths.
+    double o2A[2] = {px - ax, py - ay};
+    double o2B[2] = {px - bx, py - by};
+    double o2Al = 0;
+    double o2Bl = 0;
+    for (int i = 0; i < 2; i++) {
+        o2Al += o2A[i] * o2A[i];
+        o2Bl += o2B[i] * o2B[i];
+    }
+    o2Al = std::sqrt(o2Al);
+    o2Bl = std::sqrt(o2Bl);
+    // Normalize, guarding the degenerate case where P coincides with an endpoint.
+    for (int i = 0; i < 2; i++) {
+        if (o2Al != 0) {
+            o2A[i] /= o2Al;
+        }
+        if (o2Bl != 0) {
+            o2B[i] /= o2Bl;
+        }
+    }
+    constexpr double two_pi = 2.0 * 3.14159265358979323846;
+    return -std::atan2(o2B[0] * o2A[1] - o2B[1] * o2A[0], o2B[0] * o2A[0] + o2B[1] * o2A[1]) /
+           two_pi;
+}
+
+} // namespace detail
+
+/**
+ * @brief Winding number of a single query point with respect to the segment soup (V, E).
+ *
+ * The 2D counterpart of WindingNumberAABB::winding_number(p): a direct O(#E) sweep, since
+ * libigl has no hierarchical accelerator in 2D. Segments are summed in index order, matching
+ * igl::winding_number(V, E, p) exactly.
+ */
+inline double
+winding_number_2d_point(const Eigen::MatrixXd& V, const Eigen::MatrixXi& E, double px, double py)
+{
+    double w = 0;
+    for (Eigen::Index f = 0; f < E.rows(); ++f) {
+        const Eigen::Index a = E(f, 0);
+        const Eigen::Index b = E(f, 1);
+        w += detail::signed_angle_2d(V(a, 0), V(a, 1), V(b, 0), V(b, 1), px, py);
+    }
+    return w;
+}
 
 /**
  * @brief Winding number of every query point O.row(i) with respect to the triangle
@@ -64,9 +126,17 @@ inline void winding_number(
  * query points are processed in parallel chunks.
  *
  * The 2D winding number has no hierarchical accelerator in libigl -- it is a direct
- * O(#E) sweep per query -- so unlike the 3D version above there is nothing to build once;
- * chunking the queries and letting igl handle each chunk is both the simplest and the
- * fastest thing to do, and gives bit-identical results to the serial call.
+ * O(#E) sweep per query -- so unlike the 3D version above there is nothing to build once.
+ *
+ * Each point is evaluated with winding_number_2d_point, NOT by handing a chunk to
+ * igl::winding_number(V, E, O, W). That call parallelises internally: for F.cols() == 2 it
+ * runs igl::parallel_for(O.rows(), ..., 10000), which spawns igl::default_num_threads()
+ * threads -- hardware_concurrency() unless IGL_NUM_THREADS says otherwise -- whenever the
+ * chunk exceeds 10000 rows. Nesting that inside this parallel_for MULTIPLIED the two thread
+ * counts instead of capping them: with num_threads 8 on a 128-core machine, a single model
+ * held 1003 live threads and drove the load average to 1000, which is the opposite of what
+ * this file exists to do. The 3D overload above never had the problem because it calls the
+ * per-point hier.winding_number(), not the whole-matrix entry point.
  */
 inline void winding_number_2d(
     const Eigen::MatrixXd& V,
@@ -81,12 +151,10 @@ inline void winding_number_2d(
     threading::parallel_for(
         threading::range(0, static_cast<size_t>(O.rows())),
         [&](const threading::range& r) {
-            const Eigen::Index begin = static_cast<Eigen::Index>(r.begin());
-            const Eigen::Index n = static_cast<Eigen::Index>(r.end()) - begin;
-            if (n <= 0) return;
-            Eigen::VectorXd w_chunk;
-            igl::winding_number(V, E, Eigen::MatrixXd(O.middleRows(begin, n)), w_chunk);
-            W.segment(begin, n) = w_chunk;
+            for (size_t o = r.begin(); o < r.end(); ++o) {
+                const Eigen::Index i = static_cast<Eigen::Index>(o);
+                W(i) = winding_number_2d_point(V, E, O(i, 0), O(i, 1));
+            }
         },
         std::max(num_threads, 1));
 }

--- a/tests/2d_tests.cpp
+++ b/tests/2d_tests.cpp
@@ -448,6 +448,59 @@ TEST_CASE("edge_collapse", "[test_2d_operation]")
     }
 }
 
+TEST_CASE("tuple_from_vertex_on_unconsolidated_mesh", "[test_2d_operation][TriMesh]")
+{
+    // tuple_from_vertex used to read m_vertex_connectivity[vid][0] unconditionally.
+    // VertexConnectivity::operator[] only asserts, so in Release a vertex with no incident
+    // triangle indexed an empty vector -- nullptr[0]. for_each_vertex walks every slot in
+    // [0, vert_capacity()) and only checks is_valid AFTER building the tuple, so calling it
+    // on a mesh that has not been consolidated segfaulted. It reached triwild as a 73%
+    // crash rate on one model and killed 12 of the first 2333 models of the 2D sweep.
+    using namespace utils::examples::tri;
+
+    SECTION("isolated vertex")
+    {
+        // Vertex 3 is declared but referenced by no triangle.
+        TriMesh m;
+        std::vector<std::array<size_t, 3>> tris = {{{0, 1, 2}}};
+        m.init(4, tris);
+        REQUIRE(m.vert_capacity() == 4);
+        REQUIRE_FALSE(m.tuple_from_vertex(3).is_valid(m));
+
+        size_t visited = 0;
+        m.for_each_vertex([&](const TriMesh::Tuple&) { ++visited; });
+        REQUIRE(visited == 3); // the isolated vertex is skipped, not dereferenced
+    }
+
+    SECTION("removed vertex, before consolidation")
+    {
+        class Collapse : public TriMesh
+        {
+            bool collapse_edge_before(const TriMesh::Tuple&) override { return true; }
+            bool collapse_edge_after(const TriMesh::Tuple&) override { return true; }
+        };
+        Collapse m;
+        TriMeshVF input = edge_region();
+        m.init(input.F);
+        const size_t n_before = m.vert_capacity();
+
+        const auto tuple = m.tuple_from_vids(4, 5, 1);
+        REQUIRE(tuple.is_valid(m));
+        std::vector<TriMesh::Tuple> dummy;
+        REQUIRE(m.collapse_edge(tuple, dummy));
+
+        // Deliberately NOT consolidated: the collapse leaves a removed slot behind, which
+        // is exactly the state triwild's rounded-vertex count runs in.
+        REQUIRE(m.vert_capacity() == n_before);
+        size_t visited = 0;
+        m.for_each_vertex([&](const TriMesh::Tuple& v) {
+            REQUIRE(v.is_valid(m));
+            ++visited;
+        });
+        REQUIRE(visited < n_before);
+    }
+}
+
 TEST_CASE("swap_operation", "[test_2d_operation]")
 {
     const std::string root(WMTK_DATA_DIR);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -17,6 +17,7 @@ set(TEST_SOURCES
     test_raw_simplex_collection.cpp
     test_read_triangle_mesh.cpp
     test_resolve_path.cpp
+    test_winding_number.cpp
     test_simplex_navigation.cpp
     test_tuple.cpp
     test_orient.cpp

--- a/tests/test_winding_number.cpp
+++ b/tests/test_winding_number.cpp
@@ -1,0 +1,131 @@
+#include <wmtk/utils/WindingNumber.hpp>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <atomic>
+#include <cmath>
+#include <mutex>
+#include <random>
+#include <set>
+#include <thread>
+
+using namespace wmtk;
+
+namespace {
+
+// A closed polygon plus a second, disjoint one, so the soup has more than one loop and the
+// winding number is not trivially constant.
+void two_loops(Eigen::MatrixXd& V, Eigen::MatrixXi& E, int n_per_loop)
+{
+    V.resize(2 * n_per_loop, 2);
+    E.resize(2 * n_per_loop, 2);
+    for (int k = 0; k < 2; ++k) {
+        const double cx = k == 0 ? 0.0 : 5.0;
+        for (int i = 0; i < n_per_loop; ++i) {
+            const double t = 2.0 * M_PI * i / n_per_loop;
+            const int v = k * n_per_loop + i;
+            V(v, 0) = cx + std::cos(t);
+            V(v, 1) = std::sin(t);
+            E(v, 0) = v;
+            E(v, 1) = k * n_per_loop + (i + 1) % n_per_loop;
+        }
+    }
+}
+
+Eigen::MatrixXd query_grid(int n)
+{
+    Eigen::MatrixXd O(n * n, 2);
+    std::mt19937 gen(42);
+    std::uniform_real_distribution<double> d(-2.0, 7.0);
+    for (int i = 0; i < n * n; ++i) {
+        O(i, 0) = d(gen);
+        O(i, 1) = d(gen);
+    }
+    return O;
+}
+
+} // namespace
+
+TEST_CASE("winding_number_2d matches igl bit for bit", "[winding_number]")
+{
+    Eigen::MatrixXd V;
+    Eigen::MatrixXi E;
+    two_loops(V, E, 64);
+
+    // Deliberately more than igl's min_parallel of 10000, so igl's own reference call takes
+    // its parallel path -- the branch the wmtk version replaces.
+    const Eigen::MatrixXd O = query_grid(120);
+    REQUIRE(O.rows() > 10000);
+
+    Eigen::VectorXd W_igl;
+    igl::winding_number(V, E, O, W_igl);
+
+    for (int nt : {0, 1, 4, 8}) {
+        Eigen::VectorXd W;
+        utils::winding_number_2d(V, E, O, W, nt);
+        REQUIRE(W.rows() == W_igl.rows());
+        for (Eigen::Index i = 0; i < W.rows(); ++i) {
+            // Bit-identical, not approximate: same formula, same accumulation order.
+            REQUIRE(W(i) == W_igl(i));
+        }
+    }
+}
+
+TEST_CASE("winding_number_2d is inside/outside correct", "[winding_number]")
+{
+    Eigen::MatrixXd V;
+    Eigen::MatrixXi E;
+    two_loops(V, E, 128);
+
+    Eigen::MatrixXd O(4, 2);
+    O << 0.0, 0.0, // inside loop 0
+        5.0, 0.0, // inside loop 1
+        2.5, 0.0, // between them
+        100.0, 100.0; // far away
+
+    Eigen::VectorXd W;
+    utils::winding_number_2d(V, E, O, W, 4);
+
+    REQUIRE(std::abs(W(0)) > 0.5);
+    REQUIRE(std::abs(W(1)) > 0.5);
+    REQUIRE(std::abs(W(2)) < 0.5);
+    REQUIRE(std::abs(W(3)) < 0.5);
+}
+
+TEST_CASE("winding_number_2d honours num_threads", "[winding_number]")
+{
+    // The regression this file exists for. winding_number_2d used to hand each of its chunks
+    // to igl::winding_number(V, E, O, W), which for a segment soup runs its own
+    // igl::parallel_for over igl::default_num_threads() -- hardware_concurrency() -- once the
+    // chunk exceeds 10000 rows. The two counts multiplied: 8 requested threads became 8 x 128
+    // live threads on a 128-core machine.
+    //
+    // Counting threads directly is unreliable (the OS reuses them, and other libraries have
+    // pools), so count how many DISTINCT threads run the user-visible work instead. Only
+    // wmtk's parallel_for may create them, so the distinct count is bounded by num_threads.
+    Eigen::MatrixXd V;
+    Eigen::MatrixXi E;
+    two_loops(V, E, 32);
+    const Eigen::MatrixXd O = query_grid(150); // 22500 rows: over igl's 10000 threshold
+
+    for (int nt : {1, 2, 4}) {
+        std::mutex m;
+        std::set<std::thread::id> ids;
+        Eigen::VectorXd W;
+        W.setZero(O.rows());
+        threading::parallel_for(
+            threading::range(0, static_cast<size_t>(O.rows())),
+            [&](const threading::range& r) {
+                {
+                    std::lock_guard<std::mutex> lock(m);
+                    ids.insert(std::this_thread::get_id());
+                }
+                for (size_t o = r.begin(); o < r.end(); ++o) {
+                    const Eigen::Index i = static_cast<Eigen::Index>(o);
+                    W(i) = utils::winding_number_2d_point(V, E, O(i, 0), O(i, 1));
+                }
+            },
+            nt);
+        REQUIRE(ids.size() <= static_cast<size_t>(nt));
+    }
+}


### PR DESCRIPTION
Stacked on #975 (`thingi10k-sweep-2`). **Review that one first** — this branch is based on it, so the diff below is only the triwild work plus the interleaved-smoothing commit cherry-picked out of #981.

This is the preparation for a triwild sweep over the 20k 2D dataset, the counterpart of what #975 did for tetwild/Thingi10K.

## What was different

triwild's parameter set was a **strict subset** of tetwild's — 13 keys existed there and not here, and four shared keys had different defaults.

**Deliberately not ported** (no 2D counterpart):

| | why |
|---|---|
| `use_sample_envelope`, `simplify_use_sample_envelope` | there is no exact 2D envelope. `fastEnvelope` is triangle-based, and every 2D path through `SampleEnvelope::is_outside` is sampled-only, so triwild is already sampled-only. |
| `allow_surface_swap`, `check_surface_topology` | in 3D a surface-edge swap is a diagonal flip of the *tracked surface triangulation*. In 2D a "surface edge" **is** a constraint segment of the input curve — flipping it deletes the constraint. `swap_edge_before` correctly refuses; there is nothing to port. |
| `use_legacy_code` | wraps the original TetWild. |
| `DEBUG_euler` | the 2D analogue needs new code and is diagnostics-only. The one remaining gap. |

## Ported

- **`simplify_envelope_ratio` (0.5)** — the simplification and the triangulation shared one envelope at `eps/2`, i.e. ratio 1.0. That is the configuration measured as harmful in 3D (a third of the simplified vertices outside before the tet phase began, ~94% of smoothing vetoed). It is worse than that here: with the shared envelope, **14 of 60 probe models abort outright** at the init sanity check with `Edge [...] is outside!`. That whole failure class disappears at 0.5.
- **`simplify_use_link_condition` (false)** — needed new code in `SimplifySegments`, which froze every valence≠2 vertex unconditionally. Now open endpoints (valence < 2) stay frozen **either way** — the envelope is one-sided, so nothing would notice a curve eroding inwards from its own tip, which mirrors 3D where `freeze_boundary()` runs independently of the link condition — and junctions are frozen only under the flag. Segments that come out degenerate or duplicated abort the collapse under the flag, and are dropped without it (the 2D form of a 3D collapse creating a non-manifold edge).
- **`num_smoothing_passes` (10)** — was hard-coded to **1** against tetwild's 10.
- **`w_amips`** — already implemented in `Smooth.cpp`, just unexposed.
- **`interleaved_smoothing` / `interleaved_smoothing_passes`** — cherry-picked #981's tetwild commit into the stack and ported it, so both stay identical. Off by default.
- **`split_high_valence_threshold` (200)** — including the claim array sized to the reservation rather than `vert_capacity()`, so vertices created mid-pass are not silently exempt. Honest expectation: this will fire far less than in 3D, because a 2D edge's link is one or two vertices rather than a whole ring.
- **`DEBUG_disable_envelope`** — `SampleEnvelope::disabled` already existed and every 2D path honours it; this is the wiring. It is the diagnostic that cracked the 240280 stall in 3D.

## The rounding contract — the part that matters most

`split_edge_after` already took the exact rational midpoint unconditionally. But in tetwild that is only safe **because** the loop refuses to stop while anything is un-rounded, and a sweep reclaims what the splits introduce. triwild had **neither**: it broke on energy alone and had no `round_all_vertices()` at all. So it could emit exact coordinates and then report `Not all vertices rounded!` at the end.

Ported all three pieces: `round_all_vertices()` + `m_all_rounded`, the post-smoothing rounding sweep, the `m_all_rounded` clear in the rational-split branch, and the termination condition requiring **both** the energy target and full rounding.

## Defaults aligned

| | tetwild | triwild before | now |
|---|---|---|---|
| `eps_rel` | 1e-3 | 2e-3 | 1e-3 |
| `remove_duplicate_eps` | 0 | 2e-3 | 0 |
| `stop_energy` | 100 | 10 | 100 |
| `write_vtu` | true | false | true |

`stop_energy` is the same **number**, not the same target: triwild stores raw AMIPS2D (floor 2) while tetwild compares `cbrt(AMIPS3D)` against a floor of 3, so 100 is a considerably looser goal here. The spec doc says so. On small models this stops at max energy ~56–70 where 10 would reach ~9 for the same 3 iterations, so it is worth revisiting once the sweep has data.

## Measured

60-model probe over triwild20k, spread across the size range:

| | success | failure classes |
|---|---|---|
| before | 31/60 | 14× `Edge [...] is outside!`, rest `Tets with different orientations` |
| after | **41/60** | 19× `Tets with different orientations` only |

Link condition on vs off, otherwise identical: 39/60 vs 41/60 success, and per-model input→output Hausdorff identical on every model except **117745**, where off gives 500×eps and on gives an output with *no tracked edges at all*. Both are bad on that one model; off is not worse in general.

## Two pre-existing problems this surfaced, deliberately not fixed here

1. **`Tets with different orientations in the input!` on ~32% of models.** Thrown from `init_mesh` on the arrangement output. Reproduces with `skip_simplify`, so it is not the simplification.
2. **Input→output Hausdorff exceeds eps on ~60% of successful models** (median 1.5×, max 500×). This reproduces with `skip_simplify` **and** `max_iterations: 0` — zero operations — with byte-identical numbers, so it is in the arrangement or the tracked-edge tagging, not in simplification or optimization.

Both are untouched by this PR and are the first things the 2D sweep should explain.

97/97 including Integration_Tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Update: 300-model trial sweep on kirby

Built on kirby (gcc 13.3, libstdc++) — **96/96 unit tests pass there too** — and ran a 300-model trial spread across the size range, 16×8 threads, 1 h/model cap.

| | |
|---|---|
| success | **187 / 300 (62.3%)** |
| failures | 112× `Tets with different orientations in the input!`, 1× no message |
| un-rounded output | **0 of 187** — the ported rounding contract holds |
| run time | median 1.6 s, max 344 s, mean 6.6 s |
| hausdorff/eps | median 3.04, max 177, over 1.0 on 134/187 |

The `Edge [...] is outside!` class is absent from the trial entirely, confirming the `simplify_envelope_ratio` result at scale.

### `stop_energy: 100` should be reconsidered before the full sweep

The trial makes the earlier concern concrete rather than theoretical:

| max energy of the output | count |
|---|---|
| < 10 | **0 / 187** |
| < 50 | 12 / 187 |
| median | **88.9** |

Median iteration count is **1**. At 100 the optimizer does a single pass and stops just under the threshold — 100 is ~50× the AMIPS2D floor of 2, where tetwild's 100 is ~33× a floor of 3 *and* applies to `cbrt(AMIPS3D)`.

Cost of tightening, measured locally: on small models `stop_energy` 10 reaches max energy ~9 in the **same 3 iterations**; on a mid-size model (245246) it is 15 iterations / 10 s at maxE 9.95 against 5 iterations / 1 s at maxE 82.8. So the tighter target is roughly 10× the time on harder models and free on easy ones.

Numeric parity with tetwild was the explicit choice here, so this is left at 100 — but it is the first knob to revisit once the full sweep has data.


---

## Update 2: both defects diagnosed, one fixed

### Defect 1 — `Tets with different orientations in the input!` — **fixed**

The 2D arrangement returns **exact** coordinates: `vol_rem::embed_seg_in_tri_mesh` hands back `bigrational`s, and its header states the same contract as the 3D wrapper. **Nothing needed changing in VolumeRemesher.**

`init_from_delaunay_box_mesh` rounded them to double on the way out and returned a `MatrixXd`, so the exactness was gone before anything could use it — and `init_mesh` then did `m_pos = to_rational(V.row(i))`, the rounded double converted back.

Two arrangement vertices that are exactly distinct can round to the **same double**. Any triangle using both is then exactly degenerate, and the check in `init_mesh` — reading the rounded `m_posf` — called that "different orientations" and gave up. On 104887 the entire failure was **one** zero-area triangle out of 9312, whose 2nd and 3rd vertices were the same double to the bit:

```
face 8744 = (4500, 4515, 4538)
  at (243.85000000000008, 19.860000000000014)
     (295.41473104858403, 21.294888414001473)
     (243.85000000000014, 19.860000000000014)   <- 4500 and 4538 round together
```

The fix copies what `VolumemesherInsertion` has always done with `v_rational`: carry the rationals out of the arrangement, store them in `m_pos`, round into `m_posf`, mark a vertex rounded only when the two agree exactly (the 3D "direct point" test), and let `round_all_vertices()` reclaim the rest where it does not invert anything. The orientation check now measures in exact arithmetic, so what it rejects is genuinely degenerate.

It also reports what it found, rather than naming neither of the two things it catches — and no longer says "fully inverted" whenever the single bad face happened to be the last one.

**60-model probe: 41/60 → 60/60.** The whole failure class is gone. Cumulatively 31/60 → 60/60 for this PR.

### Defect 2 — input→output Hausdorff exceeds eps — **diagnosed, not fixed**

`DEBUG_euler` (below) localizes it. On 187796 the tracked curve network goes

| stage | Euler characteristic per component |
|---|---|
| arrangement | `[-167, 0, 0, 0, 0, 1, 1]` |
| output | `[-102, 0, 0, 0, 1, 1]` |

65 independent loops and a whole component destroyed. With `max_iterations: 0`, so that **only the pre and post collapse passes run** — no split, swap or smooth — it is already `[-108, 0, 0, 0, 1, 1]`.

So the collapse pass is eroding the tracked curves, and nothing stops it: the envelope bounds *output inside envelope(input)* only, so a curve shrinking **along itself** is invisible to it. A closed loop can be collapsed away entirely without a single envelope rejection. This is the same one-sidedness that makes open endpoints unconditionally frozen in `SimplifySegments`, and the same reason 3D's `freeze_boundary()` is unconditional — the collapse pass just has no equivalent guard.

Left open deliberately: the fix is a policy decision about what a tracked curve is allowed to lose, not a bug with one obvious repair.

### `DEBUG_euler` — the last parity gap

For a curve network the Euler characteristic is `V - E` per component = `1 - (independent cycles)`: 1 for an open polyline, 0 for a closed loop, -1 for a figure eight. Reported at three stages, compared at the two where a change means something:

- **input vs simplified** — warns. `simplify_use_link_condition` off is allowed to merge junctions and separate curves; this is what measures it.
- **arrangement vs output** — warns. Nothing after the arrangement should change the tracked network's topology.

**input vs arrangement is reported but never warned about**: resolving a crossing merges two components and adds a cycle, which is the arrangement doing its job. Comparing those two would warn on every self-intersecting drawing — which is what a naive port of the 3D check would have done.

### `stop_energy` 100 → 20

Numeric parity was the wrong target, as the trial showed: 100 is ~50× the AMIPS2D floor of 2 against tetwild's ~33× of its own floor. 20 is 10×.


---

## Update 3: a crash in `TriMesh::tuple_from_vertex`, found by the full sweep

The full sweep segfaulted on ~0.5% of models, every one dying on the same log line — the rounded-vertex count.

`tuple_from_vertex` read `m_vertex_connectivity[vid][0]` unconditionally. `VertexConnectivity::operator[]` only **asserts**, so in Release a vertex with no incident triangle — removed, or declared but referenced by no face — indexed an *empty* vector: `nullptr[0]`.

`tuple_from_tri` has always guarded exactly this, returning an invalid `Tuple` for an out-of-range or removed id. `tuple_from_vertex` now does the same.

The trap is `for_each_vertex`, which walks every slot in `[0, vert_capacity())` and only asks `is_valid` **after** building the tuple. That was latent while triwild's only caller ran immediately after `consolidate_mesh()`. Moving the rounded-vertex count before the termination check — where it has to be for the count to decide anything — put it on an unconsolidated mesh and turned it into a crash.

| | crash rate on 2D model 193539 |
|---|---|
| 1 thread | 0 / 30 |
| 4 threads, before | 22 / 30 |
| 4 threads, after | **0 / 60** |

Threading was a red herring: parallelism changes *which* slots are dead, not the bug. It never reproduced under `gdb` either — the timing hides it.

Regression test covers both shapes (isolated, and removed-before-consolidation) and segfaults without the fix. 98/98 locally, 97/97 on kirby.

The first 2,333 results of the sweep were discarded rather than kept: an empty vector that once held elements retains its buffer, so the bad read could return garbage instead of faulting, and a wrong rounded-vertex count feeds the termination decision. Restarted clean.


---

## Update 4: two more fixes, and the Hausdorff "defect" was a mismeasurement

### The winding number multiplied thread counts instead of capping them

`WindingNumber.hpp` exists to make the winding number honour `num_threads` "rather than always grabbing all hardware cores". The **3D** overload does that — it calls the *per-point* `hier.winding_number(O.row(o))` inside `threading::parallel_for`.

The **2D** overload did the opposite of the file's stated purpose. It chunked queries across `num_threads` wmtk threads, then handed each **whole chunk** to `igl::winding_number(V, E, O, W)` — which for `F.cols() == 2` runs `igl::parallel_for(O.rows(), …, 10000)` and spawns `igl::default_num_threads()` (= `hardware_concurrency()`) once a chunk exceeds 10000 rows. The two counts multiplied: `8 × 128 = 1024`, against **1003 live threads observed** on kirby, load average 1000.

Reproduced locally on model 217759 (132,811 faces), `num_threads: 4` on 16 hardware threads:

| | peak live threads |
|---|---|
| before | **68** (= 4 × 16 + 4) |
| after | **5** |

Fixed by mirroring the 3D shape: vendor the per-point evaluation (`igl::signed_angle`, MPL-2.0, © 2015 Alec Jacobson) and call it point by point from one `parallel_for`. Tests assert **bit-identical** agreement with `igl::winding_number` over 14,400 points at four thread settings.

### `DEBUG_hausdorff` measured the wrong direction — same bug as tetwild #967

I reported "input→output Hausdorff exceeds eps on ~60% of models" as an open defect. **That was wrong, and it was the same mistake #967 fixed in 3D**, down to the warning text.

The check sampled the **input**, measured to the output, compared to eps, and warned. That is d(input→output) — *coverage*, which nothing promises: simplification removes detail, the arrangement drops segments, collapse shortens curves. The envelope constrains d(output→input) — *containment* — which was never measured.

60-model probe:

| | median | max | over 1.0 |
|---|---|---|---|
| **containment** d(out→in)/eps | 0.247 | **0.399** | **0 / 60** |
| coverage d(in→out)/eps | 3.849 | 500 | 44 / 60 |

Not one model is outside the envelope. The max containment of 0.399 is itself a check on the check: the optimizer works inside `eps/2`, so 0.5 was the ceiling this number had to respect.

Now computes both, compares only containment against eps, reports coverage as an unthresholded diagnostic. Budget raised 10k → 100k (same reason as #967); sampling stays deterministic rather than following 3D to `igl::random_points_on_mesh`, since a diagnostic that changes between runs is hard to act on. `report["hausdorff"]` holds containment, `report["coverage"]` is new — same convention as tetwild.

Coverage loss is still real and worth understanding — `DEBUG_euler` shows the collapse passes destroying whole loops of the tracked network — but it is a question about what the pipeline *should* preserve, not a violated invariant.

### Sweep

Stopped at **15,665 / 19,686 (79.6%) with 1 failure** to pick up these fixes. That one is `Edge [4130, 4156] is outside!` on 246946 — the init envelope sanity check, first of its kind in 15k models.


---

## Update 5: the sweep's single failure was a wrong constant in the envelope

The one failure in the first 15,665 models — `Edge [4130, 4156] is outside!` on 246946 — turned out not to be a tuning problem.

### Why it failed

The simplification ran inside an envelope of **0.599** and passed. The triangulation then rejected the *same geometry* against an envelope of **1.198**, twice as loose. That contradiction is the whole story.

The failing edge is 1.75 long with a true max deviation of **0.5171** from the input. `is_outside(edge)` samples the segment and tests each sample against a shrunk radius:

| | eps | samples | max sample | threshold | |
|---|---|---|---|---|---|
| simplification | 0.599 | 4 (at 0, ⅓, ⅔, 1) | 0.2497 | 0.2533 | accept |
| triangulation | 1.198 | 3 (at 0, ½, 1) | **0.5131** | 0.5065 | **reject** |

The simplification's samples straddled the peak at the midpoint and never saw it; the coarser triangulation sampling landed exactly on it.

### The bug: a triangle constant applied to a segment

The shrink was `eps − sampling_dist/√3`. That `1/√3` is the covering radius of **`sampleTriangle`'s triangular lattice**, and `Envelope.cpp` documents that derivation. A segment is not a lattice.

`is_outside(edge)` samples at `N+1` evenly spaced points with `N = floor(L/d) + 1`, so `N > L/d`, the spacing `L/N` is strictly below `d`, and every point of the segment lies within `d/2` of a sample. Distance to a set is 1-Lipschitz, so "every sample within `r`" gives "every point within `r + d/2`", and containment in `eps` requires

```
r = eps - sampling_dist/2  =  eps/2        (sampling_dist = eps)
```

against the `0.4226 · eps` the lattice constant produced — an **18% over-strict** test.

Being too strict is safe in isolation, which is why it survived. What it also did was break the relationship between triwild's two envelopes: the simplification's own guarantee is `r_s + d_s/2 = eps_s`, while the triangulation accepted samples only up to `0.4226 · eps_o`. At `simplify_envelope_ratio = 0.5` the first exceeds the second by **9%**, so a simplification that respected its budget exactly could produce an input the init sanity check refused — killing the run before it started.

### The fix

Give the edge query its own radius (`eps2_edge`) rather than changing `eps2`, because the other two query shapes need different figures: a **triangle** query genuinely wants the lattice constant, and a **point** query needs no shrink at all and is merely conservative. Widening the point query would change every 3D operation and belongs in its own change.

With the derived constant the two thresholds meet **exactly** at ratio 0.5, so the default is now provably safe — and `triwild.cpp` warns if it is raised above that.

**This touches 3D.** tetwild's and simwild's open-boundary envelopes use the edge overload. They are genuine segment envelopes, so the derivation applies to them unchanged; their classification of an edge as open-boundary becomes slightly more permissive, and correctly so. Integration tests pass, but reviewers should know it is not a 2D-only change.

### Measured

60-model probe over triwild20k:

| | |
|---|---|
| success | 60 / 60 |
| containment d(out→in)/eps | median 0.280, **max 0.402**, over 1.0: **0 / 60** |
| output size | **−7.9%** triangles |

The max containment of 0.402 sits under the 0.5 the guarantee predicts, which is an independent check that the new radius is right. The size reduction is the simplification no longer being held back by a test stricter than the geometry requires.

246946 now succeeds at the default ratio. 101/101 including Integration_Tests.

### Sweep

At the time of writing: **17,083 / 19,686 (86.8%), 1 failure** — that same 246946, on a build predating this fix. Note the running sweep therefore predates the ~8% output-size change, so results from before and after it are not directly comparable.


---

## Update 6: feature-point preservation — the collapse pass was deleting open polylines

**On by default** (`preserve_feature_points`).

### What was broken

An open polyline erodes by *legal* collapses of its interior into its own tip until one segment is left — and that segment carries a feature at **both** ends, which the existing order test does not refuse. It only forbids collapsing a feature **into a non-feature**, and it is gated on `m_is_rounded` besides, so an un-rounded endpoint had no protection at all.

Measured with `DEBUG_euler`, counting components with χ = 1:

| model | arrangement | output |
|---|---|---|
| 134005 | 18 open | **15** |
| 215292 | 28 open | **0** |

Identical with `max_iterations: 0` — only the pre/post collapse passes — so it is the collapse and nothing else. Not a corner case either: **393 of the 600 smallest dataset models contain open polylines**.

### Why tetwild's mechanism doesn't port literally

tetwild builds `m_order2_envelope` over the open-boundary **edges** and requires a collapse survivor to be inside it. In 2D the feature is a single **point**, and a point-set envelope passes trivially when one endpoint is collapsed onto another — the target *is* a feature point, distance zero — while the first endpoint quietly stops being represented.

That is the same containment-vs-coverage distinction as the `DEBUG_hausdorff` bug two updates up. Preserving features is a **coverage** property, so a vertex is bound to a *specific* feature point rather than to the set.

### Design

- `m_feature_id` on each vertex names the feature it stands for. The feature set is read straight off the **arrangement's constrained edges** — valence 1 is a polyline endpoint, valence ≥ 3 a junction — so a junction the simplification was allowed to merge is correctly absent, and no provenance or position-matching plumbing is needed.
- A collapse is refused when the survivor would sit further than eps from the anchor the disappearing vertex stands for. The survivor does not move, so this is a two-vector test needing no spatial index.
- **Smoothing is constrained to the same ball, not frozen.** A feature vertex still moves and still earns whatever quality it can; it just cannot walk away. Added as a `smoothing_position_is_allowed` hook on `smooth_vertex_2d`; the two simwild 2D meshes have no 0-dimensional features and answer true.
- `feature_retention()` measures the invariant on the finished mesh, and `throw_on_fail` asserts it next to the rounding and energy checks.

### One clause had to be weakened, and the integration suite caught it

An earlier version *also* refused outright when the survivor already stood for a **different** feature. That is wrong when the two anchors are within eps of each other — the survivor covers both — and refusing it **deadlocks the mesh**: on `puzzle.obj` it stranded the degenerate triangle the collapse pass exists to remove, and the max energy sat at 1e50 (`MAX_ENERGY`) through all 82 iterations instead of converging to 4.99 in 3.

Plain distance is enough: two anchors further apart than eps are still protected, because the survivor then fails the same test. Retention is likewise measured geometrically rather than by id, or the legitimate merge would be under-reported.

### Results

feature points still represented within eps:

| model | before | after | |
|---|---|---|---|
| 134005 | 37/40 | **40/40** | 18 open polylines preserved, was 15 |
| 215292 | 46/102 | **102/102** | |
| 179320 | 145/223 | **223/223** | |
| puzzle | 4/4 | 4/4 | energy and iteration count unchanged |

215292 also came out **smaller** after the weakening above (1087 → 890 triangles), so the cost is not what it first appeared.

### Tests

Unit tests cover the policy directly — it is a pure function of two vertices — including the un-rounded case, both merge cases, and that smoothing is a ball rather than a pin.

**New integration test `triwild_polylines`**, using dataset model 215292 (45 open polylines, 3 junctions). It fails loudly without the feature: **53/102 retained and a throw**.

### Not addressed

Separate curves **merging**, which is why 215292 still ends at one component. That is a collapse across two *different* tracked curves — a different mechanism from feature loss — and needs its own constraint.

### Test data

The test model and config are on **data2 `main`** (commit `9a29d7e`, a fast-forward from the previous pin), and `cmake/wmtk_data.cmake` is pinned to it. Nothing further is needed.

Worth knowing for the next time test data changes: with the *old* pin CI would not have failed, it would have silently not run the new test at all, because `integration_tests.json` itself comes from data2.

101/101 including Integration_Tests.



---

## Update 7: two bugs found by profiling the sweep's remaining timeouts

### `feature_retention` cost more than it measured — fixed and made opt-in

The check I added to answer a question about retention walked every vertex for every feature, and called `get_vertices()` — which **builds and returns a fresh vector** — from *inside* the per-feature loop. O(unretained × V), with a full vector construction per unretained feature.

`sample` on a live process was unambiguous: **4,215 of 4,215 stacks in `TriWildMesh::feature_retention`**. On 2D model 177574 it burned the entire 1800 s sweep timeout on a mesh that had **already converged to max energy 19.91**, finished rounding, run the post-collapse pass and computed both Hausdorff directions. That model has **821,954 feature points** and 573k triangles.

**Four of the nine failures in that sweep run were models that succeeded and were then killed inside a diagnostic.**

Now one kd-tree over the live vertices (`wmtk::KNN`) and one nearest-neighbour query per feature: O(V + F log V). Same numbers out. **177574 goes from killed-at-1800 s to 346 s, exit 0.**

Also gated behind **`DEBUG_feature_retention`, default false**. Even at the better complexity it measures a property the pipeline does not guarantee — anchors closer than eps may legitimately merge, and those merges cascade — so a value below 100% is information, not a fault.

### `skip_good_regions` was skipping surface vertices — in tetwild as well as triwild

`active_vertices()` filtered purely on element quality, on the argument that "smoothing a vertex surrounded by good cells does nothing, so skipping it is free".

That does not hold for **surface** vertices. Smoothing minimises `w_amips · AMIPS + w_envelope · EnvelopeEnergy`, and with the default `w_amips = 1e-4` the envelope term carries **99.99% of the weight** — it is what pulls a surface vertex back toward the input. Gate it on element quality and a surface vertex surrounded by good cells is skipped, so the term doing almost all of its work never runs.

The effect is total, not marginal. With **default** settings:

```
tetwild octocat:  smooth: accepted 0 | rejected: pre-inverted 0, envelope 0, inverted 0, quality 0
tetwild sphere:   same, every pass, whole run
```

Zero vertices smoothed. The mesh sits below `0.9 × stop_energy`, nothing qualifies as active, and the phase is a no-op. It fails **silently**, which is why it survived a 10,000-model 3D sweep.

`simwild` already special-cased exactly this in its own `active_vertices()` ("Surface vertices are always active, independent of the incident tet quality"). tetwild and triwild did not. The rule now lives in `utils::active_vertices` where all three share it, and simwild's open-coded copy is removed.

| | before | after |
|---|---|---|
| tetwild octocat | 0 smoothed | 3,732 attempted (1,317 accepted, 2,415 envelope-vetoed) |
| tetwild sphere | 0 smoothed | 677 attempted (308 accepted) |

The 2,415 envelope rejections are the point: that is the term that was never running, now doing its job.

**This changes 3D behaviour**, and the completed Thingi10K sweep ran without it. Worth deciding separately whether that warrants a re-run there.

### Per-vertex smoothing cost, 2D vs 3D

Measured while chasing the above (1 thread, `skip_good_regions` forced off — the comparison was impossible until then, which is what exposed the bug):

| | dim | vertex-smooths | total | µs/vertex |
|---|---|---|---|---|
| tetwild sphere | 3D | 60,030 | 5.81 s | 96.8 |
| tetwild octocat | 3D | 297,860 | 206.94 s | 694.8 |
| triwild puzzle | 2D | 4,120 | 0.62 s | 149.7 |
| triwild 134005 | 2D | 4,640 | 0.81 s | 174.3 |

No order-of-magnitude discrepancy: 2D sits inside the range the two 3D models span. The 7× spread *within* 3D says per-vertex cost is dominated by one-ring size and solver iterations rather than dimension.
