### PR TITLE
TetMesh: build get_edges one entry per edge instead of six

### DIFF
--- a/src/wmtk/TetMesh.cpp
+++ b/src/wmtk/TetMesh.cpp
@@ -180,33 +180,40 @@ void TetMesh::init(const MatrixXi& T)
 
 std::vector<TetMesh::Tuple> TetMesh::get_edges() const
 {
-    std::vector<std::tuple<size_t, size_t, TetMesh::Tuple>> edges;
-    edges.reserve(tet_capacity() * 6);
+    // One entry per edge, not six. get_faces() right below already works this way: an
+    // edge's canonical representative is the one whose eid() -- the lowest tet id
+    // carrying it, times six, plus the local edge -- points back at this (tid, j). So the
+    // duplicates can be rejected as they are generated instead of being collected,
+    // sorted and uniqued afterwards.
+    //
+    // The old form built 6 * tet_capacity() entries of (v0, v1, Tuple) at 56 bytes each,
+    // sorted all of them, and copied the survivors into a second vector. On a mesh with
+    // 18M tets that is roughly 6 GB of staging plus a 108M-element sort, to produce a
+    // result 6x smaller.
+    //
+    // The output is still ordered by (min vid, max vid), and the representative is now
+    // well defined rather than whatever an unstable std::sort happened to leave first
+    // among the six copies of each edge.
+    std::vector<std::pair<std::pair<size_t, size_t>, TetMesh::Tuple>> edges;
     for (int i = 0; i < tet_capacity(); i++) {
         if (m_tet_connectivity[i].m_is_removed) continue;
         for (int j = 0; j < 6; j++) {
-            auto tup = tuple_from_edge(i, j);
-            auto v0 = tup.vid(*this);
-            auto v1 = tup.switch_vertex(*this).vid(*this);
+            const auto tup = tuple_from_edge(i, j);
+            if (tup.eid(*this) != size_t(6 * i + j)) {
+                continue; // some lower-numbered tet owns this edge
+            }
+            size_t v0 = tup.vid(*this);
+            size_t v1 = tup.switch_vertex(*this).vid(*this);
             if (v0 > v1) std::swap(v0, v1);
-            edges.emplace_back(v0, v1, tup);
+            edges.emplace_back(std::make_pair(v0, v1), tup);
         }
     }
-    std::sort(edges.begin(), edges.end(), [](auto& a, auto& b) {
-        return std::tie(std::get<0>(a), std::get<1>(a)) < std::tie(std::get<0>(b), std::get<1>(b));
+    std::sort(edges.begin(), edges.end(), [](const auto& a, const auto& b) {
+        return a.first < b.first;
     });
-    edges.erase(
-        std::unique(
-            edges.begin(),
-            edges.end(),
-            [](auto& a, auto& b) {
-                return std::tie(std::get<0>(a), std::get<1>(a)) ==
-                       std::tie(std::get<0>(b), std::get<1>(b));
-            }),
-        edges.end());
     std::vector<TetMesh::Tuple> uniq_edges;
     uniq_edges.reserve(edges.size());
-    for (auto& [v0, v1, e] : edges) uniq_edges.push_back(e);
+    for (auto& [key, e] : edges) uniq_edges.push_back(e);
     return uniq_edges;
 }
 


### PR DESCRIPTION
Stacked on #988, which is stacked on #987. Separated from #988 because **this one changes output** on 3 of the 34 integration configs, and that deserves its own review rather than being buried in a set of provably-neutral changes.

## The change

`get_faces()` right below already works this way: an edge's canonical representative is the one whose `eid()` — the lowest tet id carrying it, times six, plus the local edge — points back at this `(tid, j)`. So the five duplicates can be rejected as they are generated:

```cpp
const auto tup = tuple_from_edge(i, j);
if (tup.eid(*this) != size_t(6 * i + j)) continue;   // a lower tet owns this edge
```

The old form built `6 * tet_capacity()` entries of `(v0, v1, Tuple)` at 56 bytes each, sorted all of them, ran `std::unique`, and copied the survivors into a second vector. On a mesh with 18 M tets that is roughly **6 GB of staging plus a 108 M-element sort**, to produce a result six times smaller.

**Wall time is unchanged** — `tetwild_octocat` 64.0 s before, 65.1 s after, within noise — because this trades an `O(6T log 6T)` sort for `6T` early-exiting `eid()` calls plus an `O(E log E)` sort. The win is memory, and it shows on the meshes where the staging vector runs to gigabytes, not on the integration models.

## What changes in the output

**31 of 34 configs are byte-identical.** Three differ, deterministically — I reran one on the same build and it reproduced the new hash exactly, so this is the change and not run-to-run noise. All three follow from one mechanism: the representative changes, which reorders operations, which lands the iterative smoothing on an adjacent solution.

| config | difference |
|---|---|
| `tetwild_crown` | **identical** `#V`, `#T` and final max energy (87.32763210291333). 22 of 11,649 lines of `out_surface.obj` differ by **1–3 ulp at the 15th–16th significant digit** |
| `simwild_double_sphere_notop_3d` | final max energy differs at the **8th decimal** — 8.967814141 → 8.967814085 |
| `simwild_double_sphere_3d` | final max energy **7.883 → 7.303**, mesh ~5% smaller |

The one substantive change is an improvement: lower max energy, fewer elements.

## Worth being clear about the old outputs

The previous representative was **whatever an unstable `std::sort` happened to leave first** among the six copies of each edge. It was never chosen — it was reproducible only because libc++'s sort is deterministic for a given input, not because anything selected it. The new representative is the lowest-numbered tet carrying the edge, which is defined and stable.

So the baseline these three configs moved away from was arbitrary to begin with.

## Verification

- All 34 integration configs run serially at one thread, `sha256` over every output file, before and after. 31 identical; the 3 above characterised in detail.
- Difference confirmed deterministic by re-running.
- **101/101 tests**, serially (`ctest -j 1`), including Integration_Tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)