### PR TITLE
Evaluate AMIPS about the first vertex, not about the origin

### DIFF
--- a/src/wmtk/utils/AMIPS.cpp
+++ b/src/wmtk/utils/AMIPS.cpp
@@ -5,19 +5,31 @@ namespace wmtk {
 
 double AMIPS_energy(const std::array<double, 12>& T)
 {
+    // Evaluate about the first vertex. AMIPS is translation invariant -- f(T + c) == f(T)
+    // for any constant offset -- so this is an identity, and it is what makes the expression
+    // usable in double. The generated form below is an EXPANDED polynomial in the absolute
+    // coordinates: its numerator sums products of magnitude |x|^2 that must cancel down to
+    // roughly (element size)^2, so an element much smaller than its distance from the origin
+    // loses that ratio in significant digits.
+    //
+    // Measured on Thingi10K 1368069, whose worst tet is a surface sliver ~1e-6 across sitting
+    // at |x| ~ 150: the numerator cancels fifteen orders of magnitude and the double result
+    // was 16.26 against a true 23.35 -- 30% out. Another tet in the same cluster read 17.80
+    // when its true energy is 6.96, i.e. the optimizer was told a good element was a bad one,
+    // force-split it, and manufactured the slivers it then could not repair. With this
+    // translation both land within 8e-7 of the exact value.
+    //
+    // What remains after this is not the formula but the storage: a 1e-6 element at |x| ~ 150
+    // is only resolved to ULP(150)/1e-6 ~ 3e-8 relative, whatever the expression does.
+    //
+    // Derivatives are unaffected for the same reason: translation invariance is exact, so
+    // the jacobian and hessian formulas evaluated at translated coordinates return the same
+    // values as at the originals.
     double helper_0[12];
-    helper_0[0] = T[0];
-    helper_0[1] = T[1];
-    helper_0[2] = T[2];
-    helper_0[3] = T[3];
-    helper_0[4] = T[4];
-    helper_0[5] = T[5];
-    helper_0[6] = T[6];
-    helper_0[7] = T[7];
-    helper_0[8] = T[8];
-    helper_0[9] = T[9];
-    helper_0[10] = T[10];
-    helper_0[11] = T[11];
+    const double origin[3] = {T[0], T[1], T[2]};
+    for (int i = 0; i < 12; ++i) {
+        helper_0[i] = T[i] - origin[i % 3];
+    }
     double helper_1 = helper_0[2];
     double helper_2 = helper_0[11];
     double helper_3 = helper_0[0];
@@ -73,19 +85,31 @@ double AMIPS_energy(const std::array<double, 12>& T)
 
 void AMIPS_jacobian(const std::array<double, 12>& T, Eigen::Vector3d& result_0)
 {
+    // Evaluate about the first vertex. AMIPS is translation invariant -- f(T + c) == f(T)
+    // for any constant offset -- so this is an identity, and it is what makes the expression
+    // usable in double. The generated form below is an EXPANDED polynomial in the absolute
+    // coordinates: its numerator sums products of magnitude |x|^2 that must cancel down to
+    // roughly (element size)^2, so an element much smaller than its distance from the origin
+    // loses that ratio in significant digits.
+    //
+    // Measured on Thingi10K 1368069, whose worst tet is a surface sliver ~1e-6 across sitting
+    // at |x| ~ 150: the numerator cancels fifteen orders of magnitude and the double result
+    // was 16.26 against a true 23.35 -- 30% out. Another tet in the same cluster read 17.80
+    // when its true energy is 6.96, i.e. the optimizer was told a good element was a bad one,
+    // force-split it, and manufactured the slivers it then could not repair. With this
+    // translation both land within 8e-7 of the exact value.
+    //
+    // What remains after this is not the formula but the storage: a 1e-6 element at |x| ~ 150
+    // is only resolved to ULP(150)/1e-6 ~ 3e-8 relative, whatever the expression does.
+    //
+    // Derivatives are unaffected for the same reason: translation invariance is exact, so
+    // the jacobian and hessian formulas evaluated at translated coordinates return the same
+    // values as at the originals.
     double helper_0[12];
-    helper_0[0] = T[0];
-    helper_0[1] = T[1];
-    helper_0[2] = T[2];
-    helper_0[3] = T[3];
-    helper_0[4] = T[4];
-    helper_0[5] = T[5];
-    helper_0[6] = T[6];
-    helper_0[7] = T[7];
-    helper_0[8] = T[8];
-    helper_0[9] = T[9];
-    helper_0[10] = T[10];
-    helper_0[11] = T[11];
+    const double origin[3] = {T[0], T[1], T[2]};
+    for (int i = 0; i < 12; ++i) {
+        helper_0[i] = T[i] - origin[i % 3];
+    }
     double helper_1 = helper_0[1];
     double helper_2 = helper_0[10];
     double helper_3 = helper_1 - helper_2;
@@ -170,19 +194,31 @@ void AMIPS_jacobian(const std::array<double, 12>& T, Eigen::Vector3d& result_0)
 
 void AMIPS_hessian(const std::array<double, 12>& T, Eigen::Matrix3d& result_0)
 {
+    // Evaluate about the first vertex. AMIPS is translation invariant -- f(T + c) == f(T)
+    // for any constant offset -- so this is an identity, and it is what makes the expression
+    // usable in double. The generated form below is an EXPANDED polynomial in the absolute
+    // coordinates: its numerator sums products of magnitude |x|^2 that must cancel down to
+    // roughly (element size)^2, so an element much smaller than its distance from the origin
+    // loses that ratio in significant digits.
+    //
+    // Measured on Thingi10K 1368069, whose worst tet is a surface sliver ~1e-6 across sitting
+    // at |x| ~ 150: the numerator cancels fifteen orders of magnitude and the double result
+    // was 16.26 against a true 23.35 -- 30% out. Another tet in the same cluster read 17.80
+    // when its true energy is 6.96, i.e. the optimizer was told a good element was a bad one,
+    // force-split it, and manufactured the slivers it then could not repair. With this
+    // translation both land within 8e-7 of the exact value.
+    //
+    // What remains after this is not the formula but the storage: a 1e-6 element at |x| ~ 150
+    // is only resolved to ULP(150)/1e-6 ~ 3e-8 relative, whatever the expression does.
+    //
+    // Derivatives are unaffected for the same reason: translation invariance is exact, so
+    // the jacobian and hessian formulas evaluated at translated coordinates return the same
+    // values as at the originals.
     double helper_0[12];
-    helper_0[0] = T[0];
-    helper_0[1] = T[1];
-    helper_0[2] = T[2];
-    helper_0[3] = T[3];
-    helper_0[4] = T[4];
-    helper_0[5] = T[5];
-    helper_0[6] = T[6];
-    helper_0[7] = T[7];
-    helper_0[8] = T[8];
-    helper_0[9] = T[9];
-    helper_0[10] = T[10];
-    helper_0[11] = T[11];
+    const double origin[3] = {T[0], T[1], T[2]};
+    for (int i = 0; i < 12; ++i) {
+        helper_0[i] = T[i] - origin[i % 3];
+    }
     double helper_1 = helper_0[2];
     double helper_2 = helper_0[11];
     double helper_3 = helper_1 - helper_2;


### PR DESCRIPTION
`AMIPS_energy`, `AMIPS_jacobian` and `AMIPS_hessian` are generated code that expands the energy into a polynomial in the **absolute** vertex coordinates:

```cpp
helper_6 = 0.577350269189626*T[0] - 1.15470053837925*T[3] + 0.577350269189626*T[9];
```

The numerator sums products of magnitude `|x|²` that must cancel down to roughly `(element size)²`, so an element much smaller than its distance from the origin loses that ratio in significant digits. (The denominator is built from coefficient triples that already sum to zero and is far better conditioned — measured relative error 4e-8. The numerator is where the accuracy goes.)

Evaluating about the first vertex is a mathematical identity, since AMIPS is translation invariant, and it removes the cancellation:

```cpp
const double origin[3] = {T[0], T[1], T[2]};
for (int i = 0; i < 12; ++i) helper_0[i] = T[i] - origin[i % 3];
```

## Measured

Thingi10K **1368069**, whose worst element is a surface sliver ~1e-6 across sitting at `|x| ≈ 150` — fifteen orders of cancellation. Same expression, float64 vs 200-bit:

| tet | exact | double (absolute) | double (translated) |
|---|---|---|---|
| the stuck one | 23.3453 | **16.2612** (30% low) | 23.34536 (7.6e-07) |
| another nearby | 6.9568 | **17.8045** (156% high) | 6.956836 (5.3e-07) |

The second row is the damaging one: a **good** element, near the floor of 3, reported as a bad one. The optimizer force-splits it, and splitting near-coincident geometry manufactures the 1e-6 slivers it then cannot repair — which measure worse still, so the loop sustains itself. Sampling 4,000 tets of that mesh, 22 had relative error above 1e-6.

That is the mechanism behind the model's plateau: its max energy sat at *exactly* 19.8348 for its last 40 readings, split was the only operation that ever raised the max (48 times), and collapse restored the same value 34 times.

## Effect on that model

|  | iterations | max energy | time | tets |
|---|---|---|---|---|
| before | 80 (cap) | 19.8348 | 3719 s | 337,894 |
| after | **16** | **9.99971** | **322 s** | 306,902 |

It reaches the target instead of stalling at twice it, in a fifth of the iterations, and produces a *smaller* mesh — the extra elements were refinement spent on phantom bad tets.

## Notes

**Derivatives need no correction.** Translation invariance is exact, so the jacobian and hessian formulas evaluated at translated coordinates return the values they would at the originals. This matters because smoothing descends that gradient (`src/wmtk/optimization/AMIPSEnergy.cpp`).

**What this does not fix.** The remaining error is storage, not the formula: a 1e-6 element at `|x| ≈ 150` is resolved to `ULP(150)/1e-6 ≈ 3e-8` relative whatever the expression does. Separately, an element at 4e-6 of eps is geometrically meaningless and arguably should be collapsed rather than optimized — a different change.

## Test plan

- **107/107 ctest passing on kirby**, including `Integration_Tests` (404 s).
- Unit tests: 106,295 assertions in 97 test cases. Note these pass **without** this change too, so they do not cover it — the evidence is the numerical comparison above.
- Cost is 12 subtractions per evaluation, well under 1% of the expression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)