### PR TITLE
navigation: remove unnecessary allocations in TriMesh, TetMesh and SimplexCollection

### DIFF
--- a/src/wmtk/TetMesh.cpp
+++ b/src/wmtk/TetMesh.cpp
@@ -228,6 +228,12 @@ void TetMesh::for_each_face(const std::function<void(const TetMesh::Tuple&)>& fu
 std::vector<TetMesh::Tuple> TetMesh::get_faces() const
 {
     auto faces = std::vector<TetMesh::Tuple>();
+    // Each tet contributes at most 4 faces and exactly one is the canonical
+    // representative, so 2 * tet_capacity() is a close upper bound on a closed mesh and
+    // an over-estimate on an open one. Without this the vector doubles its way up and
+    // holds both buffers at the last reallocation -- 187M faces x 40 bytes is 7.5 GB of
+    // payload on Thingi10K 338910, and the transient peak is far worse.
+    faces.reserve(2 * tet_capacity());
     for (int i = 0; i < tet_capacity(); i++) {
         if (m_tet_connectivity[i].m_is_removed) continue;
         for (int j = 0; j < 4; j++) {
@@ -317,6 +323,7 @@ bool TetMesh::check_mesh_connectivity_validity() const
 std::vector<TetMesh::Tuple> TetMesh::get_tets() const
 {
     std::vector<TetMesh::Tuple> tets;
+    tets.reserve(tet_capacity());
     for (auto i = 0; i < tet_capacity(); i++) {
         auto& t = m_tet_connectivity[i];
         if (t.m_is_removed) continue;
@@ -332,6 +339,7 @@ std::vector<TetMesh::Tuple> TetMesh::get_tets() const
 std::vector<TetMesh::Tuple> TetMesh::get_vertices() const
 {
     std::vector<TetMesh::Tuple> verts;
+    verts.reserve(vert_capacity());
     for (auto i = 0; i < vert_capacity(); i++) {
         auto& vc = m_vertex_connectivity[i];
         if (vc.m_is_removed) continue;
@@ -736,13 +744,15 @@ std::array<TetMesh::Tuple, 6> TetMesh::tet_edges(const Tuple& t) const
     return es;
 }
 
-std::vector<size_t> TetMesh::get_one_ring_tids_for_vertex(const Tuple& t) const
+const std::vector<size_t>& TetMesh::get_one_ring_tids_for_vertex(const Tuple& t) const
 {
     return get_one_ring_tids_for_vertex(t.m_global_vid);
 }
 
-std::vector<size_t> TetMesh::get_one_ring_tids_for_vertex(const size_t vid) const
+const std::vector<size_t>& TetMesh::get_one_ring_tids_for_vertex(const size_t vid) const
 {
+    // The fan IS the stored connectivity, so hand it back rather than copying it. Matches
+    // TriMesh::get_one_ring_fids_for_vertex, which has always returned a reference.
     return m_vertex_connectivity[vid].m_conn_tets;
 }
 
@@ -760,8 +770,10 @@ std::vector<TetMesh::Tuple> TetMesh::get_one_ring_tets_for_vertex(const Tuple& t
 
 std::vector<TetMesh::Tuple> TetMesh::get_one_ring_vertices_for_vertex(const Tuple& t) const
 {
+    const auto& tids = m_vertex_connectivity[t.m_global_vid].m_conn_tets;
     std::vector<size_t> v_ids;
-    for (size_t t_id : m_vertex_connectivity[t.m_global_vid].m_conn_tets) {
+    v_ids.reserve(tids.size() * 4);
+    for (size_t t_id : tids) {
         for (size_t j = 0; j < 4; j++) {
             v_ids.push_back(m_tet_connectivity[t_id][j]);
         }
@@ -769,6 +781,7 @@ std::vector<TetMesh::Tuple> TetMesh::get_one_ring_vertices_for_vertex(const Tupl
     vector_unique(v_ids);
     vector_erase(v_ids, t.m_global_vid);
     std::vector<Tuple> vertices;
+    vertices.reserve(v_ids.size());
     for (auto v_id : v_ids) {
         vertices.push_back(tuple_from_vertex(v_id));
     }
@@ -838,8 +851,9 @@ std::vector<TetMesh::Tuple> TetMesh::get_incident_tets_for_edge(
     const size_t vid0,
     const size_t vid1) const
 {
-    auto tids = get_incident_tids_for_edge(vid0, vid1);
+    const auto tids = get_incident_tids_for_edge(vid0, vid1);
     std::vector<Tuple> tets;
+    tets.reserve(tids.size());
     for (size_t t_id : tids) {
         tets.push_back(tuple_from_tet(t_id));
         assert(tets.back().is_valid(*this));

--- a/src/wmtk/TetMesh.h
+++ b/src/wmtk/TetMesh.h
@@ -1077,8 +1077,8 @@ public:
      * @param t a Tuple that refers to a vertex
      * @return std::vector<size_t> a vector of vids
      */
-    std::vector<size_t> get_one_ring_tids_for_vertex(const Tuple& t) const;
-    std::vector<size_t> get_one_ring_tids_for_vertex(const size_t vid) const;
+    const std::vector<size_t>& get_one_ring_tids_for_vertex(const Tuple& t) const;
+    const std::vector<size_t>& get_one_ring_tids_for_vertex(const size_t vid) const;
 
     /**
      * @brief Get the one ring vertices for a vertex

--- a/src/wmtk/TriMesh.cpp
+++ b/src/wmtk/TriMesh.cpp
@@ -7,6 +7,9 @@
 #include <wmtk/utils/Logger.hpp>
 #include <wmtk/utils/TupleUtils.hpp>
 
+#include <algorithm>
+#include <limits>
+
 using namespace wmtk;
 
 namespace {
@@ -111,7 +114,13 @@ size_t TriMesh::Tuple::eid(const TriMesh& m) const
 
     const size_t v_opp = switch_vertex(m).vid(m);
 
-    const std::vector<size_t>& fids = m.m_vertex_connectivity[m_vid].m_conn_tris;
+    // Walk the smaller of the two endpoint fans: the faces carrying both vertices are the
+    // same set either way, and both fans are sorted, so the first hit is the minimum fid
+    // whichever one is scanned. switch_faces() below already picks the smaller fan; this
+    // one always took m_vid's, which on a high-valence vertex is the expensive choice.
+    const std::vector<size_t>& v0_fids = m.m_vertex_connectivity[m_vid].m_conn_tris;
+    const std::vector<size_t>& v1_fids = m.m_vertex_connectivity[v_opp].m_conn_tris;
+    const std::vector<size_t>& fids = v0_fids.size() <= v1_fids.size() ? v0_fids : v1_fids;
 
     // find face that contain m_vid and v_opp
     for (const size_t f : fids) {
@@ -126,10 +135,12 @@ size_t TriMesh::Tuple::eid(const TriMesh& m) const
                 local_v1 = (int)i;
             }
         }
-        if (local_v1 == -1) {
+        // Both tests are needed now: when the smaller fan is v_opp's, a face in it is
+        // guaranteed to carry v_opp but not m_vid, which is the reverse of the assumption
+        // the old single-fan version could make.
+        if (local_v0 == -1 || local_v1 == -1) {
             continue;
         }
-        assert(local_v0 != -1);
         size_t local_eid = 3 - (local_v0 + local_v1);
         // fids are sorted --> return smallest fid
         return 3 * f + local_eid;
@@ -1905,10 +1916,15 @@ const std::vector<size_t>& TriMesh::get_one_ring_fids_for_vertex(const size_t vi
 std::vector<wmtk::TriMesh::Tuple> TriMesh::get_one_ring_edges_for_vertex(
     const wmtk::TriMesh::Tuple& t) const
 {
+    size_t vid = t.vid(*this);
+    const auto one_ring_tris = get_one_ring_tris_for_vertex(t);
+    // On a manifold interior vertex the ring has exactly as many edges as triangles; a
+    // boundary vertex has one more. Reserving the upper bound costs nothing and removes
+    // the reallocation chain that a high-valence vertex used to pay for twice.
     std::vector<Tuple> one_ring_edges;
     std::vector<size_t> one_ring_vertices;
-    size_t vid = t.vid(*this);
-    auto one_ring_tris = get_one_ring_tris_for_vertex(t);
+    one_ring_edges.reserve(one_ring_tris.size() + 1);
+    one_ring_vertices.reserve(one_ring_tris.size() + 1);
     for (Tuple tri : one_ring_tris) {
         // find the vertex
         while (tri.vid(*this) != vid) {
@@ -1979,7 +1995,7 @@ std::array<wmtk::TriMesh::Tuple, 3> TriMesh::oriented_tri_vertices(
 {
     std::array<TriMesh::Tuple, 3> incident_verts;
     size_t fid = t.fid(*this);
-    auto indices = m_tri_connectivity[fid].m_indices;
+    const auto& indices = m_tri_connectivity[fid].m_indices;
 
     incident_verts[0] = Tuple(indices[0], 2, fid, *this);
     incident_verts[1] = Tuple(indices[1], 0, fid, *this);
@@ -1996,7 +2012,7 @@ std::array<size_t, 3> TriMesh::oriented_tri_vids(const Tuple& t) const
 std::array<size_t, 3> TriMesh::oriented_tri_vids(const size_t fid) const
 {
     std::array<size_t, 3> incident_verts;
-    auto indices = m_tri_connectivity[fid].m_indices;
+    const auto& indices = m_tri_connectivity[fid].m_indices;
 
     incident_verts[0] = indices[0];
     incident_verts[1] = indices[1];
@@ -2183,14 +2199,34 @@ TriMesh::Tuple wmtk::TriMesh::tuple_from_vids(size_t vid0, size_t vid1, size_t v
     const auto& vf1 = m_vertex_connectivity[vid1];
     const auto& vf2 = m_vertex_connectivity[vid2];
 
-    const std::vector<size_t> tris01 = set_intersection(vf0.m_conn_tris, vf1.m_conn_tris);
-    const std::vector<size_t> tris012 = set_intersection(tris01, vf2.m_conn_tris);
+    // Three-way intersection in one pass over the smallest fan. The old form built the
+    // pairwise intersection into a heap vector and then intersected that with the third
+    // fan, allocating twice to find a single face; the fans are sorted, so a membership
+    // test against the other two is enough.
+    const std::vector<size_t>* fans[3] = {&vf0.m_conn_tris, &vf1.m_conn_tris, &vf2.m_conn_tris};
+    const std::vector<size_t>* smallest = fans[0];
+    for (int i = 1; i < 3; ++i) {
+        if (fans[i]->size() < smallest->size()) {
+            smallest = fans[i];
+        }
+    }
+    const auto in_fan = [](const std::vector<size_t>& fan, const size_t f) {
+        return std::binary_search(fan.begin(), fan.end(), f);
+    };
 
-    if (tris012.size() != 1) {
-        log_and_throw_error("Cannot find face with vids ({},{},{})", vid0, vid1, vid2);
+    size_t fid = std::numeric_limits<size_t>::max();
+    size_t n_found = 0;
+    for (const size_t f : *smallest) {
+        if (in_fan(vf0.m_conn_tris, f) && in_fan(vf1.m_conn_tris, f) &&
+            in_fan(vf2.m_conn_tris, f)) {
+            fid = f;
+            ++n_found;
+        }
     }
 
-    const size_t fid = tris012[0];
+    if (n_found != 1) {
+        log_and_throw_error("Cannot find face with vids ({},{},{})", vid0, vid1, vid2);
+    }
 
     const auto& tc = m_tri_connectivity[fid].m_indices;
     size_t local_vid = -1;

--- a/src/wmtk/simplex/SimplexCollection.hpp
+++ b/src/wmtk/simplex/SimplexCollection.hpp
@@ -46,20 +46,46 @@ public:
      *
      * There is no sorting or any check if the simplex already exists.
      */
+    // The faces are appended straight into this collection. Going through
+    // faces_from_simplex() would build a whole temporary SimplexCollection -- three heap
+    // allocations for a Tet -- copy it in, and destroy it; TetMeshSubstructure's link
+    // computation calls this ten times per edge.
     void add_with_faces(const Edge& s)
     {
         add(s);
-        add(faces_from_simplex(s));
+        const auto& v = s.vertices();
+        m_v.emplace_back(Vertex(v[0]));
+        m_v.emplace_back(Vertex(v[1]));
     }
     void add_with_faces(const Face& s)
     {
         add(s);
-        add(faces_from_simplex(s));
+        const auto& v = s.vertices();
+        m_v.emplace_back(Vertex(v[0]));
+        m_v.emplace_back(Vertex(v[1]));
+        m_v.emplace_back(Vertex(v[2]));
+        m_e.emplace_back(Edge(v[0], v[1]));
+        m_e.emplace_back(Edge(v[0], v[2]));
+        m_e.emplace_back(Edge(v[1], v[2]));
     }
     void add_with_faces(const Tet& s)
     {
         add(s);
-        add(faces_from_simplex(s));
+        const auto& v = s.vertices();
+        m_v.emplace_back(Vertex(v[0]));
+        m_v.emplace_back(Vertex(v[1]));
+        m_v.emplace_back(Vertex(v[2]));
+        m_v.emplace_back(Vertex(v[3]));
+        m_e.emplace_back(Edge(v[0], v[1]));
+        m_e.emplace_back(Edge(v[0], v[2]));
+        m_e.emplace_back(Edge(v[0], v[3]));
+        m_e.emplace_back(Edge(v[1], v[2]));
+        m_e.emplace_back(Edge(v[1], v[3]));
+        m_e.emplace_back(Edge(v[2], v[3]));
+        m_f.emplace_back(Face(v[0], v[1], v[2]));
+        m_f.emplace_back(Face(v[0], v[1], v[3]));
+        m_f.emplace_back(Face(v[0], v[2], v[3]));
+        m_f.emplace_back(Face(v[1], v[2], v[3]));
     }
 
     void add(const SimplexCollection& simplex_collection);

--- a/src/wmtk/utils/VectorUtils.h
+++ b/src/wmtk/utils/VectorUtils.h
@@ -131,7 +131,7 @@ inline void array_replace_inline(std::array<T, N>& arr, const T& v0, const T& v1
 template <typename T, size_t N>
 inline std::array<T, N> array_replace(const std::array<T, N>& arr, const T& v0, const T& v1)
 {
-    std::array<size_t, 4> out = arr;
+    std::array<T, N> out = arr;
     array_replace_inline(out, v0, v1);
     return out;
 }


### PR DESCRIPTION
Stacked on #987 (the one correctness finding from the same audit). `TetMesh::get_edges()` is deliberately **not** here — it is the one change that can move output, so it gets its own PR on top of this one.

**Nothing in this PR changes what any function computes**, and that is verified rather than asserted — see Verification below.

## Allocations removed

- **`TetMesh::get_one_ring_tids_for_vertex` returned `m_conn_tets` by value**, copying the fan on every call. Now returns a const reference, which is what the TriMesh counterpart `get_one_ring_fids_for_vertex` has always done.
- **`SimplexCollection::add_with_faces`** went through `faces_from_simplex`, which builds a whole temporary `SimplexCollection` — three heap allocations for a `Tet` — copies it into the target and destroys it. Now appends in place. `TetMeshSubstructure`'s link computation calls this ten times per edge.
- **`TriMesh::tuple_from_vids`** chained two `set_intersection` calls, allocating an intermediate vector to find a single face. Now one pass over the smallest fan with binary-search membership against the other two.
- `oriented_tri_vertices` / `oriented_tri_vids` copied `m_indices` instead of referencing it.

## Reserves

Added where the final size is known up front — already present in some of these functions and not others: `TetMesh::get_faces`, `get_tets`, `get_vertices`, `get_incident_tets_for_edge`, `get_one_ring_vertices_for_vertex`, and `TriMesh::get_one_ring_edges_for_vertex`.

**`get_faces` is the one that matters.** On Thingi10K 338910 it materialises **187,057,181 Tuples of 40 bytes — 7.5 GB of payload** — and without a reserve the vector doubles its way there, holding the old and new buffers at the final reallocation. That model OOMs at a 128 GB cap; a 300 GB run reached 180 GB and was still climbing, with 81 GB measured at the moment insertion finished. All the growth is in this pass.

## Algorithmic

`TriMesh::Tuple::eid()` now walks the smaller of the two endpoint fans instead of always `m_vid`'s. The faces carrying both vertices are the same set either way and both fans are sorted, so the first hit is the minimum fid regardless — `switch_faces()` twenty lines below already picked the smaller fan.

This needed one real change rather than a swap: the old version could assume every face it scanned contained `m_vid`, because it only walked `m_vid`'s fan. When the smaller fan is the opposite vertex's, that assumption inverts, so the `local_v0 == -1` case is now a `continue` instead of an assert.

## Also

`array_replace` in `VectorUtils.h` declared its local as `std::array<size_t, 4>` regardless of its own `T` and `N`, so the template only ever compiled for that one instantiation.

## Verification

- **Byte-exact**: every one of the 34 integration configs run through `wmtk_app` **serially at one thread**, one model at a time, before and after, with `sha256` over every file produced. **All 56 output files identical.** Serial is the point — the schedulers are order-dependent under threading, so a parallel run cannot distinguish a regression from a scheduling difference.
- **101/101 tests**, run serially (`ctest -j 1`), including Integration_Tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)