### PR TITLE
tetwild: stop merging the simplified surface onto an epsilon grid

### DIFF
--- a/components/tetwild/wmtk/components/tetwild/tetwild.cpp
+++ b/components/tetwild/wmtk/components/tetwild/tetwild.cpp
@@ -291,7 +291,23 @@ TetWildMesh::ExportStruct tetwild_with_export(nlohmann::json json_params)
 
 
     params.init(box_minmax.first, box_minmax.second);
-    wmtk::remove_duplicates(vsimp, fsimp, 1e-10 * params.diag_l);
+
+    // The surface handed to the arrangement is taken as the simplification left it.
+    //
+    // This used to run wmtk::remove_duplicates(vsimp, fsimp, 1e-10 * diag_l) here, which
+    // merged vertices wrongly. It is not a proximity merge: it forwards to
+    // igl::remove_duplicate_vertices, which SNAPS coordinates to an epsilon grid and
+    // takes unique rows, so whether two vertices merge depends on which side of a cell
+    // boundary they fall on rather than on how far apart they are. Two vertices 2*eps
+    // apart merge when they land in the same cell; two a tenth of eps apart survive when
+    // a boundary runs between them.
+    //
+    // Nothing here needs it. collapse_shortest() is followed by consolidate_mesh(), so
+    // the ids are already contiguous, vert_capacity()/tri_capacity() are the live counts,
+    // and vsimp/fsimp are exactly sized with no stale slots. The simplification also
+    // maintains a valid manifold connectivity -- checked immediately above by
+    // check_mesh_connectivity_validity() -- so there are no coincident vertices or
+    // duplicated faces for it to find.
 
     // Built around the ORIGINAL input, like the simplification one, but at the full tet eps.
     // A separate object because surf_mesh's is deliberately tighter now.


### PR DESCRIPTION
Stacked on #990. Removes `wmtk::remove_duplicates(vsimp, fsimp, 1e-10 * diag_l)`, which ran between the surface simplification and the arrangement.

## It is not a proximity merge

It forwards to `igl::remove_duplicate_vertices`, which **snaps coordinates to an epsilon grid and takes unique rows**. So whether two vertices merge depends on which side of a cell boundary they fall on, not on how far apart they are:

- two vertices `2·eps` apart **merge** when they land in the same cell
- two `eps/10` apart **survive** when a boundary runs between them

## Nothing at the call site needs it

`collapse_shortest()` is followed by `consolidate_mesh()`, so ids are contiguous and `vert_capacity()`/`tri_capacity()` are the live counts — `vsimp`/`fsimp` are exactly sized with no stale slots to compact. The surface has also just passed `check_mesh_connectivity_validity()`, which throws on failure, so there are no coincident vertices or duplicated faces to find.

## What else went with it

The function does three more things behind the same name:

1. **Duplicate-face removal** — `igl::unique_rows` after rotating each face to start at its lowest id, so it only catches *same-orientation* duplicates.
2. **Repeated-vertex faces and reversed twins** of the immediately preceding row.
3. **An area threshold** that compares an area against `epsilon`, which is a *length*. Dimensionally wrong; harmless only because `1e-10 * diag_l` is tiny either way.

(1) and (2) exist to clean up damage **the merge itself causes** — a repeated-vertex face only arises once two of its corners have been merged — so they have nothing to do once it is gone.

## This leaves the function with no live caller

`EmbedSurface::remove_duplicates` in simwild wraps it but is itself never called; the three tetwild test call sites were already commented out; `attic` is not referenced from the top-level `CMakeLists`. I left `wmtk::remove_duplicates` in place — deleting it is a separate decision.

## Verification, and why "all green" is weak here

**106/106 tests including Integration_Tests.**

That is weaker evidence than it looks, and worth being explicit about: on all four tetwild integration models the call was **already a no-op** —

```
#v: 4551 -> 4551      #v: 6770 -> 6770
#v:  575 ->  575      #v:  382 ->  382
```

— so the suite never exercised the code path at all.

On real Thingi10K data it fires on **5.0% of models** (60 of 1200 sampled), and is not marginal when it does:

| model | #v in | #v out | lost | #f in | #f out |
|---|---|---|---|---|---|
| 100727 | 5930 | 1615 | **73%** | 3230 | 3230 |
| 106327 | 6125 | 3650 | 40% | 7316 | 7316 |
| 105799 | 5722 | 3478 | 39% | 6972 | 6972 |

100727 lost 73% of its vertices **with the face count unchanged** — thousands of distinct vertices merged and every triangle rewritten onto the survivors. That is the behaviour this removes, and no test covers it. A full 10,000-model Thingi10K sweep is being restarted from scratch on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)