### PR TITLE
TriMesh: fix the dangling else in get_vertices that killed the lvid == 0 case

### DIFF
--- a/src/wmtk/TriMesh.cpp
+++ b/src/wmtk/TriMesh.cpp
@@ -2107,17 +2107,22 @@ std::vector<TriMesh::Tuple> TriMesh::get_vertices() const
         size_t fid = *min_element(v_conn_fids.begin(), v_conn_fids.end());
 
         // get the 3 vid
-        const std::array<size_t, 3> f_conn_verts = m_tri_connectivity[fid].m_indices;
+        const std::array<size_t, 3>& f_conn_verts = m_tri_connectivity[fid].m_indices;
         assert(i == f_conn_verts[0] || i == f_conn_verts[1] || i == f_conn_verts[2]);
 
+        // The local edge opposite the vertex's own local index, i.e. (lvid + 2) % 3. The
+        // second test used to be a plain `if`, so its `else` ran whenever the vertex was
+        // not local index 1 -- overwriting the lvid == 0 case with 1 and leaving that
+        // branch dead. Both edges do contain the vertex, so the tuple stayed valid and
+        // nothing caught it; it was simply not the edge this is documented to return.
         size_t eid = -1;
-
-        // eid is the same as the lvid
-        if (i == f_conn_verts[0]) eid = 2;
-        if (i == f_conn_verts[1])
+        if (i == f_conn_verts[0]) {
+            eid = 2;
+        } else if (i == f_conn_verts[1]) {
             eid = 0;
-        else
+        } else {
             eid = 1;
+        }
 
         Tuple v_tuple = Tuple(i, eid, fid, *this);
         assert(v_tuple.is_valid(*this));


### PR DESCRIPTION
Found while auditing navigation in `TriMesh`/`TetMesh` for unnecessary allocations. This is the one **correctness** finding; the performance work is stacked on top in a separate PR.

## The bug

[`TriMesh::get_vertices()`](https://github.com/wildmeshing/wildmeshing-toolkit/blob/main/src/wmtk/TriMesh.cpp) intends the local edge to be `(lvid + 2) % 3` — 2, 0, 1 for local vertex 0, 1, 2. The second test was a plain `if`, so its `else` ran whenever the vertex was *not* local index 1:

```cpp
if (i == f_conn_verts[0]) eid = 2;
if (i == f_conn_verts[1]) eid = 0;
else                      eid = 1;   // also runs when i == f_conn_verts[0]
```

`eid = 2` is set and immediately overwritten. **That branch is dead.** Roughly a third of vertices are local index 0 of their min-fid face, and every one of them came back with local edge 1 instead of 2.

## Why nobody noticed

Local edge 1 also contains local vertex 0, so the tuple was always *valid* — just not the edge the comment promises. Nothing asserts on it.

## Blast radius: none today

I audited all 90 call sites of `get_vertices()`. Every one reads only `vid()`:

- both VTU writers build a `vid → index` map
- `IsotropicRemeshing::write_triangle_mesh` takes `t.vid(*this)`
- triwild's rounding and feature-retention loops take `v.vid(*this)`
- qslim, topological_offset and the tests take `.size()`

The single place the whole tuple is forwarded is triwild's `Smooth.cpp`, which feeds `vertex_smooth` — and smoothing acts on the vertex, not the edge.

So this is behaviour-preserving as things stand. It is fixed so the next caller that *does* read the edge component gets what the documentation says.

Also takes `m_indices` by const reference instead of copying the array.

## Verification

**101/101 tests pass, including Integration_Tests** — no output changes, consistent with the audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)