### PR TITLE
Bump VolumeRemesher and fast-envelope for the predicate denominator fix

### DIFF
--- a/cmake/recipes/fenvelope.cmake
+++ b/cmake/recipes/fenvelope.cmake
@@ -43,13 +43,16 @@ CPMAddPackage(
     # `FastEnvelope::init(V, edges, eps)` in 3D and the new `FastEnvelope2D` -- which is what
     # lets SampleEnvelope answer segment and 2D queries exactly instead of throwing.
     #
-    # Note fast-envelope declares Indirect_Predicates itself (cmake/recipes/ipred.cmake) at a
-    # different commit from the one VolumeRemesher pins. FetchContent keeps the first
-    # declaration, and the top-level CMakeLists includes volumeremesher before fenvelope, so
-    # VolumeRemesher's pin is the one that takes effect. That include order is load-bearing.
+    # And PR #8, which points fast-envelope's own Indirect_Predicates declaration
+    # (cmake/recipes/ipred.cmake) at the same commit VolumeRemesher uses. FetchContent keeps
+    # the first declaration and silently ignores later ones, so while the two disagreed the
+    # include order here decided the version for both -- volumeremesher comes first in the
+    # top-level CMakeLists, so fast-envelope ran on a different Indirect_Predicates than the
+    # one it was built and tested against upstream. Now that both pin the same commit that
+    # include order no longer matters; keep them moving together.
     GITHUB_REPOSITORY wildmeshing/fast-envelope
     # main. A commit rather than the branch name, so the build stays reproducible.
-    GIT_TAG 928e5ecd09bc7de9319468788727572f9b7c1f5d
+    GIT_TAG b116e1511e2130885ef3cc288c1253fc079b6989
     OPTIONS
     "FAST_ENVELOPE_WITH_UNIT_TESTS OFF"
 )

--- a/cmake/recipes/volumeremesher.cmake
+++ b/cmake/recipes/volumeremesher.cmake
@@ -31,7 +31,7 @@ include(CPM)
 CPMAddPackage(
     NAME VolumeRemesher
     GITHUB_REPOSITORY wildmeshing/VolumeRemesher
-    GIT_TAG 7e5d2b49a2c866770e15c9252c07533b50636c8a
+    GIT_TAG ba8a7329cf1225356dcc8e7bcee0883e0cc51e85
     OPTIONS
     "VOLUMEREMESHER_BUILD_TESTS OFF"
 )


### PR DESCRIPTION
VolumeRemesher `7e5d2b4` → `ba8a732`, fast-envelope `928e5ec` → `b116e15`. Both bring in `wildmeshing/Indirect_Predicates @ 013c7c1` (upstream `797c07c` plus one fix).

## The bug

`genericPoint::orient3D` returns `sgn(det)` of a determinant **scaled by its operands' homogeneous denominators**, so it is correct only if every denominator is positive. Two things maintain that:

1. the constructor negates `(lx, ly, lz, d)` when `d` is reliably negative;
2. `getIntervalLambda` returns `false` when `d`'s sign is **not** reliable, so the predicate abandons the interval filter and redoes the work in exact bigfloat.

`SSI`, `LPI` and `TPI` do both. `LNC`, `BPT` and `TBC` did neither. Those three build their denominator as the **product** of their generators' denominators, so they inherit an undecided sign from any generator whose own filter gave up — routine for an LPI or TPI in a near-planar region.

`implicitPoint3D_TBC` is the barycenter apex VolumeRemesher fans a non-tetrahedralizable BSP cell from, and `makeTetrahedra`'s winding-flip trusts `orient3D`, so the wrong sign became **tets with negative volume**. On Thingi10K 100727: 19 558 of 150 705 TBC vertices handed the predicate an undecided sign, and six tets came out inverted — which tetwild reported as `Face [3863, 3880, 1267799] appears more than once in the tet list`.

Nothing here is decided in floating point. The exact tier was always right; the filter wrongly reported that it did not need to run. The wrong answers are also permutation-consistent (even permutations agree, odd ones negate), so a symmetry check would not have caught it.

Upstream: [MarcoAttene/Indirect_Predicates#15](https://github.com/MarcoAttene/Indirect_Predicates/pull/15). **Both dependencies should go back to upstream together once it lands.**

## Also in this bump

- **VolumeRemesher [#23](https://github.com/wildmeshing/VolumeRemesher/pull/23)** adds a debug-build post-condition that every emitted tet has positive volume (checked against exact rational coordinates — re-asking `orient3D` would be circular), a `predicate_invariants` test that pins the two invariants in seconds so a future repin fails there rather than as a bad mesh, and documentation that NFG's arbitrary-precision types allocate from **thread-local** pools, so a `bigrational` must never outlive the thread that built it.
- **fast-envelope [#8](https://github.com/wildmeshing/fast-envelope/pull/8)** points its own Indirect_Predicates declaration at the same commit VolumeRemesher uses. They previously disagreed (`8d354b9` vs `797c07c`), and since `FetchContent` keeps only the first declaration, the include order in the top-level `CMakeLists` silently decided the version for both — fast-envelope ran here on a different Indirect_Predicates than the one it is built and tested against upstream. `fenvelope.cmake`'s comment calling that order load-bearing is updated.

## Verification

- toolkit `ctest`: **107/107**, 242 s. **No golden hashes moved** (tetwild, triwild and simwild configs included).
- VolumeRemesher `ctest`: 24/24, reference hashes unchanged; the `embed_regression` replay now passes (was 6 inverted tets).
- fast-envelope `ctest`: 20/20.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
