### PR TITLE
simwild 3D: keep exact coordinates out of the output by construction

### DIFF
--- a/components/simwild/wmtk/components/simwild/EdgeSplitting.cpp
+++ b/components/simwild/wmtk/components/simwild/EdgeSplitting.cpp
@@ -12,6 +12,7 @@ void SimWildMesh::split_all_edges()
     igl::Timer timer;
     double time;
     m_force_split_count = 0;
+    m_exact_split_count = 0;
     timer.start();
     std::vector<std::pair<std::string, Tuple>> collect_all_ops;
     for (const Tuple& loc : get_edges()) {
@@ -74,6 +75,11 @@ void SimWildMesh::split_all_edges()
         wmtk::logger().info(
             "[force-split] {} worst-tet longest edges force-split",
             m_force_split_count);
+    }
+    if (m_exact_split_count > 0) {
+        wmtk::logger().info(
+            "{} splits fell back to the exact rational midpoint",
+            m_exact_split_count);
     }
     // Consumed: the queued force-split edges no longer exist after this pass
     m_force_split_edges.clear();
@@ -178,6 +184,7 @@ bool SimWildMesh::split_edge_after(const Tuple& loc)
         std::atomic_ref<size_t>(m_force_split_count).fetch_add(1, std::memory_order_relaxed);
     }
     if (!m_vertex_attribute[v_id].m_is_rounded) {
+        std::atomic_ref<size_t>(m_exact_split_count).fetch_add(1, std::memory_order_relaxed);
         m_vertex_attribute[v_id].m_pos =
             (m_vertex_attribute[v1_id].m_pos + m_vertex_attribute[v2_id].m_pos) / 2;
         p = to_double(m_vertex_attribute[v_id].m_pos);
@@ -188,6 +195,9 @@ bool SimWildMesh::split_edge_after(const Tuple& loc)
                 return false;
             }
         }
+        // This split keeps an un-rounded vertex, so the sweep must not skip the next pass.
+        // Set after the rollback checks above, which leave the mesh unchanged.
+        m_all_rounded.store(false, std::memory_order_relaxed);
     }
 
     // If a Voronoi split function is set, binary-search vmid onto its zero-crossing.

--- a/components/simwild/wmtk/components/simwild/SimWildMesh.cpp
+++ b/components/simwild/wmtk/components/simwild/SimWildMesh.cpp
@@ -447,7 +447,6 @@ bool SimWildMesh::check_mesh_quality(double& max_rel_quality, const bool verbose
 size_t SimWildMesh::refine_sizing_around_worst()
 {
     const int n_rings = std::max(0, m_params.stuck_refine_rings);
-    const double filter_energy = m_params.stop_energy;
 
     // m_quality stores AMIPS^3, so the energy the "max energy" refers to is its cube root.
     const auto worst = utils::select_worst_cells(

--- a/components/simwild/wmtk/components/simwild/SimWildMesh.cpp
+++ b/components/simwild/wmtk/components/simwild/SimWildMesh.cpp
@@ -73,7 +73,13 @@ void SimWildMesh::mesh_improvement(int max_its)
         ///energy check
         logger().info("max rel quality {}", quality_rel);
         if (check_mesh_quality(quality_rel, true)) {
-            break;
+            // Energy alone is not a sufficient termination condition -- see
+            // round_and_check_all_rounded. Keep iterating while anything is un-rounded, and
+            // let max_its bound the run as before.
+            if (round_and_check_all_rounded()) {
+                break;
+            }
+            logger().info("quality target reached, but some vertices are un-rounded; continuing");
         }
         consolidate_mesh();
 
@@ -142,6 +148,11 @@ void SimWildMesh::mesh_improvement(int max_its)
 
     logger().info("========it post========");
     local_operations({{0, 1, 0, 0}});
+
+    // The post pass is collapse-only, so it cannot un-round anything; this is the last
+    // chance to reclaim a vertex that the loop left rational because it ran out of
+    // iterations.
+    round_all_vertices();
 }
 
 double SimWildMesh::local_operations(const std::array<int, 4>& ops, bool collapse_limit_length)
@@ -201,7 +212,11 @@ double SimWildMesh::local_operations(const std::array<int, 4>& ops, bool collaps
                 }
                 check_mesh_quality(quality_rel, true);
                 sanity_checks();
-                if (quality_rel < 1.0) {
+                // Quality is met, but an un-rounded vertex means the mesh is not finished --
+                // see round_and_check_all_rounded. Returning here regardless would skip the
+                // smoothing pass, which is what frees a stuck vertex, so the run would spin
+                // to max_its without ever reclaiming it.
+                if (quality_rel < 1.0 && round_and_check_all_rounded()) {
                     return quality_rel;
                 }
             }
@@ -218,7 +233,7 @@ double SimWildMesh::local_operations(const std::array<int, 4>& ops, bool collaps
                 }
                 check_mesh_quality(quality_rel, true);
                 sanity_checks();
-                if (quality_rel < 1.0) {
+                if (quality_rel < 1.0 && round_and_check_all_rounded()) {
                     return quality_rel;
                 }
             }
@@ -234,16 +249,27 @@ double SimWildMesh::local_operations(const std::array<int, 4>& ops, bool collaps
                 logger().info("cnt_surface_swap (cumulative) = {}", cnt_surface_swap.load());
                 check_mesh_quality(quality_rel, true);
                 sanity_checks();
-                if (quality_rel < 1.0) {
+                if (quality_rel < 1.0 && round_and_check_all_rounded()) {
                     return quality_rel;
                 }
             }
         } else if (i == 3) {
             logger().info("==smoothing ==");
             smooth_all_vertices(ops[i]);
+            // Reclaim whatever smoothing just made roundable, before the quality check that
+            // may return. Smoothing is what frees a stuck vertex, and a vertex left rational
+            // makes every incident tet take the exact-arithmetic path in get_quality, so
+            // rounding here also keeps the following passes on doubles.
+            //
+            // Guarded on ops[i] so it really is once per iteration: this branch is also
+            // entered by the collapse-only pre and post passes, which pass ops[3] == 0 and
+            // have no smoothing for the sweep to follow.
+            if (ops[i] > 0) {
+                round_all_vertices();
+            }
             check_mesh_quality(quality_rel, true);
             sanity_checks();
-            if (ops[i] > 0 && quality_rel < 1.0) {
+            if (ops[i] > 0 && quality_rel < 1.0 && round_and_check_all_rounded()) {
                 return quality_rel;
             }
         }
@@ -999,6 +1025,42 @@ std::vector<std::array<size_t, 3>> SimWildMesh::get_faces_by_condition(
     return res;
 }
 
+size_t SimWildMesh::round_all_vertices()
+{
+    if (m_all_rounded.load(std::memory_order_relaxed)) {
+        return 0;
+    }
+
+    size_t reclaimed = 0, still_unrounded = 0;
+    for (const Tuple& v : get_vertices()) {
+        if (m_vertex_attribute[v.vid(*this)].m_is_rounded) {
+            continue;
+        }
+        if (round(v)) {
+            ++reclaimed;
+        } else {
+            ++still_unrounded;
+        }
+    }
+
+    if (still_unrounded == 0) {
+        m_all_rounded.store(true, std::memory_order_relaxed);
+    }
+    if (reclaimed > 0 || still_unrounded > 0) {
+        logger().info(
+            "rounding sweep: reclaimed {}, still unrounded {}",
+            reclaimed,
+            still_unrounded);
+    }
+    return reclaimed;
+}
+
+bool SimWildMesh::round_and_check_all_rounded()
+{
+    round_all_vertices();
+    return m_all_rounded.load(std::memory_order_relaxed);
+}
+
 bool SimWildMesh::all_rounded() const
 {
     size_t cnt_round = 0;
@@ -1132,6 +1194,11 @@ void SimWildMesh::write_vtu(const std::string& path)
     v_order.setZero();
     VectorXd v_id(vert_capacity());
     v_id.setZero();
+    // A vertex whose exact position has no double representation. V.row(vid) below is its
+    // rounding, which is NOT where the vertex is -- so an inverted-looking tet in ParaView is
+    // expected here and nowhere else.
+    VectorXd v_is_rounded(vert_capacity());
+    v_is_rounded.setZero();
 
     std::vector<MatrixXd> tags(m_tags_count, MatrixXd(tet_capacity(), 1));
     VectorXd amips(tet_capacity());
@@ -1172,6 +1239,7 @@ void SimWildMesh::write_vtu(const std::string& path)
         v_sizing_field[vid] = m_vertex_attribute[vid].m_sizing_scalar;
         v_order[vid] = m_vertex_attribute[vid].m_order;
         v_id[vid] = vid;
+        v_is_rounded[vid] = m_vertex_attribute[vid].m_is_rounded ? 1 : 0;
     }
 
     paraviewo::VTUWriter writer;
@@ -1188,6 +1256,7 @@ void SimWildMesh::write_vtu(const std::string& path)
     writer.add_cell_field("quality_rel", amips_rel);
     writer.add_field("sizing_field", v_sizing_field);
     writer.add_field("vid", v_id);
+    writer.add_field("is_rounded", v_is_rounded);
     writer.write_mesh(out_path, V, T, paraviewo::CellType::Tetrahedron);
 
     // surface

--- a/components/simwild/wmtk/components/simwild/SimWildMesh.h
+++ b/components/simwild/wmtk/components/simwild/SimWildMesh.h
@@ -129,7 +129,19 @@ public:
 
     double time_env = 0.0;
     igl::Timer isout_timer;
-    const double MAX_ENERGY = std::numeric_limits<double>::max();
+    /**
+     * @brief The sentinel get_quality returns for an element AMIPS cannot score.
+     *
+     * Not an energy: a positively oriented tet whose volume is too small for AMIPS, or one
+     * that produces inf/nan, gets this instead. m_quality holds AMIPS^3, so it surfaces in
+     * the logs as its cube root, cbrt(1e50) = 4.6e16.
+     *
+     * 1e50 rather than double::max, matching tetwild and triwild, because every downstream
+     * arithmetic on it must stay finite -- avg_energy sums qualities, so a single degenerate
+     * tet turned the reported average into inf, and every ratio that divides by the max was
+     * meaningless from then on. 1e50 leaves headroom for all of it.
+     */
+    const double MAX_ENERGY = 1e50;
 
     Parameters& m_params;
     std::vector<Vector3d> m_V_envelope;

--- a/components/simwild/wmtk/components/simwild/SimWildMesh.h
+++ b/components/simwild/wmtk/components/simwild/SimWildMesh.h
@@ -22,6 +22,7 @@
 // clang-format on
 
 #include <igl/remove_unreferenced.h>
+#include <atomic>
 #include <memory>
 
 #include <wmtk/utils/SurfaceTopology.hpp>
@@ -392,6 +393,47 @@ public:
     bool round(const Tuple& loc);
 
     /**
+     * @brief Try to round every un-rounded vertex; returns the number reclaimed.
+     *
+     * round() is otherwise only attempted as a side effect of another operation
+     * (smooth_before on the vertex being smoothed, collapse_edge_after on the merged one),
+     * and neither reaches a vertex that only becomes roundable later: smoothing skips
+     * "good" regions by default. Without a sweep such a vertex keeps exact coordinates
+     * into the output for no geometric reason.
+     *
+     * Skipped outright when m_all_rounded says there is nothing to do.
+     */
+    size_t round_all_vertices();
+
+    /**
+     * @brief Run the rounding sweep, then report whether the mesh is now fully rounded.
+     *
+     * The termination condition of the operation loop. Energy alone is not sufficient: a mesh
+     * that hits the quality target while some vertex still carries exact coordinates is not
+     * finished, because the output is what the caller consumes and rational coordinates in it
+     * are a defect regardless of how good the elements are.
+     *
+     * This is also what makes the exact-rational fallback in split_edge_after safe. A split is
+     * the only operation that can un-round a vertex; collapse, the swaps and smoothing never
+     * do; and the post-optimization pass is collapse-only.
+     *
+     * O(1) once m_all_rounded is set, so it is cheap enough to sit on every early-out.
+     */
+    bool round_and_check_all_rounded();
+
+    /**
+     * @brief True when every vertex is known to be rounded.
+     *
+     * Only trusted when true, and only round_all_vertices() sets it that way. Any code that
+     * leaves a vertex un-rounded must clear it, or the sweep will skip the vertex forever.
+     * Atomic because operations that clear it run in parallel.
+     *
+     * Distinct from all_rounded(), which counts. This is the cheap "is there anything to
+     * do" flag; that is the answer.
+     */
+    std::atomic<bool> m_all_rounded = false;
+
+    /**
      * @brief Check if all vertices of the mesh are rounded.
      *
      */
@@ -542,6 +584,15 @@ public:
     /// Count of force-splits taken in the current split pass (atomic_ref from the
     /// parallel split; reset + logged by split_all_edges). Diagnostic only.
     size_t m_force_split_count = 0;
+    /**
+     * @brief Splits in the last pass that fell back to the exact rational midpoint.
+     *
+     * A split is the only operation that can un-round a vertex, so this is exactly how often
+     * the mesh acquired exact coordinates during optimization -- the counterpart of the
+     * "rounded n/m" line, which says how many it still carries. Non-zero on real inputs: on
+     * the challenging-model set it ranges from 1 to 44 per run.
+     */
+    size_t m_exact_split_count = 0;
 
     /// True iff edge (v1,v2) is a worst tet's longest edge queued for force-split.
     bool is_force_split_edge(size_t v1, size_t v2) const

--- a/components/simwild/wmtk/components/simwild/SimWildMeshTri.cpp
+++ b/components/simwild/wmtk/components/simwild/SimWildMeshTri.cpp
@@ -459,8 +459,6 @@ size_t SimWildMeshTri::refine_sizing_around_worst()
     const double factor = m_params.stuck_refine_factor;
     const double floor = m_params.stuck_refine_min_scalar;
 
-    const double filter_energy = m_params.stop_energy;
-
     // Find the num_worst valid tets with the highest energy. `worst` is kept
     // sorted ascending by quality, size <= num_worst (front = smallest kept).
     std::vector<std::pair<double, size_t>> worst;

--- a/components/simwild/wmtk/components/simwild/SimWildMeshTri.hpp
+++ b/components/simwild/wmtk/components/simwild/SimWildMeshTri.hpp
@@ -92,7 +92,17 @@ public:
     std::map<int64_t, std::string> m_tag_id_to_name;
     std::map<std::string, int64_t> m_tag_name_to_id;
 
-    const double MAX_ENERGY = std::numeric_limits<double>::max();
+    /**
+     * @brief The sentinel get_quality returns for a face AMIPS2D cannot score.
+     *
+     * Not an energy: a positively oriented triangle whose area is too small for AMIPS, or one
+     * that produces inf/nan, gets this instead. Unlike the 3D mesh this stores AMIPS2D
+     * directly, so it surfaces in the logs verbatim as 1e+50.
+     *
+     * 1e50 rather than double::max, matching tetwild and triwild -- see SimWildMesh::MAX_ENERGY
+     * for why the arithmetic headroom matters.
+     */
+    const double MAX_ENERGY = 1e50;
 
     Parameters& m_params;
     std::vector<Vector2d> m_V_envelope;

--- a/components/simwild/wmtk/components/simwild/VolumemesherInsertion.cpp
+++ b/components/simwild/wmtk/components/simwild/VolumemesherInsertion.cpp
@@ -144,6 +144,7 @@ void SimWildMesh::init_from_image(
                 if (m_vertex_attribute[vid].m_is_rounded) {
                     m_vertex_attribute[vid].m_pos = V.row(vid);
                     m_vertex_attribute[vid].m_is_rounded = false;
+                    m_all_rounded.store(false, std::memory_order_relaxed);
                 }
             }
         }

--- a/components/simwild/wmtk/components/simwild/simwild.cpp
+++ b/components/simwild/wmtk/components/simwild/simwild.cpp
@@ -207,6 +207,14 @@ void run_3D(const nlohmann::json& json_params, const InputData& input_data)
     double time = timer.getElapsedTime();
     logger().info("total optimization time {}s", time);
 
+    // The output is what the caller consumes, and write_msh emits m_posf unconditionally --
+    // for an un-rounded vertex that double is not the vertex's real position, so the written
+    // mesh can contain inverted tets. Report it rather than letting it pass silently.
+    const bool all_rounded = mesh.all_rounded();
+    if (!all_rounded) {
+        logger().error("Not all vertices rounded!");
+    }
+
     /////////output
     auto [max_energy, avg_energy] = mesh.get_max_avg_energy();
     const std::string report_file = json_params["report"];
@@ -220,6 +228,7 @@ void run_3D(const nlohmann::json& json_params, const InputData& input_data)
         report["eps"] = params.eps;
         report["threads"] = params.NUM_THREADS;
         report["time"] = time;
+        report["all_rounded"] = all_rounded;
         fout << std::setw(4) << report;
         fout.close();
     }


### PR DESCRIPTION
First of three PRs bringing simwild to parity with tetwild and triwild on exact coordinates. (Originally planned to stack on #997, which merged while this was being written, so it targets `main`.)

## The gap

`SimWildMesh::split_edge_after` already falls back to the exact rational midpoint when the rounded one inverts an incident tet — the same fix triwild and tetwild carry, and the reason a stuck region can keep being refined instead of stalling. tetwild's comment says exact coordinates are kept out of the output *"by the iteration, not here"*.

simwild had the fallback but not that iteration:

| | tetwild / triwild | simwild 3D (before) |
|---|---|---|
| `m_all_rounded` | yes | **no** |
| `round_all_vertices()` | yes | **no** |
| sweep once per iteration | yes | **no** |
| loop refuses to stop while un-rounded | yes | **no** |
| driver reports `all_rounded` | yes | **no** |

A vertex un-rounded by a late split was reclaimed only if smoothing or a collapse happened to visit it. Otherwise `write_msh` emitted its `m_posf`, which for an un-rounded vertex is **not where the vertex is**, so the written mesh could contain inverted tets. Silently.

`stop_at_float` is not this guard. It is the opposite polarity — an early exit that stops as soon as everything is rounded, ignoring the energy target — and it defaults to false. Both coexist unchanged.

## One place simwild genuinely differs

`local_operations` returns early from **four** points once the quality target is met. Returning there regardless of rounding would skip the smoothing pass, which is what frees a stuck vertex, so the run would spin to `max_its` without ever reclaiming it. All four early-outs and the `mesh_improvement` stop check now go through `round_and_check_all_rounded()`, which sweeps first and is O(1) once `m_all_rounded` is set.

## Measurements

Challenging-model set through simwild 3D, `eps_rel` 1e-3, `stop_energy` 10, serial:

| model | exact-midpoint splits | un-rounded mid-run | exits |
|---|---|---|---|
| 101168 | 1 | — | all rounded |
| 101954 | 0 | — | all rounded |
| 103197 | 6 | — | all rounded |
| 104509 | **44** | 8999/9000 | all rounded |
| 108010 | 8 | 5870/5875 | all rounded |

So the fallback fires on real inputs and un-rounded vertices really do exist mid-run — but every run happened to reclaim them before finishing. **This changes no output today.** What changes is that the invariant now holds by construction rather than by luck.

## Validation

- `ctest` **107/107**.
- All 6 simwild 3D integration configs: identical `#v`, `#t`, `max_energy`, `avg_energy`, `eps`.
- All 5 challenging models above: identical `#v`, `#t`, `max_energy`. Runtime within noise (101168: 231s -> 236s).
- Second commit (`MAX_ENERGY`): all **13** runnable simwild configs (2D and 3D) identical on the same fields.

Nothing to re-bless: the golden-hash framework is still only on the unmerged `danielepanozzo/integration-test-hashes` branch, and the ctest `Integration_Tests` case asserts termination, not output.

## Second commit: `MAX_ENERGY` 1e50

Both simwild meshes used `std::numeric_limits<double>::max()` where tetwild and triwild use `1e50`. `MAX_ENERGY` is not an energy — it is what `get_quality` returns for an element AMIPS cannot score — so its only job is to be large and to survive the arithmetic downstream. `double::max` does not: `avg_energy` sums qualities, so one degenerate element turned the reported average into `inf`.

Also removes the dead `const double filter_energy = m_params.stop_energy;` from both `refine_sizing_around_worst` overloads — declared, never used, and it reads like the tetwild clamp is present here when it is not (simwild filters on *relative* quality).

## Also

- per-pass count of exact-midpoint splits in the log
- `is_rounded` VTU field, so an inverted-looking tet in ParaView can be attributed

## Next in the stack

- **PR B** — simwild 2D rational coordinates. `SimWildMeshTri` contains no `Rational` at all, and its split *refuses* on inversion — the version triwild diagnosed as a stall cause (5 of 8 runs diverging on Thingi10K 509315).
- **PR C** — VolumeRemesher 2D insertion route for simwild, so a 2D run can take a curve network the way a 3D run takes a surface mesh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)