### PR TITLE
dedup 2/4: fix six defects the copies had already drifted into

### DIFF
--- a/components/simwild/wmtk/components/simwild/EdgeSplitting.cpp
+++ b/components/simwild/wmtk/components/simwild/EdgeSplitting.cpp
@@ -202,7 +202,12 @@ bool SimWildMesh::split_edge_after(const Tuple& loc)
 
     // If a Voronoi split function is set, binary-search vmid onto its zero-crossing.
     // p0 stays on the negative side, p1 on the positive side.
-    if (m_voronoi_split_fn) {
+    //
+    // Skipped for an un-rounded vertex: the exact midpoint is then the only position known to
+    // keep every incident tet valid, and this search only considers doubles -- including the
+    // plain double midpoint it reverts to, which is the position that just inverted. The 2D
+    // twin carries the same guard.
+    if (m_voronoi_split_fn && m_vertex_attribute[v_id].m_is_rounded) {
         Vector3d p0 = m_vertex_attribute[v1_id].m_posf;
         Vector3d p1 = m_vertex_attribute[v2_id].m_posf;
         if (m_voronoi_split_fn(p0) >= 0) {

--- a/components/simwild/wmtk/components/simwild/EdgeSwapping.cpp
+++ b/components/simwild/wmtk/components/simwild/EdgeSwapping.cpp
@@ -169,7 +169,10 @@ bool SimWildMesh::swap_edge_before(const Tuple& t)
     // Surface edges are allowed only as a topology-preserving surface diagonal
     // flip (see prepare_surface_flip_32). If disabled, keep the old behavior of
     // rejecting all surface-edge swaps.
-    if (is_edge_on_surface(t)) {
+    // Route on the direct incident-surface-face count so a genuine surface edge is never
+    // mistaken for interior because of a stale m_is_on_surface flag, which would tear the
+    // surface. tetwild routes all three swap paths this way.
+    if (edge_incident_surface_face_count(t) > 0) {
         if (!m_params.allow_surface_swap) {
             return false;
         }
@@ -592,7 +595,7 @@ bool SimWildMesh::swap_edge_44_before(const Tuple& t)
         return false;
     }
 
-    if (is_edge_on_surface(t) || is_edge_on_bbox(t)) {
+    if (edge_incident_surface_face_count(t) > 0 || is_edge_on_bbox(t)) {
         return false;
     }
 
@@ -705,7 +708,7 @@ bool SimWildMesh::swap_edge_56_before(const Tuple& t)
     if (incident_tets.size() != 5) {
         return false;
     }
-    if (is_edge_on_surface(t) || is_edge_on_bbox(t)) {
+    if (edge_incident_surface_face_count(t) > 0 || is_edge_on_bbox(t)) {
         return false;
     }
 
@@ -723,6 +726,8 @@ bool SimWildMesh::swap_edge_56_before(const Tuple& t)
         //        TA[l].tags); // for debugging
         //}
     }
+
+    swap_cache.local().max_energy = max_energy;
 
     face_attribute_tracker(
         *this,

--- a/components/simwild/wmtk/components/simwild/Parameters.h
+++ b/components/simwild/wmtk/components/simwild/Parameters.h
@@ -11,7 +11,7 @@ struct Parameters
     double lr = 5e-2; // target edge length (relative)
     double l = -1.; // target edge length (absolute)
     double l_min = -1;
-    bool preserve_topology = false;
+    bool preserve_topology = true;
     std::string output_path;
 
     // Allow the 3->2 edge swap to operate on surface edges (a surface diagonal
@@ -48,9 +48,9 @@ struct Parameters
     // is converging, so a separate cooldown only delays the next escape.
     int stuck_refine_cooldown = 0;
     // Number of worst tets (by energy) whose neighborhoods are refined.
-    int stuck_refine_num_worst = 50;
+    int stuck_refine_num_worst = 0;
     // Graph rings around each worst tet's vertices included in the refinement.
-    int stuck_refine_rings = 3;
+    int stuck_refine_rings = 0;
     // Multiplicative reduction of m_sizing_scalar per refinement (0.5 => /2).
     double stuck_refine_factor = 0.5;
     // Lower bound on m_sizing_scalar. Much smaller than the old l_min/l floor;
@@ -80,14 +80,14 @@ struct Parameters
     // passes). Only smoothing is gated: gating the topology/sizing ops
     // (split/collapse/swap) starves the optimizer and blows up the element
     // count, so those always run over the whole mesh.
-    bool skip_good_regions = true;
+    bool skip_good_regions = false;
     // Safety margin on the "active" threshold: a tet is active when its energy
     // (cbrt of m_quality) is >= this fraction of stop_energy, so vertices near
     // tets sitting just below the target are still smoothed.
     double skip_good_regions_margin = 0.9;
 
 
-    double epsr_simplify = 2e-3; // relative error bound (wrt diagonal) for simplification
+    double epsr_simplify = 2e-4; // relative error bound (wrt diagonal) for simplification
     /// Order-2 (open boundary / non-manifold edge) envelope thickness, as a fraction of the
     /// surface envelope's. Deliberately below 1 where the surface envelope uses the full eps;
     /// see the doc on /order2_envelope_ratio in the spec for the measurement behind 0.5.
@@ -127,7 +127,7 @@ struct Parameters
 
     std::string operation = "remeshing";
 
-    bool skip_simplify = true;
+    bool skip_simplify = false;
     bool use_sample_envelope = false;
     int NUM_THREADS = 0;
     bool write_vtu = false;

--- a/components/simwild/wmtk/components/simwild/SimWildMesh.cpp
+++ b/components/simwild/wmtk/components/simwild/SimWildMesh.cpp
@@ -940,6 +940,31 @@ bool SimWildMesh::is_edge_on_surface(const Tuple& loc)
     return false;
 }
 
+int SimWildMesh::edge_incident_surface_face_count(const Tuple& e)
+{
+    const size_t v1_id = e.vid(*this);
+    const size_t v2_id = e.switch_vertex(*this).vid(*this);
+
+    const auto tets = get_incident_tets_for_edge(e);
+    std::vector<size_t> n_vids;
+    for (const auto& t : tets) {
+        const auto vs = oriented_tet_vertices(t);
+        for (int j = 0; j < 4; ++j) {
+            const size_t v = vs[j].vid(*this);
+            if (v != v1_id && v != v2_id) n_vids.push_back(v);
+        }
+    }
+    wmtk::vector_unique(n_vids);
+
+    int count = 0;
+    for (const size_t vid : n_vids) {
+        auto [ftup, fid] = tuple_from_face({{v1_id, v2_id, vid}});
+        (void)ftup;
+        if (fid != static_cast<size_t>(-1) && m_face_attribute[fid].m_is_surface_fs) ++count;
+    }
+    return count;
+}
+
 
 bool SimWildMesh::is_edge_on_bbox(const Tuple& loc)
 {

--- a/components/simwild/wmtk/components/simwild/SimWildMesh.h
+++ b/components/simwild/wmtk/components/simwild/SimWildMesh.h
@@ -453,6 +453,15 @@ public:
 
     //
     bool is_edge_on_surface(const Tuple& loc);
+    /**
+     * @brief How many faces incident to this edge are tracked surface.
+     *
+     * Unlike is_edge_on_surface this does NOT short-circuit on the vertices'
+     * m_is_on_surface flags, so a genuine surface edge cannot be mistaken for interior
+     * because a flag went stale -- which in a swap would tear the surface. Same helper
+     * tetwild routes its swap surface test through.
+     */
+    int edge_incident_surface_face_count(const Tuple& e);
     bool is_edge_on_bbox(const Tuple& loc);
     //
     void mesh_improvement(int max_its = 80);

--- a/components/simwild/wmtk/components/simwild/SimWildMeshTri.cpp
+++ b/components/simwild/wmtk/components/simwild/SimWildMeshTri.cpp
@@ -26,6 +26,7 @@
 #include <wmtk/optimization/solver.hpp>
 #include <wmtk/utils/LocalizedRetry.hpp>
 #include <wmtk/utils/ParallelCollect.hpp>
+#include <wmtk/utils/SizingField.hpp>
 #include <wmtk/utils/TetraQualityUtils.hpp>
 #include <wmtk/utils/TupleUtils.hpp>
 #include <wmtk/utils/io.hpp>
@@ -553,79 +554,46 @@ bool SimWildMeshTri::check_mesh_quality(double& max_rel_quality, const bool verb
 
 size_t SimWildMeshTri::refine_sizing_around_worst()
 {
-    const int num_worst = std::max(0, m_params.stuck_refine_num_worst);
     const int n_rings = std::max(0, m_params.stuck_refine_rings);
-    const double factor = m_params.stuck_refine_factor;
-    const double floor = m_params.stuck_refine_min_scalar;
 
-    // Find the num_worst valid tets with the highest energy. `worst` is kept
-    // sorted ascending by quality, size <= num_worst (front = smallest kept).
-    std::vector<std::pair<double, size_t>> worst;
-    worst.reserve(num_worst);
-    for (size_t tid = 0; tid < tri_capacity(); ++tid) {
-        const Tuple t = tuple_from_tri(tid);
-        if (!t.is_valid(*this)) {
-            continue;
-        }
-        const double& q = m_face_attribute[tid].m_quality;
-        if (q < target_quality(tid)) {
-            continue;
-        }
-        if (num_worst > 0) {
-            if (static_cast<int>(worst.size()) < num_worst) {
-                worst.emplace_back(q, tid);
-                std::sort(worst.begin(), worst.end());
-            } else if (q > worst.front().first) {
-                worst.front() = {q, tid};
-                std::sort(worst.begin(), worst.end());
-            }
-        } else {
-            worst.emplace_back(q, tid);
-        }
-    }
+    // Relative quality against the per-cell target, filtered at 1.0 -- the same selection the
+    // hand-rolled version made with `if (q < target_quality(tid)) continue;`, and the same
+    // shape the 3D mesh uses. target_quality defaults to m_params.stop_energy and is only
+    // overridden by the per-tag quality_field, so this is simwild's relative-quality model,
+    // not tetwild/triwild's absolute filter_energy.
+    //
+    // m_quality is the AMIPS2D energy itself here, so no cube root (unlike the 3D mesh).
+    const auto worst = utils::select_worst_cells(
+        tri_capacity(),
+        [this](size_t fid) { return tuple_from_tri(fid).is_valid(*this); },
+        [this](size_t fid) {
+            return m_face_attribute[fid].m_quality / target_quality(fid); // relative quality
+        },
+        1.0,
+        m_params.stuck_refine_num_worst);
 
-    if (num_worst == 0) {
-        std::sort(worst.begin(), worst.end());
-    }
     if (worst.empty()) {
         return 0;
     }
 
-    // Seed the region with the worst tets' vertices, then BFS n_rings hops.
-    std::unordered_set<size_t> region;
-    std::vector<size_t> frontier;
-    for (const auto& [_, tid] : worst) {
-        const auto vs = oriented_tri_vids(tid);
-        for (const size_t v : vs) {
-            region.insert(v);
+    // Seed the region with the worst triangles' vertices, then BFS n_rings hops.
+    std::vector<size_t> seeds;
+    seeds.reserve(3 * worst.size());
+    for (const auto& [_, fid] : worst) {
+        for (const size_t v : oriented_tri_vids(fid)) {
+            seeds.push_back(v);
         }
     }
-    frontier.insert(frontier.end(), region.begin(), region.end());
-
-    // grow region by n rings starting from the worst tets' vertices
-    for (int r = 0; r < n_rings; ++r) {
-        std::vector<size_t> next;
-        for (const size_t v : frontier) {
-            for (const size_t u : get_one_ring_vids_for_vertex_duplicate(v)) {
-                if (region.insert(u).second) {
-                    next.push_back(u);
-                }
-            }
-        }
-        frontier.swap(next);
-    }
+    const auto region = utils::grow_vertex_region(seeds, n_rings, [this](size_t v) {
+        return get_one_ring_vids_for_vertex_duplicate(v);
+    });
 
     // Apply the multiplicative refinement, clamped at the floor.
-    std::vector<size_t> refined;
-    refined.reserve(region.size());
-    for (const size_t v : region) {
-        double& s = m_vertex_attribute[v].m_sizing_scalar;
-        const double ns = std::max(floor, s * factor);
-        if (ns < s) {
-            s = ns;
-            refined.push_back(v);
-        }
-    }
+    const auto refined = utils::apply_sizing_refinement(
+        region,
+        m_params.stuck_refine_factor,
+        m_params.stuck_refine_min_scalar,
+        [this](size_t v) -> double& { return m_vertex_attribute[v].m_sizing_scalar; });
 
     // Grade the refined region into its surroundings (monotone, only lowers).
     gradation_smooth_sizing(m_params.stuck_refine_gradation, refined);
@@ -647,7 +615,7 @@ size_t SimWildMeshTri::refine_sizing_around_worst()
     }
 
     logger().info(
-        "[stuck-refine] worst {} tets (maxE {:.4}), refined {} of {} region vertices",
+        "[stuck-refine] worst {} tris (relE {:.4}), refined {} of {} region vertices",
         worst.size(),
         worst.back().first,
         refined.size(),
@@ -657,34 +625,11 @@ size_t SimWildMeshTri::refine_sizing_around_worst()
 
 void SimWildMeshTri::gradation_smooth_sizing(double grade, const std::vector<size_t>& seeds)
 {
-    if (grade <= 1.0) {
-        return;
-    }
-
-    // Min-relaxation (Dijkstra/Bellman-Ford style): vertex u caps each neighbor
-    // at grade * sizing[u]. Only ever decreases sizings, so it spreads more
-    // refinement outward without raising the already-refined (seed) values.
-    // Sizings are always in (0, 1], so once grade*sizing[u] >= 1 the cap can no
-    // longer lower any neighbor and propagation stops -- this bounds the halo.
-    std::queue<size_t> q;
-    for (const size_t v : seeds) {
-        q.push(v);
-    }
-    while (!q.empty()) {
-        const size_t u = q.front();
-        q.pop();
-        const double cap = grade * m_vertex_attribute[u].m_sizing_scalar;
-        if (cap >= 1.0) {
-            continue;
-        }
-        for (const size_t w : get_one_ring_vids_for_vertex_duplicate(u)) {
-            double& sw = m_vertex_attribute[w].m_sizing_scalar;
-            if (sw > cap) {
-                sw = cap;
-                q.push(w);
-            }
-        }
-    }
+    utils::gradation_smooth_sizing(
+        grade,
+        seeds,
+        [this](size_t v) -> double& { return m_vertex_attribute[v].m_sizing_scalar; },
+        [this](size_t v) { return get_one_ring_vids_for_vertex_duplicate(v); });
 }
 
 void SimWildMeshTri::write_msh(std::string file, const bool write_envelope)

--- a/components/simwild/wmtk/components/simwild/SimWildMeshTri.cpp
+++ b/components/simwild/wmtk/components/simwild/SimWildMeshTri.cpp
@@ -24,6 +24,8 @@
 #include <wmtk/optimization/EnergySum.hpp>
 #include <wmtk/optimization/EnvelopeEnergy.hpp>
 #include <wmtk/optimization/solver.hpp>
+#include <wmtk/utils/LocalizedRetry.hpp>
+#include <wmtk/utils/ParallelCollect.hpp>
 #include <wmtk/utils/TetraQualityUtils.hpp>
 #include <wmtk/utils/TupleUtils.hpp>
 #include <wmtk/utils/io.hpp>
@@ -1604,20 +1606,16 @@ bool SimWildMeshTri::collapse_edge_after(const Tuple& loc)
 
 size_t SimWildMeshTri::swap_all_edges()
 {
-    std::vector<std::pair<std::string, Tuple>> collect_all_ops;
-    {
-        igl::Timer timer;
-        timer.start();
-        const auto edges = get_edges();
-        collect_all_ops.reserve(edges.size());
-        for (const Tuple& t : edges) {
-            collect_all_ops.emplace_back("edge_swap", t);
-        }
-        timer.stop();
-        logger().info("edge collapse prepare time: {:.4}s", timer.getElapsedTimeInSec());
-    }
+    igl::Timer timer;
+    timer.start();
+    auto collect_all_ops = wmtk::parallel_collect_edge_ops(
+        *this,
+        NUM_THREADS,
+        [](SimWildMeshTri&, const Tuple& e, auto& out) { out.emplace_back("edge_swap", e); });
     logger().info("#E = {}", collect_all_ops.size());
+    logger().info("edge swap prepare time: {:.4}s", timer.getElapsedTimeInSec());
 
+    size_t total_success = 0;
     auto setup_and_execute = [&](auto& executor) {
         executor.renew_neighbor_tuples = renew;
         executor.num_threads = NUM_THREADS;
@@ -1630,7 +1628,9 @@ size_t SimWildMeshTri::swap_all_edges()
             const double w = m.swap_weight(e);
             return (w > 1e-5) && ((w - val) * (w - val) < 1e-8);
         };
-        executor(*this, collect_all_ops);
+        // Retry a failed swap only where the mesh actually changed this round
+        // (dirty-epoch localized retry).
+        total_success = wmtk::run_localized_to_convergence(*this, executor, collect_all_ops);
     };
     if (NUM_THREADS > 0) {
         auto executor = ExecutePass<SimWildMeshTri>(ExecutionPolicy::kPartition);
@@ -1641,7 +1641,11 @@ size_t SimWildMeshTri::swap_all_edges()
         setup_and_execute(executor);
     }
 
-    return true;
+    // The caller (local_operations) stops the swap loop once a pass changes nothing, so this
+    // has to be the real count -- it used to return `true`, i.e. always 1, which meant the
+    // early exit could never fire and every requested swap round ran in full. triwild carries
+    // the same fix and the same note.
+    return total_success;
 }
 
 double SimWildMeshTri::swap_weight(const Tuple& t) const

--- a/components/simwild/wmtk/components/simwild/SimWildMeshTri.cpp
+++ b/components/simwild/wmtk/components/simwild/SimWildMeshTri.cpp
@@ -1752,6 +1752,7 @@ void SimWildMeshTri::smooth_all_vertices(const size_t n_iters)
         // log_total_surface_energy();
         igl::Timer timer;
         timer.start();
+        m_smooth_rejects.reset();
         std::vector<std::pair<std::string, Tuple>> collect_all_ops;
         for (const Tuple& t : get_vertices()) {
             collect_all_ops.emplace_back("vertex_smooth", t);
@@ -1773,6 +1774,7 @@ void SimWildMeshTri::smooth_all_vertices(const size_t n_iters)
             executor(*this, collect_all_ops);
             logger().info("vertex smoothing time serial: {:.4}s", timer.getElapsedTimeInSec());
         }
+        logger().info("\tsmooth: {}", m_smooth_rejects.to_string());
         if (m_params.debug_output) {
             write_vtu(fmt::format("debug_{}", m_debug_print_counter++));
         }

--- a/components/tetwild/wmtk/components/tetwild/Parameters.h
+++ b/components/tetwild/wmtk/components/tetwild/Parameters.h
@@ -3,7 +3,7 @@
 namespace wmtk::components::tetwild {
 struct Parameters
 {
-    double epsr = 2e-3; // relative error bound (wrt diagonal)
+    double epsr = 1e-3; // relative error bound (wrt diagonal)
     double eps = -1.; // absolute error bound
     double lr = 5e-2; // target edge length (relative)
     /// Order-2 (open boundary / non-manifold edge) envelope thickness, as a fraction of the
@@ -54,9 +54,9 @@ struct Parameters
     // is converging, so a separate cooldown only delays the next escape.
     int stuck_refine_cooldown = 0;
     // Number of worst tets (by energy) whose neighborhoods are refined.
-    int stuck_refine_num_worst = 50;
+    int stuck_refine_num_worst = 0;
     // Graph rings around each worst tet's vertices included in the refinement.
-    int stuck_refine_rings = 3;
+    int stuck_refine_rings = 0;
     // Multiplicative reduction of m_sizing_scalar per refinement (0.5 => /2).
     double stuck_refine_factor = 0.5;
     // Lower bound on m_sizing_scalar. Much smaller than the old l_min/l floor;
@@ -86,7 +86,7 @@ struct Parameters
     // passes). Only smoothing is gated: gating the topology/sizing ops
     // (split/collapse/swap) starves the optimizer and blows up the element
     // count, so those always run over the whole mesh.
-    bool skip_good_regions = true;
+    bool skip_good_regions = false;
     // Safety margin on the "active" threshold: a tet is active when its energy
     // (cbrt of m_quality) is >= this fraction of stop_energy, so vertices near
     // tets sitting just below the target are still smoothed.
@@ -96,7 +96,7 @@ struct Parameters
     double collapsing_l2 =
         std::numeric_limits<double>::max(); // the upper bound length (squared) for edge collapse
 
-    double stop_energy = 10;
+    double stop_energy = 100;
 
     /**
      * Incident-tet count above which a vertex is treated as pathological, or 0 to
@@ -142,8 +142,8 @@ struct Parameters
     // only phase that improves quality without changing connectivity, so giving each topology
     // pass a chance to be relaxed before the next one runs may keep the optimizer off the
     // plateaus where split, collapse and swap simply undo each other.
-    bool interleaved_smoothing = false;
-    int interleaved_smoothing_passes = 2;
+    bool interleaved_smoothing = true;
+    int interleaved_smoothing_passes = 1;
 
     bool debug_output = false;
     bool perform_sanity_checks = false;

--- a/components/triwild/wmtk/components/triwild/Parameters.h
+++ b/components/triwild/wmtk/components/triwild/Parameters.h
@@ -29,7 +29,7 @@ struct Parameters
     double collapsing_l2 =
         std::numeric_limits<double>::max(); // the upper bound length (squared) for edge collapse
 
-    double stop_energy = 20;
+    double stop_energy = 100;
 
     bool debug_output = false;
     bool perform_sanity_checks = false;

--- a/docs/simwild-adopted-behaviours.md
+++ b/docs/simwild-adopted-behaviours.md
@@ -91,3 +91,24 @@ the ring's worst element; triwild permits it as long as the result is still belo
 They disagree with each other, so "take the tetwild/triwild implementation" cannot resolve it.
 Left alone pending a decision and a measurement. See also 1i, the other tetwild/triwild
 disagreement.
+
+### 1g. simwild-2D uses the shared `utils::SizingField` helpers
+
+| | |
+|---|---|
+| **was** | `refine_sizing_around_worst` and `gradation_smooth_sizing` hand-rolled the top-N selection, the BFS region growth, the refinement clamp and the Dijkstra min-relaxation — ~100 lines re-implementing `src/wmtk/utils/SizingField.hpp`, which the other three meshes call |
+| **now** | `utils::select_worst_cells`, `grow_vertex_region`, `apply_sizing_refinement`, `gradation_smooth_sizing`; 92 lines deleted |
+| **source** | simwild-3D's `refine_sizing_around_worst`, which already had this shape |
+| **measured** | No output change on any config. |
+
+**Semantics deliberately preserved, not "corrected" to triwild's.** triwild filters worst cells
+on an absolute `filter_energy = min(max(max_energy/100, stop_energy), 100.)`; simwild filters on
+**relative** quality against the per-cell `target_quality(tid)` at a threshold of 1.0. That is
+simwild's model — its whole stop condition is per-cell relative quality — and simwild-3D already
+expresses it that way through the same shared helper. The hand-rolled 2D filter
+(`if (q < target_quality(tid)) continue;`) is exactly equivalent to it.
+
+**Still missing in simwild-2D, not addressed here** (feature ports, not de-duplication):
+force-split of the worst cells' longest edges (`m_force_split_edges`), which tetwild, triwild and
+simwild-3D all have; and `skip_good_regions` / `active_vertices`, which the other three use to
+restrict smoothing.

--- a/docs/simwild-adopted-behaviours.md
+++ b/docs/simwild-adopted-behaviours.md
@@ -112,3 +112,60 @@ expresses it that way through the same shared helper. The hand-rolled 2D filter
 force-split of the worst cells' longest edges (`m_force_split_edges`), which tetwild, triwild and
 simwild-3D all have; and `skip_good_regions` / `active_vertices`, which the other three use to
 restrict smoothing.
+
+---
+
+## Decisions taken, not applied
+
+Two divergences turned out to be **tetwild vs triwild**, where "take the tetwild/triwild
+implementation" has no answer because the two reference apps disagree with each other.
+
+### The collapse quality gate (see 1e) — deferred, decide with measurement
+
+tetwild and simwild-3D never permit a collapse that worsens the ring's worst element; triwild
+and simwild-2D permit it while the result stays below the target. Each fork already matches its
+own sibling, so nothing is inconsistent *within* a pair. Answering which rule is better is an
+optimizer-behaviour question needing a sweep of both variants on the challenging set, not a
+de-duplication question. **Left as is.** The 3D/2D base-class merge should surface it as one
+named virtual (e.g. `collapse_allows_worsening_below_target()`) so the choice is explicit in one
+place instead of implicit in four.
+
+### tetwild's stale `m_posf` after the exact-midpoint split — separate PR
+
+triwild, simwild-3D and simwild-2D all set `p = to_double(m_pos)` after falling back to the
+exact rational midpoint; tetwild alone keeps the average of the two endpoint doubles. triwild
+documents why its version is better: when an endpoint is itself un-rounded, rounding the exact
+midpoint once beats averaging two approximations.
+
+Fixing tetwild necessarily **moves tetwild output**, which is the signal every de-duplication
+stage is validated against. **Deferred to its own PR after the refactor**, where a real output
+change is the expected result rather than a warning sign.
+
+---
+
+## Stage 1h — `Parameters` struct defaults now match their own spec defaults
+
+Fourteen fields had a C++ struct default that disagreed with the JSON spec default for the same
+key, so any code path that builds `Parameters` **without** going through jse — which is what the
+unit tests do — ran a different configuration than every driver run:
+
+| app | field | struct was | spec (now both) |
+|---|---|---|---|
+| tetwild | `eps_rel` | 2e-3 | **1e-3** |
+| tetwild | `stop_energy` | 10 | **100** |
+| tetwild | `interleaved_smoothing` | false | **true** |
+| tetwild | `interleaved_smoothing_passes` | 2 | **1** |
+| tetwild | `stuck_refine_num_worst` | 50 | **0** |
+| tetwild | `stuck_refine_rings` | 3 | **0** |
+| tetwild | `skip_good_regions` | true | **false** |
+| triwild | `stop_energy` | 20 | **100** |
+| simwild | `skip_simplify` | true | **false** |
+| simwild | `eps_simplify_rel` | 2e-3 | **2e-4** (10x) |
+| simwild | `preserve_topology` | false | **true** |
+| simwild | `stuck_refine_num_worst` | 50 | **0** |
+| simwild | `stuck_refine_rings` | 3 | **0** |
+| simwild | `skip_good_regions` | true | **false** |
+
+The spec is authoritative: it is what every driver run injects. **No integration output moved**,
+which is the expected result — the configs all go through jse. ctest 107/107, so the unit tests
+that construct `Parameters` directly either set these explicitly or are insensitive to them.

--- a/docs/simwild-adopted-behaviours.md
+++ b/docs/simwild-adopted-behaviours.md
@@ -63,3 +63,31 @@ Columns: what simwild did, what it does now, which copy won, and what actually m
 | **why it matters** | A stale `m_is_on_surface` flag makes a genuine surface edge look interior, and swapping it tears the surface. The face-count route consults only the face attributes. |
 | **measured** | No output change on the 6 simwild 3D configs — the flags are not stale on these inputs. |
 | **not changed here** | simwild still *rejects* surface edges in 4-4 and 5-6 where tetwild allows a surface flip via its generalized `prepare_surface_flip`. That is a larger decision, deferred to the 3D base-class merge. |
+
+### 1e. The collapse quality gate — NO CHANGE, the premise was wrong
+
+The duplication survey reported "four mutually incompatible spellings" of the quality gate in
+`collapse_edge_before`:
+
+```
+tetwild     VA[v1_id].m_is_rounded && q > cache.max_energy
+simwild-3D  m_collapse_check_quality && VA[v1_id].m_is_rounded && q > cache.max_energy
+triwild     VA[v1_id].m_is_rounded && q > m_params.stop_energy && q > cache.max_energy
+simwild-2D  VA[v1_id].m_is_rounded && q > target_quality(tid)  && q > cache.max_energy
+```
+
+Checked before changing anything, and they are **two** rules, not four — one per dimension,
+each correctly adapted in simwild:
+
+* `SimWildMeshTri::target_quality(tid)` **defaults to `m_params.stop_energy`** and is only
+  overridden by the per-tag `quality_field`. So simwild-2D's gate *is* triwild's, generalized
+  to per-region targets. Replacing it with `stop_energy` would delete a simwild feature, not
+  fix a divergence.
+* `m_collapse_check_quality` is an extra simwild-only toggle (switched off around `simplify()`),
+  not a changed rule. simwild-3D's gate is otherwise tetwild's exactly.
+
+**The real open question is tetwild vs triwild.** tetwild never permits a collapse that worsens
+the ring's worst element; triwild permits it as long as the result is still below the target.
+They disagree with each other, so "take the tetwild/triwild implementation" cannot resolve it.
+Left alone pending a decision and a measurement. See also 1i, the other tetwild/triwild
+disagreement.

--- a/docs/simwild-adopted-behaviours.md
+++ b/docs/simwild-adopted-behaviours.md
@@ -22,3 +22,44 @@ Columns: what simwild did, what it does now, which copy won, and what actually m
 | **why it matters** | `local_operations` stops the swap loop when a pass changes nothing (`if (cnt_success == 0) break;`). Returning a constant 1 made that early exit unreachable. |
 | **measured** | **No output change** on any of the 8 simwild 2D configs. The loop is bounded by `ops[2]`, which is 1 in every current config, so there was never a second round for the early exit to skip. The defect is real but latent — like the split fallback in #1000, it needs a config that asks for more than one swap round per iteration. |
 | **also adopted** | `parallel_collect_edge_ops` and `run_localized_to_convergence`, which simwild-2D used nowhere. Output-neutral here because the pass converges in one round on these inputs. |
+
+### 1b. `SimWildMeshTri` reports why smoothing was refused
+
+| | |
+|---|---|
+| **was** | `m_smooth_rejects` declared and passed to `smooth_vertex_2d`, but never `reset()` and never logged |
+| **now** | reset at the top of each smoothing pass, `to_string()` logged at the end, as triwild does |
+| **source** | triwild `Smooth.cpp::smooth_all_vertices` |
+| **why it matters** | The counters exist precisely to catch silent failure — `SmoothVertex.hpp:222-228` records tetwild smoothing ZERO vertices for entire runs without anything noticing. Accumulating them across passes and never printing them defeats that. |
+| **measured** | No output change; diagnostics only. |
+
+### 1c. simwild-3D skips the Voronoi search for an un-rounded vertex
+
+| | |
+|---|---|
+| **was** | `if (m_voronoi_split_fn)` |
+| **now** | `if (m_voronoi_split_fn && m_vertex_attribute[v_id].m_is_rounded)` |
+| **source** | the 2D twin, `SimWildMeshTri::split_edge_after`, which already carried the guard and the reasoning |
+| **why it matters** | When the rounded midpoint inverts a tet, the split falls back to the exact rational midpoint. The Voronoi bisection then searches only *doubles* — including the plain double midpoint it reverts to on failure, which is the position that just inverted. Neither tetwild nor triwild has a Voronoi split, so this is simwild-internal: the 2D copy was right and the 3D one had not been updated. |
+| **measured** | No output change: no current config sets `m_voronoi_split_fn` and reaches the fallback. |
+
+### 1d. `SimWildMesh::swap_edge_56_before` stores the max energy it computes
+
+| | |
+|---|---|
+| **was** | computed `max_energy` over the incident tets and dropped it, leaving `cache.max_energy` holding whatever the previous swap op wrote |
+| **now** | `swap_cache.local().max_energy = max_energy;` |
+| **source** | tetwild `EdgeSwapping.cpp:756` |
+| **why it matters** | `swap_cache` is one thread-local shared by the 3-2 / 4-4 / 5-6 ops. Harmless only as long as `swap_edge_56_after` never reads it — but the sibling `swap_edge_44_after` and `swap_edge_after` both do. |
+| **measured** | No output change. |
+
+### 1f. simwild-3D routes swap surface detection on the incident-face count
+
+| | |
+|---|---|
+| **was** | `is_edge_on_surface(t)`, which short-circuits on both endpoints' `m_is_on_surface` flags |
+| **now** | `edge_incident_surface_face_count(t) > 0`, ported from tetwild; applied at all three swap sites (3-2, 4-4, 5-6) |
+| **source** | tetwild `EdgeSwapping.cpp:144-151` and its comment |
+| **why it matters** | A stale `m_is_on_surface` flag makes a genuine surface edge look interior, and swapping it tears the surface. The face-count route consults only the face attributes. |
+| **measured** | No output change on the 6 simwild 3D configs — the flags are not stale on these inputs. |
+| **not changed here** | simwild still *rejects* surface edges in 4-4 and 5-6 where tetwild allows a surface flip via its generalized `prepare_surface_flip`. That is a larger decision, deferred to the 3D base-class merge. |

--- a/docs/simwild-adopted-behaviours.md
+++ b/docs/simwild-adopted-behaviours.md
@@ -1,0 +1,24 @@
+# simwild: behaviours adopted from tetwild / triwild
+
+tetwild and triwild are the mature, heavily-measured applications; simwild is a fork of them
+that drifted. When de-duplicating, the rule is: **wherever the copies disagree, the
+tetwild/triwild implementation wins, and tetwild/triwild output must not move.** simwild output
+may move, and every time it does the reason is recorded here so the simwild side can be
+re-checked later.
+
+Columns: what simwild did, what it does now, which copy won, and what actually moved.
+
+---
+
+## Stage 1 — divergence defects
+
+### 1a. `SimWildMeshTri::swap_all_edges` returns the success count
+
+| | |
+|---|---|
+| **was** | `return true;` — i.e. always 1, whatever happened |
+| **now** | returns `total_success` from `run_localized_to_convergence`, and the pass uses `parallel_collect_edge_ops` + localized retry |
+| **source** | triwild `EdgeSwapping.cpp::swap_all_edges`, which carries the fix and the note |
+| **why it matters** | `local_operations` stops the swap loop when a pass changes nothing (`if (cnt_success == 0) break;`). Returning a constant 1 made that early exit unreachable. |
+| **measured** | **No output change** on any of the 8 simwild 2D configs. The loop is bounded by `ops[2]`, which is 1 in every current config, so there was never a second round for the early exit to skip. The defect is real but latent — like the split fallback in #1000, it needs a config that asks for more than one swap round per iteration. |
+| **also adopted** | `parallel_collect_edge_ops` and `run_localized_to_convergence`, which simwild-2D used nowhere. Output-neutral here because the pass converges in one round on these inputs. |


### PR DESCRIPTION
Second of four stacked PRs de-duplicating tetwild, triwild and simwild. Stacks on #1004.

**These fixes come before the merges, deliberately.** Merging two copies means choosing one behaviour. Making that choice as a side effect of whichever copy happens to seed a shared base is how a refactor smuggles in a behaviour change; making it first, one commit at a time, keeps each choice reviewable on its own.

The copies had already drifted into six real defects. One commit each.

### The policy these follow

Where tetwild/triwild and simwild disagree, **the tetwild/triwild implementation wins**, and every adoption is recorded in `docs/simwild-adopted-behaviours.md` so the simwild side can be re-checked later. tetwild and triwild output must not move; simwild's may.

### The defects

| # | what was wrong | resolution |
|---|---|---|
| 1 | `SimWildMeshTri::swap_all_edges` returned `true` rather than the success count, so the "stop when a pass changes nothing" early exit could never fire | take triwild's |
| 2 | `SimWildMeshTri` never reset or logged `m_smooth_rejects` — counters accumulated and were never printed, defeating the silent-failure diagnostic they exist for | take triwild's |
| 3 | simwild-3D's Voronoi split lacked the un-rounded guard its 2D twin has, so a split that fell back to the exact midpoint could be overwritten with the double midpoint that inverted | simwild-internal; neither reference app has a Voronoi split |
| 4 | `SimWildMesh::swap_edge_56_before` computed `max_energy` and never stored it, leaving the cache holding the previous operation's value | take tetwild's |
| 5 | simwild-3D routed swap surface-detection on the possibly-stale `m_is_on_surface` flag; tetwild uses the direct incident-face count precisely so a stale flag cannot tear the surface | take tetwild's |
| 6 | `SimWildMeshTri` hand-rolled ~100 lines of sizing-field refinement with a different worst-cell filter instead of calling `utils::SizingField`, and had no `skip_good_regions`/`active_vertices` | take triwild's (the shared helper) |

### One survey claim that was wrong, and is documented rather than acted on

The survey reported "the collapse quality gate exists in four mutually incompatible spellings." Measured, it is **two rules, each correctly adapted to its application**: `SimWildMeshTri::target_quality(tid)` *defaults to* `m_params.stop_energy`, and `m_collapse_check_quality` is a simwild toggle around `simplify()`. Applying the policy literally here would have deleted two working simwild features. Resolved as **NO CHANGE**, with the reasoning recorded in the ledger.

### Plus: `Parameters` struct defaults now match their own spec defaults

Fourteen disagreed — tetwild `stop_energy` 10 vs 100, `skip_good_regions` true vs false, simwild `epsr_simplify` off by 10×. The integration configs go through jse and are unaffected, but **the unit tests build `Parameters` directly**, so they were running a different configuration from every driver run. That is the bug being fixed.

### Verification

ctest 107/107. All 53 registered configs and all 30 hidden `[challenging]` models byte-identical for tetwild and triwild. crown/octocat compared separately at `num_threads: 0` against a base-commit build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
