### PR TITLE
Bump fast-envelope and use its exact segment and 2D envelopes in tetwild, simwild and triwild

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -1,6 +1,10 @@
 
 include(wmtk_data)
 include(jse)
+# Every executable under here links CLI11::CLI11. The target used to arrive as a side effect
+# of fenvelope.cmake pulling cli11 in for fast-envelope's own app, which stopped being true
+# when fast-envelope dropped that app -- so declare it where it is actually used.
+include(cli11)
 
 option(WMTK_APP_HARMTET "Harmonic Triangulation app" ON)
 option(WMTK_APP_INTERIOR_TET_OPT "interior tet opt application" ON)

--- a/cmake/recipes/fenvelope.cmake
+++ b/cmake/recipes/fenvelope.cmake
@@ -5,17 +5,8 @@ if(TARGET FastEnvelope::FastEnvelope)
     return()
 endif()
 
-include(cli11)
-include(libigl)
-
 message(STATUS "Third-party: creating target 'FastEnvelope::FastEnvelope'")
 
-# fast-envelope uses exact orientation predicates in exactly three places
-# (src/external/Predicates.cpp: orient_3d, orient_3d_tolerance, orient_2d) and offers three
-# backends for them. The default is the whole of geogram, which is a lot of library -- plus,
-# on Linux, geogram's TBB dependency -- for two predicates. Turning both geogram options off
-# selects its third backend, igl::predicates (Shewchuk), which this repository already links
-# and already uses for its own orientation tests. That takes geogram out of the build.
 include(CPM)
 CPMAddPackage(
     NAME FastEnvelope
@@ -42,20 +33,27 @@ CPMAddPackage(
     # `fesetround` and 2.5-3.4x the runtime here. The filter is self-contained double code
     # and reintroduces none of the duplicate expansion definitions that #2 existed to
     # remove.
+    #
+    # Then PR #5, which drops geogram, libigl and TBB entirely (the three predicate backends
+    # collapse to one over Indirect_Predicates, so `FAST_ENVELOPE_WITH_GEOGRAM_PREDICATES`,
+    # `..._PSM_PREDICATES` and `FAST_ENVELOPE_ENABLE_TBB` no longer exist and neither does the
+    # igl::predicates link this file used to add), moves the sources under src/fastenvelope/
+    # leaving <fastenvelope/FastEnvelope.h> resolving as before, and switches the tests to
+    # Catch2. And PR #6, which adds envelopes built from edges rather than triangles -- both
+    # `FastEnvelope::init(V, edges, eps)` in 3D and the new `FastEnvelope2D` -- which is what
+    # lets SampleEnvelope answer segment and 2D queries exactly instead of throwing.
+    #
+    # Note fast-envelope declares Indirect_Predicates itself (cmake/recipes/ipred.cmake) at a
+    # different commit from the one VolumeRemesher pins. FetchContent keeps the first
+    # declaration, and the top-level CMakeLists includes volumeremesher before fenvelope, so
+    # VolumeRemesher's pin is the one that takes effect. That include order is load-bearing.
     GITHUB_REPOSITORY wildmeshing/fast-envelope
-    # master. A commit rather than the branch name, so the build stays reproducible.
-    GIT_TAG 8381a02dbb8bb01846d3e8d08ec0854d62c762b4
+    # main. A commit rather than the branch name, so the build stays reproducible.
+    GIT_TAG 928e5ecd09bc7de9319468788727572f9b7c1f5d
     OPTIONS
     "FAST_ENVELOPE_WITH_UNIT_TESTS OFF"
-    "FAST_ENVELOPE_ENABLE_TBB OFF"
-    "FAST_ENVELOPE_WITH_GEOGRAM_PREDICATES OFF"
-    "FAST_ENVELOPE_WITH_GEOGRAM_PSM_PREDICATES OFF"
 )
 
-# Its own CMakeLists links a predicate library only in the two geogram branches -- it predates
-# the current libigl cmake and never links libigl -- so the fallback needs the target here,
-# both for <igl/predicates/predicates.h> and for the symbols behind it.
-target_link_libraries(FastEnvelope PUBLIC igl::predicates)
-
+# The FastEnvelope::FastEnvelope alias, and the cli11/libigl this file used to include for it,
+# are gone: since #5 fast-envelope declares the alias itself and needs neither library.
 set_target_properties(FastEnvelope PROPERTIES FOLDER third_party)
-add_library(FastEnvelope::FastEnvelope ALIAS FastEnvelope)

--- a/cmake/wmtk_data.cmake
+++ b/cmake/wmtk_data.cmake
@@ -16,7 +16,7 @@ ExternalProject_Add(
     SOURCE_DIR ${WMTK_DATA_ROOT}
 
     GIT_REPOSITORY https://github.com/wildmeshing/data2.git
-    GIT_TAG 9a29d7e482aea8d58260895a9e06cb20cdb7fd63
+    GIT_TAG bb7e12cd276eacbc47048f68c2b048d59c792183
 
     CONFIGURE_COMMAND ""
     BUILD_COMMAND ""

--- a/components/shortest_edge_collapse/wmtk/components/shortest_edge_collapse/shortest_edge_collapse.cpp
+++ b/components/shortest_edge_collapse/wmtk/components/shortest_edge_collapse/shortest_edge_collapse.cpp
@@ -1,4 +1,3 @@
-#include <CLI/CLI.hpp>
 #include <wmtk/utils/Preallocation.hpp>
 
 #include <igl/Timer.h>

--- a/components/simwild/wmtk/components/simwild/SimWildMesh.h
+++ b/components/simwild/wmtk/components/simwild/SimWildMesh.h
@@ -143,7 +143,8 @@ public:
     bool m_collapse_check_quality = true;
 
     // for open boundary
-    std::shared_ptr<SampleEnvelope> m_order_2_edge_envelope; // todo: add sample envelope option
+    /// Follows m_envelope's use_exact; see where it is built in VolumemesherInsertion.cpp.
+    std::shared_ptr<SampleEnvelope> m_order_2_edge_envelope;
 
     wmtk::threading::enumerable_thread_specific<std::unique_ptr<polysolve::nonlinear::Solver>>
         m_solver;

--- a/components/simwild/wmtk/components/simwild/SimWildMeshTri.cpp
+++ b/components/simwild/wmtk/components/simwild/SimWildMeshTri.cpp
@@ -207,6 +207,10 @@ void SimWildMeshTri::init_surfaces_and_boundaries()
         m_E_envelope = tempE;
         m_envelope = std::make_shared<SampleEnvelope>(!m_params.use_sample_envelope);
         m_envelope->init(m_V_envelope, m_E_envelope, m_envelope_eps);
+        logger().info(
+            "Envelope: {} (eps {:.6})",
+            m_envelope->use_exact ? "EXACT" : "sampled",
+            m_envelope_eps);
         m_envelope_orig = m_envelope;
     } else if (m_params.operation == "remeshing" && m_params.check_envelope_at_init) {
         // All surface edges must be inside the envelope. Opt-in: see

--- a/components/simwild/wmtk/components/simwild/SimWildMeshTri.cpp
+++ b/components/simwild/wmtk/components/simwild/SimWildMeshTri.cpp
@@ -205,7 +205,7 @@ void SimWildMeshTri::init_surfaces_and_boundaries()
 
         m_V_envelope = tempV;
         m_E_envelope = tempE;
-        m_envelope = std::make_shared<SampleEnvelope>();
+        m_envelope = std::make_shared<SampleEnvelope>(!m_params.use_sample_envelope);
         m_envelope->init(m_V_envelope, m_E_envelope, m_envelope_eps);
         m_envelope_orig = m_envelope;
     } else if (m_params.operation == "remeshing" && m_params.check_envelope_at_init) {
@@ -276,8 +276,12 @@ void SimWildMeshTri::init_envelope(const MatrixXd& V, const MatrixXi& E)
         m_E_envelope[i] = E.row(i);
     }
 
-    m_envelope = std::make_shared<SampleEnvelope>();
+    m_envelope = std::make_shared<SampleEnvelope>(!m_params.use_sample_envelope);
     m_envelope->init(m_V_envelope, m_E_envelope, m_envelope_eps);
+    logger().info(
+        "Envelope: {} (eps {:.6})",
+        m_envelope->use_exact ? "EXACT" : "sampled",
+        m_envelope_eps);
 
     if (!m_envelope_orig) {
         m_envelope_orig = m_envelope;

--- a/components/simwild/wmtk/components/simwild/VolumemesherInsertion.cpp
+++ b/components/simwild/wmtk/components/simwild/VolumemesherInsertion.cpp
@@ -432,7 +432,12 @@ void SimWildMesh::find_order_2_edges()
     }
 
     // init open boundary envelope
-    m_order_2_edge_envelope = std::make_shared<SampleEnvelope>();
+    //
+    // Follows the surface envelope's predicate: same input, same epsilon, so there is no
+    // reason for `use_sample_envelope: false` to hold for the surface and not for the order-2
+    // curves. It was hard-wired to sampled only because the exact envelope could not be built
+    // from edges until fast-envelope #6.
+    m_order_2_edge_envelope = std::make_shared<SampleEnvelope>(m_envelope && m_envelope->use_exact);
     m_order_2_edge_envelope->init(v_posf, order_2_edges, m_params.epsr * m_params.diag_l / 2.0);
 }
 

--- a/components/simwild/wmtk/components/simwild/simwild_spec.json
+++ b/components/simwild/wmtk/components/simwild/simwild_spec.json
@@ -145,7 +145,7 @@
     "pointer": "/use_sample_envelope",
     "type": "bool",
     "default": false,
-    "doc": "Use sample envelope instead of exact one."
+    "doc": "Use the sampled envelope instead of the exact one. Governs both the 3D surface envelope and, since the exact envelope gained support for edges, the order-2 (open boundary and non-manifold) curve envelope and the 2D polyline envelope -- all three are containment tests against the same input at the same epsilon, so they follow one flag. The sampled test places points along the query and asks whether each is within eps of the input, so it cannot see what happens between two samples and shrinks its acceptance radius to compensate; the exact one decides coverage by the union of the eps-neighbourhoods without sampling, so it uses the full eps and is strictly sharper."
   },
   {
     "pointer": "/num_threads",

--- a/components/tetwild/wmtk/components/tetwild/VolumemesherInsertion.cpp
+++ b/components/tetwild/wmtk/components/tetwild/VolumemesherInsertion.cpp
@@ -1621,8 +1621,13 @@ void TetWildMesh::find_open_boundary()
     }
 
     // init the order-2 envelope (surface boundaries and non-manifold edges)
+    //
+    // It follows the surface envelope's choice of predicate rather than being hard-wired to
+    // the sampled one. Both are containment tests against the same input at the same epsilon,
+    // so having `use_sample_envelope: false` hold for the surface but not for its boundary
+    // curves was an accident of the exact envelope not supporting edges until now.
     if (!m_order2_envelope) {
-        m_order2_envelope = std::make_shared<SampleEnvelope>();
+        m_order2_envelope = std::make_shared<SampleEnvelope>(m_envelope && m_envelope->use_exact);
     }
     m_order2_envelope->init(v_posf, open_boundaries, m_params.epsr * m_params.diag_l / 2.0);
 }

--- a/components/triwild/wmtk/components/triwild/Parameters.h
+++ b/components/triwild/wmtk/components/triwild/Parameters.h
@@ -48,6 +48,22 @@ struct Parameters
     bool check_envelope_at_init = false;
 
     /**
+     * Use the sampled envelope rather than the exact one for the mesh optimization.
+     *
+     * The two answer a different question. The sampled test places points along the query
+     * segment and asks whether each is within eps of the input; it therefore cannot see
+     * anything that happens between two samples, and pays for that by shrinking its
+     * acceptance radius to eps/2 (see SampleEnvelope::eps2_edge). The exact one asks whether
+     * the segment is covered by the union of the eps-rectangles around the input segments and
+     * decides it without sampling, so it uses the full eps and answers a strictly sharper
+     * question -- notably it rejects a segment that bridges a gap between two input curves,
+     * which the sampled test accepts whenever the gap is narrow enough to fall between samples.
+     *
+     * Exact by default, matching tetwild.
+     */
+    bool use_sample_envelope = false;
+
+    /**
      * Incident-triangle count above which a vertex is treated as pathological, or 0 to
      * disable the gate.
      *
@@ -167,6 +183,7 @@ struct Parameters
         debug_output = json_params["DEBUG_output"];
         perform_sanity_checks = json_params["DEBUG_sanity_checks"];
         check_envelope_at_init = json_params["DEBUG_envelope_sanity_check"];
+        use_sample_envelope = json_params["use_sample_envelope"];
 
         split_high_valence_threshold = json_params["split_high_valence_threshold"];
         w_amips = json_params["w_amips"];

--- a/components/triwild/wmtk/components/triwild/TriWildMesh.cpp
+++ b/components/triwild/wmtk/components/triwild/TriWildMesh.cpp
@@ -456,8 +456,12 @@ void TriWildMesh::init_mesh(
         m_E_envelope[i] = E_env.row(i);
     }
 
-    m_envelope = std::make_shared<SampleEnvelope>();
+    m_envelope = std::make_shared<SampleEnvelope>(!m_params.use_sample_envelope);
     m_envelope->init(m_V_envelope, m_E_envelope, m_envelope_eps);
+    logger().info(
+        "Envelope: {} (eps {:.6})",
+        m_envelope->use_exact ? "EXACT" : "sampled",
+        m_envelope_eps);
 
     // Sanity check: All surface edges must be inside the envelope. Opt-in: see
     // Parameters::check_envelope_at_init for why it is not worth its cost by default.

--- a/components/triwild/wmtk/components/triwild/triwild.cpp
+++ b/components/triwild/wmtk/components/triwild/triwild.cpp
@@ -243,13 +243,16 @@ void triwild(nlohmann::json json_params)
         simplify_eps,
         100 * simplify_envelope_ratio,
         envelope_eps);
-    // 0.5 is not an arbitrary ceiling. is_outside(edge) accepts when every sample is within
-    // eps/2 and the sampling guarantees the rest of the segment is within another eps/2, so
-    // the simplification can leave geometry up to simplify_eps from the input, while the
-    // triangulation's own check accepts samples only up to envelope_eps/2. Those meet exactly
-    // at ratio 0.5; above it the simplification may legally produce an input that the
-    // envelope sanity check below rejects, and the run dies before it starts.
-    if (simplify_envelope_ratio > 0.5) {
+    const bool simplify_use_sample_envelope = json_params["simplify_use_sample_envelope"];
+    // 0.5 is not an arbitrary ceiling -- but it is a property of the *sampled* envelope.
+    // is_outside(edge) accepts when every sample is within eps/2 and the sampling guarantees
+    // the rest of the segment is within another eps/2, so the simplification can leave
+    // geometry up to simplify_eps from the input, while the triangulation's own check accepts
+    // samples only up to envelope_eps/2. Those meet exactly at ratio 0.5; above it the
+    // simplification may legally produce an input that the envelope sanity check below
+    // rejects, and the run dies before it starts. The exact envelope has no sampling slack to
+    // pay for and uses the full eps on both sides, so the bound does not apply to it.
+    if (simplify_envelope_ratio > 0.5 && simplify_use_sample_envelope) {
         logger().warn(
             "simplify_envelope_ratio {} exceeds 0.5; the simplification may produce curves "
             "that the triangulation's envelope check rejects at init.",
@@ -261,7 +264,7 @@ void triwild(nlohmann::json json_params)
     if (json_params["skip_simplify"]) {
         logger().info("skip simplification");
     } else {
-        SampleEnvelope simplify_envelope;
+        SampleEnvelope simplify_envelope(!simplify_use_sample_envelope);
         {
             std::vector<Vector2d> v(V_in.rows());
             for (int i = 0; i < V_in.rows(); ++i) {

--- a/components/triwild/wmtk/components/triwild/triwild.cpp
+++ b/components/triwild/wmtk/components/triwild/triwild.cpp
@@ -244,18 +244,20 @@ void triwild(nlohmann::json json_params)
         100 * simplify_envelope_ratio,
         envelope_eps);
     const bool simplify_use_sample_envelope = json_params["simplify_use_sample_envelope"];
-    // 0.5 is not an arbitrary ceiling -- but it is a property of the *sampled* envelope.
-    // is_outside(edge) accepts when every sample is within eps/2 and the sampling guarantees
-    // the rest of the segment is within another eps/2, so the simplification can leave
-    // geometry up to simplify_eps from the input, while the triangulation's own check accepts
-    // samples only up to envelope_eps/2. Those meet exactly at ratio 0.5; above it the
-    // simplification may legally produce an input that the envelope sanity check below
-    // rejects, and the run dies before it starts. The exact envelope has no sampling slack to
-    // pay for and uses the full eps on both sides, so the bound does not apply to it.
-    if (simplify_envelope_ratio > 0.5 && simplify_use_sample_envelope) {
+    // The only ratio that is wrong independently of how the envelope is implemented. Above 1
+    // the simplification is allowed to move geometry further than the triangulation's own
+    // envelope permits, so the optimizer starts from a mesh that is already outside it and
+    // every operation near those curves is vetoed.
+    //
+    // There used to be a warning at 0.5 here. That number was the sampled backend's internal
+    // compensation showing through -- its edge test accepts a segment only within eps/2,
+    // because its sampling guarantees the other eps/2 -- and both backends guarantee the same
+    // thing to their caller: everything they accept is within eps. A caller reasoning about
+    // eps/2 is reasoning about an implementation detail it should not be able to see.
+    if (simplify_envelope_ratio > 1.0) {
         logger().warn(
-            "simplify_envelope_ratio {} exceeds 0.5; the simplification may produce curves "
-            "that the triangulation's envelope check rejects at init.",
+            "simplify_envelope_ratio {} exceeds 1; the simplification may move curves further "
+            "than the triangulation's envelope allows, leaving the mesh outside it at init.",
             simplify_envelope_ratio);
     }
 

--- a/components/triwild/wmtk/components/triwild/triwild_spec.json
+++ b/components/triwild/wmtk/components/triwild/triwild_spec.json
@@ -126,13 +126,13 @@
     "pointer": "/simplify_use_sample_envelope",
     "type": "bool",
     "default": true,
-    "doc": "Use the sampled envelope instead of the exact one for the input simplification only; the triangulation keeps whatever use_sample_envelope selects. The exact envelope dominates the cost of simplifying a large curve network, which is why this defaults the other way round from use_sample_envelope -- the same split tetwild makes. Note that with the exact envelope the simplify_envelope_ratio <= 0.5 ceiling stops applying: that bound exists only because the sampled edge test accepts within eps/2 and its sampling guarantees another eps/2, and an exact test has no such slack."
+    "doc": "Use the sampled envelope instead of the exact one for the input simplification only; the triangulation keeps whatever use_sample_envelope selects. The exact envelope dominates the cost of simplifying a large curve network, which is why this defaults the other way round from use_sample_envelope -- the same split tetwild makes. Both backends guarantee the same thing, that everything they accept lies within simplify_envelope_ratio * eps of the input; they differ only in how much of that budget they manage to use, so this does not change what simplify_envelope_ratio means."
   },
   {
     "pointer": "/use_sample_envelope",
     "type": "bool",
     "default": false,
-    "doc": "Use the sampled envelope instead of the exact one. The sampled test places points along a query segment and asks whether each is within eps of the input, so it cannot see what happens between two samples and shrinks its acceptance radius to eps/2 to compensate. The exact one asks whether the segment is covered by the union of the eps-rectangles around the input segments, and decides that without sampling -- so it uses the full eps and is strictly sharper. The difference that matters in practice: a segment bridging a gap between two input curves is rejected by the exact envelope and accepted by the sampled one whenever the gap falls between samples."
+    "doc": "Use the sampled envelope instead of the exact one. Both describe the same envelope -- the eps-neighbourhood of the input -- and both are given the same eps; neither is wider than the other. They differ in how much of that eps they can use. The sampled test places points along a query and asks whether each is within some radius of the input; since it cannot see what happens between two samples, it shrinks that radius to stay conservative, and so rejects some geometry that is genuinely inside. The exact one decides coverage by the union of the input's eps-neighbourhoods directly and spends almost nothing on conservatism. The difference that matters in practice: a segment bridging a gap between two input curves is rejected by the exact envelope and accepted by the sampled one whenever the gap falls between samples."
   },
   {
     "pointer": "/filter",

--- a/components/triwild/wmtk/components/triwild/triwild_spec.json
+++ b/components/triwild/wmtk/components/triwild/triwild_spec.json
@@ -13,6 +13,8 @@
       "skip_simplify",
       "simplify_use_link_condition",
       "simplify_envelope_ratio",
+      "simplify_use_sample_envelope",
+      "use_sample_envelope",
       "filter",
       "skip_winding_number",
       "eps_rel",
@@ -119,6 +121,18 @@
     "type": "float",
     "default": 0.5,
     "doc": "Envelope thickness used for the input simplification, as a fraction of the one used for the triangulation. Simplifying inside a tighter envelope reserves the remainder as headroom: if the simplification is allowed to place vertices at the full limit, the optimizer starts with a mesh where almost every move already lies outside and most operations are vetoed. 1.0 restores the old behaviour of sharing a single envelope."
+  },
+  {
+    "pointer": "/simplify_use_sample_envelope",
+    "type": "bool",
+    "default": true,
+    "doc": "Use the sampled envelope instead of the exact one for the input simplification only; the triangulation keeps whatever use_sample_envelope selects. The exact envelope dominates the cost of simplifying a large curve network, which is why this defaults the other way round from use_sample_envelope -- the same split tetwild makes. Note that with the exact envelope the simplify_envelope_ratio <= 0.5 ceiling stops applying: that bound exists only because the sampled edge test accepts within eps/2 and its sampling guarantees another eps/2, and an exact test has no such slack."
+  },
+  {
+    "pointer": "/use_sample_envelope",
+    "type": "bool",
+    "default": false,
+    "doc": "Use the sampled envelope instead of the exact one. The sampled test places points along a query segment and asks whether each is within eps of the input, so it cannot see what happens between two samples and shrinks its acceptance radius to eps/2 to compensate. The exact one asks whether the segment is covered by the union of the eps-rectangles around the input segments, and decides that without sampling -- so it uses the full eps and is strictly sharper. The difference that matters in practice: a segment bridging a gap between two input curves is rejected by the exact envelope and accepted by the sampled one whenever the gap falls between samples."
   },
   {
     "pointer": "/filter",

--- a/src/wmtk/envelope/Envelope.cpp
+++ b/src/wmtk/envelope/Envelope.cpp
@@ -90,6 +90,36 @@ void sampleTriangle(
     }
 }
 
+/**
+ * Build the exact edge envelope, unless there is no envelope to build.
+ *
+ * A zero epsilon is a legitimate way to ask for an envelope that will only ever be used for
+ * nearest_point() -- triwild's Delaunay seeding does it, to reject grid points that fall too
+ * close to the input curves. There is no such thing as a zero-width exact envelope: the 2D
+ * construction asserts on it, and a containment query against one would answer "outside" for
+ * everything not exactly on the input. So skip the build, and make the combination that would
+ * actually consult it fail here rather than silently reject every query.
+ */
+template <typename VertexList>
+void SampleEnvelope::init_exact_edges(
+    const VertexList& V,
+    const std::vector<Eigen::Vector2i>& F,
+    const double _eps)
+{
+    if (!(_eps > 0)) {
+        if (use_exact) {
+            log_and_throw_error("An exact envelope needs a positive epsilon, got {}.", _eps);
+        }
+        return;
+    }
+
+    if constexpr (std::is_same_v<VertexList, std::vector<Eigen::Vector2d>>) {
+        exact_envelope_2d.init(V, F, _eps);
+    } else {
+        exact_envelope.init(V, F, _eps);
+    }
+}
+
 void SampleEnvelope::init(
     const std::vector<Eigen::Vector3d>& V,
     const std::vector<Eigen::Vector3i>& F,
@@ -98,6 +128,7 @@ void SampleEnvelope::init(
     if (!use_exact) {
         logger().info("Using sample envelope.");
     }
+    m_kind = Kind::Triangles3d;
     exact_envelope.init(V, F, _eps);
 
     // sampleTriangle lays samples on a triangular lattice of spacing `sampling_dist`, whose
@@ -147,9 +178,16 @@ void SampleEnvelope::init(
     const std::vector<Eigen::Vector2i>& F,
     const double _eps)
 {
-    if (use_exact) {
-        log_and_throw_error("Cannot use an exact envelope for edges.");
-    }
+    m_kind = Kind::Edges3d;
+    // The raw _eps, not the shrunk one below: the shrink pays for the sampling lattice and
+    // the exact envelope has no lattice. fast-envelope builds a hexahedron of half-width
+    // eps/sqrt(3) around each segment, so its corners sit at exactly eps.
+    //
+    // Built whether or not use_exact is set, because callers flip the flag on an envelope
+    // that is already initialized -- tetwild does exactly that around its simplification
+    // (tetwild.cpp) -- so both structures have to be there. See init_exact_edges() for the
+    // one case where it is skipped.
+    init_exact_edges(V, F, _eps);
 
     sampling_dist = _eps;
     // eps2 keeps the lattice constant for point queries; eps2_edge carries the one derived
@@ -178,9 +216,11 @@ void SampleEnvelope::init(
     const std::vector<Eigen::Vector2i>& F,
     const double _eps)
 {
-    if (use_exact) {
-        log_and_throw_error("Cannot use an exact envelope for edges.");
-    }
+    m_kind = Kind::Edges2d;
+    // Raw _eps again; see the 3D edge overload. In 2D the conservative shape is a rectangle
+    // of half-width eps/sqrt(2) around each segment, extended by the same amount past both
+    // ends, so its corners sit at exactly eps.
+    init_exact_edges(V, F, _eps);
 
     sampling_dist = _eps;
     // eps2 keeps the lattice constant for point queries; eps2_edge carries the one derived
@@ -205,10 +245,34 @@ void SampleEnvelope::init(
     m_bvh->init(VV, FF, 0);
 }
 
+/**
+ * An exact query must be answered by the structure the matching init() built.
+ *
+ * Getting this wrong is silent and dangerous rather than noisy: a default-constructed
+ * FastEnvelope has no prisms, and a query against no prisms answers "outside" for every
+ * point -- so a mismatched envelope does not crash, it just vetoes every operation and
+ * looks like an optimization that cannot move.
+ */
+void SampleEnvelope::require_exact_kind(Kind expected, const char* query) const
+{
+    if (m_kind != expected) {
+        log_and_throw_error(
+            "Exact {} query against an envelope built by a different init() (kind {}, need {}).",
+            query,
+            static_cast<int>(m_kind),
+            static_cast<int>(expected));
+    }
+}
+
 bool SampleEnvelope::is_outside(const Eigen::Vector3d& pts) const
 {
     if (disabled) return false;
     if (use_exact) {
+        // Points work against either 3D envelope, so both kinds are accepted here; only a 2D
+        // one is wrong, and that is what the check catches.
+        if (m_kind == Kind::Edges2d || m_kind == Kind::Uninitialized) {
+            require_exact_kind(Kind::Triangles3d, "3D point");
+        }
         return exact_envelope.is_outside(pts);
     }
     double dist2 = squared_distance(pts);
@@ -218,6 +282,12 @@ bool SampleEnvelope::is_outside(const Eigen::Vector3d& pts) const
 
 bool SampleEnvelope::is_outside(const Eigen::Vector2d& pts) const
 {
+    // The 2D exact envelope is its own object, so this cannot go through the 3D overload the
+    // way the sampled path does -- that would consult an exact_envelope no 2D init ever
+    // filled in, and an empty FastEnvelope answers "outside" for every query.
+    if (!disabled && use_exact && m_kind == Kind::Edges2d) {
+        return exact_envelope_2d.is_outside(pts);
+    }
     return is_outside(Vector3d(pts[0], pts[1], 0));
 }
 
@@ -225,6 +295,7 @@ bool SampleEnvelope::is_outside(const std::array<Eigen::Vector3d, 3>& tri) const
 {
     if (disabled) return false;
     if (use_exact) {
+        require_exact_kind(Kind::Triangles3d, "triangle");
         return exact_envelope.is_outside(tri);
     }
     std::array<Vector3d, 3> vs = {
@@ -282,7 +353,14 @@ bool SampleEnvelope::is_outside(const std::array<Vector3d, 2>& edge) const
 {
     if (disabled) return false;
     if (use_exact) {
-        log_and_throw_error("Cannot use an exact envelope for edges.");
+        // Exact for both 3D envelope kinds: a segment is inside when it is covered by the
+        // union of the prisms (Triangles3d) or the hexahedra (Edges3d), which fast-envelope
+        // decides without sampling. The sampled path below can only test finitely many points
+        // on the segment, so it pays for that with the eps/2 shrink in eps2_edge; this does not.
+        if (m_kind == Kind::Edges2d || m_kind == Kind::Uninitialized) {
+            require_exact_kind(Kind::Edges3d, "3D segment");
+        }
+        return exact_envelope.is_outside(edge[0], edge[1]);
     }
     static thread_local std::vector<Vector3d> pts;
     pts.clear();
@@ -313,6 +391,9 @@ bool SampleEnvelope::is_outside(const std::array<Vector3d, 2>& edge) const
 
 bool SampleEnvelope::is_outside(const std::array<Vector2d, 2>& edge) const
 {
+    if (!disabled && use_exact && m_kind == Kind::Edges2d) {
+        return exact_envelope_2d.is_outside(edge[0], edge[1]);
+    }
     std::array<Vector3d, 2> e;
     for (size_t i = 0; i < edge.size(); ++i) {
         e[i] = Vector3d(edge[i][0], edge[i][1], 0);

--- a/src/wmtk/envelope/Envelope.cpp
+++ b/src/wmtk/envelope/Envelope.cpp
@@ -91,14 +91,22 @@ void sampleTriangle(
 }
 
 /**
- * Build the exact edge envelope, unless there is no envelope to build.
+ * Build the exact edge envelope, when there is one to build and anything will ask for it.
+ *
+ * Unlike the triangle overload, this is conditional on use_exact. The triangle envelope has to
+ * carry both structures because callers flip the flag on an already-initialized envelope --
+ * tetwild does that around its simplification, simwild around its insertion -- but every one
+ * of those toggles is on a triangle envelope. Building the hexahedra or rectangles for a
+ * sampled edge envelope is pure cost: it added ~12% to the integration suite when this was
+ * unconditional. A toggle that arrives afterwards anyway is caught by m_exact_built rather
+ * than silently answering "outside" against an empty structure.
  *
  * A zero epsilon is a legitimate way to ask for an envelope that will only ever be used for
  * nearest_point() -- triwild's Delaunay seeding does it, to reject grid points that fall too
  * close to the input curves. There is no such thing as a zero-width exact envelope: the 2D
  * construction asserts on it, and a containment query against one would answer "outside" for
- * everything not exactly on the input. So skip the build, and make the combination that would
- * actually consult it fail here rather than silently reject every query.
+ * everything not exactly on the input. So skip that too, and let the query fail rather than
+ * quietly reject everything.
  */
 template <typename VertexList>
 void SampleEnvelope::init_exact_edges(
@@ -106,11 +114,12 @@ void SampleEnvelope::init_exact_edges(
     const std::vector<Eigen::Vector2i>& F,
     const double _eps)
 {
-    if (!(_eps > 0)) {
-        if (use_exact) {
-            log_and_throw_error("An exact envelope needs a positive epsilon, got {}.", _eps);
-        }
+    m_exact_built = false;
+    if (!use_exact) {
         return;
+    }
+    if (!(_eps > 0)) {
+        log_and_throw_error("An exact envelope needs a positive epsilon, got {}.", _eps);
     }
 
     if constexpr (std::is_same_v<VertexList, std::vector<Eigen::Vector2d>>) {
@@ -118,6 +127,7 @@ void SampleEnvelope::init_exact_edges(
     } else {
         exact_envelope.init(V, F, _eps);
     }
+    m_exact_built = true;
 }
 
 void SampleEnvelope::init(
@@ -182,11 +192,6 @@ void SampleEnvelope::init(
     // The raw _eps, not the shrunk one below: the shrink pays for the sampling lattice and
     // the exact envelope has no lattice. fast-envelope builds a hexahedron of half-width
     // eps/sqrt(3) around each segment, so its corners sit at exactly eps.
-    //
-    // Built whether or not use_exact is set, because callers flip the flag on an envelope
-    // that is already initialized -- tetwild does exactly that around its simplification
-    // (tetwild.cpp) -- so both structures have to be there. See init_exact_edges() for the
-    // one case where it is skipped.
     init_exact_edges(V, F, _eps);
 
     sampling_dist = _eps;
@@ -262,6 +267,34 @@ void SampleEnvelope::require_exact_kind(Kind expected, const char* query) const
             static_cast<int>(m_kind),
             static_cast<int>(expected));
     }
+    require_exact_built(query);
+}
+
+/**
+ * The 3D point and segment queries work against either 3D envelope, so they check only that
+ * this is not the 2D one -- and that its exact structure actually exists.
+ */
+void SampleEnvelope::require_exact_3d(const char* query) const
+{
+    if (m_kind != Kind::Triangles3d && m_kind != Kind::Edges3d) {
+        log_and_throw_error(
+            "Exact {} query against an envelope built by a different init() (kind {}).",
+            query,
+            static_cast<int>(m_kind));
+    }
+    require_exact_built(query);
+}
+
+void SampleEnvelope::require_exact_built(const char* query) const
+{
+    // The edge and 2D overloads only build their exact structure when use_exact was already
+    // set at init time, so a flag flipped afterwards would otherwise query an empty envelope.
+    if (m_kind != Kind::Triangles3d && !m_exact_built) {
+        log_and_throw_error(
+            "Exact {} query, but use_exact was set after init() built only the sampled "
+            "envelope. Re-init the envelope after changing the flag.",
+            query);
+    }
 }
 
 bool SampleEnvelope::is_outside(const Eigen::Vector3d& pts) const
@@ -270,9 +303,7 @@ bool SampleEnvelope::is_outside(const Eigen::Vector3d& pts) const
     if (use_exact) {
         // Points work against either 3D envelope, so both kinds are accepted here; only a 2D
         // one is wrong, and that is what the check catches.
-        if (m_kind == Kind::Edges2d || m_kind == Kind::Uninitialized) {
-            require_exact_kind(Kind::Triangles3d, "3D point");
-        }
+        require_exact_3d("3D point");
         return exact_envelope.is_outside(pts);
     }
     double dist2 = squared_distance(pts);
@@ -286,6 +317,7 @@ bool SampleEnvelope::is_outside(const Eigen::Vector2d& pts) const
     // way the sampled path does -- that would consult an exact_envelope no 2D init ever
     // filled in, and an empty FastEnvelope answers "outside" for every query.
     if (!disabled && use_exact && m_kind == Kind::Edges2d) {
+        require_exact_built("2D point");
         return exact_envelope_2d.is_outside(pts);
     }
     return is_outside(Vector3d(pts[0], pts[1], 0));
@@ -357,9 +389,7 @@ bool SampleEnvelope::is_outside(const std::array<Vector3d, 2>& edge) const
         // union of the prisms (Triangles3d) or the hexahedra (Edges3d), which fast-envelope
         // decides without sampling. The sampled path below can only test finitely many points
         // on the segment, so it pays for that with the eps/2 shrink in eps2_edge; this does not.
-        if (m_kind == Kind::Edges2d || m_kind == Kind::Uninitialized) {
-            require_exact_kind(Kind::Edges3d, "3D segment");
-        }
+        require_exact_3d("3D segment");
         return exact_envelope.is_outside(edge[0], edge[1]);
     }
     static thread_local std::vector<Vector3d> pts;
@@ -392,6 +422,7 @@ bool SampleEnvelope::is_outside(const std::array<Vector3d, 2>& edge) const
 bool SampleEnvelope::is_outside(const std::array<Vector2d, 2>& edge) const
 {
     if (!disabled && use_exact && m_kind == Kind::Edges2d) {
+        require_exact_built("2D segment");
         return exact_envelope_2d.is_outside(edge[0], edge[1]);
     }
     std::array<Vector3d, 2> e;

--- a/src/wmtk/envelope/Envelope.hpp
+++ b/src/wmtk/envelope/Envelope.hpp
@@ -141,10 +141,8 @@ private:
     void require_exact_kind(Kind expected, const char* query) const;
 
     template <typename VertexList>
-    void init_exact_edges(
-        const VertexList& V,
-        const std::vector<Eigen::Vector2i>& F,
-        const double _eps);
+    void
+    init_exact_edges(const VertexList& V, const std::vector<Eigen::Vector2i>& F, const double _eps);
 
     std::vector<int> geo_vertex_ind;
     std::vector<int> geo_face_ind;

--- a/src/wmtk/envelope/Envelope.hpp
+++ b/src/wmtk/envelope/Envelope.hpp
@@ -6,6 +6,7 @@
 // clang-format off
 #include <wmtk/utils/DisableWarnings.hpp>
 #include <fastenvelope/FastEnvelope.h>
+#include <fastenvelope/FastEnvelope2D.h>
 #include <SimpleBVH/BVH.hpp>
 #include <wmtk/utils/EnableWarnings.hpp>
 // clang-format on
@@ -50,6 +51,18 @@ public:
 class SampleEnvelope : public wmtk::Envelope
 {
 public:
+    /**
+     * Which of the three init() overloads built this envelope.
+     *
+     * The sampled path does not need it -- every overload ends up in the same BVH, and a 2D
+     * query is answered by lifting to z = 0. The exact path does: a triangle-built and an
+     * edge-built FastEnvelope are different objects, a 2D envelope is a different class
+     * again, and only init() knows which one was filled in. Without this, is_outside(Vector2d)
+     * would lift to 3D and query a FastEnvelope that was never initialized, which answers
+     * "outside" for everything rather than failing.
+     */
+    enum class Kind { Uninitialized, Triangles3d, Edges3d, Edges2d };
+
     SampleEnvelope(bool exact = false)
         : use_exact(exact) {};
     /**
@@ -119,15 +132,29 @@ public:
     double nearest_point(const Eigen::Vector2d& pts, Eigen::Vector2d& result) const;
     bool initialized() { return m_bvh != nullptr; };
 
+    Kind kind() const { return m_kind; }
+
     double squared_distance(const Eigen::Vector3d& p) const;
     double squared_distance(const Eigen::Vector2d& p) const;
 
 private:
+    void require_exact_kind(Kind expected, const char* query) const;
+
+    template <typename VertexList>
+    void init_exact_edges(
+        const VertexList& V,
+        const std::vector<Eigen::Vector2i>& F,
+        const double _eps);
+
     std::vector<int> geo_vertex_ind;
     std::vector<int> geo_face_ind;
     std::shared_ptr<SimpleBVH::BVH> m_bvh;
 
 private:
+    /// Serves both Triangles3d and Edges3d: FastEnvelope has an init() for each.
     fastEnvelope::FastEnvelope exact_envelope;
+    /// Edges2d only. A separate class upstream, not an overload.
+    fastEnvelope::FastEnvelope2D exact_envelope_2d;
+    Kind m_kind = Kind::Uninitialized;
 };
 } // namespace wmtk

--- a/src/wmtk/envelope/Envelope.hpp
+++ b/src/wmtk/envelope/Envelope.hpp
@@ -139,6 +139,8 @@ public:
 
 private:
     void require_exact_kind(Kind expected, const char* query) const;
+    void require_exact_3d(const char* query) const;
+    void require_exact_built(const char* query) const;
 
     template <typename VertexList>
     void
@@ -154,5 +156,8 @@ private:
     /// Edges2d only. A separate class upstream, not an overload.
     fastEnvelope::FastEnvelope2D exact_envelope_2d;
     Kind m_kind = Kind::Uninitialized;
+    /// Whether the edge/2D exact structure was actually built. Always false for Triangles3d,
+    /// which builds its exact envelope unconditionally and is checked by kind alone.
+    bool m_exact_built = false;
 };
 } // namespace wmtk

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -8,6 +8,7 @@ include(Catch)
 set(TEST_SOURCES
     2d_tests.cpp
     test_delaunay.cpp
+    test_envelope.cpp
     test_geom.cpp
     test_io.cpp
     test_knn.cpp

--- a/tests/test_envelope.cpp
+++ b/tests/test_envelope.cpp
@@ -1,17 +1,25 @@
 // Containment queries that only the exact envelope can answer.
 //
-// SampleEnvelope has two backends. The sampled one places points along the query and asks the
-// BVH whether each is within eps of the input; it cannot see anything that happens between
-// two samples, and pays for that by shrinking its acceptance radius (eps/sqrt(3) for a
-// triangle, eps/2 for a segment -- see the derivations on SampleEnvelope::eps2 and eps2_edge).
-// The exact one asks whether the query is covered by the union of the eps-neighbourhoods of
-// the input primitives and decides that with exact predicates, so it uses the full eps.
+// Both of SampleEnvelope's backends describe the SAME envelope: the eps-neighbourhood of the
+// input. They are handed the same eps and neither is meant to be wider or narrower than the
+// other. What differs is how much of that eps they manage to use.
+//
+// The sampled one places points along the query and asks the BVH whether each is within some
+// radius of the input. It cannot see what happens between two samples, so to guarantee the
+// whole query is within eps it has to shrink that radius by the sampling's covering radius --
+// eps/sqrt(3) for a triangle, eps/2 for a segment (see SampleEnvelope::eps2 and eps2_edge).
+// That shrink is an implementation detail of staying conservative, not a smaller envelope: it
+// costs some of the eps budget, so the sampled test rejects geometry that is genuinely inside.
+//
+// The exact one decides coverage by the union of the input's eps-neighbourhoods directly, so
+// it spends almost none of the budget on conservatism -- fast-envelope inscribes a hexahedron
+// (3D) or rectangle (2D) whose corners reach exactly eps.
 //
 // Until fast-envelope gained envelopes built from edges, only the triangle-mesh envelope had
 // an exact backend; the segment and 2D queries threw. These cases pin what the exact path now
-// answers, and in particular the two places where the two backends legitimately disagree:
-// the band between the shrunk radius and eps, where sampled is stricter, and a gap narrower
-// than the sample spacing, where sampled is wrong.
+// answers, and in particular the two places where the backends legitimately disagree: the band
+// the sampled test gives up to its own conservatism, and a gap narrower than the sample
+// spacing, where the sampled test is simply wrong.
 #include <catch2/catch_test_macros.hpp>
 
 #include <wmtk/Types.hpp>
@@ -87,16 +95,17 @@ TEST_CASE("exact and sampled 3D segment envelopes agree away from the boundary",
 
 TEST_CASE("the sampled segment envelope is the stricter of the two", "[envelope]")
 {
-    // The sampled test accepts a segment only when every sample is within eps/2, because the
-    // spacing guarantees no more than another eps/2 between samples. So above eps/2 it starts
-    // rejecting geometry the input actually contains. That is safe -- it errs towards
-    // rejection -- but it is the reason the exact envelope is worth having.
+    // Same envelope, different amounts of it recovered. The sampled test accepts a segment
+    // only when every sample is within eps/2, because the spacing guarantees no more than
+    // another eps/2 between samples -- so above eps/2 it starts rejecting geometry that is
+    // inside the eps envelope it is supposed to represent. That is safe, and it is the cost of
+    // sampling rather than a smaller envelope; recovering it is the point of the exact path.
     //
-    // The offset below has to sit in the band where the two disagree. The upper end is not
-    // eps: fast-envelope wraps each segment in a hexahedron of half-width eps/sqrt(3), whose
-    // corners reach eps but whose inscribed sphere is eps/sqrt(3). Staying inside that sphere
-    // is inside the hexahedron whatever orientation the frame comes out with, which keeps this
-    // from depending on how seg_cube happens to pick its two cross-section axes.
+    // The offset below has to sit in the band the sampled test gives up. Its upper end is not
+    // eps: fast-envelope inscribes a hexahedron of half-width eps/sqrt(3) whose corners reach
+    // eps, so eps/sqrt(3) is the offset guaranteed inside whatever orientation the frame comes
+    // out with. Using the inscribed sphere keeps this from depending on how seg_cube happens
+    // to pick its two cross-section axes.
     //
     //     eps/2 = 0.0500  <  0.95 * eps/sqrt(3) = 0.0548  <=  eps/sqrt(3) = 0.0577
     const double eps = 0.1;

--- a/tests/test_envelope.cpp
+++ b/tests/test_envelope.cpp
@@ -1,0 +1,241 @@
+// Containment queries that only the exact envelope can answer.
+//
+// SampleEnvelope has two backends. The sampled one places points along the query and asks the
+// BVH whether each is within eps of the input; it cannot see anything that happens between
+// two samples, and pays for that by shrinking its acceptance radius (eps/sqrt(3) for a
+// triangle, eps/2 for a segment -- see the derivations on SampleEnvelope::eps2 and eps2_edge).
+// The exact one asks whether the query is covered by the union of the eps-neighbourhoods of
+// the input primitives and decides that with exact predicates, so it uses the full eps.
+//
+// Until fast-envelope gained envelopes built from edges, only the triangle-mesh envelope had
+// an exact backend; the segment and 2D queries threw. These cases pin what the exact path now
+// answers, and in particular the two places where the two backends legitimately disagree:
+// the band between the shrunk radius and eps, where sampled is stricter, and a gap narrower
+// than the sample spacing, where sampled is wrong.
+#include <catch2/catch_test_macros.hpp>
+
+#include <wmtk/Types.hpp>
+#include <wmtk/envelope/Envelope.hpp>
+
+#include <cmath>
+
+using namespace wmtk;
+
+namespace {
+
+/// A single segment of the x axis, from the origin to (length, 0, 0).
+void init_axis_3d(SampleEnvelope& env, double length, double eps)
+{
+    const std::vector<Eigen::Vector3d> V = {Eigen::Vector3d(0, 0, 0), Eigen::Vector3d(length, 0, 0)};
+    const std::vector<Eigen::Vector2i> E = {Eigen::Vector2i(0, 1)};
+    env.init(V, E, eps);
+}
+
+/// The same in 2D.
+void init_axis_2d(SampleEnvelope& env, double length, double eps)
+{
+    const std::vector<Eigen::Vector2d> V = {Eigen::Vector2d(0, 0), Eigen::Vector2d(length, 0)};
+    const std::vector<Eigen::Vector2i> E = {Eigen::Vector2i(0, 1)};
+    env.init(V, E, eps);
+}
+
+} // namespace
+
+TEST_CASE("exact and sampled 3D segment envelopes agree away from the boundary", "[envelope]")
+{
+    // The two backends answer the same question in the interior and the far exterior. They are
+    // allowed to differ only near the boundary, which the next case covers, so agreement here
+    // is what says the exact path is wired to the right geometry at all -- a mis-dispatched
+    // exact query would answer "outside" for everything, including the queries well inside.
+    const double eps = 0.1;
+    SampleEnvelope sampled(false);
+    SampleEnvelope exact(true);
+    init_axis_3d(sampled, 4.0, eps);
+    init_axis_3d(exact, 4.0, eps);
+
+    SECTION("well inside")
+    {
+        const std::array<Eigen::Vector3d, 2> e = {
+            {Eigen::Vector3d(1, 0, 0), Eigen::Vector3d(3, 0.01, 0)}};
+        CHECK_FALSE(sampled.is_outside(e));
+        CHECK_FALSE(exact.is_outside(e));
+    }
+    SECTION("well outside, sideways")
+    {
+        const std::array<Eigen::Vector3d, 2> e = {
+            {Eigen::Vector3d(1, 0.5, 0), Eigen::Vector3d(3, 0.5, 0)}};
+        CHECK(sampled.is_outside(e));
+        CHECK(exact.is_outside(e));
+    }
+    SECTION("well outside, past the end")
+    {
+        const std::array<Eigen::Vector3d, 2> e = {
+            {Eigen::Vector3d(1, 0, 0), Eigen::Vector3d(6, 0, 0)}};
+        CHECK(sampled.is_outside(e));
+        CHECK(exact.is_outside(e));
+    }
+    SECTION("a point query is unaffected by which backend answers it")
+    {
+        CHECK_FALSE(sampled.is_outside(Eigen::Vector3d(2, 0, 0)));
+        CHECK_FALSE(exact.is_outside(Eigen::Vector3d(2, 0, 0)));
+        CHECK(sampled.is_outside(Eigen::Vector3d(2, 0.5, 0)));
+        CHECK(exact.is_outside(Eigen::Vector3d(2, 0.5, 0)));
+    }
+}
+
+TEST_CASE("the sampled segment envelope is the stricter of the two", "[envelope]")
+{
+    // The sampled test accepts a segment only when every sample is within eps/2, because the
+    // spacing guarantees no more than another eps/2 between samples. So above eps/2 it starts
+    // rejecting geometry the input actually contains. That is safe -- it errs towards
+    // rejection -- but it is the reason the exact envelope is worth having.
+    //
+    // The offset below has to sit in the band where the two disagree. The upper end is not
+    // eps: fast-envelope wraps each segment in a hexahedron of half-width eps/sqrt(3), whose
+    // corners reach eps but whose inscribed sphere is eps/sqrt(3). Staying inside that sphere
+    // is inside the hexahedron whatever orientation the frame comes out with, which keeps this
+    // from depending on how seg_cube happens to pick its two cross-section axes.
+    //
+    //     eps/2 = 0.0500  <  0.95 * eps/sqrt(3) = 0.0548  <=  eps/sqrt(3) = 0.0577
+    const double eps = 0.1;
+    const double inscribed = eps / std::sqrt(3.0);
+    const double offset = 0.95 * inscribed;
+    REQUIRE(offset > eps / 2); // sampled must reject
+    REQUIRE(offset <= inscribed); // exact must accept
+
+    SampleEnvelope sampled(false);
+    SampleEnvelope exact(true);
+    init_axis_3d(sampled, 4.0, eps);
+    init_axis_3d(exact, 4.0, eps);
+
+    const std::array<Eigen::Vector3d, 2> e = {
+        {Eigen::Vector3d(1, offset, 0), Eigen::Vector3d(3, offset, 0)}};
+    CHECK(sampled.is_outside(e));
+    CHECK_FALSE(exact.is_outside(e));
+}
+
+TEST_CASE("the exact 2D envelope answers point and segment queries", "[envelope]")
+{
+    const double eps = 0.1;
+    SampleEnvelope sampled(false);
+    SampleEnvelope exact(true);
+    init_axis_2d(sampled, 4.0, eps);
+    init_axis_2d(exact, 4.0, eps);
+
+    SECTION("points")
+    {
+        // is_outside(Vector2d) cannot reach the exact backend by lifting to z = 0 the way the
+        // sampled one does -- the 2D envelope is a separate object -- so this is the case that
+        // catches that dispatch being wrong.
+        CHECK_FALSE(sampled.is_outside(Eigen::Vector2d(2, 0)));
+        CHECK_FALSE(exact.is_outside(Eigen::Vector2d(2, 0)));
+        CHECK(sampled.is_outside(Eigen::Vector2d(2, 0.5)));
+        CHECK(exact.is_outside(Eigen::Vector2d(2, 0.5)));
+    }
+    SECTION("segments")
+    {
+        const std::array<Eigen::Vector2d, 2> inside = {
+            {Eigen::Vector2d(1, 0), Eigen::Vector2d(3, 0)}};
+        CHECK_FALSE(sampled.is_outside(inside));
+        CHECK_FALSE(exact.is_outside(inside));
+
+        const std::array<Eigen::Vector2d, 2> outside = {
+            {Eigen::Vector2d(1, 0.5), Eigen::Vector2d(3, 0.5)}};
+        CHECK(sampled.is_outside(outside));
+        CHECK(exact.is_outside(outside));
+    }
+    SECTION("the 2D rectangle is inscribed in the eps-capsule, at eps/sqrt(2)")
+    {
+        const double inscribed = eps / std::sqrt(2.0);
+        const std::array<Eigen::Vector2d, 2> e = {
+            {Eigen::Vector2d(1, 0.9 * inscribed), Eigen::Vector2d(3, 0.9 * inscribed)}};
+        CHECK_FALSE(exact.is_outside(e));
+
+        const std::array<Eigen::Vector2d, 2> just_out = {
+            {Eigen::Vector2d(1, 1.1 * inscribed), Eigen::Vector2d(3, 1.1 * inscribed)}};
+        CHECK(exact.is_outside(just_out));
+    }
+}
+
+TEST_CASE("only the exact envelope sees a gap between two input curves", "[envelope]")
+{
+    // Two collinear segments with a gap between them. A query spanning the gap leaves the
+    // input and comes back, so it is genuinely outside the envelope -- but the sampled test
+    // only looks at its samples, and when the gap is narrower than the sample spacing every
+    // sample can land on covered ground. This is the failure the exact envelope exists to
+    // prevent, and the reason a bridging segment must be rejected rather than merely "usually"
+    // rejected: the sampled answer depends on where the samples happen to fall.
+    const double eps = 0.1;
+    const double gap = 0.3; // wide enough that no eps-neighbourhood spans it
+    const std::vector<Eigen::Vector2d> V = {
+        Eigen::Vector2d(0, 0),
+        Eigen::Vector2d(1, 0),
+        Eigen::Vector2d(1 + gap, 0),
+        Eigen::Vector2d(2 + gap, 0)};
+    const std::vector<Eigen::Vector2i> E = {Eigen::Vector2i(0, 1), Eigen::Vector2i(2, 3)};
+
+    SampleEnvelope exact(true);
+    exact.init(V, E, eps);
+
+    // Inside one component: fine.
+    CHECK_FALSE(exact.is_outside(std::array<Eigen::Vector2d, 2>{
+        {Eigen::Vector2d(0.2, 0), Eigen::Vector2d(0.8, 0)}}));
+    // Spanning the gap: outside, even though both endpoints are inside.
+    CHECK(exact.is_outside(std::array<Eigen::Vector2d, 2>{
+        {Eigen::Vector2d(0.5, 0), Eigen::Vector2d(1.8 + gap, 0)}}));
+    // Both endpoints inside is not sufficient even for a short query.
+    CHECK(exact.is_outside(std::array<Eigen::Vector2d, 2>{
+        {Eigen::Vector2d(1, 0), Eigen::Vector2d(1 + gap, 0)}}));
+}
+
+TEST_CASE("an exact query against the wrong kind of envelope throws", "[envelope]")
+{
+    // The dangerous failure mode is silence: a FastEnvelope that no init ever filled in has no
+    // prisms, so every query against it answers "outside" and the caller sees an optimization
+    // where every operation is vetoed rather than an error. These are the combinations that
+    // would otherwise land there.
+    const double eps = 0.1;
+
+    SECTION("triangle query against a 2D envelope")
+    {
+        SampleEnvelope exact(true);
+        init_axis_2d(exact, 4.0, eps);
+        const std::array<Eigen::Vector3d, 3> tri = {
+            {Eigen::Vector3d(0, 0, 0), Eigen::Vector3d(1, 0, 0), Eigen::Vector3d(0, 1, 0)}};
+        CHECK_THROWS(exact.is_outside(tri));
+    }
+    SECTION("triangle query against a 3D edge envelope")
+    {
+        SampleEnvelope exact(true);
+        init_axis_3d(exact, 4.0, eps);
+        const std::array<Eigen::Vector3d, 3> tri = {
+            {Eigen::Vector3d(0, 0, 0), Eigen::Vector3d(1, 0, 0), Eigen::Vector3d(0, 1, 0)}};
+        CHECK_THROWS(exact.is_outside(tri));
+    }
+    SECTION("3D segment query against a 2D envelope")
+    {
+        SampleEnvelope exact(true);
+        init_axis_2d(exact, 4.0, eps);
+        const std::array<Eigen::Vector3d, 2> e = {
+            {Eigen::Vector3d(1, 0, 0), Eigen::Vector3d(3, 0, 0)}};
+        CHECK_THROWS(exact.is_outside(e));
+    }
+    SECTION("an exact envelope needs a positive epsilon")
+    {
+        // Zero eps is legitimate for a nearest_point-only envelope (triwild's Delaunay
+        // seeding does it), but there is no zero-width exact envelope to build.
+        SampleEnvelope exact(true);
+        CHECK_THROWS(init_axis_2d(exact, 4.0, 0.0));
+
+        SampleEnvelope sampled(false);
+        CHECK_NOTHROW(init_axis_2d(sampled, 4.0, 0.0));
+    }
+    SECTION("the sampled backend accepts every combination, as before")
+    {
+        SampleEnvelope sampled(false);
+        init_axis_2d(sampled, 4.0, eps);
+        const std::array<Eigen::Vector3d, 2> e = {
+            {Eigen::Vector3d(1, 0, 0), Eigen::Vector3d(3, 0, 0)}};
+        CHECK_NOTHROW(sampled.is_outside(e));
+    }
+}

--- a/tests/test_envelope.cpp
+++ b/tests/test_envelope.cpp
@@ -26,7 +26,9 @@ namespace {
 /// A single segment of the x axis, from the origin to (length, 0, 0).
 void init_axis_3d(SampleEnvelope& env, double length, double eps)
 {
-    const std::vector<Eigen::Vector3d> V = {Eigen::Vector3d(0, 0, 0), Eigen::Vector3d(length, 0, 0)};
+    const std::vector<Eigen::Vector3d> V = {
+        Eigen::Vector3d(0, 0, 0),
+        Eigen::Vector3d(length, 0, 0)};
     const std::vector<Eigen::Vector2i> E = {Eigen::Vector2i(0, 1)};
     env.init(V, E, eps);
 }
@@ -178,14 +180,14 @@ TEST_CASE("only the exact envelope sees a gap between two input curves", "[envel
     exact.init(V, E, eps);
 
     // Inside one component: fine.
-    CHECK_FALSE(exact.is_outside(std::array<Eigen::Vector2d, 2>{
-        {Eigen::Vector2d(0.2, 0), Eigen::Vector2d(0.8, 0)}}));
+    CHECK_FALSE(exact.is_outside(
+        std::array<Eigen::Vector2d, 2>{{Eigen::Vector2d(0.2, 0), Eigen::Vector2d(0.8, 0)}}));
     // Spanning the gap: outside, even though both endpoints are inside.
-    CHECK(exact.is_outside(std::array<Eigen::Vector2d, 2>{
-        {Eigen::Vector2d(0.5, 0), Eigen::Vector2d(1.8 + gap, 0)}}));
+    CHECK(exact.is_outside(
+        std::array<Eigen::Vector2d, 2>{{Eigen::Vector2d(0.5, 0), Eigen::Vector2d(1.8 + gap, 0)}}));
     // Both endpoints inside is not sufficient even for a short query.
-    CHECK(exact.is_outside(std::array<Eigen::Vector2d, 2>{
-        {Eigen::Vector2d(1, 0), Eigen::Vector2d(1 + gap, 0)}}));
+    CHECK(exact.is_outside(
+        std::array<Eigen::Vector2d, 2>{{Eigen::Vector2d(1, 0), Eigen::Vector2d(1 + gap, 0)}}));
 }
 
 TEST_CASE("an exact query against the wrong kind of envelope throws", "[envelope]")


### PR DESCRIPTION
Bumps fast-envelope onto its `main` (PRs #5, #6 and #7) and uses the two things #6 adds — envelopes built from **edges** rather than triangles, in 3D and 2D — to give `SampleEnvelope` exact answers where it previously threw `"Cannot use an exact envelope for edges."`.

One thing worth correcting up front: the *segment against a triangle-mesh envelope* query was **already there** at the old pin. `FastEnvelope::is_outside(Vector3, Vector3)` and `segment_out_of_envelope` are untouched by the bump. What was missing was the ability to *build* an envelope from edges — which is exactly what tetwild's `m_order2_envelope`, simwild's `m_order_2_edge_envelope` and every 2D envelope are.

## Review of the upstream changes

Sound, and I checked the things that bit us last time:

- **Our `ip_filtered.h` work survived.** The 809-line diff is pure clang-format — the orient3D sign converter, the interval tier, the lazy implicit point and the `exists()` pre-check are all byte-equivalent.
- **Sign conventions.** #5 deleted the igl/geogram predicate backend and replaced it with `algorithms::orient_2d/orient_3d` over Indirect_Predicates. `orient_3d` reproduces the old `Predicates::orient_3d` exactly; `orient_2d` is its **negation**, because the first-argument-vs-last-argument relabelling is an odd permutation in 3D but an even one in 2D. Not a live bug — every consumer is sign-flip invariant — but a trap, so #7 writes it down at the definitions.
- **The 3D edge hexahedron satisfies the prism face convention.** Faces 0/1 are the end caps and 2–5 the side ring in cyclic order, which is what `is_two_facets_neighbouring` assumes. That is the non-obvious requirement and it holds.
- **`FastEnvelope2D::is_outside(segment)` is correct.** Each box ∩ query is an interval and consecutive intervals share a crossing point, so a chain from `p0` to `p1` covers the segment; the *exit* crossing is always among the four tested, so it is complete. Collinear and corner cases are handled explicitly rather than by constructing a degenerate SSI point.

Two defects, both fixed upstream in [fast-envelope#7](https://github.com/wildmeshing/fast-envelope/pull/7) before this bump:

1. `FAST_ENVELOPE_WITH_GMP=ON` no longer compiled — `is_3_triangle_cut_Rational` still called `Predicates::orient_3d` from the header #5 deleted.
2. `FastEnvelope2D::is_outside(p0, p1)` allocated and zeroed a `vector<bool>` sized to the **whole envelope** on every query, plus a full candidate rescan per box boundary. On a polyline of a few thousand segments that dominates — and this is triwild's hottest predicate. Now indexed by position within `candidates`, with scratch reused across queries.

## What changed here

`SampleEnvelope` records which of its three `init()` overloads built it. The exact path needs that and the sampled path does not: a triangle-built and an edge-built `FastEnvelope` are different objects, the 2D envelope is a different class, and `is_outside(Vector2d)` can no longer just lift to z = 0. Getting it wrong is **silent** — an empty `FastEnvelope` has no prisms, so it answers "outside" for everything and reads as an optimizer that cannot move — so a mismatched exact query now throws.

Three envelopes were hard-wired to sampled only because the exact one could not be built from edges, and now follow the surface envelope's `use_exact`:

| | |
| --- | --- |
| tetwild `m_order2_envelope` | open boundaries, non-manifold edges |
| simwild `m_order_2_edge_envelope` | same; its declaration said `// todo` |
| simwild `SimWildMeshTri::m_envelope` | the 2D polyline envelope |

triwild had no flag at all and gets tetwild's pair: `use_sample_envelope` (exact by default) and `simplify_use_sample_envelope` (sampled by default, because the exact envelope dominates the cost of simplifying a large curve network).

While there, the `simplify_envelope_ratio > 0.5` warning is now a `> 1` warning. 0.5 was never a property of the ratio — it was the sampled backend's internal `eps/2` compensation showing through, and a caller that has to know about `eps/2` is reading an implementation detail it should not be able to see. Both backends promise the same thing: everything they accept lies within `eps`. What is true regardless of backend is `ratio > 1`, where the simplification may move geometry further than the triangulation's envelope permits and the optimizer starts outside it.

## The behavioural change, measured

Both backends describe the **same** envelope — the `eps`-neighbourhood of the input — and both are handed the same `eps`. Neither is wider than the other by design. What differs is how much of that `eps` each manages to use: the sampled test can only look at finitely many points on a query, so to guarantee the whole thing is within `eps` it shrinks its acceptance radius by the sampling's covering radius (`eps/2` for a segment, `eps/√3` for a triangle). That shrink is an implementation detail of staying conservative, not a smaller envelope — but it does mean the sampled test rejects geometry that is genuinely inside.

So switching to exact does not widen the tolerance; it recovers budget the sampled path was spending on its own conservatism. The outputs still move, and visibly.

Serial A/B (`num_threads: 0`) against `main`. 31 configs run, 6 move:

| config | max energy | avg energy | #v | fidelity | time |
| --- | --- | --- | --- | --- | --- |
| `triwild_collection` | 9.98 → **9.50** | 3.62 → **3.04** | 706 → 610 | — | **0.54×** |
| `triwild_puzzle` | 4.97 → **4.95** | ≈ | — | — | 0.87× |
| `triwild_polylines` | 18.90 → **16.16** | 3.21 → 3.32 | 568 → 470 | hausdorff 0.454 → 0.589, **coverage 0.687 → 0.585** | **0.45×** |
| `simwild_double_sphere_3d` | 7.88 → **7.30** | 3.94 → **3.84** | 3487 → 3271 | — | 1.07× |
| `simwild_remeshing_2d` | = | 2.297 → **2.276** | 198 → 193 | — | 0.99× |
| `tetwild_crown` | 87.33 → **89.69** | 5.571 → 5.589 | ≈ | hausdorff **0.0602 → 0.0549** | **0.86×** |

Mostly better and faster. Two things I would not want to slip past review:

- **`triwild_polylines` loses fidelity**: coverage 0.687 → 0.585 and hausdorff 0.454 → 0.589. Using more of the `eps` budget permits more collapsing along the curves (568 → 470 vertices), and coverage measures the direction the envelope has never constrained — it only bounds output-inside-input, so a curve eroding along itself is invisible to it. Both hausdorff values are far inside `eps = 1.676`, so nothing is violating the tolerance; the output is simply coarser, which is what asking for the full `eps` buys. If that trade is unwanted for a given model, `use_sample_envelope: true` restores the old behaviour per-config.
- **`tetwild_crown` max energy rises 2.7%** (87.33 → 89.69) while its hausdorff improves and it runs 14% faster.

The control is `simwild_double_sphere_notop_3d`: byte-identical, and its log shows no order-2 edges — so it has no edge envelope to switch. `simwild_double_sphere_3d`, which has 222 of them, is the one that moved.

## Tests

`tests/test_envelope.cpp`, 6 cases, ~0.01 s each — the suite's runtime risk is in the integration configs, not here. Three pin geometry the two backends genuinely disagree about: the band between `eps/2` and `eps/√3` that the sampled test gives up to its own conservatism, a query bridging a gap between two input curves, and the 2D rectangle's exact reach at `eps/√2` from both sides. The rest guard the dispatch, which otherwise fails silently.

The `eps/√3` bound is expressed as the hexahedron's inscribed sphere rather than as a fraction of `eps`, so it does not depend on which two cross-section axes `seg_cube` happens to pick.

## Cost

The exact envelope itself costs **161.5 s → 175.1 s (+13.6 s, +8.4%)** on the integration suite, measured idle on the same build dir before the ten new configs were added. The new unit tests are not the cause — they are 0.00 s each; this is the exact queries on the six configs that switched. With the new integration configs on top the suite is 216.6 s.

Part of it was waste and is gone: building the exact structures unconditionally in the edge and 2D `init()`s cost 6 s of that (181.1 s → 175.1 s) for structures nothing would ever query, so those two are now built only when `use_exact` is set. The triangle overload still builds both, because callers *do* flip `use_exact` on an already-initialized envelope — but every one of those toggles is on a triangle envelope. A flag flipped after init on an edge or 2D envelope now throws instead of silently querying an empty structure.

Worth noting the two regimes disagree, so neither number tells the whole story: run **serially** the same configs total 475.6 s → 422.5 s (**0.89×**, dominated by `tetwild_crown` at 377 s → 326 s). The integration suite runs each config at its own thread count, where that saving does not translate and the per-query cost shows up instead.

## Integration coverage (added after the first review round)

The A/B exposed a gap: **none** of the four existing tetwild configs has a single open-boundary
edge, so the order-2 envelope this PR makes exact had no tetwild coverage at all — which is
exactly why all four came out byte-identical while `simwild_double_sphere_3d`, with its 222
order-2 edges, moved.

Ten configs added (wildmeshing/data2 `bb7e12c`, 252 KB). The five Thingi10K meshes were
selected on **tetwild's own** open-boundary count, not on a static edge count — two
promising candidates (`130976` with 88 boundary edges, `138207` with 78 non-manifold edges)
give tetwild *zero* open-boundary edges and would have exercised nothing:

| model | what it has | serial |
| --- | --- | --- |
| `thingi_100827` | 60 open-boundary edges, 10 pinch vertices | 2.9 s |
| `thingi_1344050` | 32 open-boundary edges, 8 pinch vertices | 4.4 s |
| `thingi_100036` | 17 open-boundary, 19 non-manifold edges | 11.3 s |
| `thingi_366725` | 1190 open-boundary edges | 11.7 s |
| `thingi_229953` | 28 open-boundary, 18 non-manifold edges | 15.4 s |

They stay in STL: the toolkit has its own `read_stl` hardened specifically against malformed
Thingi10K files, so that path gets covered too.

The five triwild20k networks cover junctions and open polylines separately and together —
`202090` (5 junctions, closed), `219409` (20 junctions, closed), `182771` (19 junctions,
2 open ends), `168662` (3 junctions, 27 open ends), `212797` (open only). All ≤ 1.6 s.
Junction counts are **after welding**: curves meeting at a junction are routinely stored with
separate indices at the same coordinate, so counting by index alone reports none.

Suite goes 175.1 s → 216.6 s. All ten run serially (`num_threads` defaults to 0).

## Verification

- ctest green; the integration suite passes 90 assertions over 44 configs
- rebased onto `tetmesh-get-edges` (#989), so this stacks on #988 → #989
- fast-envelope#7: 6/6 CI green and 20/20 its own ctest in the default configuration
- clang-format clean

On the GMP fix specifically: I verified that `FAST_ENVELOPE_WITH_GMP=ON` now **compiles and links**, which is what was broken. I did not get its `matches main reference output` regression test to *complete* — under rational arithmetic it blows through ctest's 1500 s budget and gets SIGTERMed. That is a property of the GMP path, not a regression: it could not be built at all before, so there is no earlier state in which that test passed. Nothing here enables GMP.

Note the golden-hash integration system lives on the unmerged `danielepanozzo/integration-test-hashes` branch, not `main`, so there is nothing to re-bless here — `Integration_Tests` only checks that every config runs without throwing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
