### PR TITLE
simwild 2D: insert a curve network with VolumeRemesher

### DIFF
--- a/cmake/wmtk_data.cmake
+++ b/cmake/wmtk_data.cmake
@@ -19,7 +19,7 @@ ExternalProject_Add(
     # Adds the challenging-low-stop-energy models: the 30 meshes that exhausted
     # max_iterations = 80 at stop_energy 10 before this branch. Hidden test group, never
     # runs in CI -- see the challenging-low-stop-energy-models case in integration_tests.cpp.
-    GIT_TAG d1c5dffab5043a9307c0b00c9b7e81bdba0026e6
+    GIT_TAG c446756ef2aaee8501ff193fcc52ae98db0b294a
 
     CONFIGURE_COMMAND ""
     BUILD_COMMAND ""

--- a/components/simwild/wmtk/components/simwild/CMakeLists.txt
+++ b/components/simwild/wmtk/components/simwild/CMakeLists.txt
@@ -12,6 +12,9 @@ set(SRC_FILES
 	EmbedSurface.hpp
 	EmbedSurface.cpp
 
+	EmbedCurves.hpp
+	EmbedCurves.cpp
+
 	Parameters.h
 
 	EdgeSplitting.cpp

--- a/components/simwild/wmtk/components/simwild/EmbedCurves.cpp
+++ b/components/simwild/wmtk/components/simwild/EmbedCurves.cpp
@@ -1,0 +1,246 @@
+#include "EmbedCurves.hpp"
+
+#include <wmtk/envelope/Envelope.hpp>
+#include <wmtk/utils/EmbedSegments.hpp>
+#include <wmtk/utils/Logger.hpp>
+#include <wmtk/utils/SimplifySegments.hpp>
+#include <wmtk/utils/WindingNumber.hpp>
+
+#include <fstream>
+
+namespace wmtk::components::simwild {
+
+namespace {
+
+Vector2d apply_transform(const Matrix3d& M, const Vector2d& p)
+{
+    const Eigen::Vector3d q = M * Eigen::Vector3d(p[0], p[1], 1.0);
+    return Vector2d(q[0], q[1]);
+}
+
+} // namespace
+
+EmbedCurves::EmbedCurves(
+    const std::vector<std::string>& input_paths,
+    const std::vector<Matrix3d>& input_transform,
+    const double tol_rel,
+    const double tol_abs)
+{
+    assert(input_paths.size() == input_transform.size());
+
+    utils::read_input_curves(input_paths, tol_rel, m_V_curves, m_E_curves, m_Vs, m_Es);
+
+    // Transform each input in place, then rebuild the union from the transformed copies. The
+    // union has to agree with the per-input meshes: it is what gets arranged, they are what
+    // the winding number is evaluated against.
+    bool any_transform = false;
+    for (size_t i = 0; i < m_Vs.size(); ++i) {
+        if (input_transform[i].isIdentity()) {
+            continue;
+        }
+        any_transform = true;
+        for (int j = 0; j < m_Vs[i].rows(); ++j) {
+            m_Vs[i].row(j) = apply_transform(input_transform[i], Vector2d(m_Vs[i].row(j)));
+        }
+    }
+    if (any_transform) {
+        int nv = 0, ne = 0;
+        for (size_t i = 0; i < m_Vs.size(); ++i) {
+            nv += int(m_Vs[i].rows());
+            ne += int(m_Es[i].rows());
+        }
+        m_V_curves.resize(nv, 2);
+        m_E_curves.resize(ne, 2);
+        int voff = 0, eoff = 0;
+        for (size_t i = 0; i < m_Vs.size(); ++i) {
+            m_V_curves.block(voff, 0, m_Vs[i].rows(), 2) = m_Vs[i];
+            m_E_curves.block(eoff, 0, m_Es[i].rows(), 2) = m_Es[i].array() + voff;
+            voff += int(m_Vs[i].rows());
+            eoff += int(m_Es[i].rows());
+        }
+    }
+
+    if (m_V_curves.rows() == 0 || m_E_curves.rows() == 0) {
+        log_and_throw_error(
+            "No curves read. A 2D input must be an OBJ with 'l' polyline records; a file with "
+            "'f' records is a surface and belongs on the 3D route.");
+    }
+
+    logger().info(
+        "Read {} curve network(s): #V = {}, #E = {}",
+        m_Vs.size(),
+        m_V_curves.rows(),
+        m_E_curves.rows());
+}
+
+std::pair<Vector2d, Vector2d> EmbedCurves::bbox_curves_minmax() const
+{
+    return {m_V_curves.colwise().minCoeff(), m_V_curves.colwise().maxCoeff()};
+}
+
+void EmbedCurves::simplify_curves(
+    const double eps,
+    const bool use_exact_envelope,
+    const int num_threads)
+{
+    SampleEnvelope envelope(use_exact_envelope);
+    {
+        std::vector<Vector2d> v(m_V_curves.rows());
+        for (int i = 0; i < m_V_curves.rows(); ++i) {
+            v[i] = m_V_curves.row(i);
+        }
+        std::vector<Vector2i> e(m_E_curves.rows());
+        for (int i = 0; i < m_E_curves.rows(); ++i) {
+            e[i] = m_E_curves.row(i);
+        }
+        envelope.init(v, e, eps);
+    }
+
+    const int nv_before = int(m_V_curves.rows());
+    const int ne_before = int(m_E_curves.rows());
+    // Link condition on: simplification here may not change the topology of the curve
+    // network, because the winding-number tags are evaluated against the untouched per-input
+    // copies and merging two curves would make them disagree.
+    const size_t removed =
+        utils::simplify_segments(m_V_curves, m_E_curves, envelope, /*use_link_condition=*/true);
+    logger().info(
+        "input simplification: #V {} -> {}, #E {} -> {} ({} vertices removed), envelope {} "
+        "(eps {:.4})",
+        nv_before,
+        m_V_curves.rows(),
+        ne_before,
+        m_E_curves.rows(),
+        removed,
+        envelope.use_exact ? "EXACT" : "sampled",
+        eps);
+}
+
+bool EmbedCurves::embed_curves()
+{
+    std::vector<Vector2r> V_rational;
+    utils::embed_segments(m_V_curves, m_E_curves, m_V_emb, V_rational, m_F_emb, m_E_constrained);
+
+    m_V_emb_r.resize(V_rational.size(), 2);
+    for (size_t i = 0; i < V_rational.size(); ++i) {
+        m_V_emb_r(i, 0) = V_rational[i][0];
+        m_V_emb_r(i, 1) = V_rational[i][1];
+    }
+
+    // "All rounded" means every arrangement vertex has an exact double representation. A
+    // crossing between two segments generally does not: it is an SSI point, and rounding it
+    // can make two exactly-distinct vertices collide on the same double. That is precisely
+    // the geometry the exact-coordinate path exists for.
+    bool all_rounded = true;
+    for (int i = 0; i < m_V_emb.rows(); ++i) {
+        if (to_rational(Vector2d(m_V_emb.row(i))) != Vector2r(m_V_emb_r.row(i))) {
+            all_rounded = false;
+            break;
+        }
+    }
+
+    tag_from_winding_number();
+
+    logger().info(
+        "2D embedding: #V = {}, #F = {}, all rounded = {}",
+        m_V_emb.rows(),
+        m_F_emb.rows(),
+        all_rounded);
+
+    return all_rounded;
+}
+
+void EmbedCurves::tag_from_winding_number()
+{
+    MatrixXd C(m_F_emb.rows(), 2);
+    for (int i = 0; i < m_F_emb.rows(); ++i) {
+        C.row(i) =
+            (m_V_emb.row(m_F_emb(i, 0)) + m_V_emb.row(m_F_emb(i, 1)) + m_V_emb.row(m_F_emb(i, 2))) /
+            3.0;
+    }
+
+    m_F_tags.resize(m_F_emb.rows(), m_Vs.size());
+    for (size_t input_idx = 0; input_idx < m_Vs.size(); ++input_idx) {
+        const MatrixXd& V = m_Vs[input_idx];
+        MatrixXi E = m_Es[input_idx];
+
+        VectorXd W;
+        utils::winding_number_2d(V, E, C, W, m_num_threads);
+
+        if (W.size() > 0 && W.maxCoeff() <= 0.5) {
+            // Nothing is inside, which for a closed curve means it is wound the other way.
+            // The 3D tag_from_winding_number does not do this and silently produces an
+            // all-zero tag column; triwild does, and so does this.
+            logger().info("Correcting winding number for input {}", input_idx);
+            for (int i = 0; i < E.rows(); ++i) {
+                std::swap(E(i, 0), E(i, 1));
+            }
+            utils::winding_number_2d(V, E, C, W, m_num_threads);
+        }
+        if (W.size() == 0 || W.maxCoeff() <= 0.5) {
+            logger().warn(
+                "No winding number above 0.5 for input {}: it tags no face. An open polyline "
+                "encloses nothing, so it cannot define a material.",
+                input_idx);
+        }
+
+        for (int i = 0; i < W.size(); ++i) {
+            if (W(i) > 0.5) {
+                m_F_tags.coeffRef(i, int(input_idx)) = 1;
+            }
+        }
+    }
+    m_F_tags.makeCompressed();
+}
+
+void EmbedCurves::consolidate()
+{
+    std::vector<int> old2new(m_V_emb.rows(), -1);
+    int n_new = 0;
+    for (int i = 0; i < m_F_emb.rows(); ++i) {
+        for (int j = 0; j < 3; ++j) {
+            const int v = m_F_emb(i, j);
+            if (old2new[v] < 0) {
+                old2new[v] = n_new++;
+            }
+        }
+    }
+    if (n_new == m_V_emb.rows()) {
+        return; // every vertex is referenced, which is the usual case
+    }
+
+    MatrixXd V(n_new, 2);
+    MatrixXr Vr(n_new, 2);
+    for (int i = 0; i < m_V_emb.rows(); ++i) {
+        if (old2new[i] < 0) {
+            continue;
+        }
+        V.row(old2new[i]) = m_V_emb.row(i);
+        Vr.row(old2new[i]) = m_V_emb_r.row(i);
+    }
+    for (int i = 0; i < m_F_emb.rows(); ++i) {
+        for (int j = 0; j < 3; ++j) {
+            m_F_emb(i, j) = old2new[m_F_emb(i, j)];
+        }
+    }
+    for (int i = 0; i < m_E_constrained.rows(); ++i) {
+        for (int j = 0; j < 2; ++j) {
+            m_E_constrained(i, j) = old2new[m_E_constrained(i, j)];
+        }
+    }
+    m_V_emb = V;
+    m_V_emb_r = Vr;
+    logger().info("consolidate: #V {} -> {}", old2new.size(), n_new);
+}
+
+void EmbedCurves::write_curves_obj(const std::string& filename) const
+{
+    std::ofstream out(filename);
+    for (int i = 0; i < m_V_curves.rows(); ++i) {
+        out << "v " << m_V_curves(i, 0) << " " << m_V_curves(i, 1) << " 0\n";
+    }
+    for (int i = 0; i < m_E_curves.rows(); ++i) {
+        out << "l " << m_E_curves(i, 0) + 1 << " " << m_E_curves(i, 1) + 1 << "\n";
+    }
+}
+
+} // namespace wmtk::components::simwild

--- a/components/simwild/wmtk/components/simwild/EmbedCurves.hpp
+++ b/components/simwild/wmtk/components/simwild/EmbedCurves.hpp
@@ -1,0 +1,111 @@
+#pragma once
+
+#include <wmtk/Types.hpp>
+
+#include <string>
+#include <vector>
+
+namespace wmtk::components::simwild {
+
+/**
+ * @brief Turn a set of 2D curve networks into one tagged triangle mesh.
+ *
+ * The 2D counterpart of EmbedSurface, member for member, with each 3D primitive replaced by
+ * the 2D one:
+ *
+ *   EmbedSurface                              EmbedCurves
+ *   ------------------------------------      ------------------------------------------
+ *   read_triangle_mesh + 4x4 transform        read_input_curves + 3x3 transform
+ *   simplify_surface (ShortestEdgeCollapse)   simplify_curves (simplify_segments)
+ *   delaunay_box_mesh + embed_tri_in_poly     embed_segments (grid is inside it)
+ *   winding_number  (solid angle)             winding_number_2d
+ *   T_emb (Nx4), T_tags (#T x #inputs)        F_emb (Nx3), F_tags (#F x #inputs)
+ *
+ * The tagging contract is identical and is what makes this a *simwild* input rather than a
+ * triwild one: tag i is set on a cell when input i's winding number at the cell's barycenter
+ * exceeds 0.5, so a cell inside two inputs carries both tags and the material interfaces fall
+ * out of where adjacent cells disagree.
+ *
+ * Unlike the 3D path there is no separate background mesh to build: the 2D arrangement
+ * triangulates every point it is handed, so the background grid is just extra points appended
+ * to the same array (wmtk::utils::embed_segments does that).
+ */
+class EmbedCurves
+{
+public:
+    /**
+     * @param input_paths       one curve network per entry, as OBJ 'v'/'l' polylines
+     * @param input_transform   3x3 homogeneous transform per input; identity where omitted
+     * @param tol_rel, tol_abs  merge input vertices closer than this (negative disables)
+     */
+    EmbedCurves(
+        const std::vector<std::string>& input_paths,
+        const std::vector<Matrix3d>& input_transform = {},
+        const double tol_rel = -1,
+        const double tol_abs = -1);
+
+    /**
+     * @brief Simplify the input curves while staying within the eps envelope.
+     *
+     * Must be a small envelope: the winding-number tags below are evaluated against the
+     * ORIGINAL per-input curves, not the simplified union, so moving the curves too far
+     * makes the tags disagree with the geometry. Same constraint EmbedSurface documents.
+     */
+    void
+    simplify_curves(const double eps, const bool use_exact_envelope, const int num_threads = 0);
+
+    /**
+     * @brief Compute the exact arrangement of the (simplified) curve union.
+     *
+     * @return true when every arrangement vertex has an exact double representation.
+     */
+    bool embed_curves();
+
+    /**
+     * @brief Remove vertices not referenced by any output face.
+     */
+    void consolidate();
+
+    const MatrixXd& V_emb() const { return m_V_emb; }
+    const MatrixXr& V_emb_r() const { return m_V_emb_r; }
+    const MatrixXi& F_emb() const { return m_F_emb; }
+    const MatrixSi& F_tags() const { return m_F_tags; }
+    /// The simplified input curves -- what the envelope is built from.
+    const MatrixXd& V_curves() const { return m_V_curves; }
+    const MatrixXi& E_curves() const { return m_E_curves; }
+    /// The constrained edges of the arrangement, i.e. the output edges tiling the input.
+    const MatrixXi& E_constrained() const { return m_E_constrained; }
+
+    std::pair<Vector2d, Vector2d> bbox_curves_minmax() const;
+
+    void write_curves_obj(const std::string& filename) const;
+
+    int m_num_threads = 0;
+
+private:
+    /**
+     * @brief One binary tag column per input, set where that input's winding number at a
+     * face barycenter exceeds 0.5.
+     *
+     * Auto-corrects an inverted input orientation and warns when an input claims nothing, as
+     * triwild's compute_winding_numbers does and the 3D tag_from_winding_number does not.
+     */
+    void tag_from_winding_number();
+
+private:
+    /// Per input, as read: kept separate because the winding number is per input.
+    std::vector<MatrixXd> m_Vs;
+    std::vector<MatrixXi> m_Es;
+
+    /// The union, which is what gets simplified and arranged.
+    MatrixXd m_V_curves;
+    MatrixXi m_E_curves;
+
+    MatrixXd m_V_emb;
+    MatrixXr m_V_emb_r;
+    MatrixXi m_F_emb;
+    MatrixXi m_E_constrained;
+    MatrixSi m_F_tags;
+};
+
+} // namespace wmtk::components::simwild

--- a/components/simwild/wmtk/components/simwild/SimWildMeshTri.cpp
+++ b/components/simwild/wmtk/components/simwild/SimWildMeshTri.cpp
@@ -120,8 +120,8 @@ void SimWildMeshTri::init_from_image(
     m_face_attribute.resize(T.rows());
     m_edge_attribute.resize(T.rows() * 3);
 
-    // The 2D input is float (simwild.cpp refuses a rational one), so every vertex is exactly
-    // representable and starts rounded. Only a split can un-round one after this.
+    // A float input is exactly representable by construction, so every vertex starts rounded.
+    // Only a split can un-round one after this.
     for (int i = 0; i < vert_capacity(); i++) {
         m_vertex_attribute[i].m_posf = V.row(i);
         m_vertex_attribute[i].m_pos = to_rational(m_vertex_attribute[i].m_posf);
@@ -150,6 +150,95 @@ void SimWildMeshTri::init_from_image(
     // add tags
     for (size_t i = 0; i < (size_t)T_tags.rows(); ++i) {
         // m_face_attribute[i].tags.resize(m_tags_count);
+        for (size_t j = 0; j < m_tags_count; ++j) {
+            if (T_tags.coeff(i, j) != 0) {
+                m_face_attribute[i].tags.insert(j);
+            }
+        }
+    }
+
+    // add tag names
+    for (size_t i = 0; i < tag_names.size(); ++i) {
+        m_tag_id_to_name[i] = tag_names[i];
+        m_tag_name_to_id[tag_names[i]] = i;
+    }
+
+    init_surfaces_and_boundaries();
+}
+
+void SimWildMeshTri::init_from_image(
+    const MatrixXr& V,
+    const MatrixXi& T,
+    const MatrixSi& T_tags,
+    const std::vector<std::string>& tag_names)
+{
+    assert(V.cols() == 2);
+    assert(T.cols() == 3);
+    assert(T_tags.rows() == T.rows());
+    assert(T_tags.cols() == tag_names.size());
+
+    init(T);
+
+    assert(check_mesh_connectivity_validity());
+
+    m_tags_count = T_tags.cols();
+
+    m_vertex_attribute.resize(V.rows());
+    m_face_attribute.resize(T.rows());
+    m_edge_attribute.resize(T.rows() * 3);
+
+    // A vertex is "direct" when its exact coordinate IS a double -- the round trip through
+    // to_double/to_rational returns it unchanged. Those start rounded; the rest are the
+    // arrangement's crossing vertices, which generally have no double representation at all.
+    size_t n_indirect = 0;
+    for (int i = 0; i < vert_capacity(); i++) {
+        VertexAttributes& va = m_vertex_attribute[i];
+        va.m_pos = V.row(i);
+        va.m_posf = to_double(va.m_pos);
+        va.m_is_rounded = (to_rational(va.m_posf) == va.m_pos);
+        if (!va.m_is_rounded) {
+            ++n_indirect;
+        }
+    }
+    if (n_indirect > 0) {
+        m_all_rounded.store(false, std::memory_order_relaxed);
+    }
+
+    // Orientation is checked in EXACT arithmetic: an un-rounded vertex sends is_inverted down
+    // the rational path, which is the whole point of keeping V. Rounding first and checking
+    // after would reject valid input, because two exactly-distinct arrangement vertices can
+    // round onto the same double and make a valid triangle look degenerate.
+    bool is_mesh_inverted = false;
+    for (const Tuple& t : get_faces()) {
+        if (is_mesh_inverted ^ is_inverted(t)) {
+            if (!is_mesh_inverted) {
+                is_mesh_inverted = true;
+            } else {
+                log_and_throw_error("Faces with different orientations in the input!");
+            }
+        }
+    }
+    if (is_mesh_inverted) {
+        log_and_throw_error(
+            "Input mesh is fully inverted! This should not happen... Might be a bug.");
+    }
+
+    // Reclaim what can be rounded without inverting an incident face. round() takes the
+    // vertices one at a time, so a vertex that only becomes roundable once a neighbour has
+    // committed is still picked up -- the sweep is serial for exactly that reason.
+    const size_t reclaimed = round_all_vertices();
+    logger().info(
+        "init: {} of {} vertices had no exact double representation, {} reclaimed by rounding",
+        n_indirect,
+        vert_capacity(),
+        reclaimed);
+
+    for (const Tuple& t : get_faces()) {
+        m_face_attribute[t.fid(*this)].m_quality = get_quality(t);
+    }
+
+    // add tags
+    for (size_t i = 0; i < (size_t)T_tags.rows(); ++i) {
         for (size_t j = 0; j < m_tags_count; ++j) {
             if (T_tags.coeff(i, j) != 0) {
                 m_face_attribute[i].tags.insert(j);

--- a/components/simwild/wmtk/components/simwild/SimWildMeshTri.hpp
+++ b/components/simwild/wmtk/components/simwild/SimWildMeshTri.hpp
@@ -217,6 +217,19 @@ public:
         const MatrixSi& T_tags,
         const std::vector<std::string>& tag_names);
 
+    /**
+     * @brief Same, from EXACT input positions.
+     *
+     * Taken when the 2D arrangement produced a vertex with no double representation -- a
+     * crossing between two input segments generally has none. Rounds what it can and leaves
+     * the rest rational; the optimization loop reclaims them.
+     */
+    void init_from_image(
+        const MatrixXr& V,
+        const MatrixXi& T,
+        const MatrixSi& T_tags,
+        const std::vector<std::string>& tag_names);
+
     void init_surfaces_and_boundaries();
 
     void init_envelope(const MatrixXd& V, const MatrixXi& F);

--- a/components/simwild/wmtk/components/simwild/read_image_msh.cpp
+++ b/components/simwild/wmtk/components/simwild/read_image_msh.cpp
@@ -3,12 +3,41 @@
 #include <igl/predicates/predicates.h>
 #include <set>
 #include <wmtk/Types.hpp>
+#include <wmtk/components/simwild/EmbedCurves.hpp>
 #include <wmtk/components/simwild/EmbedSurface.hpp>
 #include <wmtk/simplex/Simplex.hpp>
 #include <wmtk/utils/Logger.hpp>
 #include <wmtk/utils/io.hpp>
 
 namespace wmtk::components::simwild {
+
+Matrix3d get_input_transform_2d(const nlohmann::json& json_params, const size_t input_index)
+{
+    const nlohmann::json& its_j = json_params["input_transform"];
+
+    if (input_index >= its_j.size() || its_j[input_index].size() == 0) {
+        return Matrix3d::Identity();
+    }
+    if (its_j[input_index].size() != 3) {
+        log_and_throw_error(
+            "Input transform for input {} is invalid: a 2D input takes a 3x3 homogeneous "
+            "matrix, not {}x{}.",
+            input_index,
+            its_j[input_index].size(),
+            its_j[input_index].size());
+    }
+
+    const std::array<std::array<double, 3>, 3> it_arr = its_j[input_index];
+    Matrix3d A;
+    for (size_t i = 0; i < 3; ++i) {
+        for (size_t j = 0; j < 3; ++j) {
+            A(i, j) = it_arr[i][j];
+        }
+    }
+    logger().info("Input transform for input {}:\n{}", input_index, A);
+
+    return A;
+}
 
 Matrix4d get_input_transform(const nlohmann::json& json_params, const size_t input_index)
 {
@@ -466,5 +495,137 @@ InputData read_mesh(
     return input_data;
 }
 
+InputData read_curves(
+    const std::vector<std::string>& input_paths,
+    const std::string& output_filename,
+    const nlohmann::json& json_params)
+{
+    InputData input_data;
+
+    std::vector<Matrix3d> input_transforms(input_paths.size());
+    for (size_t i = 0; i < input_transforms.size(); ++i) {
+        input_transforms[i] = get_input_transform_2d(json_params, i);
+    }
+
+    const int NUM_THREADS = json_params["num_threads"];
+    const bool debug_output = json_params["DEBUG_output"];
+    const bool preserve_topology = json_params["preserve_topology"];
+    const bool skip_simplify = json_params["skip_simplify"];
+    const double epsr_simplify = json_params["eps_simplify_rel"];
+    double eps_simplify = json_params["eps_simplify"];
+    const std::vector<std::string> input_names = json_params["input_names"];
+
+    double tol_rel = -1;
+    double tol_abs = -1;
+    if (!preserve_topology) {
+        tol_rel = 0.1 * epsr_simplify;
+        tol_abs = 0.1 * eps_simplify;
+    }
+
+    EmbedCurves curves(input_paths, input_transforms, tol_rel, tol_abs);
+    curves.m_num_threads = NUM_THREADS;
+
+    if (debug_output) {
+        curves.write_curves_obj(output_filename + "_input.obj");
+    }
+
+    if (!preserve_topology && !skip_simplify) {
+        // Same condition the 3D route uses: simplification can change the topology of the
+        // input, so it only runs when the caller has said that is acceptable.
+        const auto [bbox_min, bbox_max] = curves.bbox_curves_minmax();
+        const double diag = (bbox_max - bbox_min).norm();
+        if (epsr_simplify > 0) {
+            eps_simplify = diag * epsr_simplify;
+        }
+        curves.simplify_curves(eps_simplify, !json_params["use_sample_envelope"], NUM_THREADS);
+
+        if (debug_output) {
+            curves.write_curves_obj(output_filename + "_input_simplified.obj");
+        }
+    }
+
+    // The envelope is built from the SIMPLIFIED input curves, taken here -- after
+    // simplification, before the arrangement -- exactly as read_mesh does in 3D.
+    input_data.V_envelope = curves.V_curves();
+    input_data.F_envelope = curves.E_curves();
+
+    const bool all_rounded = curves.embed_curves();
+    curves.consolidate();
+
+    input_data.V_input = curves.V_emb();
+    if (!all_rounded) {
+        input_data.V_input_r = curves.V_emb_r();
+    }
+    input_data.T_input = curves.F_emb();
+    input_data.T_input_tag = curves.F_tags();
+    for (int i = 0; i < input_data.T_input_tag.cols(); ++i) {
+        input_data.tag_names.push_back(
+            i < int(input_names.size()) ? input_names[i] : "tag_" + std::to_string(i));
+    }
+
+    wmtk::logger().info("======= finish curve-triangle conversion =========");
+
+    return input_data;
+}
+
+int resolve_input_dimension(
+    const std::vector<std::string>& input_paths,
+    const nlohmann::json& json_params)
+{
+    // 0 means "let the .msh reader decide from the file's content", which is what it has
+    // always done: a msh with faces and no tets is 2D, one with tets is 3D.
+    const std::string extension = std::filesystem::path(input_paths[0]).extension().string();
+
+    int sniffed = 0;
+    if (extension != ".msh") {
+        // A curve network and a surface are both OBJ, so the extension cannot separate them.
+        // 'f' records mean a surface; 'l' records with no 'f' mean a curve network.
+        bool has_f = false, has_l = false;
+        std::ifstream in(input_paths[0]);
+        if (!in) {
+            log_and_throw_error("Could not open input file {}", input_paths[0]);
+        }
+        std::string line;
+        while (std::getline(in, line)) {
+            if (line.size() < 2 || line[1] != ' ') {
+                continue;
+            }
+            if (line[0] == 'f') {
+                has_f = true;
+                break; // a surface: no need to read further
+            }
+            if (line[0] == 'l') {
+                has_l = true;
+            }
+        }
+        sniffed = has_f ? 3 : (has_l ? 2 : 3);
+    }
+
+    const std::string d = json_params.value("dimension", std::string("auto"));
+    if (d == "auto") {
+        logger().info(
+            "dimension: auto -> {}",
+            sniffed == 0 ? "from the msh content" : (sniffed == 2 ? "2D curves" : "3D surface"));
+        return sniffed;
+    }
+
+    const int forced = std::stoi(d);
+    if (forced != 2 && forced != 3) {
+        log_and_throw_error("dimension must be \"auto\", \"2\" or \"3\", not \"{}\"", d);
+    }
+    if (sniffed != 0 && sniffed != forced) {
+        // Disagree loudly rather than proceeding: without the sniff, a curve network read as
+        // a surface surfaces much later as an empty-face assertion inside EmbedSurface.
+        log_and_throw_error(
+            "dimension is set to {} but {} looks like a {}D input ({}). Remove the dimension "
+            "key to accept the detected one.",
+            forced,
+            input_paths[0],
+            sniffed,
+            sniffed == 2 ? "OBJ with 'l' polylines and no 'f' faces" : "OBJ with 'f' faces");
+    }
+    logger().info("dimension: {} (forced)", forced);
+    return forced;
+}
 
 } // namespace wmtk::components::simwild

--- a/components/simwild/wmtk/components/simwild/read_image_msh.hpp
+++ b/components/simwild/wmtk/components/simwild/read_image_msh.hpp
@@ -33,4 +33,30 @@ InputData read_mesh(
     const std::string& output_filename,
     const nlohmann::json& json_params);
 
+/**
+ * @brief Read one or multiple 2D curve networks and convert them into a tagged triangle mesh.
+ *
+ * The 2D counterpart of read_mesh: exact arrangement of the curves, then a per-input winding
+ * number to tag which faces belong to which material. See EmbedCurves.
+ */
+InputData read_curves(
+    const std::vector<std::string>& input_paths,
+    const std::string& output_filename,
+    const nlohmann::json& json_params);
+
+/**
+ * @brief Decide whether an input is 2D or 3D.
+ *
+ * `dimension` is "auto" (the default), 2 or 3. Auto looks at the first input:
+ *   - .msh                            -> 0, meaning "the msh reader decides from the content"
+ *   - OBJ/OFF/STL with any 'f' record -> 3, a surface for EmbedSurface
+ *   - OBJ with 'l' but no 'f'         -> 2, a curve network for EmbedCurves
+ *
+ * An explicit 2 or 3 forces the route; it does not skip the sniff, it disagrees with it
+ * loudly, because the failure otherwise surfaces as a confusing parse error much later.
+ */
+int resolve_input_dimension(
+    const std::vector<std::string>& input_paths,
+    const nlohmann::json& json_params);
+
 } // namespace wmtk::components::simwild

--- a/components/simwild/wmtk/components/simwild/simwild.cpp
+++ b/components/simwild/wmtk/components/simwild/simwild.cpp
@@ -255,14 +255,20 @@ void run_2D(const nlohmann::json& json_params, const InputData& input_data)
     if (input_data.V_envelope.size() != 0) {
         mesh.init_envelope(input_data.V_envelope, input_data.F_envelope);
     }
-    if (input_data.V_input_r.size() != 0) {
-        log_and_throw_error("Input must be float for 2D!");
+    if (input_data.V_input_r.size() == 0) {
+        mesh.init_from_image(
+            input_data.V_input,
+            input_data.T_input,
+            input_data.T_input_tag,
+            input_data.tag_names);
+    } else {
+        logger().warn("Use RATIONAL input for 2D");
+        mesh.init_from_image(
+            input_data.V_input_r,
+            input_data.T_input,
+            input_data.T_input_tag,
+            input_data.tag_names);
     }
-    mesh.init_from_image(
-        input_data.V_input,
-        input_data.T_input,
-        input_data.T_input_tag,
-        input_data.tag_names);
 
     auto write_unique_vtu = [&params, &mesh]() {
         static size_t vtu_counter = 0;
@@ -371,11 +377,17 @@ void simwild(nlohmann::json json_params)
     igl::Timer timer;
     timer.start();
 
-    // read image or .msh
+    // Three input routes, one per kind of input:
+    //   .msh          -> an already-tagged mesh, 2D or 3D by content (no insertion)
+    //   surface OBJ   -> EmbedSurface, the 3D VolumeRemesher arrangement
+    //   curve OBJ     -> EmbedCurves,  the 2D VolumeRemesher arrangement
     InputData input_data;
-    std::string extension = std::filesystem::path(input_paths[0]).extension().string();
+    const std::string extension = std::filesystem::path(input_paths[0]).extension().string();
+    const int dimension = resolve_input_dimension(input_paths, json_params);
     if (extension == ".msh") {
         input_data = read_image_msh(input_paths[0]);
+    } else if (dimension == 2) {
+        input_data = read_curves(input_paths, output_filename.string(), json_params);
     } else {
         input_data = read_mesh(input_paths, output_filename.string(), json_params);
     }

--- a/components/simwild/wmtk/components/simwild/simwild_spec.json
+++ b/components/simwild/wmtk/components/simwild/simwild_spec.json
@@ -3,7 +3,10 @@
     "doc": "[README](https://github.com/wildmeshing/wildmeshing-toolkit/blob/main/components/simwild/README.md)",
     "pointer": "/",
     "type": "object",
-    "required": ["application", "input"],
+    "required": [
+      "application",
+      "input"
+    ],
     "optional": [
       "operation",
       "output",
@@ -62,19 +65,32 @@
   {
     "pointer": "/application",
     "type": "string",
-    "options": ["simwild"],
+    "options": [
+      "simwild"
+    ],
     "doc": "Application name must be simwild."
   },
   {
     "pointer": "/input",
     "type": "list",
-    "doc": "List of triangular input meshes.",
+    "doc": "List of input files. A .msh is an already-tagged mesh and is used as-is. Anything else is inserted by VolumeRemesher: a triangular surface mesh in 3D, or an OBJ curve network ('v'/'l' polylines) in 2D. See /dimension.",
     "min": 1
   },
   {
     "pointer": "/input/*",
     "type": "string",
-    "doc": "Triangular input mesh."
+    "doc": "One input file."
+  },
+  {
+    "pointer": "/dimension",
+    "type": "string",
+    "default": "auto",
+    "options": [
+      "auto",
+      "2",
+      "3"
+    ],
+    "doc": "Whether the input is 2D or 3D, as a string. 'auto' looks at the first input: a .msh decides from its own content, an OBJ with 'f' records is a 3D surface, an OBJ with 'l' records and no 'f' is a 2D curve network. A curve network and a surface are both .obj, so the extension alone cannot separate them. Setting \"2\" or \"3\" forces the route and errors if the file disagrees, rather than failing later with a confusing parse error."
   },
   {
     "pointer": "/input_names",
@@ -117,13 +133,13 @@
   {
     "pointer": "/input_transform/*",
     "type": "list",
-    "doc": "Transformation matrix (4x4 homogeneous coordinates) for one input.",
+    "doc": "Homogeneous transformation matrix for one input: 4x4 for a 3D input, 3x3 for a 2D one. An empty list means identity.",
     "max": 4
   },
   {
     "pointer": "/input_transform/*/*",
     "type": "list",
-    "min": 4,
+    "min": 3,
     "max": 4
   },
   {
@@ -163,7 +179,7 @@
   {
     "pointer": "/eps_rel",
     "type": "float",
-    "default": 2e-3,
+    "default": 0.002,
     "doc": "Envelope thickness relative to the bounding box"
   },
   {
@@ -175,7 +191,7 @@
   {
     "pointer": "/eps_simplify_rel",
     "type": "float",
-    "default": 2e-4,
+    "default": 0.0002,
     "doc": "Envelope thickness relative to the bounding box for the initial simplification. Will be ignored if skip_simplify is true or the input is already a tet mesh."
   },
   {
@@ -199,7 +215,7 @@
   {
     "pointer": "/length_rel",
     "type": "float",
-    "default": 5e-2,
+    "default": 0.05,
     "doc": "Target edge length relative to the bounding box"
   },
   {
@@ -211,8 +227,13 @@
   {
     "pointer": "/sizing_field/*",
     "type": "object",
-    "required": ["tags"],
-    "optional": ["length", "length_rel"],
+    "required": [
+      "tags"
+    ],
+    "optional": [
+      "length",
+      "length_rel"
+    ],
     "doc": "A region and its target length."
   },
   {
@@ -229,7 +250,7 @@
   {
     "pointer": "/sizing_field/*/length_rel",
     "type": "float",
-    "default": 5e-2,
+    "default": 0.05,
     "doc": "Target edge length relative to the bounding box for the region."
   },
   {
@@ -241,7 +262,10 @@
   {
     "pointer": "/quality_field/*",
     "type": "object",
-    "required": ["tags", "quality"],
+    "required": [
+      "tags",
+      "quality"
+    ],
     "doc": "A region and its target quality."
   },
   {
@@ -276,7 +300,7 @@
   {
     "pointer": "/w_amips",
     "type": "float",
-    "default": 1e-4,
+    "default": 0.0001,
     "min": 0,
     "max": 1,
     "doc": "AMIPS energy"

--- a/components/triwild/wmtk/components/triwild/CMakeLists.txt
+++ b/components/triwild/wmtk/components/triwild/CMakeLists.txt
@@ -20,9 +20,6 @@ set(SRC_FILES
 
 	triwild.hpp
 	triwild.cpp
-
-	init_from_delaunay.hpp
-	init_from_delaunay.cpp
 )
 
 target_sources(wmtk_${COMPONENT_NAME} PRIVATE ${SRC_FILES})

--- a/components/triwild/wmtk/components/triwild/triwild.cpp
+++ b/components/triwild/wmtk/components/triwild/triwild.cpp
@@ -10,7 +10,7 @@
 
 #include "Parameters.h"
 #include "TriWildMesh.h"
-#include "init_from_delaunay.hpp"
+#include <wmtk/utils/EmbedSegments.hpp>
 
 #include <triwild_spec.hpp>
 
@@ -209,7 +209,7 @@ void triwild(nlohmann::json json_params)
     MatrixXi E_in;
     std::vector<MatrixXd> Vs;
     std::vector<MatrixXi> Es;
-    read_input_curves(input_paths, json_params["remove_duplicate_eps"], V_in, E_in, Vs, Es);
+    wmtk::utils::read_input_curves(input_paths, json_params["remove_duplicate_eps"], V_in, E_in, Vs, Es);
 
     // Informational input-topology report; gated behind DEBUG_euler because it is only
     // meaningful next to the matching computations later in the run.
@@ -320,7 +320,7 @@ void triwild(nlohmann::json json_params)
     std::vector<Vector2r> V_rational; // the same vertices, exact
     MatrixXi F;
     MatrixXi E; // constraint edges in the arrangement
-    init_from_delaunay_box_mesh(V_simp, E_simp, V, V_rational, F, E);
+    wmtk::utils::embed_segments(V_simp, E_simp, V, V_rational, F, E);
 
     // The arrangement is the baseline for everything after it. It is EXPECTED to differ
     // from the input: resolving a crossing inserts a vertex shared by both curves, which

--- a/components/triwild/wmtk/components/triwild/triwild.cpp
+++ b/components/triwild/wmtk/components/triwild/triwild.cpp
@@ -8,9 +8,9 @@
 #include <wmtk/utils/SimplifySegments.hpp>
 #include <wmtk/utils/resolve_path.hpp>
 
+#include <wmtk/utils/EmbedSegments.hpp>
 #include "Parameters.h"
 #include "TriWildMesh.h"
-#include <wmtk/utils/EmbedSegments.hpp>
 
 #include <triwild_spec.hpp>
 
@@ -209,7 +209,13 @@ void triwild(nlohmann::json json_params)
     MatrixXi E_in;
     std::vector<MatrixXd> Vs;
     std::vector<MatrixXi> Es;
-    wmtk::utils::read_input_curves(input_paths, json_params["remove_duplicate_eps"], V_in, E_in, Vs, Es);
+    wmtk::utils::read_input_curves(
+        input_paths,
+        json_params["remove_duplicate_eps"],
+        V_in,
+        E_in,
+        Vs,
+        Es);
 
     // Informational input-topology report; gated behind DEBUG_euler because it is only
     // meaningful next to the matching computations later in the run.

--- a/src/wmtk/utils/EmbedSegments.cpp
+++ b/src/wmtk/utils/EmbedSegments.cpp
@@ -1,4 +1,4 @@
-#include "init_from_delaunay.hpp"
+#include "EmbedSegments.hpp"
 
 #include <VolumeRemesher/2d/embed2d.h>
 #include <VolumeRemesher/numerics.h>
@@ -13,7 +13,7 @@
 #include <cstdint>
 #include <set>
 
-namespace wmtk::components::triwild {
+namespace wmtk::utils {
 
 namespace {
 
@@ -21,7 +21,7 @@ namespace {
 // how VolumeRemesher was configured (see cmake/recipes/volumemesher.cmake). Go
 // through wmtk::Rational -- the same conversion the 3D insertion uses -- so both
 // backends are handled.
-Rational to_rational(const vol_rem::bigrational& r)
+Rational bigrational_to_rational(const vol_rem::bigrational& r)
 {
     Rational q;
 #ifdef USE_GNU_GMP_CLASSES
@@ -117,7 +117,7 @@ void append_background_grid(const MatrixXd& V, const MatrixXi& E, std::vector<do
 
 } // namespace
 
-void init_from_delaunay_box_mesh(
+void embed_segments(
     const MatrixXd& V,
     const MatrixXi& E,
     MatrixXd& V_out,
@@ -181,8 +181,8 @@ void init_from_delaunay_box_mesh(
     V_out.resize(nv, 2);
     size_t n_indirect = 0;
     for (int v = 0; v < nv; ++v) {
-        V_rational[v][0] = to_rational(vertices[2 * v + 0]);
-        V_rational[v][1] = to_rational(vertices[2 * v + 1]);
+        V_rational[v][0] = bigrational_to_rational(vertices[2 * v + 0]);
+        V_rational[v][1] = bigrational_to_rational(vertices[2 * v + 1]);
         V_out(v, 0) = V_rational[v][0].to_double();
         V_out(v, 1) = V_rational[v][1].to_double();
         if (Rational(V_out(v, 0)) != V_rational[v][0] ||
@@ -283,4 +283,4 @@ void read_input_curves(
     }
 }
 
-} // namespace wmtk::components::triwild
+} // namespace wmtk::utils

--- a/src/wmtk/utils/EmbedSegments.hpp
+++ b/src/wmtk/utils/EmbedSegments.hpp
@@ -2,7 +2,7 @@
 
 #include <wmtk/Types.hpp>
 
-namespace wmtk::components::triwild {
+namespace wmtk::utils {
 
 /**
  * @brief Initializes a triangulation from a 2D point set and edge set by computing the exact
@@ -29,7 +29,7 @@ namespace wmtk::components::triwild {
  * @param F_out output faces (Lx3)
  * @param E_out output edges (Px2) - the output edges tiling the input edges
  */
-void init_from_delaunay_box_mesh(
+void embed_segments(
     const MatrixXd& V,
     const MatrixXi& E,
     MatrixXd& V_out,
@@ -63,4 +63,4 @@ void read_input_curves(
     std::vector<MatrixXd>& Vs_out,
     std::vector<MatrixXi>& Es_out);
 
-} // namespace wmtk::components::triwild
+} // namespace wmtk::utils


### PR DESCRIPTION
Stacked on #1000. Third of three PRs. This is the one the previous two were for.

## The gap

A 3D simwild run takes surface meshes, inserts them into a background tet mesh with `vol_rem::embed_tri_in_poly_mesh`, and tags each tet by the winding number of each input. A 2D run had **no insertion stage at all** — its only input was a `.msh` that was *already* a tagged triangle mesh.

The 2D arrangement was not missing from the codebase. triwild has driven `vol_rem::embed_seg_in_tri_mesh` all along. simwild just had no route to it.

## Three commits

**1. Move triwild's 2D arrangement helpers into the toolkit.** `components/triwild/init_from_delaunay.{hpp,cpp}` becomes `src/wmtk/utils/EmbedSegments.{hpp,cpp}`, with `init_from_delaunay_box_mesh` renamed `embed_segments` — it has nothing to do with Delaunay. A component may not depend on another component, and this is where its siblings already live: `SimplifySegments.hpp` and `WindingNumber.hpp` are both shared 2D helpers in the same directory, both already called from triwild. No CMake change either side. **Pure move — the three triwild configs are identical on all 10 report fields.**

**2. `EmbedCurves`, the 2D counterpart of `EmbedSurface`,** member for member:

| `EmbedSurface` (3D) | `EmbedCurves` (2D) |
|---|---|
| `read_triangle_mesh` + 4x4 transform | `read_input_curves` + 3x3 transform |
| `simplify_surface` (ShortestEdgeCollapse) | `simplify_curves` (`simplify_segments`) |
| `delaunay_box_mesh` + `embed_tri_in_poly_mesh` | `embed_segments` (the grid is inside it) |
| `winding_number` (solid angle) | `winding_number_2d` |
| `T_emb` (Nx4), `T_tags` (#T x #inputs) | `F_emb` (Nx3), `F_tags` (#F x #inputs) |

The tagging contract is what makes this a *simwild* input rather than a triwild one: tag *i* is set on a cell when input *i*'s winding number at the cell barycenter exceeds 0.5, so a cell inside two inputs carries both tags and the material interfaces fall out of where adjacent cells disagree.

Two things the 2D tagging does that the 3D one does not, both ported from triwild: **auto-correct an inverted input orientation**, and **warn when an input claims no face**. The 3D version silently emits an all-zero tag column.

**3. Route selection, and rational input.** `.msh` keeps deciding from its own content. For everything else the extension cannot separate a curve network from a surface — both are `.obj` — so the first input is sniffed: an `f` record means a 3D surface, an `l` record with no `f` means a 2D curve network. A new `dimension` key (`"auto"` | `"2"` | `"3"`) forces the choice, and **errors when the file disagrees** rather than failing much later inside `EmbedSurface` with an empty-face assertion.

`run_2D` accepts rational input instead of throwing `"Input must be float for 2D!"`, via a `MatrixXr` overload of `SimWildMeshTri::init_from_image`. It checks orientation in **exact** arithmetic before rounding anything — two exactly-distinct arrangement vertices can round onto the same double and make a valid triangle look degenerate, which `init_from_delaunay`'s header records as having made about a third of the 20k 2D dataset unusable.

## The reproducer

Two new integration configs on `data/models/triwild_polylines.obj`, already in data2:

| config | arrangement | indirect vertices | result |
|---|---|---|---|
| `simwild_curves_2d` | 347 V / 688 F | **4** | 7 its, max energy 8.29, 0.14 s |
| `simwild_curves_two_inputs_2d` | 443 V / 880 F | **9**, of which **1 survives the init rounding sweep** | 8 its, 0.22 s |

Those indirect vertices are the whole point. The exact-coordinate machinery in #1000 had **no reproducer** on the old 2D inputs — hand-made tagged meshes with no sub-ULP geometry, 0 exact-midpoint splits across all 7 configs. An arrangement's crossing vertices are exactly the geometry with no double representation. This is where that work starts carrying weight, and the second config is the first 2D input that genuinely cannot be represented in doubles.

`ctest` **107/107** with both configs registered. data2 pin bumped to `c446756`.

## Two things worth flagging

- **`resolve_input_dimension` reads `dimension` with `.value()`, not `operator[]`.** A const `operator[]` on a missing key is UB in a release build — it dereferences `end()` — and it surfaced here as `type must be string, but is number`, thrown before any logging, which is a remarkably unhelpful way to learn a key was absent. Worth knowing the next time a config-reading change dies silently.
- **`simwild_curves_two_inputs_2d` stalls around max energy 15 at `stop_energy` 10**, so its config asks for 20. Two overlapping copies of the same curve network make slivers at every crossing. That is a convergence question, not a correctness one, and not what this PR is about — but it is a ready-made small reproducer if anyone wants to chase 2D convergence next.

## Known limitation, stated not fixed

`init_surfaces_and_boundaries` derives surface edges from **tag differences between adjacent faces**, identically to 3D. An open curve that does not separate two differently-tagged regions therefore produces no surface edge and is not constrained — the `winding_number_2d` warning fires, but the curve is not preserved. That is simwild's semantics in both dimensions; triwild differs because it marks the arrangement's constrained edges directly. `EmbedCurves::E_constrained()` is plumbed through and unused, which is where a future fix would start.

🤖 Generated with [Claude Code](https://claude.com/claude-code)