### PR TITLE
tetwild sweep: TETWILD_SANITY_CHECKS to turn on the exact orientation checks

### DIFF
--- a/components/tetwild/wmtk/components/tetwild/scripts/README.md
+++ b/components/tetwild/wmtk/components/tetwild/scripts/README.md
@@ -67,6 +67,7 @@ TETWILD_JOB_TIMEOUT=21600 python3 run_tetwild_sweep.py
 | `TETWILD_SEED` | 0 | for `TETWILD_SAMPLE=random` |
 | `TETWILD_REPORT_ONLY` | unset | regenerate the report and exit |
 | `TETWILD_REPORT_BANNER` | unset | note shown at the top of the HTML report |
+| `TETWILD_SANITY_CHECKS` | unset | run with `DEBUG_sanity_checks` — exact-rational orientation checks. Slow, but the only way an inverted tet coming out of the arrangement is named in the log |
 
 `TETWILD_MEM_GB` is a cap **per model**, not a budget for the sweep — 8 × 128 G is more
 than most machines have. It is a runaway-killer: it stops one pathological mesh from

--- a/components/tetwild/wmtk/components/tetwild/scripts/run_tetwild_sweep.py
+++ b/components/tetwild/wmtk/components/tetwild/scripts/run_tetwild_sweep.py
@@ -41,6 +41,9 @@ Configuration -- environment variables:
     TETWILD_SAMPLE        name | smallest | spread | random  (default smallest)
     TETWILD_SEED          seed for TETWILD_SAMPLE=random  (default 0)
     TETWILD_REPORT_ONLY   if set, only regenerate the report and exit
+    TETWILD_SANITY_CHECKS if set, run with DEBUG_sanity_checks (exact-rational
+                          orientation checks; slow, but the only way an inverted tet
+                          coming out of the arrangement is named in the log)
 
 Memory note: the cap is PER MODEL, not a budget for the sweep. 8 x 128G is more than
 kirby has, so the cap is a runaway-killer, not an admission control -- it stops one
@@ -104,6 +107,16 @@ PARAMS = {
     # for nothing. The 2D sweep has always forced this off.
     "write_vtu": False,
 }
+
+# Opt-in exact-rational checking. The orientation checks that name an inverted tet
+# directly -- "After embed_tri_in_poly_mesh: Tet [...] is inverted!" -- sit behind
+# DEBUG_sanity_checks and are off by default, so a run that produces inverted tets says
+# nothing about them unless two happen to collide on a shared face, at which point a
+# downstream combinatorial check reports a "duplicate face" and points at the wrong
+# cause. Set TETWILD_SANITY_CHECKS=1 to hunt for the real thing. It is expensive: the
+# per-operation checks run for the whole optimization, not just insertion.
+if os.environ.get("TETWILD_SANITY_CHECKS"):
+    PARAMS["DEBUG_sanity_checks"] = True
 
 # Which of a run's output files to keep. The .vtu files are large visualization
 # dumps; the .msh is the actual tet mesh. Keep the mesh, the surfaces, and all the


### PR DESCRIPTION
The checks that name an inverted tet directly — `After embed_tri_in_poly_mesh: Tet [...] is inverted!` — sit behind `DEBUG_sanity_checks` and are **off by default**. So a run that produces inverted tets says nothing about them. The failure only surfaces later, if two of them happen to share a face, as

```
Face [3863, 3880, 1267799] appears more than once in the tet list
```

from a downstream combinatorial check that points at the wrong cause — it reads as duplicated geometry when the actual condition is a wrong winding.

Chasing that on Thingi10K 100727 cost most of a day, and the answer turned out to be six tets with negative exact signed volume coming straight out of the arrangement. Filed upstream as [VolumeRemesher#23](https://github.com/wildmeshing/VolumeRemesher/pull/23).

Setting `TETWILD_SANITY_CHECKS=1` puts `DEBUG_sanity_checks` into the per-model config, so a sweep can hunt for the real condition instead of its symptom. Off by default: the per-operation checks run for the whole optimization, not just insertion, and are expensive.

An env var rather than hand-editing the deployed script, because doing it by hand is how `SAMPLE=name` got silently reverted earlier today — a stale working copy was written over the committed one, and the sweep would have run in the wrong order without anyone noticing.

Scripts only; no library or component code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)