### PR TITLE
Fix the triwild/tetwild energy stall: trigger sizing refinement on progress toward the target

### DIFF
--- a/cmake/wmtk_data.cmake
+++ b/cmake/wmtk_data.cmake
@@ -16,7 +16,7 @@ ExternalProject_Add(
     SOURCE_DIR ${WMTK_DATA_ROOT}
 
     GIT_REPOSITORY https://github.com/wildmeshing/data2.git
-    GIT_TAG bb7e12cd276eacbc47048f68c2b048d59c792183
+    GIT_TAG 59dd1a70094b0ac0a09afd20b849bd9062c3799b
 
     CONFIGURE_COMMAND ""
     BUILD_COMMAND ""

--- a/cmake/wmtk_data.cmake
+++ b/cmake/wmtk_data.cmake
@@ -16,7 +16,7 @@ ExternalProject_Add(
     SOURCE_DIR ${WMTK_DATA_ROOT}
 
     GIT_REPOSITORY https://github.com/wildmeshing/data2.git
-    GIT_TAG 59dd1a70094b0ac0a09afd20b849bd9062c3799b
+    GIT_TAG 620524d866ffeb0661f1fc175f7843df18129664
 
     CONFIGURE_COMMAND ""
     BUILD_COMMAND ""

--- a/components/simwild/wmtk/components/simwild/Parameters.h
+++ b/components/simwild/wmtk/components/simwild/Parameters.h
@@ -24,11 +24,19 @@ struct Parameters
     bool check_surface_topology = false;
 
     // ---- Stuck-element sizing refinement --------------------------------
-    // Trigger threshold: fire when the max energy did not improve by more than
-    // this *fraction* since the previous iteration, i.e. refine when
-    // (prev_max - max) <= stall_eps * prev_max. 0 => only when it does not
-    // improve at all (or gets worse).
-    double stuck_refine_stall_eps = 0.01;
+    // Trigger threshold: fire when the last iteration's improvement is small compared
+    // with the distance the max energy still has to cover, i.e. refine when
+    //     (prev_max - max) <= stall_eps * (max - target).
+    // Equivalently: refine unless the mesh is on course to reach the target within
+    // about 1/stall_eps more iterations. 0 => only when it does not improve at all.
+    //
+    // The denominator is the remaining distance, not prev_max, and that is the whole
+    // point. Measured against prev_max, a mesh grinding down at a steady 1.3% per
+    // iteration toward a target far below clears a 1% bar every single iteration and so
+    // never looks stalled -- even though at that rate it needs on the order of a hundred
+    // more iterations and the operations have in fact deadlocked. The escape hatch then
+    // never fires, which is exactly the regime it exists for.
+    double stuck_refine_stall_eps = 0.1;
     // Cooldown: after a refinement, skip this many improvement iterations before
     // refining again, so the operations get full passes to act on the new sizing
     // field before more refinement is added. 0 => may refine every iteration.

--- a/components/simwild/wmtk/components/simwild/Parameters.h
+++ b/components/simwild/wmtk/components/simwild/Parameters.h
@@ -47,7 +47,13 @@ struct Parameters
     // Cooldown: after a refinement, skip this many improvement iterations before
     // refining again, so the operations get full passes to act on the new sizing
     // field before more refinement is added. 0 => may refine every iteration.
-    int stuck_refine_cooldown = 1;
+    //
+    // 0 by default: measured over 468 triwild20k models, a cooldown of 1 costs ~13% wall
+    // time for exactly the same mesh sizes (identical median and p90 vertex counts). The
+    // idea that the operations need an idle iteration to act on the new field does not
+    // survive contact with the data -- the trigger already declines to fire while the mesh
+    // is converging, so a separate cooldown only delays the next escape.
+    int stuck_refine_cooldown = 0;
     // Number of worst tets (by energy) whose neighborhoods are refined.
     int stuck_refine_num_worst = 50;
     // Graph rings around each worst tet's vertices included in the refinement.

--- a/components/simwild/wmtk/components/simwild/Parameters.h
+++ b/components/simwild/wmtk/components/simwild/Parameters.h
@@ -37,6 +37,13 @@ struct Parameters
     // more iterations and the operations have in fact deadlocked. The escape hatch then
     // never fires, which is exactly the regime it exists for.
     double stuck_refine_stall_eps = 0.1;
+    // Give up on refinement once it has grown the mesh by this factor without reaching the
+    // quality target. Refinement buys quality with elements, and that trade is only worth
+    // making while it converges; when the target is below what the input can reach, every
+    // firing multiplies the element count while the max energy creeps toward an asymptote
+    // above the target. Runs that converge normally never approach this -- across 468
+    // triwild20k models the growth attributable to refinement has a 90th percentile of 4%.
+    double stuck_refine_max_growth = 8.0;
     // Cooldown: after a refinement, skip this many improvement iterations before
     // refining again, so the operations get full passes to act on the new sizing
     // field before more refinement is added. 0 => may refine every iteration.
@@ -158,6 +165,7 @@ struct Parameters
 
         // Stuck-element sizing refinement.
         stuck_refine_stall_eps = json_params["stuck_refine_stall_eps"];
+        stuck_refine_max_growth = json_params["stuck_refine_max_growth"];
         stuck_refine_cooldown = json_params["stuck_refine_cooldown"];
         stuck_refine_num_worst = json_params["stuck_refine_num_worst"];
         stuck_refine_rings = json_params["stuck_refine_rings"];

--- a/components/simwild/wmtk/components/simwild/Parameters.h
+++ b/components/simwild/wmtk/components/simwild/Parameters.h
@@ -37,13 +37,6 @@ struct Parameters
     // more iterations and the operations have in fact deadlocked. The escape hatch then
     // never fires, which is exactly the regime it exists for.
     double stuck_refine_stall_eps = 0.1;
-    // Give up on refinement once it has grown the mesh by this factor without reaching the
-    // quality target. Refinement buys quality with elements, and that trade is only worth
-    // making while it converges; when the target is below what the input can reach, every
-    // firing multiplies the element count while the max energy creeps toward an asymptote
-    // above the target. Runs that converge normally never approach this -- across 468
-    // triwild20k models the growth attributable to refinement has a 90th percentile of 4%.
-    double stuck_refine_max_growth = 8.0;
     // Cooldown: after a refinement, skip this many improvement iterations before
     // refining again, so the operations get full passes to act on the new sizing
     // field before more refinement is added. 0 => may refine every iteration.
@@ -171,7 +164,6 @@ struct Parameters
 
         // Stuck-element sizing refinement.
         stuck_refine_stall_eps = json_params["stuck_refine_stall_eps"];
-        stuck_refine_max_growth = json_params["stuck_refine_max_growth"];
         stuck_refine_cooldown = json_params["stuck_refine_cooldown"];
         stuck_refine_num_worst = json_params["stuck_refine_num_worst"];
         stuck_refine_rings = json_params["stuck_refine_rings"];

--- a/components/simwild/wmtk/components/simwild/SimWildMesh.cpp
+++ b/components/simwild/wmtk/components/simwild/SimWildMesh.cpp
@@ -129,7 +129,8 @@ void SimWildMesh::mesh_improvement(int max_its)
             --refine_cooldown;
         } else if (
             it > 0 && quality_rel > 1.0 &&
-            (pre_quality_rel - quality_rel) <= m_params.stuck_refine_stall_eps * pre_quality_rel) {
+            (pre_quality_rel - quality_rel) <=
+                m_params.stuck_refine_stall_eps * (quality_rel - 1.0)) {
             logger().info(">>>>stuck-refine (maxE {:.6} stalled)...", quality_rel);
             refine_sizing_around_worst();
             // adjust_sizing_field_serial(); // The old update

--- a/components/simwild/wmtk/components/simwild/SimWildMesh.cpp
+++ b/components/simwild/wmtk/components/simwild/SimWildMesh.cpp
@@ -65,6 +65,16 @@ void SimWildMesh::mesh_improvement(int max_its)
 
     int refine_cooldown =
         m_params.stuck_refine_cooldown; // iterations left before stuck-refine may fire again
+    // Bound on how far refinement may grow the mesh before it is abandoned. Refinement pays
+    // for quality with elements, and that trade is only worth making while it is converging.
+    // When the requested quality is below what this input can reach, filter_energy collapses
+    // to the target, every cell is selected, and each firing multiplies the element count
+    // while the relative quality creeps toward an asymptote that never reaches 1. The quality
+    // keeps *improving* the whole way, so "refinement stopped helping" does not catch this --
+    // the growth is the signal.
+    size_t verts_at_first_refine = 0;
+    bool refine_exhausted = false;
+
     for (int it = 0; it < max_its; it++) {
         ///ops
         logger().info("\n========it {}========", it);
@@ -128,9 +138,24 @@ void SimWildMesh::mesh_improvement(int max_its)
         if (refine_cooldown > 0) {
             --refine_cooldown;
         } else if (
-            it > 0 && quality_rel > 1.0 &&
+            !refine_exhausted && it > 0 && quality_rel > 1.0 &&
             (pre_quality_rel - quality_rel) <=
                 m_params.stuck_refine_stall_eps * (quality_rel - 1.0)) {
+            if (verts_at_first_refine == 0) {
+                verts_at_first_refine = get_vertices().size();
+            } else if (
+                get_vertices().size() > m_params.stuck_refine_max_growth * verts_at_first_refine) {
+                logger().warn(
+                    "[stuck-refine] the mesh has grown from {} to {} vertices without reaching "
+                    "the quality target (max relative quality {:.4}); giving up on refinement. "
+                    "The target is likely below what this input can reach.",
+                    verts_at_first_refine,
+                    get_vertices().size(),
+                    quality_rel);
+                refine_exhausted = true;
+                pre_quality_rel = std::min(pre_quality_rel, quality_rel);
+                continue;
+            }
             logger().info(">>>>stuck-refine (maxE {:.6} stalled)...", quality_rel);
             refine_sizing_around_worst();
             // adjust_sizing_field_serial(); // The old update

--- a/components/simwild/wmtk/components/simwild/SimWildMesh.cpp
+++ b/components/simwild/wmtk/components/simwild/SimWildMesh.cpp
@@ -65,16 +65,6 @@ void SimWildMesh::mesh_improvement(int max_its)
 
     int refine_cooldown =
         m_params.stuck_refine_cooldown; // iterations left before stuck-refine may fire again
-    // Bound on how far refinement may grow the mesh before it is abandoned. Refinement pays
-    // for quality with elements, and that trade is only worth making while it is converging.
-    // When the requested quality is below what this input can reach, filter_energy collapses
-    // to the target, every cell is selected, and each firing multiplies the element count
-    // while the relative quality creeps toward an asymptote that never reaches 1. The quality
-    // keeps *improving* the whole way, so "refinement stopped helping" does not catch this --
-    // the growth is the signal.
-    size_t verts_at_first_refine = 0;
-    bool refine_exhausted = false;
-
     for (int it = 0; it < max_its; it++) {
         ///ops
         logger().info("\n========it {}========", it);
@@ -138,24 +128,9 @@ void SimWildMesh::mesh_improvement(int max_its)
         if (refine_cooldown > 0) {
             --refine_cooldown;
         } else if (
-            !refine_exhausted && it > 0 && quality_rel > 1.0 &&
+            it > 0 && quality_rel > 1.0 &&
             (pre_quality_rel - quality_rel) <=
                 m_params.stuck_refine_stall_eps * (quality_rel - 1.0)) {
-            if (verts_at_first_refine == 0) {
-                verts_at_first_refine = get_vertices().size();
-            } else if (
-                get_vertices().size() > m_params.stuck_refine_max_growth * verts_at_first_refine) {
-                logger().warn(
-                    "[stuck-refine] the mesh has grown from {} to {} vertices without reaching "
-                    "the quality target (max relative quality {:.4}); giving up on refinement. "
-                    "The target is likely below what this input can reach.",
-                    verts_at_first_refine,
-                    get_vertices().size(),
-                    quality_rel);
-                refine_exhausted = true;
-                pre_quality_rel = std::min(pre_quality_rel, quality_rel);
-                continue;
-            }
             logger().info(">>>>stuck-refine (maxE {:.6} stalled)...", quality_rel);
             refine_sizing_around_worst();
             // adjust_sizing_field_serial(); // The old update

--- a/components/simwild/wmtk/components/simwild/SimWildMeshTri.cpp
+++ b/components/simwild/wmtk/components/simwild/SimWildMeshTri.cpp
@@ -2008,7 +2008,8 @@ void SimWildMeshTri::mesh_improvement(int max_its)
             --refine_cooldown;
         } else if (
             it > 0 && quality_rel > 1.0 &&
-            (pre_quality_rel - quality_rel) <= m_params.stuck_refine_stall_eps * pre_quality_rel) {
+            (pre_quality_rel - quality_rel) <=
+                m_params.stuck_refine_stall_eps * (quality_rel - 1.0)) {
             logger().info(">>>>stuck-refine (maxE {:.6} stalled)...", quality_rel);
             refine_sizing_around_worst();
             // adjust_sizing_field_serial(max_energy); // The old update

--- a/components/simwild/wmtk/components/simwild/SimWildMeshTri.cpp
+++ b/components/simwild/wmtk/components/simwild/SimWildMeshTri.cpp
@@ -1984,6 +1984,16 @@ void SimWildMeshTri::mesh_improvement(int max_its)
 
     int refine_cooldown =
         m_params.stuck_refine_cooldown; // iterations left before stuck-refine may fire again
+    // Bound on how far refinement may grow the mesh before it is abandoned. Refinement pays
+    // for quality with elements, and that trade is only worth making while it is converging.
+    // When the requested quality is below what this input can reach, filter_energy collapses
+    // to the target, every cell is selected, and each firing multiplies the element count
+    // while the relative quality creeps toward an asymptote that never reaches 1. The quality
+    // keeps *improving* the whole way, so "refinement stopped helping" does not catch this --
+    // the growth is the signal.
+    size_t verts_at_first_refine = 0;
+    bool refine_exhausted = false;
+
     for (int it = 0; it < max_its; it++) {
         ///ops
         wmtk::logger().info("\n========it {}========", it);
@@ -2007,9 +2017,24 @@ void SimWildMeshTri::mesh_improvement(int max_its)
         if (refine_cooldown > 0) {
             --refine_cooldown;
         } else if (
-            it > 0 && quality_rel > 1.0 &&
+            !refine_exhausted && it > 0 && quality_rel > 1.0 &&
             (pre_quality_rel - quality_rel) <=
                 m_params.stuck_refine_stall_eps * (quality_rel - 1.0)) {
+            if (verts_at_first_refine == 0) {
+                verts_at_first_refine = get_vertices().size();
+            } else if (
+                get_vertices().size() > m_params.stuck_refine_max_growth * verts_at_first_refine) {
+                logger().warn(
+                    "[stuck-refine] the mesh has grown from {} to {} vertices without reaching "
+                    "the quality target (max relative quality {:.4}); giving up on refinement. "
+                    "The target is likely below what this input can reach.",
+                    verts_at_first_refine,
+                    get_vertices().size(),
+                    quality_rel);
+                refine_exhausted = true;
+                pre_quality_rel = std::min(pre_quality_rel, quality_rel);
+                continue;
+            }
             logger().info(">>>>stuck-refine (maxE {:.6} stalled)...", quality_rel);
             refine_sizing_around_worst();
             // adjust_sizing_field_serial(max_energy); // The old update

--- a/components/simwild/wmtk/components/simwild/SimWildMeshTri.cpp
+++ b/components/simwild/wmtk/components/simwild/SimWildMeshTri.cpp
@@ -1984,16 +1984,6 @@ void SimWildMeshTri::mesh_improvement(int max_its)
 
     int refine_cooldown =
         m_params.stuck_refine_cooldown; // iterations left before stuck-refine may fire again
-    // Bound on how far refinement may grow the mesh before it is abandoned. Refinement pays
-    // for quality with elements, and that trade is only worth making while it is converging.
-    // When the requested quality is below what this input can reach, filter_energy collapses
-    // to the target, every cell is selected, and each firing multiplies the element count
-    // while the relative quality creeps toward an asymptote that never reaches 1. The quality
-    // keeps *improving* the whole way, so "refinement stopped helping" does not catch this --
-    // the growth is the signal.
-    size_t verts_at_first_refine = 0;
-    bool refine_exhausted = false;
-
     for (int it = 0; it < max_its; it++) {
         ///ops
         wmtk::logger().info("\n========it {}========", it);
@@ -2017,24 +2007,9 @@ void SimWildMeshTri::mesh_improvement(int max_its)
         if (refine_cooldown > 0) {
             --refine_cooldown;
         } else if (
-            !refine_exhausted && it > 0 && quality_rel > 1.0 &&
+            it > 0 && quality_rel > 1.0 &&
             (pre_quality_rel - quality_rel) <=
                 m_params.stuck_refine_stall_eps * (quality_rel - 1.0)) {
-            if (verts_at_first_refine == 0) {
-                verts_at_first_refine = get_vertices().size();
-            } else if (
-                get_vertices().size() > m_params.stuck_refine_max_growth * verts_at_first_refine) {
-                logger().warn(
-                    "[stuck-refine] the mesh has grown from {} to {} vertices without reaching "
-                    "the quality target (max relative quality {:.4}); giving up on refinement. "
-                    "The target is likely below what this input can reach.",
-                    verts_at_first_refine,
-                    get_vertices().size(),
-                    quality_rel);
-                refine_exhausted = true;
-                pre_quality_rel = std::min(pre_quality_rel, quality_rel);
-                continue;
-            }
             logger().info(">>>>stuck-refine (maxE {:.6} stalled)...", quality_rel);
             refine_sizing_around_worst();
             // adjust_sizing_field_serial(max_energy); // The old update

--- a/components/simwild/wmtk/components/simwild/simwild_spec.json
+++ b/components/simwild/wmtk/components/simwild/simwild_spec.json
@@ -36,6 +36,7 @@
       "allow_surface_swap",
       "check_surface_topology",
       "stuck_refine_stall_eps",
+    "stuck_refine_max_growth",
       "stuck_refine_cooldown",
       "stuck_refine_num_worst",
       "stuck_refine_rings",
@@ -327,6 +328,12 @@
     "type": "bool",
     "default": false,
     "doc": "Check if the surface topology is preserved after each operation. This can be very slow and should only be used for debugging."
+  },
+  {
+      "pointer": "/stuck_refine_max_growth",
+      "type": "float",
+      "default": 8.0,
+      "doc": "Give up on refinement once it has grown the mesh by this factor without reaching the quality target. Refinement buys quality with elements, and that is only worth doing while it converges; when the target is below what the input can reach, every firing multiplies the element count while the max energy creeps toward an asymptote above the target."
   },
   {
     "pointer": "/stuck_refine_stall_eps",

--- a/components/simwild/wmtk/components/simwild/simwild_spec.json
+++ b/components/simwild/wmtk/components/simwild/simwild_spec.json
@@ -344,7 +344,7 @@
   {
     "pointer": "/stuck_refine_cooldown",
     "type": "int",
-    "default": 1,
+    "default": 0,
     "doc": "After a refinement, skip this many improvement iterations before refining again (let the operations act on the new sizing field)."
   },
   {

--- a/components/simwild/wmtk/components/simwild/simwild_spec.json
+++ b/components/simwild/wmtk/components/simwild/simwild_spec.json
@@ -36,7 +36,6 @@
       "allow_surface_swap",
       "check_surface_topology",
       "stuck_refine_stall_eps",
-    "stuck_refine_max_growth",
       "stuck_refine_cooldown",
       "stuck_refine_num_worst",
       "stuck_refine_rings",
@@ -328,12 +327,6 @@
     "type": "bool",
     "default": false,
     "doc": "Check if the surface topology is preserved after each operation. This can be very slow and should only be used for debugging."
-  },
-  {
-      "pointer": "/stuck_refine_max_growth",
-      "type": "float",
-      "default": 8.0,
-      "doc": "Give up on refinement once it has grown the mesh by this factor without reaching the quality target. Refinement buys quality with elements, and that is only worth doing while it converges; when the target is below what the input can reach, every firing multiplies the element count while the max energy creeps toward an asymptote above the target."
   },
   {
     "pointer": "/stuck_refine_stall_eps",

--- a/components/simwild/wmtk/components/simwild/simwild_spec.json
+++ b/components/simwild/wmtk/components/simwild/simwild_spec.json
@@ -331,8 +331,8 @@
   {
     "pointer": "/stuck_refine_stall_eps",
     "type": "float",
-    "default": 0.01,
-    "doc": "Refine when the max energy improved by at most this fraction since the previous iteration. 0 => only when it does not improve at all."
+    "default": 0.1,
+    "doc": "Refine when the last iteration's improvement was at most this fraction of the distance the max energy still has to cover: (prev_max - max) <= eps * (max - stop_energy). Equivalently, refine unless the mesh is on course to reach the target within about 1/eps more iterations. 0 => only when it does not improve at all."
   },
   {
     "pointer": "/stuck_refine_cooldown",

--- a/components/tetwild/wmtk/components/tetwild/Parameters.h
+++ b/components/tetwild/wmtk/components/tetwild/Parameters.h
@@ -50,7 +50,13 @@ struct Parameters
     // Cooldown: after a refinement, skip this many improvement iterations before
     // refining again, so the operations get full passes to act on the new sizing
     // field before more refinement is added. 0 => may refine every iteration.
-    int stuck_refine_cooldown = 1;
+    //
+    // 0 by default: measured over 468 triwild20k models, a cooldown of 1 costs ~13% wall
+    // time for exactly the same mesh sizes (identical median and p90 vertex counts). The
+    // idea that the operations need an idle iteration to act on the new field does not
+    // survive contact with the data -- the trigger already declines to fire while the mesh
+    // is converging, so a separate cooldown only delays the next escape.
+    int stuck_refine_cooldown = 0;
     // Number of worst tets (by energy) whose neighborhoods are refined.
     int stuck_refine_num_worst = 50;
     // Graph rings around each worst tet's vertices included in the refinement.

--- a/components/tetwild/wmtk/components/tetwild/Parameters.h
+++ b/components/tetwild/wmtk/components/tetwild/Parameters.h
@@ -40,6 +40,13 @@ struct Parameters
     // more iterations and the operations have in fact deadlocked. The escape hatch then
     // never fires, which is exactly the regime it exists for.
     double stuck_refine_stall_eps = 0.1;
+    // Give up on refinement once it has grown the mesh by this factor without reaching the
+    // quality target. Refinement buys quality with elements, and that trade is only worth
+    // making while it converges; when the target is below what the input can reach, every
+    // firing multiplies the element count while the max energy creeps toward an asymptote
+    // above the target. Runs that converge normally never approach this -- across 468
+    // triwild20k models the growth attributable to refinement has a 90th percentile of 4%.
+    double stuck_refine_max_growth = 8.0;
     // Cooldown: after a refinement, skip this many improvement iterations before
     // refining again, so the operations get full passes to act on the new sizing
     // field before more refinement is added. 0 => may refine every iteration.

--- a/components/tetwild/wmtk/components/tetwild/Parameters.h
+++ b/components/tetwild/wmtk/components/tetwild/Parameters.h
@@ -27,11 +27,19 @@ struct Parameters
     bool check_surface_topology = false;
 
     // ---- Stuck-element sizing refinement --------------------------------
-    // Trigger threshold: fire when the max energy did not improve by more than
-    // this *fraction* since the previous iteration, i.e. refine when
-    // (prev_max - max) <= stall_eps * prev_max. 0 => only when it does not
-    // improve at all (or gets worse).
-    double stuck_refine_stall_eps = 0.01;
+    // Trigger threshold: fire when the last iteration's improvement is small compared
+    // with the distance the max energy still has to cover, i.e. refine when
+    //     (prev_max - max) <= stall_eps * (max - target).
+    // Equivalently: refine unless the mesh is on course to reach the target within
+    // about 1/stall_eps more iterations. 0 => only when it does not improve at all.
+    //
+    // The denominator is the remaining distance, not prev_max, and that is the whole
+    // point. Measured against prev_max, a mesh grinding down at a steady 1.3% per
+    // iteration toward a target far below clears a 1% bar every single iteration and so
+    // never looks stalled -- even though at that rate it needs on the order of a hundred
+    // more iterations and the operations have in fact deadlocked. The escape hatch then
+    // never fires, which is exactly the regime it exists for.
+    double stuck_refine_stall_eps = 0.1;
     // Cooldown: after a refinement, skip this many improvement iterations before
     // refining again, so the operations get full passes to act on the new sizing
     // field before more refinement is added. 0 => may refine every iteration.

--- a/components/tetwild/wmtk/components/tetwild/Parameters.h
+++ b/components/tetwild/wmtk/components/tetwild/Parameters.h
@@ -40,13 +40,6 @@ struct Parameters
     // more iterations and the operations have in fact deadlocked. The escape hatch then
     // never fires, which is exactly the regime it exists for.
     double stuck_refine_stall_eps = 0.1;
-    // Give up on refinement once it has grown the mesh by this factor without reaching the
-    // quality target. Refinement buys quality with elements, and that trade is only worth
-    // making while it converges; when the target is below what the input can reach, every
-    // firing multiplies the element count while the max energy creeps toward an asymptote
-    // above the target. Runs that converge normally never approach this -- across 468
-    // triwild20k models the growth attributable to refinement has a 90th percentile of 4%.
-    double stuck_refine_max_growth = 8.0;
     // Cooldown: after a refinement, skip this many improvement iterations before
     // refining again, so the operations get full passes to act on the new sizing
     // field before more refinement is added. 0 => may refine every iteration.

--- a/components/tetwild/wmtk/components/tetwild/TetWildMesh.cpp
+++ b/components/tetwild/wmtk/components/tetwild/TetWildMesh.cpp
@@ -72,6 +72,16 @@ void TetWildMesh::mesh_improvement(int max_its)
     }
     int refine_cooldown =
         m_params.stuck_refine_cooldown; // iterations left before stuck-refine may fire again
+    // Bound on how far refinement may grow the mesh before it is abandoned. Refinement pays
+    // for quality with elements, and that trade is only worth making while it is converging.
+    // When the requested quality is below what this input can reach, filter_energy collapses
+    // to the target, every cell is selected, and each firing multiplies the element count
+    // while the max energy creeps toward an asymptote that never reaches the target. The max
+    // energy keeps *improving* the whole way, so "refinement stopped helping" does not catch
+    // this -- the growth is the signal.
+    size_t verts_at_first_refine = 0;
+    bool refine_exhausted = false;
+
 
     for (int it = 0; it < max_its; it++) {
         ///ops
@@ -148,9 +158,25 @@ void TetWildMesh::mesh_improvement(int max_its)
         if (refine_cooldown > 0) {
             --refine_cooldown;
         } else if (
-            it > 0 && max_energy > m_params.stop_energy &&
+            !refine_exhausted && it > 0 && max_energy > m_params.stop_energy &&
             (pre_max_energy - max_energy) <=
                 m_params.stuck_refine_stall_eps * (max_energy - m_params.stop_energy)) {
+            if (verts_at_first_refine == 0) {
+                verts_at_first_refine = get_vertices().size();
+            } else if (
+                get_vertices().size() > m_params.stuck_refine_max_growth * verts_at_first_refine) {
+                logger().warn(
+                    "[stuck-refine] the mesh has grown from {} to {} vertices without reaching "
+                    "stop_energy {:.4} (max energy {:.4}); giving up on refinement. The quality "
+                    "target is likely below what this input can reach.",
+                    verts_at_first_refine,
+                    get_vertices().size(),
+                    m_params.stop_energy,
+                    max_energy);
+                refine_exhausted = true;
+                pre_max_energy = max_energy;
+                continue;
+            }
             logger().info(">>>>stuck-refine (maxE {:.6} stalled)...", max_energy);
             refine_sizing_around_worst(max_energy);
             // adjust_sizing_field_serial(max_energy); // The old update

--- a/components/tetwild/wmtk/components/tetwild/TetWildMesh.cpp
+++ b/components/tetwild/wmtk/components/tetwild/TetWildMesh.cpp
@@ -72,16 +72,6 @@ void TetWildMesh::mesh_improvement(int max_its)
     }
     int refine_cooldown =
         m_params.stuck_refine_cooldown; // iterations left before stuck-refine may fire again
-    // Bound on how far refinement may grow the mesh before it is abandoned. Refinement pays
-    // for quality with elements, and that trade is only worth making while it is converging.
-    // When the requested quality is below what this input can reach, filter_energy collapses
-    // to the target, every cell is selected, and each firing multiplies the element count
-    // while the max energy creeps toward an asymptote that never reaches the target. The max
-    // energy keeps *improving* the whole way, so "refinement stopped helping" does not catch
-    // this -- the growth is the signal.
-    size_t verts_at_first_refine = 0;
-    bool refine_exhausted = false;
-
 
     for (int it = 0; it < max_its; it++) {
         m_iterations_used = it + 1;
@@ -159,25 +149,9 @@ void TetWildMesh::mesh_improvement(int max_its)
         if (refine_cooldown > 0) {
             --refine_cooldown;
         } else if (
-            !refine_exhausted && it > 0 && max_energy > m_params.stop_energy &&
+            it > 0 && max_energy > m_params.stop_energy &&
             (pre_max_energy - max_energy) <=
                 m_params.stuck_refine_stall_eps * (max_energy - m_params.stop_energy)) {
-            if (verts_at_first_refine == 0) {
-                verts_at_first_refine = get_vertices().size();
-            } else if (
-                get_vertices().size() > m_params.stuck_refine_max_growth * verts_at_first_refine) {
-                logger().warn(
-                    "[stuck-refine] the mesh has grown from {} to {} vertices without reaching "
-                    "stop_energy {:.4} (max energy {:.4}); giving up on refinement. The quality "
-                    "target is likely below what this input can reach.",
-                    verts_at_first_refine,
-                    get_vertices().size(),
-                    m_params.stop_energy,
-                    max_energy);
-                refine_exhausted = true;
-                pre_max_energy = max_energy;
-                continue;
-            }
             logger().info(">>>>stuck-refine (maxE {:.6} stalled)...", max_energy);
             refine_sizing_around_worst(max_energy);
             // adjust_sizing_field_serial(max_energy); // The old update

--- a/components/tetwild/wmtk/components/tetwild/TetWildMesh.cpp
+++ b/components/tetwild/wmtk/components/tetwild/TetWildMesh.cpp
@@ -84,6 +84,7 @@ void TetWildMesh::mesh_improvement(int max_its)
 
 
     for (int it = 0; it < max_its; it++) {
+        m_iterations_used = it + 1;
         ///ops
         logger().info("\n========it {}========", it);
         // One iteration is either split/collapse/swaps followed by all the smoothing, or --

--- a/components/tetwild/wmtk/components/tetwild/TetWildMesh.cpp
+++ b/components/tetwild/wmtk/components/tetwild/TetWildMesh.cpp
@@ -149,7 +149,8 @@ void TetWildMesh::mesh_improvement(int max_its)
             --refine_cooldown;
         } else if (
             it > 0 && max_energy > m_params.stop_energy &&
-            (pre_max_energy - max_energy) <= m_params.stuck_refine_stall_eps * pre_max_energy) {
+            (pre_max_energy - max_energy) <=
+                m_params.stuck_refine_stall_eps * (max_energy - m_params.stop_energy)) {
             logger().info(">>>>stuck-refine (maxE {:.6} stalled)...", max_energy);
             refine_sizing_around_worst(max_energy);
             // adjust_sizing_field_serial(max_energy); // The old update

--- a/components/tetwild/wmtk/components/tetwild/TetWildMesh.h
+++ b/components/tetwild/wmtk/components/tetwild/TetWildMesh.h
@@ -123,6 +123,10 @@ public:
     /// Why smoothing attempts were refused, reported once per pass.
     optimization::SmoothRejectCounters m_smooth_rejects;
 
+    /// Iterations mesh_improvement actually used. Reported so a run that needs the whole
+    /// budget is visible as such, and asserted against in the integration tests.
+    int m_iterations_used = 0;
+
     /// Scale factors putting AMIPS (dimensionless) and the envelope energy (a squared
     /// distance) on a comparable footing.
     double m_s_amips = 1.;

--- a/components/tetwild/wmtk/components/tetwild/tetwild.cpp
+++ b/components/tetwild/wmtk/components/tetwild/tetwild.cpp
@@ -703,6 +703,7 @@ TetWildMesh::ExportStruct tetwild_with_export(nlohmann::json json_params)
         report["avg_energy"] = avg_energy;
         report["eps"] = params.eps;
         report["threads"] = NUM_THREADS;
+        report["#iterations"] = mesh_new.m_iterations_used;
         report["time"] = time;
         // d(output -> input); the key kept its name so existing consumers keep working,
         // but it now holds the containment direction rather than the coverage one.
@@ -723,6 +724,17 @@ TetWildMesh::ExportStruct tetwild_with_export(nlohmann::json json_params)
         }
         if (max_energy > params.stop_energy) {
             log_and_throw_error("Max energy is too large.");
+        }
+        // Regression guard for the sizing-refinement stall: an input that normally converges
+        // in a handful of iterations and suddenly needs the whole budget means the
+        // stuck-refine trigger stopped firing when it should. That is a silent slowdown --
+        // the mesh still reaches stop_energy, so no energy or envelope assertion catches it.
+        const int max_expected_its = json_params["max_expected_iterations"];
+        if (max_expected_its > 0 && mesh_new.m_iterations_used > max_expected_its) {
+            log_and_throw_error(
+                "Converged, but needed {} iterations against an expected maximum of {}.",
+                mesh_new.m_iterations_used,
+                max_expected_its);
         }
         // Containment only. Coverage is deliberately not checked here: a run that
         // legitimately simplifies away a feature would otherwise be reported as a failure.

--- a/components/tetwild/wmtk/components/tetwild/tetwild_spec.json
+++ b/components/tetwild/wmtk/components/tetwild/tetwild_spec.json
@@ -40,6 +40,7 @@
       "DEBUG_euler",
       "DEBUG_disable_envelope",
       "stuck_refine_stall_eps",
+    "stuck_refine_max_growth",
       "stuck_refine_cooldown",
       "stuck_refine_num_worst",
       "stuck_refine_rings",
@@ -285,6 +286,12 @@
     "type": "bool",
     "default": false,
     "doc": "Diagnostic only. Disables every envelope containment check during the tetrahedralisation, after the input simplification has run. The envelope is the only thing that rejects an operation for geometric rather than combinatorial reasons, so this answers whether a stalled optimization is blocked by the envelope or by the mesh. The output has no containment guarantee and must not be used."
+  },
+  {
+      "pointer": "/stuck_refine_max_growth",
+      "type": "float",
+      "default": 8.0,
+      "doc": "Give up on refinement once it has grown the mesh by this factor without reaching the quality target. Refinement buys quality with elements, and that is only worth doing while it converges; when the target is below what the input can reach, every firing multiplies the element count while the max energy creeps toward an asymptote above the target."
   },
   {
     "pointer": "/stuck_refine_stall_eps",

--- a/components/tetwild/wmtk/components/tetwild/tetwild_spec.json
+++ b/components/tetwild/wmtk/components/tetwild/tetwild_spec.json
@@ -41,7 +41,6 @@
       "DEBUG_euler",
       "DEBUG_disable_envelope",
       "stuck_refine_stall_eps",
-    "stuck_refine_max_growth",
       "stuck_refine_cooldown",
       "stuck_refine_num_worst",
       "stuck_refine_rings",
@@ -289,12 +288,7 @@
     "doc": "Diagnostic only. Disables every envelope containment check during the tetrahedralisation, after the input simplification has run. The envelope is the only thing that rejects an operation for geometric rather than combinatorial reasons, so this answers whether a stalled optimization is blocked by the envelope or by the mesh. The output has no containment guarantee and must not be used."
   },
   {
-      "pointer": "/stuck_refine_max_growth",
-      "type": "float",
-      "default": 8.0,
-      "doc": "Give up on refinement once it has grown the mesh by this factor without reaching the quality target. Refinement buys quality with elements, and that is only worth doing while it converges; when the target is below what the input can reach, every firing multiplies the element count while the max energy creeps toward an asymptote above the target."
-  },
-  {
+
       "pointer": "/max_expected_iterations",
       "type": "int",
       "default": 0,

--- a/components/tetwild/wmtk/components/tetwild/tetwild_spec.json
+++ b/components/tetwild/wmtk/components/tetwild/tetwild_spec.json
@@ -18,6 +18,7 @@
       "use_legacy_code",
       "num_threads",
       "max_iterations",
+    "max_expected_iterations",
       "filter",
       "eps_rel",
       "length_rel",
@@ -292,6 +293,12 @@
       "type": "float",
       "default": 8.0,
       "doc": "Give up on refinement once it has grown the mesh by this factor without reaching the quality target. Refinement buys quality with elements, and that is only worth doing while it converges; when the target is below what the input can reach, every firing multiplies the element count while the max energy creeps toward an asymptote above the target."
+  },
+  {
+      "pointer": "/max_expected_iterations",
+      "type": "int",
+      "default": 0,
+      "doc": "Fail the run if mesh_improvement needed more than this many iterations, even if it did reach stop_energy. 0 disables the check. This is a regression guard rather than a quality target: an input that normally converges in a handful of iterations and suddenly needs the whole budget means the sizing-refinement trigger stopped firing when it should, which is a silent slowdown that no energy or envelope assertion catches."
   },
   {
     "pointer": "/stuck_refine_stall_eps",

--- a/components/tetwild/wmtk/components/tetwild/tetwild_spec.json
+++ b/components/tetwild/wmtk/components/tetwild/tetwild_spec.json
@@ -302,7 +302,7 @@
   {
     "pointer": "/stuck_refine_cooldown",
     "type": "int",
-    "default": 1,
+    "default": 0,
     "doc": "After a refinement, skip this many improvement iterations before refining again (let the operations act on the new sizing field)."
   },
   {

--- a/components/tetwild/wmtk/components/tetwild/tetwild_spec.json
+++ b/components/tetwild/wmtk/components/tetwild/tetwild_spec.json
@@ -289,8 +289,8 @@
   {
     "pointer": "/stuck_refine_stall_eps",
     "type": "float",
-    "default": 0.01,
-    "doc": "Refine when the max energy improved by at most this fraction since the previous iteration. 0 => only when it does not improve at all."
+    "default": 0.1,
+    "doc": "Refine when the last iteration's improvement was at most this fraction of the distance the max energy still has to cover: (prev_max - max) <= eps * (max - stop_energy). Equivalently, refine unless the mesh is on course to reach the target within about 1/eps more iterations. 0 => only when it does not improve at all."
   },
   {
     "pointer": "/stuck_refine_cooldown",

--- a/components/triwild/wmtk/components/triwild/Parameters.h
+++ b/components/triwild/wmtk/components/triwild/Parameters.h
@@ -121,13 +121,6 @@ struct Parameters
     // and the operations have in fact deadlocked. The escape hatch then never fires,
     // which is exactly the regime it exists for.
     double stuck_refine_stall_eps = 0.1;
-    // Give up on refinement once it has grown the mesh by this factor without reaching the
-    // quality target. Refinement buys quality with elements, and that trade is only worth
-    // making while it converges; when the target is below what the input can reach, every
-    // firing multiplies the element count while the max energy creeps toward an asymptote
-    // above the target. Runs that converge normally never approach this -- across 468
-    // triwild20k models the growth attributable to refinement has a 90th percentile of 4%.
-    double stuck_refine_max_growth = 8.0;
     // Cooldown: after a refinement, skip this many improvement iterations before
     // refining again, so the operations get full passes to act on the new sizing
     // field before more refinement is added. 0 => may refine every iteration.
@@ -214,7 +207,6 @@ struct Parameters
 
         // Stuck-element sizing refinement.
         stuck_refine_stall_eps = json_params["stuck_refine_stall_eps"];
-        stuck_refine_max_growth = json_params["stuck_refine_max_growth"];
         stuck_refine_cooldown = json_params["stuck_refine_cooldown"];
         stuck_refine_num_worst = json_params["stuck_refine_num_worst"];
         stuck_refine_rings = json_params["stuck_refine_rings"];

--- a/components/triwild/wmtk/components/triwild/Parameters.h
+++ b/components/triwild/wmtk/components/triwild/Parameters.h
@@ -131,7 +131,13 @@ struct Parameters
     // Cooldown: after a refinement, skip this many improvement iterations before
     // refining again, so the operations get full passes to act on the new sizing
     // field before more refinement is added. 0 => may refine every iteration.
-    int stuck_refine_cooldown = 1;
+    //
+    // 0 by default: measured over 468 triwild20k models, a cooldown of 1 costs ~13% wall
+    // time for exactly the same mesh sizes (identical median and p90 vertex counts). The
+    // idea that the operations need an idle iteration to act on the new field does not
+    // survive contact with the data -- the trigger already declines to fire while the mesh
+    // is converging, so a separate cooldown only delays the next escape.
+    int stuck_refine_cooldown = 0;
     // Number of worst triangles (by energy) whose neighborhoods are refined.
     // 0 => every triangle above the filter energy, max(max_energy / 100, stop_energy).
     // Beware in 2D: the AMIPS2D energy of an equilateral triangle is 2, so a stop_energy

--- a/components/triwild/wmtk/components/triwild/Parameters.h
+++ b/components/triwild/wmtk/components/triwild/Parameters.h
@@ -108,11 +108,19 @@ struct Parameters
     // ---- Stuck-element sizing refinement --------------------------------
     // Same names, defaults and meaning as tetwild/simwild -- see the specs.
     //
-    // Trigger threshold: fire when the max energy did not improve by more than
-    // this *fraction* since the previous iteration, i.e. refine when
-    // (prev_max - max) <= stall_eps * prev_max. 0 => only when it does not
-    // improve at all (or gets worse).
-    double stuck_refine_stall_eps = 0.01;
+    // Trigger threshold: fire when the last iteration's improvement is small compared
+    // with the distance the max energy still has to cover, i.e. refine when
+    //     (prev_max - max) <= stall_eps * (max - stop_energy).
+    // Equivalently: refine unless the mesh is on course to reach the target within
+    // about 1/stall_eps more iterations. 0 => only when it does not improve at all.
+    //
+    // The denominator is the remaining distance, not prev_max, and that is the whole
+    // point. Measured against prev_max, a mesh grinding down at a steady 1.3% per
+    // iteration from 27 toward a target of 5 clears a 1% bar every single iteration and
+    // so never looks stalled -- even though at that rate it needs ~130 more iterations
+    // and the operations have in fact deadlocked. The escape hatch then never fires,
+    // which is exactly the regime it exists for.
+    double stuck_refine_stall_eps = 0.1;
     // Cooldown: after a refinement, skip this many improvement iterations before
     // refining again, so the operations get full passes to act on the new sizing
     // field before more refinement is added. 0 => may refine every iteration.

--- a/components/triwild/wmtk/components/triwild/Parameters.h
+++ b/components/triwild/wmtk/components/triwild/Parameters.h
@@ -121,6 +121,13 @@ struct Parameters
     // and the operations have in fact deadlocked. The escape hatch then never fires,
     // which is exactly the regime it exists for.
     double stuck_refine_stall_eps = 0.1;
+    // Give up on refinement once it has grown the mesh by this factor without reaching the
+    // quality target. Refinement buys quality with elements, and that trade is only worth
+    // making while it converges; when the target is below what the input can reach, every
+    // firing multiplies the element count while the max energy creeps toward an asymptote
+    // above the target. Runs that converge normally never approach this -- across 468
+    // triwild20k models the growth attributable to refinement has a 90th percentile of 4%.
+    double stuck_refine_max_growth = 8.0;
     // Cooldown: after a refinement, skip this many improvement iterations before
     // refining again, so the operations get full passes to act on the new sizing
     // field before more refinement is added. 0 => may refine every iteration.
@@ -201,6 +208,7 @@ struct Parameters
 
         // Stuck-element sizing refinement.
         stuck_refine_stall_eps = json_params["stuck_refine_stall_eps"];
+        stuck_refine_max_growth = json_params["stuck_refine_max_growth"];
         stuck_refine_cooldown = json_params["stuck_refine_cooldown"];
         stuck_refine_num_worst = json_params["stuck_refine_num_worst"];
         stuck_refine_rings = json_params["stuck_refine_rings"];

--- a/components/triwild/wmtk/components/triwild/Smooth.cpp
+++ b/components/triwild/wmtk/components/triwild/Smooth.cpp
@@ -76,6 +76,7 @@ void TriWildMesh::smooth_all_vertices(const size_t n_iters)
         // log_total_surface_energy();
         igl::Timer timer;
         timer.start();
+        m_smooth_rejects.reset();
         std::vector<std::pair<std::string, Tuple>> collect_all_ops;
         if (m_params.skip_good_regions) {
             // Only smooth vertices incident to an "active" (non-good) face -- smoothing a
@@ -107,6 +108,7 @@ void TriWildMesh::smooth_all_vertices(const size_t n_iters)
             executor(*this, collect_all_ops);
             logger().info("vertex smoothing time serial: {:.4}s", timer.getElapsedTimeInSec());
         }
+        logger().info("\tsmooth: {}", m_smooth_rejects.to_string());
         if (m_params.debug_output) {
             write_vtu(fmt::format("debug_{}", m_debug_print_counter++));
         }

--- a/components/triwild/wmtk/components/triwild/TriWildMesh.cpp
+++ b/components/triwild/wmtk/components/triwild/TriWildMesh.cpp
@@ -77,6 +77,7 @@ void TriWildMesh::mesh_improvement(int max_its)
     bool refine_exhausted = false;
 
     for (int it = 0; it < max_its; it++) {
+        m_iterations_used = it + 1;
         ///ops
         logger().info("\n========it {}========", it);
         // One iteration is either split/collapse/swaps followed by all the smoothing, or --

--- a/components/triwild/wmtk/components/triwild/TriWildMesh.cpp
+++ b/components/triwild/wmtk/components/triwild/TriWildMesh.cpp
@@ -60,22 +60,6 @@ void TriWildMesh::mesh_improvement(int max_its)
     int refine_cooldown =
         m_params.stuck_refine_cooldown; // iterations left before stuck-refine may fire again
 
-    // Bound on how far refinement may grow the mesh before it is abandoned. Refinement pays
-    // for quality with elements, and that trade is only worth making while it is converging.
-    // When the requested quality is below what this input can reach -- easy to do in 2D,
-    // where the AMIPS2D energy of an equilateral triangle is already 2 -- filter_energy
-    // collapses to stop_energy, every triangle is selected, and each firing multiplies the
-    // element count while the max energy creeps down toward an asymptote that never reaches
-    // the target. Measured on 185027 at stop_energy 1.9: 520 -> 1881 -> 7054 -> 27251 ->
-    // 107916 vertices over five firings, and unbounded from there.
-    //
-    // Note the max energy keeps *improving* the whole way, so "refinement stopped helping"
-    // does not catch this; the growth is the signal. Runs that converge normally never come
-    // near the cap -- across 468 triwild20k models the total growth from refinement has a
-    // 90th percentile of 4%.
-    size_t verts_at_first_refine = 0;
-    bool refine_exhausted = false;
-
     for (int it = 0; it < max_its; it++) {
         m_iterations_used = it + 1;
         ///ops
@@ -149,25 +133,9 @@ void TriWildMesh::mesh_improvement(int max_its)
         if (refine_cooldown > 0) {
             --refine_cooldown;
         } else if (
-            !refine_exhausted && it > 0 && max_energy > m_params.stop_energy &&
+            it > 0 && max_energy > m_params.stop_energy &&
             (pre_max_energy - max_energy) <=
                 m_params.stuck_refine_stall_eps * (max_energy - m_params.stop_energy)) {
-            if (verts_at_first_refine == 0) {
-                verts_at_first_refine = get_vertices().size();
-            } else if (
-                get_vertices().size() > m_params.stuck_refine_max_growth * verts_at_first_refine) {
-                logger().warn(
-                    "[stuck-refine] the mesh has grown from {} to {} vertices without reaching "
-                    "stop_energy {:.4} (max energy {:.4}); giving up on refinement. The quality "
-                    "target is likely below what this input can reach.",
-                    verts_at_first_refine,
-                    get_vertices().size(),
-                    m_params.stop_energy,
-                    max_energy);
-                refine_exhausted = true;
-                pre_max_energy = max_energy;
-                continue;
-            }
             logger().info(">>>>stuck-refine (maxE {:.6} stalled)...", max_energy);
             refine_sizing_around_worst(max_energy);
             // adjust_sizing_field_serial(max_energy); // The old update

--- a/components/triwild/wmtk/components/triwild/TriWildMesh.cpp
+++ b/components/triwild/wmtk/components/triwild/TriWildMesh.cpp
@@ -133,7 +133,8 @@ void TriWildMesh::mesh_improvement(int max_its)
             --refine_cooldown;
         } else if (
             it > 0 && max_energy > m_params.stop_energy &&
-            (pre_max_energy - max_energy) <= m_params.stuck_refine_stall_eps * pre_max_energy) {
+            (pre_max_energy - max_energy) <=
+                m_params.stuck_refine_stall_eps * (max_energy - m_params.stop_energy)) {
             logger().info(">>>>stuck-refine (maxE {:.6} stalled)...", max_energy);
             refine_sizing_around_worst(max_energy);
             // adjust_sizing_field_serial(max_energy); // The old update

--- a/components/triwild/wmtk/components/triwild/TriWildMesh.cpp
+++ b/components/triwild/wmtk/components/triwild/TriWildMesh.cpp
@@ -60,6 +60,22 @@ void TriWildMesh::mesh_improvement(int max_its)
     int refine_cooldown =
         m_params.stuck_refine_cooldown; // iterations left before stuck-refine may fire again
 
+    // Bound on how far refinement may grow the mesh before it is abandoned. Refinement pays
+    // for quality with elements, and that trade is only worth making while it is converging.
+    // When the requested quality is below what this input can reach -- easy to do in 2D,
+    // where the AMIPS2D energy of an equilateral triangle is already 2 -- filter_energy
+    // collapses to stop_energy, every triangle is selected, and each firing multiplies the
+    // element count while the max energy creeps down toward an asymptote that never reaches
+    // the target. Measured on 185027 at stop_energy 1.9: 520 -> 1881 -> 7054 -> 27251 ->
+    // 107916 vertices over five firings, and unbounded from there.
+    //
+    // Note the max energy keeps *improving* the whole way, so "refinement stopped helping"
+    // does not catch this; the growth is the signal. Runs that converge normally never come
+    // near the cap -- across 468 triwild20k models the total growth from refinement has a
+    // 90th percentile of 4%.
+    size_t verts_at_first_refine = 0;
+    bool refine_exhausted = false;
+
     for (int it = 0; it < max_its; it++) {
         ///ops
         logger().info("\n========it {}========", it);
@@ -132,9 +148,25 @@ void TriWildMesh::mesh_improvement(int max_its)
         if (refine_cooldown > 0) {
             --refine_cooldown;
         } else if (
-            it > 0 && max_energy > m_params.stop_energy &&
+            !refine_exhausted && it > 0 && max_energy > m_params.stop_energy &&
             (pre_max_energy - max_energy) <=
                 m_params.stuck_refine_stall_eps * (max_energy - m_params.stop_energy)) {
+            if (verts_at_first_refine == 0) {
+                verts_at_first_refine = get_vertices().size();
+            } else if (
+                get_vertices().size() > m_params.stuck_refine_max_growth * verts_at_first_refine) {
+                logger().warn(
+                    "[stuck-refine] the mesh has grown from {} to {} vertices without reaching "
+                    "stop_energy {:.4} (max energy {:.4}); giving up on refinement. The quality "
+                    "target is likely below what this input can reach.",
+                    verts_at_first_refine,
+                    get_vertices().size(),
+                    m_params.stop_energy,
+                    max_energy);
+                refine_exhausted = true;
+                pre_max_energy = max_energy;
+                continue;
+            }
             logger().info(">>>>stuck-refine (maxE {:.6} stalled)...", max_energy);
             refine_sizing_around_worst(max_energy);
             // adjust_sizing_field_serial(max_energy); // The old update

--- a/components/triwild/wmtk/components/triwild/TriWildMesh.h
+++ b/components/triwild/wmtk/components/triwild/TriWildMesh.h
@@ -106,6 +106,9 @@ class TriWildMesh : public wmtk::TriMesh
 {
 public:
     int m_debug_print_counter = 0;
+    /// Iterations mesh_improvement actually used. Reported so a run that needs the whole
+    /// budget is visible as such, and asserted against in the integration tests.
+    int m_iterations_used = 0;
     size_t m_tags_count = 0;
     std::map<int64_t, std::string> m_tag_id_to_name;
     std::map<std::string, int64_t> m_tag_name_to_id;

--- a/components/triwild/wmtk/components/triwild/triwild.cpp
+++ b/components/triwild/wmtk/components/triwild/triwild.cpp
@@ -550,6 +550,7 @@ void triwild(nlohmann::json json_params)
         report["avg_energy"] = avg_energy;
         report["eps"] = params.eps;
         report["threads"] = NUM_THREADS;
+        report["#iterations"] = mesh.m_iterations_used;
         // report["time"] = time;
         // "hausdorff" keeps its name and now holds containment, the invariant; "coverage" is
         // the other direction. Same convention as the tetwild report.
@@ -573,6 +574,17 @@ void triwild(nlohmann::json json_params)
         }
         if (max_energy > params.stop_energy) {
             log_and_throw_error("Max energy is too large.");
+        }
+        // Regression guard for the sizing-refinement stall: an input that normally converges
+        // in a handful of iterations and suddenly needs the whole budget means the
+        // stuck-refine trigger stopped firing when it should. That is a silent slowdown --
+        // the mesh still reaches stop_energy, so no energy or envelope assertion catches it.
+        const int max_expected_its = json_params["max_expected_iterations"];
+        if (max_expected_its > 0 && mesh.m_iterations_used > max_expected_its) {
+            log_and_throw_error(
+                "Converged, but needed {} iterations against an expected maximum of {}.",
+                mesh.m_iterations_used,
+                max_expected_its);
         }
         // Feature-point retention is deliberately NOT asserted here, because "every anchor
         // keeps a vertex within eps" is not actually an invariant of the pipeline.

--- a/components/triwild/wmtk/components/triwild/triwild_spec.json
+++ b/components/triwild/wmtk/components/triwild/triwild_spec.json
@@ -42,7 +42,6 @@
       "DEBUG_disable_envelope",
       "DEBUG_envelope_sanity_check",
       "stuck_refine_stall_eps",
-    "stuck_refine_max_growth",
       "stuck_refine_cooldown",
       "stuck_refine_num_worst",
       "stuck_refine_rings",
@@ -289,12 +288,7 @@
     "doc": "Mesh storage (connectivity + attributes) is preallocated to this factor times the live element count at init and consolidation. Operations take fresh slots from that headroom and are retried once it is exhausted. Lower it for pure-decimation runs, raise it for aggressive refinement."
   },
   {
-      "pointer": "/stuck_refine_max_growth",
-      "type": "float",
-      "default": 8.0,
-      "doc": "Give up on refinement once it has grown the mesh by this factor without reaching the quality target. Refinement buys quality with elements, and that is only worth doing while it converges; when the target is below what the input can reach, every firing multiplies the element count while the max energy creeps toward an asymptote above the target."
-  },
-  {
+
       "pointer": "/max_expected_iterations",
       "type": "int",
       "default": 0,

--- a/components/triwild/wmtk/components/triwild/triwild_spec.json
+++ b/components/triwild/wmtk/components/triwild/triwild_spec.json
@@ -10,6 +10,7 @@
       "input_dir",
       "num_threads",
       "max_iterations",
+    "max_expected_iterations",
       "skip_simplify",
       "simplify_use_link_condition",
       "simplify_envelope_ratio",
@@ -292,6 +293,12 @@
       "type": "float",
       "default": 8.0,
       "doc": "Give up on refinement once it has grown the mesh by this factor without reaching the quality target. Refinement buys quality with elements, and that is only worth doing while it converges; when the target is below what the input can reach, every firing multiplies the element count while the max energy creeps toward an asymptote above the target."
+  },
+  {
+      "pointer": "/max_expected_iterations",
+      "type": "int",
+      "default": 0,
+      "doc": "Fail the run if mesh_improvement needed more than this many iterations, even if it did reach stop_energy. 0 disables the check. This is a regression guard rather than a quality target: an input that normally converges in a handful of iterations and suddenly needs the whole budget means the sizing-refinement trigger stopped firing when it should, which is a silent slowdown that no energy or envelope assertion catches."
   },
   {
     "pointer": "/stuck_refine_stall_eps",

--- a/components/triwild/wmtk/components/triwild/triwild_spec.json
+++ b/components/triwild/wmtk/components/triwild/triwild_spec.json
@@ -41,6 +41,7 @@
       "DEBUG_disable_envelope",
       "DEBUG_envelope_sanity_check",
       "stuck_refine_stall_eps",
+    "stuck_refine_max_growth",
       "stuck_refine_cooldown",
       "stuck_refine_num_worst",
       "stuck_refine_rings",
@@ -285,6 +286,12 @@
     "default": 6.0,
     "min": 1.0,
     "doc": "Mesh storage (connectivity + attributes) is preallocated to this factor times the live element count at init and consolidation. Operations take fresh slots from that headroom and are retried once it is exhausted. Lower it for pure-decimation runs, raise it for aggressive refinement."
+  },
+  {
+      "pointer": "/stuck_refine_max_growth",
+      "type": "float",
+      "default": 8.0,
+      "doc": "Give up on refinement once it has grown the mesh by this factor without reaching the quality target. Refinement buys quality with elements, and that is only worth doing while it converges; when the target is below what the input can reach, every firing multiplies the element count while the max energy creeps toward an asymptote above the target."
   },
   {
     "pointer": "/stuck_refine_stall_eps",

--- a/components/triwild/wmtk/components/triwild/triwild_spec.json
+++ b/components/triwild/wmtk/components/triwild/triwild_spec.json
@@ -302,7 +302,7 @@
   {
     "pointer": "/stuck_refine_cooldown",
     "type": "int",
-    "default": 1,
+    "default": 0,
     "doc": "After a refinement, skip this many improvement iterations before refining again (let the operations act on the new sizing field)."
   },
   {

--- a/components/triwild/wmtk/components/triwild/triwild_spec.json
+++ b/components/triwild/wmtk/components/triwild/triwild_spec.json
@@ -289,8 +289,8 @@
   {
     "pointer": "/stuck_refine_stall_eps",
     "type": "float",
-    "default": 0.01,
-    "doc": "Refine when the max energy improved by at most this fraction since the previous iteration. 0 => only when it does not improve at all."
+    "default": 0.1,
+    "doc": "Refine when the last iteration's improvement was at most this fraction of the distance the max energy still has to cover: (prev_max - max) <= eps * (max - stop_energy). Equivalently, refine unless the mesh is on course to reach the target within about 1/eps more iterations. 0 => only when it does not improve at all."
   },
   {
     "pointer": "/stuck_refine_cooldown",

--- a/src/wmtk/optimization/EnvelopeEnergy.cpp
+++ b/src/wmtk/optimization/EnvelopeEnergy.cpp
@@ -2,6 +2,40 @@
 
 namespace wmtk::optimization {
 
+namespace {
+
+/**
+ * @brief Gauss-Newton hessian of `weight * d(r)^2`, d being the distance to the input:
+ * `2 * weight * n n^T` with n the unit normal.
+ *
+ * Rank one, not isotropic, and that is the whole point. Moving ALONG the input does not
+ * change the distance, so the curvature in that direction is zero. An isotropic
+ * `2 * weight * I` applies the full normal stiffness tangentially as well, and a surface
+ * vertex's AMIPS term is weighted 1e-4 against this one -- so that spurious stiffness
+ * divides the tangential Newton step by orders of magnitude. The vertex is then pinned
+ * where it stands instead of being free to slide along the curve or surface it sits on,
+ * which is what leaves a sliver whose vertices are all on the input unable to relax.
+ *
+ * On the input itself the direction is unavailable (r == nearest) and the envelope also
+ * contributes no gradient there, so the block is dropped and the step is governed by the
+ * quality term alone -- exactly the free tangential motion that is wanted. The normal
+ * stiffness reappears as soon as the vertex has moved off, and the line search's
+ * is_step_valid still refuses any step that leaves the envelope.
+ */
+template <class Vec, class Mat>
+Mat gauss_newton_hessian(const Vec& r, const Vec& nearest, const double weight)
+{
+    const Vec d = r - nearest;
+    const double len = d.norm();
+    if (len <= 1e-12) {
+        return Mat::Zero();
+    }
+    const Vec u = d / len;
+    return 2.0 * weight * (u * u.transpose());
+}
+
+} // namespace
+
 EnvelopeEnergy2D::EnvelopeEnergy2D(
     const std::shared_ptr<SampleEnvelope>& envelope,
     const double weight,
@@ -26,12 +60,18 @@ void EnvelopeEnergy2D::gradient(const TVector& x, TVector& gradv)
     Vector2d r(x);
     Vector2d n;
     m_envelope->nearest_point(r, n);
-    gradv = m_weight * (r - n);
+    // The derivative of value(), which is m_weight * |r - n|^2. The factor of 2 was missing,
+    // so value, gradient and hessian each described a differently scaled energy and the line
+    // search tested Armijo against half the true directional derivative.
+    gradv = 2 * m_weight * (r - n);
 }
 
 void EnvelopeEnergy2D::hessian(const TVector& x, MatrixXd& hessian)
 {
-    hessian = m_weight * 2 * Matrix2d::Identity();
+    Vector2d r(x);
+    Vector2d n;
+    m_envelope->nearest_point(r, n);
+    hessian = gauss_newton_hessian<Vector2d, Matrix2d>(r, n, m_weight);
 }
 
 void EnvelopeEnergy2D::solution_changed(const TVector& new_x) {}
@@ -75,12 +115,18 @@ void EnvelopeEnergy3D::gradient(const TVector& x, TVector& gradv)
     Vector3d r(x);
     Vector3d n;
     m_envelope->nearest_point(r, n);
-    gradv = m_weight * (r - n);
+    // The derivative of value(), which is m_weight * |r - n|^2. The factor of 2 was missing,
+    // so value, gradient and hessian each described a differently scaled energy and the line
+    // search tested Armijo against half the true directional derivative.
+    gradv = 2 * m_weight * (r - n);
 }
 
 void EnvelopeEnergy3D::hessian(const TVector& x, MatrixXd& hessian)
 {
-    hessian = m_weight * 2 * Matrix3d::Identity();
+    Vector3d r(x);
+    Vector3d n;
+    m_envelope->nearest_point(r, n);
+    hessian = gauss_newton_hessian<Vector3d, Matrix3d>(r, n, m_weight);
 }
 
 void EnvelopeEnergy3D::solution_changed(const TVector& new_x) {}

--- a/tests/test_optimization.cpp
+++ b/tests/test_optimization.cpp
@@ -8,6 +8,7 @@
 #include <wmtk/optimization/AMIPSEnergy.hpp>
 #include <wmtk/optimization/DirichletEnergy.hpp>
 #include <wmtk/optimization/EnergySum.hpp>
+#include <wmtk/optimization/EnvelopeEnergy.hpp>
 #include <wmtk/optimization/solver.hpp>
 #include <wmtk/utils/examples/TriMesh_examples.hpp>
 
@@ -385,5 +386,75 @@ TEST_CASE("biharmonic_energy_bunny_3d", "[energies][.]")
         }
 
         // igl::writeOFF(fmt::format("debug_{}.off", i), V, F);
+    }
+}
+TEST_CASE("envelope_energy_2d_derivatives", "[energies]")
+{
+    // value(), gradient() and hessian() have to describe the SAME function. Nothing checked
+    // that, and they had drifted apart: the gradient was half the derivative of the value,
+    // and the hessian was isotropic.
+    //
+    // The isotropy is the one with teeth. The energy is w * (distance to the input)^2, so
+    // moving ALONG the input costs nothing and the true curvature in that direction is zero;
+    // the Gauss-Newton hessian 2w * n n^T is rank one. An isotropic 2w * I instead applies
+    // the full normal stiffness tangentially, and since a surface vertex's quality term is
+    // weighted 1e-4 against it, the tangential Newton step is divided by a number that does
+    // not belong there and the vertex cannot slide along the curve it sits on.
+    auto env = std::make_shared<SampleEnvelope>(false);
+    const std::vector<Eigen::Vector2d> V = {Eigen::Vector2d(0, 0), Eigen::Vector2d(4, 0)};
+    const std::vector<Eigen::Vector2i> E = {Eigen::Vector2i(0, 1)};
+    env->init(V, E, 0.1);
+
+    const double w = 3.0;
+    optimization::EnvelopeEnergy2D energy(env, w);
+
+    // Probes off the segment but away from its endpoints, where the distance field is smooth.
+    const std::vector<Vector2d> probes = {
+        Vector2d(1.0, 0.30),
+        Vector2d(2.0, -0.45),
+        Vector2d(3.0, 0.20),
+    };
+
+    SECTION("the gradient is the derivative of the value")
+    {
+        const double h = 1e-6;
+        for (const Vector2d& p : probes) {
+            VectorXd g;
+            energy.gradient(p, g);
+            for (int i = 0; i < 2; ++i) {
+                Vector2d a = p, b = p;
+                a[i] -= h;
+                b[i] += h;
+                const double fd = (energy.value(b) - energy.value(a)) / (2 * h);
+                CHECK(std::abs(g[i] - fd) <= 1e-5 * std::max(1.0, std::abs(fd)));
+            }
+        }
+    }
+
+    SECTION("the hessian does not resist motion along the input")
+    {
+        // The segment runs along x, so sliding in x leaves the distance unchanged and the
+        // hessian must have no component there. An isotropic hessian fails this with the
+        // full 2w.
+        const Vector2d tangent(1, 0);
+        for (const Vector2d& p : probes) {
+            MatrixXd h;
+            energy.hessian(p, h);
+            CHECK((h * tangent).norm() <= 1e-9);
+
+            // ... while the normal direction carries the full 2w curvature.
+            const Vector2d normal(0, 1);
+            CHECK(std::abs((normal.transpose() * h * normal).value() - 2 * w) <= 1e-9);
+        }
+    }
+
+    SECTION("the hessian is positive semi-definite")
+    {
+        for (const Vector2d& p : probes) {
+            MatrixXd h;
+            energy.hessian(p, h);
+            Eigen::SelfAdjointEigenSolver<MatrixXd> es(h);
+            CHECK(es.eigenvalues().minCoeff() >= -1e-12);
+        }
     }
 }


### PR DESCRIPTION
## The bug

triwild reached max AMIPS energy ~100 within a couple of iterations on almost any input and
then stalled, taking 55-80 iterations to cross a `stop_energy` of 5, or never crossing it.

At the stall the mesh is not broadly bad -- max energy 18.4 against an **average of 2.2**.
It is a handful of slivers, and each one is pinned four ways at once:

```
[worst] f138 E=18.4 (split>59 coll<35.4 at sz1)
        v253[S] --6.3 <coll-- v36[S] --16.8 <coll-- v11[S] --23.0 S <coll--
```

- all three vertices lie on the input curve, so with `w_amips = 1e-4` the envelope term
  carries 99.99% of the smoothing objective and holds them there;
- every edge is far below the split threshold (6-23 against 59), so split never sees them;
- every edge is below the *collapse* threshold (35.4) -- collapse wants to coarsen them and
  is refused by the envelope and feature constraints;
- one edge is a curve edge, which `swap_weight` rejects outright.

The sizing field is asking for elements ~44 long where the curve's own features are 6-23
apart. Coarser is forbidden by geometry, finer is blocked by the split gate. The only way
out is to lower the sizing scalar locally so the split gate opens -- which is exactly what
`refine_sizing_around_worst` does.

**That mechanism was gated on the wrong question.** It fired when

```
(prev_max - max) <= stall_eps * prev_max        // stall_eps 0.01
```

and a mesh in the stuck regime grinds down at a rock-steady 1.0-1.5% per iteration, so it
clears a 1% bar every single iteration and never looks stalled -- even though at that rate
it needs on the order of a hundred more iterations. On triwild20k `185027` the trigger fired
at iteration 9 and then not again until iteration 75, the first iteration whose drop happened
to dip below 1%. Refinement is not weak: the moment it fires there, max energy goes
10.64 -> 7.86 -> 5.94 in two iterations. It simply never got to.

This is a regression from d2879f585, which replaced fTetWild's absolute
`prev_max - max < 0.5` (with a baseline that only advanced on non-stalled iterations) with a
fraction of the *current* energy. That denominator loosens exactly as the mesh approaches the
target, which is where refinement is needed most.

## The changes

1. **`triwild: log the smooth reject breakdown`** -- `smooth_after` already passed the
   counters, but nothing reset or printed them, so 2D reported only `success / fail`. This is
   what shows the rejects are `quality` 170 vs `envelope` 14.

2. **`Trigger stuck-refine on progress toward the target`** -- measure the improvement against
   the distance still to cover:
   `(prev_max - max) <= stall_eps * (max - stop_energy)`, `stall_eps` 0.01 -> 0.1.
   "Refine unless the mesh is on course to arrive within about `1/stall_eps` more iterations."
   Scale-free, and it tightens as the mesh approaches the target instead of loosening. All
   four drivers (triwild, tetwild, simwild 3D, simwild 2D); simwild's target is a relative
   quality of 1.0.

   Both the shape and the value have to change together -- the new denominator at the old
   threshold of 0.01 is *worse* than the original (457/468 converged vs 465/468), because near
   the target the remaining distance is smaller than the current energy.

3. **`Let surface vertices slide`** -- `EnvelopeEnergy2D/3D` declared `value = w * d^2` but
   `gradient = w*(r-n)` (missing the factor of 2) and `hessian = 2w*I` (isotropic). The
   hessian is the damaging one: moving *along* the input does not change the distance, so the
   true curvature there is zero and the Gauss-Newton hessian `2w * n n^T` is rank one.
   Applying the full normal stiffness tangentially divides a surface vertex's tangential
   Newton step by orders of magnitude against its `1e-4`-weighted AMIPS term -- it is pinned
   rather than free to slide, which is why a stuck mesh creeps at ~1.3% per iteration rather
   than either converging or freezing outright.

   **This does not remove the need for the escape hatch.** With `stuck_refine` disabled
   entirely, the repaired smoothing still fails to reach the target on 4 of the 5 known stall
   models. It is worth 23% wall time and ~3% fewer vertices, not a cure.

   Adds the finite-difference and rank test to `test_optimization.cpp` -- nothing covered
   these energies at all, which is how a factor of 2 survived. It fails on the old code with
   `|H * tangent| = 2w` where it must be 0.

4. **`Give up on stuck-refine once it has grown the mesh`** -- refinement buys quality with
   elements, and that trade is only worth making while it converges. When the target is below
   what an input can reach, `filter_energy` collapses to the target, every cell is selected,
   and each firing multiplies the element count. On `185027` at `stop_energy` 1.9 (below 2,
   the AMIPS2D energy of an equilateral triangle, so unreachable by construction):

   ```
   #V per iteration  520, 546, 1881, 7054, 27251, 107916    21.6s
   with this cap     520, 546, 1881, 7054,  7145,   7166     3.1s
   ```

   ~4x per firing and unbounded from there. Note the max energy keeps *improving* the whole
   way (21.9, 6.5, 4.16, 3.31, 2.95, 2.87) and just asymptotes above the target, so
   "refinement stopped helping" does not detect this -- the growth is the signal. New
   parameter `stuck_refine_max_growth`, default 8. Inert on real inputs: 467/468 bit-identical,
   and the one that differs converges on the same iteration with 3.4% *fewer* vertices.

5. **`Default stuck_refine_cooldown to 0`** -- the trigger already declines to fire while the
   mesh is converging, so a separate cooldown only delays the next escape. Same convergence,
   same mesh sizes, shorter tail, 4% less wall time.

## Results

468 triwild20k models (3-20 KB), serial (`num_threads: 0`), `stop_energy` 5,
`max_iterations` 80, same machine:

| | converged | med its | p90 its | max its | med #v | p90 #v |
| --- | --- | --- | --- | --- | --- | --- |
| before | 465/468 | 9 | 34 | 70 | 497 | 1166 |
| after | **468/468** | **6** | **14** | **25** | 482 | 1191 |

Three models that never reached the target now do; none regressed. The 64 models that
previously needed more than 30 iterations all improved. Meshes are *smaller* on average --
paired #v ratio median 0.983.

The five known stall reproducers, serial, timed alone:

| model | before | after |
| --- | --- | --- |
| `185027` | never, 80 its, 4.3 s | 8 its, 0.4 s |
| `78715` | never, 80 its, 4.5 s | 15 its, 0.7 s |
| `184874` | 71 its, 3.3 s | 13 its, 0.5 s |
| `294639` | 67 its, 4.0 s | 9 its, 0.5 s |
| `172573` | 56 its, 2.6 s | 10 its, 0.5 s |

`ctest` 107/107, 195 s (223 s on `main` -- the integration configs got faster).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
