### PR TITLE
cmake: bump VolumeRemesher to main (7e5d2b49)

### DIFF
--- a/cmake/recipes/volumeremesher.cmake
+++ b/cmake/recipes/volumeremesher.cmake
@@ -21,11 +21,17 @@ message(STATUS "Third-party: creating target 'VolumeRemesher::VolumeRemesher'")
 # branch of the arrangement-vertex conversions in tetwild, simwild and triwild, which
 # is exact: the built-in bigrational::get_str() emits the fraction in base 2, the base
 # init_from_bin parses.
+#
+# Pinned at main. The previous pin (dcf40546) was two commits behind it; the only
+# functional change between them is PR #17, which reuses a cell's local data structure
+# across non-splitting constraints in BSP.cpp -- a performance change in the
+# arrangement core, so it is the kind of bump that wants the full test suite run
+# against it rather than a smoke test.
 include(CPM)
 CPMAddPackage(
     NAME VolumeRemesher
     GITHUB_REPOSITORY wildmeshing/VolumeRemesher
-    GIT_TAG dcf40546f9c71c82c72eb4c29527c30ac40f640b
+    GIT_TAG 7e5d2b49a2c866770e15c9252c07533b50636c8a
     OPTIONS
     "VOLUMEREMESHER_BUILD_TESTS OFF"
 )


### PR DESCRIPTION
Stacked on #982 (`triwild-sweep`). Review that one first; this diff is one line plus a comment.

## What

`dcf40546` → `7e5d2b49a2c8`, the current head of `wildmeshing/VolumeRemesher` main — two commits.

Only one is functional: **PR #17, "Reuse the cell's local data structure across non-splitting constraints"**, `+53/-31` in `src/VolumeRemesher/BSP.cpp`. That is the arrangement core that tetwild, simwild and triwild all go through for insertion, so despite the size of the diff here it is not a cosmetic bump.

## Verification

- Confirmed CPM actually fetched the new tag rather than reusing a cached slot (source cache slot at `7e5d2b49a2c8`).
- Full build clean. The two remaining warnings come from the NFG dependency and predate this change.
- **101/101 tests, including Integration_Tests.**

## Left alone

`cmake/recipes/volumemesher.cmake` pins the same repository at `6ac1839d`, three weeks further back. It is included only by `attic/`, and `attic` is not referenced from the top-level `CMakeLists.txt`, so nothing in the normal build uses it. Two live pins for one repository is a trap, but bumping a recipe nothing compiles risks breaking `attic` against an API it has not tracked in a month. Happy to delete or bump it in a follow-up if you have a preference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)