### PR TITLE
tetwild: drop delaunay points no tet uses, instead of segfaulting on them

### DIFF
--- a/src/wmtk/utils/DelaunayBoxMesh.cpp
+++ b/src/wmtk/utils/DelaunayBoxMesh.cpp
@@ -1,3 +1,4 @@
+#include <limits>
 #include <wmtk/utils/DelaunayBoxMesh.hpp>
 
 #include <wmtk/utils/Logger.hpp>
@@ -82,6 +83,45 @@ void delaunay_box_mesh(
         "after delaunay tets.size() = {} | points.size() = {}",
         tets.size(),
         points.size());
+
+    // Drop the points the tetrahedrization does not use, and renumber the tets onto what is
+    // left. delaunay3D dedups its input (unique_points) and maps the tets it returns back to
+    // ORIGINAL indices, so when two input points coincide exactly only one of the two indices
+    // is ever referenced -- the other belongs to no tet. Left in, the caller builds a vertex
+    // for it with an empty m_conn_tets that TetMesh::init() does not mark removed, and the
+    // first get_vertices() calls tuple_from_vertex on it, which reads m_conn_tets[0] on an
+    // empty vector. Release builds segfault; the assert that would name it is compiled out.
+    // (TetMesh::init_with_isolated_vertices has always marked tet-less vertices removed;
+    // plain init() never has.)
+    //
+    // Compacting rather than marking them removed, because the callers rely on vertex ids
+    // being contiguous: they size their attribute vectors from points.size() and index them
+    // by position.
+    //
+    // Found on Thingi10K 117682, which died 20 s in with SIGSEGV. Its simplified surface
+    // carries exactly two coincident vertex pairs.
+    {
+        std::vector<size_t> remap(points.size(), std::numeric_limits<size_t>::max());
+        for (const auto& t : tets) {
+            for (const size_t v : t) remap[v] = 0;
+        }
+        size_t live = 0;
+        for (size_t i = 0; i < points.size(); ++i) {
+            if (remap[i] == 0) {
+                points[live] = points[i];
+                remap[i] = live++;
+            }
+        }
+        if (live != points.size()) {
+            logger().info(
+                "dropped {} delaunay point(s) that no tet uses (exactly coincident input)",
+                points.size() - live);
+            points.resize(live);
+            for (auto& t : tets) {
+                for (size_t& v : t) v = remap[v];
+            }
+        }
+    }
 }
 
 } // namespace wmtk::utils


### PR DESCRIPTION
Thingi10K model **117682** died 20 s into the sweep with SIGSEGV, immediately after insertion:

```
after delauney tets.size() 97840  points.size() 16357
init finished
attribute vectors created
   <- segfault
```

## Cause

`delaunay3D` dedups its input (`unique_points`) and maps the tets it returns back to **original** point indices:

```cpp
unique_points(points, coords, to_original);
tet[j] = to_original[mesh.vertices[tn[j]].original_index];
```

So when two input points coincide exactly, only one of the two indices is ever referenced — the other belongs to no tet. `init()` builds a vertex for it with an empty `m_conn_tets` and does **not** mark it removed, and the very next call, `get_vertices()`, runs `tuple_from_vertex` on it:

```cpp
size_t tid = m_vertex_connectivity[vid].m_conn_tets[0];   // empty vector
```

`get_vertices()` guards this with `assert(!vc.m_conn_tets.empty())`, which is compiled out in Release.

`TetMesh::init_with_isolated_vertices` has always marked tet-less vertices removed. Plain `init()` never has, and nothing between the two guaranteed the tets covered every vertex.

117682's simplified surface carries exactly two coincident pairs:

```
(-28.3937206268311, -32.0351448059082, 5.0) x2
( 28.6062793731689, -32.0351448059082, 5.0) x2
```

## Fix

Compact the point array to what the tets reference, and renumber.

**Not** by marking the orphans removed, even though `init_with_isolated_vertices` shows how: everything downstream relies on vertex ids being contiguous. `VolumemesherInsertion.cpp` flattens the background mesh by indexing `m_vertex_attribute` by position while `tet_index` carries raw vids, so removing a vertex mid-array would silently misalign the coordinates handed to the remesher — a wrong answer instead of a crash.

## Why now

Latent until `7f03e51dee` removed the epsilon-grid merge from the simplified surface. Removing that merge was correct: it snapped coordinates to a grid, so whether two vertices merged depended on which side of a cell boundary they fell on rather than how far apart they were.

But that commit also argued the simplification could not leave coincident vertices, because it maintains valid manifold connectivity. That does not follow — two topologically distinct vertices can share a position — and 117682 is the counterexample. The protection belongs here, in the mesh layer, not in a merge that damaged distinct vertices.

## Test plan

- **117682** reproduces the SIGSEGV deterministically on `main` at `num_threads` 1 and 8, in ~20 s. With this change it logs `dropped 2 delaunay point(s) that no tet uses (exactly coincident input)` — matching the two coincident pairs — then runs through insertion into the optimization normally, reaching iteration 9 with max energy descending 102 → 89.7 → 71.2.
- Unit tests: **106,295 assertions in 97 test cases, all passing.**
- The compaction is a no-op on any model whose points are all referenced, and logs nothing in that case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)