### PR TITLE
triwild: let the operations clean up junctions, anchoring only endpoints

### DIFF
--- a/components/triwild/wmtk/components/triwild/Parameters.h
+++ b/components/triwild/wmtk/components/triwild/Parameters.h
@@ -24,6 +24,27 @@ struct Parameters
      * which nothing else refuses. Off only for A/B against the old behaviour.
      */
     bool preserve_feature_points = true;
+
+    /**
+     * Let the operations clean up junctions, anchoring only open-polyline endpoints.
+     *
+     * The erosion argument above is about ENDPOINTS: a polyline eats its own tip. A junction
+     * -- valence >= 3 in the constrained edges -- cannot erode a curve away, because every
+     * curve through it stays a constrained edge and the envelope still holds it within eps.
+     * Anchoring it buys little and costs a great deal, because on a self-intersecting input
+     * nearly every arrangement vertex is a crossing: on 2D model 242427, 79615 of 87610
+     * vertices are junctions, so almost every edge joins two of them and collapse -- the only
+     * operation that removes a bad element outright -- is refused everywhere. That model then
+     * never leaves MAX_ENERGY: it sat at 1e50 for the whole run while the sizing field
+     * saturated and the split pass grew it from 13k to 621k vertices.
+     *
+     * With junctions free it converges to max energy 10.48, fully rounded, in 12 iterations.
+     * Measured no change on the two models the endpoint guard was introduced for (215292 and
+     * 134005): identical energies, iteration counts and Euler characteristics either way.
+     *
+     * Ignored when preserve_feature_points is off, which already anchors nothing.
+     */
+    bool allow_junction_cleanup = true;
     std::string output_path;
 
     double splitting_l2 = -1.; // the lower bound length (squared) for edge split
@@ -193,6 +214,7 @@ struct Parameters
         stop_energy = json_params["stop_energy"];
         preserve_topology = json_params["preserve_topology"];
         preserve_feature_points = json_params["preserve_feature_points"];
+        allow_junction_cleanup = json_params["allow_junction_cleanup"];
 
         debug_output = json_params["DEBUG_output"];
         perform_sanity_checks = json_params["DEBUG_sanity_checks"];

--- a/components/triwild/wmtk/components/triwild/TriWildMesh.cpp
+++ b/components/triwild/wmtk/components/triwild/TriWildMesh.cpp
@@ -440,20 +440,29 @@ void TriWildMesh::init_mesh(
             if (val == 0 || val == 2) {
                 continue;
             }
-            m_vertex_attribute[v].m_feature_id = m_feature_points.size();
-            m_feature_points.push_back(m_vertex_attribute[v].m_posf);
             if (val == 1) {
                 ++n_endpoints;
             } else {
                 ++n_junctions;
+                // The erosion above is an ENDPOINT property. A junction cannot erode a curve
+                // away -- every curve through it stays constrained and inside the envelope --
+                // while anchoring it can freeze the whole mesh, because on a self-intersecting
+                // input almost every arrangement vertex is a crossing. See
+                // Parameters::allow_junction_cleanup.
+                if (m_params.allow_junction_cleanup) {
+                    continue;
+                }
             }
+            m_vertex_attribute[v].m_feature_id = m_feature_points.size();
+            m_feature_points.push_back(m_vertex_attribute[v].m_posf);
         }
-        if (!m_feature_points.empty()) {
+        if (n_endpoints + n_junctions > 0) {
             logger().info(
-                "feature points: {} polyline endpoints, {} junctions (kept within {:.6} of "
-                "their input positions)",
+                "feature points: {} polyline endpoints, {} junctions; anchoring {} of them "
+                "within {:.6} of their input positions",
                 n_endpoints,
                 n_junctions,
+                m_feature_points.size(),
                 m_envelope_eps);
         }
     }

--- a/components/triwild/wmtk/components/triwild/triwild_spec.json
+++ b/components/triwild/wmtk/components/triwild/triwild_spec.json
@@ -28,6 +28,7 @@
       "interleaved_smoothing_passes",
       "preserve_topology",
       "preserve_feature_points",
+      "allow_junction_cleanup",
       "remove_duplicate_eps",
       "throw_on_fail",
       "log_file",
@@ -237,6 +238,12 @@
     "type": "bool",
     "default": true,
     "doc": "Keep the curve network's 0-dimensional features -- the endpoints of open polylines, and junctions -- within eps of where the arrangement placed them. Each such vertex is bound to a specific feature point, so a collapse is refused when it would leave that point unrepresented or move it further than eps, and smoothing may move the vertex anywhere inside that ball but no further. Without this the collapse pass deletes open polylines outright: a polyline erodes into its own tip until a single segment is left, and that segment carries a feature at BOTH ends, which the surface order test does not refuse (it only forbids collapsing a feature into a non-feature). Measured on the 2D dataset, model 215292 went from 28 open components after the arrangement to 0 in the output. Turn off only to reproduce the old behaviour."
+  },
+  {
+    "pointer": "/allow_junction_cleanup",
+    "type": "bool",
+    "default": true,
+    "doc": "Let the operations clean up junctions, anchoring only the endpoints of open polylines. The erosion the endpoint guard exists for is a property of ENDPOINTS -- a polyline eats its own tip -- and does not apply to a junction (valence >= 3 in the constrained edges), because every curve through a junction remains a constrained edge and the envelope still holds it within eps. Anchoring junctions buys little and costs a great deal on a self-intersecting input, where nearly every arrangement vertex is a crossing: on model 242427, 79615 of 87610 vertices are junctions, so almost every edge joins two of them and collapse -- the only operation that removes a bad element outright -- is refused across the whole mesh. That model never leaves MAX_ENERGY, sitting at 1e50 for the entire run while the sizing field saturates and the split pass grows it from 13k to 621k vertices. With junctions free it converges to max energy 10.48, fully rounded, in 12 iterations, and the two models the endpoint guard was introduced for (215292, 134005) are bit-identical either way. Ignored when preserve_feature_points is off."
   },
   {
     "pointer": "/preserve_topology",


### PR DESCRIPTION
`preserve_feature_points` anchors every 0-dimensional feature of the curve network — open-polyline endpoints **and** junctions — within eps of where the arrangement placed them. The erosion it exists to prevent is an *endpoint* property: a polyline collapses its interior into its own tip until one segment is left, and that segment carries a feature at both ends. A junction (valence ≥ 3 in the constrained edges) cannot erode a curve away — every curve through it stays a constrained edge, and the envelope still holds it within eps.

Anchoring junctions anyway is nearly free on a well-behaved input and catastrophic on a self-intersecting one, where almost every arrangement vertex is a crossing.

## The failure

2D model `242427` (1.9 MB, from the triwild20k sweep). 7,880 simplified segments produce **166,909 constrained edges**, and **79,615 of 87,610 vertices are junctions**. Almost every edge therefore joins two anchored vertices, and collapse — the only operation that removes a bad element outright — is refused across the whole mesh:

```
feature points: 234 polyline endpoints, 79615 junctions
[feature] 124844 collapses refused to keep a polyline endpoint or junction
          within 0.920016 of its input position
```

The mesh never leaves `MAX_ENERGY`. Over 62 iterations:

- max energy stayed at `1e+50`, or `1.394e+16` — *the same value every time*, the same unrepairable slivers
- the rounding sweep `reclaimed 0` of ~30k un-rounded vertices per iteration; only collapse clears them, and collapse was refused
- stuck-refine fired 51 times, reporting `refined 0 of 18 region vertices` — the sizing field had saturated at its floor
- the split pass then refined the graded region to 1000× resolution: **12,978 → 144,192 → 621,083 vertices**
- `0 of 185` blocks ever got below energy 100

It was still running after an hour when the sweep reached it, on a 1.9 MB input.

With junctions free it converges to **max energy 10.4798, fully rounded, in 12 iterations** at 5,108 vertices.

## The change

`allow_junction_cleanup`, **default true**. Ignored when `preserve_feature_points` is off, which already anchors nothing. The log line now reports how many features are actually anchored rather than how many exist — on 242427 that is 234 rather than 79,849.

## Test plan

Both models the endpoint guard was introduced for are **identical either way**:

| model | option | max energy | iters | #t | Euler |
|---|---|---|---|---|---|
| 215292 | on | 9.8284 | 5 | 736 | changed |
| 215292 | off | 9.8284 | 5 | 736 | changed |
| 134005 | on | 9.8484 | 1 | 469 | unchanged |
| 134005 | off | 9.8484 | 1 | 469 | unchanged |
| 242427 | on | 10.4798 | 12 | 10035 | — |
| 242427 | off | *never converges* | — | — | — |

215292's curve topology changes across the optimization in **both** configurations, so that pre-existing behaviour is unaffected by this change. (Worth noting separately: the endpoint guard does not actually preserve 215292's 29 components today — that is a real open issue, but a different one.)

Unit tests: **106,295 assertions in 97 test cases, all passing.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)