### PR TITLE
dedup 3/4: share what needs no mesh type

### DIFF
--- a/components/simwild/wmtk/components/simwild/EmbedCurves.cpp
+++ b/components/simwild/wmtk/components/simwild/EmbedCurves.cpp
@@ -84,17 +84,7 @@ void EmbedCurves::simplify_curves(
     const int num_threads)
 {
     SampleEnvelope envelope(use_exact_envelope);
-    {
-        std::vector<Vector2d> v(m_V_curves.rows());
-        for (int i = 0; i < m_V_curves.rows(); ++i) {
-            v[i] = m_V_curves.row(i);
-        }
-        std::vector<Vector2i> e(m_E_curves.rows());
-        for (int i = 0; i < m_E_curves.rows(); ++i) {
-            e[i] = m_E_curves.row(i);
-        }
-        envelope.init(v, e, eps);
-    }
+    envelope.init(m_V_curves, m_E_curves, eps);
 
     const int nv_before = int(m_V_curves.rows());
     const int ne_before = int(m_E_curves.rows());

--- a/components/simwild/wmtk/components/simwild/EmbedSurface.cpp
+++ b/components/simwild/wmtk/components/simwild/EmbedSurface.cpp
@@ -1,4 +1,5 @@
 #include "EmbedSurface.hpp"
+#include <wmtk/utils/EmbedTriangles.hpp>
 
 // clang-format off
 #include <igl/remove_unreferenced.h>
@@ -165,290 +166,25 @@ void embed_surface(
         triangle_indices[3 * i + 2] = (uint32_t)F_surface(i, 2);
     }
 
-    // Remesher outputs. Unlike "_old", this variant actually uses the tet-based
-    // outputs: out_tets (the remesher's tetrahedra), final_tets_parent (parent
-    // polyhedral cell of each tet), cells_with_faces_on_input (per-cell flag),
-    // and final_tets_parent_faces (the parent faces bounding each tet). The
-    // embedded_cells polygonal-cell decoding used by "_old" is not needed here.
-    std::vector<vol_rem::bigrational> embedded_vertices;
-    std::vector<uint32_t> embedded_facets;
-    std::vector<uint32_t> embedded_cells;
-    std::vector<uint32_t> embedded_facets_on_input;
-
-    std::vector<std::array<uint32_t, 4>> out_tets;
-    std::vector<uint32_t> final_tets_parent;
-    std::vector<bool> cells_with_faces_on_input;
-    std::vector<std::vector<uint32_t>> final_tets_parent_faces;
-
-    std::vector<double> edge_vrt_coords;
-    std::vector<uint32_t> edge_indexes;
-    std::vector<double> point_coords;
-    std::vector<std::vector<std::array<uint32_t, 4>>> out_triangle_provenance;
-    std::vector<std::vector<std::array<uint32_t, 3>>> out_edge_provenance;
-    std::vector<std::array<uint32_t, 2>> out_point_provenance;
-
-    // Step 3: run the exact arrangement (identical call to the "_old" variant).
-    // volumeremesher embed
-    vol_rem::embed_tri_in_poly_mesh(
+    // Steps 3-5: the exact arrangement and everything that has to happen to its output --
+    // bigrational conversion, facet decoding, surface tracking, vertex compaction and the
+    // per-tet face-flag reorder. Shared with tetwild, which does the same from its own
+    // vector-of-Vector3d inputs.
+    std::vector<bool> polygon_faces_on_input;
+    wmtk::utils::EmbedTrianglesOptions opts;
+    opts.check_orientation = perform_sanity_checks;
+    wmtk::utils::embed_triangles_in_tets(
         tri_vrt_coord,
         triangle_indices,
         tet_vrt_coord,
         tet_indices,
-        embedded_vertices,
-        embedded_facets,
-        embedded_cells,
-        out_tets,
-        final_tets_parent,
-        embedded_facets_on_input,
-        cells_with_faces_on_input,
-        final_tets_parent_faces,
-        edge_vrt_coords,
-        edge_indexes,
-        point_coords,
-        out_triangle_provenance,
-        out_edge_provenance,
-        out_point_provenance,
-        true);
-
-    // Step 4a: copy the arrangement vertices to exact rational Vector3r (same as
-    // "_old"). No compaction yet -- unused vertices are pruned near the end.
-    for (int i = 0; i < embedded_vertices.size() / 3; i++) {
-        v_rational.push_back(Vector3r());
-#ifdef USE_GNU_GMP_CLASSES
-        v_rational.back()[0].init(embedded_vertices[3 * i + 0].get_mpq_t());
-        v_rational.back()[1].init(embedded_vertices[3 * i + 1].get_mpq_t());
-        v_rational.back()[2].init(embedded_vertices[3 * i + 2].get_mpq_t());
-#else
-        v_rational.back()[0].init_from_bin(embedded_vertices[3 * i + 0].get_str());
-        v_rational.back()[1].init_from_bin(embedded_vertices[3 * i + 1].get_str());
-        v_rational.back()[2].init_from_bin(embedded_vertices[3 * i + 2].get_str());
-#endif
-    }
-
-    // Debug-only sanity check: the remesher now returns tets already in the WMTK
-    // orientation ((v1-v0)x(v2-v0).(v3-v0) > 0), so out_tets is used directly (no
-    // orientation fix-up when filling tets_after below). This verification is
-    // exact-rational and O(#tets) -- prohibitively expensive on large meshes --
-    // so it is compiled out of release builds.
-    if (perform_sanity_checks) {
-        logger().info("Check tet orientation after embedding...");
-        for (const auto& vids : out_tets) {
-            Vector3r n = (v_rational[vids[1]] - v_rational[vids[0]])
-                             .cross(v_rational[vids[2]] - v_rational[vids[0]]);
-            Vector3r d = v_rational[vids[3]] - v_rational[vids[0]];
-            auto res = n.dot(d);
-            if (res > 0) {
-                continue;
-            }
-            logger().error(
-                "After embed_tri_in_poly_mesh: Tet {} is inverted! res = {}",
-                vids,
-                res.to_double());
-            for (size_t i = 0; i < vids.size(); ++i) {
-                logger().error("v{} = {}", i, to_double(v_rational[vids[i]]).transpose());
-            }
-        }
-        logger().info("done");
-    }
-
-    // Step 4b: decode embedded_facets into triangles. KEY DIFFERENCE vs "_old":
-    // here every facet must already be a triangle, so the array has a fixed
-    // stride of 4 (1 size prefix + 3 vertex ids). If the remesher ever returns a
-    // non-triangular facet this throws, rather than triangulating it like "_old".
-    logger().info("Facets loop...");
-    polygon_faces.reserve(embedded_facets.size() / 4);
-    for (size_t i = 0; i < embedded_facets.size(); i += 4) {
-        const size_t polysize = embedded_facets[i];
-        if (polysize != 3) {
-            log_and_throw_error("Facets must be triangles!");
-        }
-        std::array<size_t, 3> polygon;
-        for (size_t j = 0; j < 3; ++j) {
-            polygon[j] = embedded_facets[j + i + 1];
-        }
-        polygon_faces.push_back(polygon);
-    }
-    logger().info("done");
-
-    // Per-face on-input-surface flags, same as "_old".
-    logger().info("Tags loop...");
-    std::vector<bool> polygon_faces_on_input(polygon_faces.size(), false);
-    for (size_t i = 0; i < embedded_facets_on_input.size(); ++i) {
-        polygon_faces_on_input[embedded_facets_on_input[i]] = true;
-    }
-    logger().info("done");
-
-    // Step 4c: surface tracking. KEY DIFFERENCE vs "_old": rather than matching
-    // each cell's faces by unordered vertex sets after self-tetrahedralizing, it
-    // uses the remesher-provided metadata. For each output tet it looks at its
-    // parent cell (final_tets_parent) and the parent polygon faces bounding it
-    // (final_tets_parent_faces), and marks the corresponding local tet face.
-    logger().info("tracking surface...");
-    assert(final_tets_parent_faces.size() == out_tets.size());
-    for (size_t i = 0; i < out_tets.size(); ++i) {
-        const auto& tetra = out_tets[i];
-        const uint32_t tetra_parent = final_tets_parent[i];
-
-        // Fast path: if the parent cell has no faces on the input surface, none
-        // of this tet's faces can either -- push four false flags and move on.
-        if (!cells_with_faces_on_input[tetra_parent]) {
-            for (int i = 0; i < 4; ++i) {
-                tet_face_on_input_surface.push_back(false);
-            }
-            continue;
-        }
-
-        // The tet's four faces as sorted vertex sets, opposite each local vertex:
-        // f0 opposite v0, f1 opposite v1, f2 opposite v2, f3 opposite v3. Sorting
-        // lets us compare against each (also sorted) parent face by equality.
-        // vector of std array and sort
-        std::array<size_t, 3> local_f0{{tetra[1], tetra[2], tetra[3]}};
-        std::sort(local_f0.begin(), local_f0.end());
-        std::array<size_t, 3> local_f1{{tetra[0], tetra[2], tetra[3]}};
-        std::sort(local_f1.begin(), local_f1.end());
-        std::array<size_t, 3> local_f2{{tetra[0], tetra[1], tetra[3]}};
-        std::sort(local_f2.begin(), local_f2.end());
-        std::array<size_t, 3> local_f3{{tetra[0], tetra[1], tetra[2]}};
-        std::sort(local_f3.begin(), local_f3.end());
-
-        // For each parent face bounding this tet, find which local face it is and
-        // copy that face's on-input flag into the matching slot.
-        // track surface
-        std::array<bool, 4> tet_face_on_input{{false, false, false, false}};
-        for (const auto& f : final_tets_parent_faces[i]) {
-            assert(polygon_faces[f].size() == 3);
-
-            std::array<size_t, 3> f_vs = polygon_faces[f];
-            std::sort(f_vs.begin(), f_vs.end());
-
-            int64_t local_f_idx = -1;
-
-            // decide which face it is
-
-            if (f_vs == local_f0) {
-                local_f_idx = 0;
-            } else if (f_vs == local_f1) {
-                local_f_idx = 1;
-            } else if (f_vs == local_f2) {
-                local_f_idx = 2;
-            } else if (f_vs == local_f3) {
-                local_f_idx = 3;
-            }
-            if (local_f_idx == -1) {
-                log_and_throw_error("Could not find local index for tracked surface.");
-            }
-
-            tet_face_on_input[local_f_idx] = polygon_faces_on_input[f];
-        }
-
-        for (int k = 0; k < 4; k++) {
-            tet_face_on_input_surface.push_back(tet_face_on_input[k]);
-        }
-    }
-
-    // A vertex is on the input surface iff it is a corner of an on-input facet
-    // (same rule as "_old").
-    // track vertices on input
-    is_v_on_input.resize(v_rational.size(), false);
-    for (int i = 0; i < polygon_faces.size(); i++) {
-        if (polygon_faces_on_input[i]) {
-            is_v_on_input[polygon_faces[i][0]] = true;
-            is_v_on_input[polygon_faces[i][1]] = true;
-            is_v_on_input[polygon_faces[i][2]] = true;
-        }
-    }
-    logger().info("done");
-
-    // Step 4d: compact the vertex set. KEY DIFFERENCE vs "_old", which keeps all
-    // vertices (and even adds centroids): here the remesher's arrangement may
-    // contain vertices not referenced by any output tet, so drop the unused ones.
-    // Build v_map (old id -> new id) over the used vertices, rebuild the coord
-    // and on-input arrays in the new numbering, then remap tets and facets.
-    logger().info("removing unreferenced vertices...");
-    std::vector<bool> v_is_used_in_tet(v_rational.size(), false);
-    for (const auto& t : out_tets) {
-        for (const auto& v : t) {
-            v_is_used_in_tet[v] = true;
-        }
-    }
-    std::vector<int64_t> v_map(v_rational.size(), -1);
-    std::vector<Vector3r> v_coords_final;
-    std::vector<bool> is_v_on_input_buffer;
-
-    for (size_t i = 0; i < v_rational.size(); ++i) {
-        if (v_is_used_in_tet[i]) {
-            v_map[i] = v_coords_final.size();
-            v_coords_final.emplace_back(v_rational[i]);
-            is_v_on_input_buffer.emplace_back(is_v_on_input[i]);
-        }
-    }
-    // update vertices
-    v_rational = v_coords_final;
-    is_v_on_input = is_v_on_input_buffer;
-    // update tets (in place, into the compacted numbering)
-    for (auto& t : out_tets) {
-        for (int i = 0; i < 4; ++i) {
-            assert(v_map[t[i]] >= 0);
-            t[i] = v_map[t[i]];
-        }
-    }
-    // update polygon_faces (in place, into the compacted numbering)
-    for (auto& t : polygon_faces) {
-        for (int i = 0; i < 3; ++i) {
-            assert(v_map[t[i]] >= 0);
-            t[i] = v_map[t[i]];
-        }
-    }
-    logger().info("done");
-
-    // Step 5: publish the tets. makeTetrahedra already emits WMTK-positively
-    // oriented tets, so the vertices are copied straight through -- no swap. Only
-    // the per-tet face flags need reordering: the tracking loop stored them in
-    // "opposite-vertex" order (fl[k] = flag of the face opposite out_tets[i][k]),
-    // which we map to WMTK's local face order.
-    tets_after.resize(out_tets.size());
-    for (size_t i = 0; i < out_tets.size(); ++i) {
-        tets_after[i][0] = out_tets[i][0];
-        tets_after[i][1] = out_tets[i][1];
-        tets_after[i][2] = out_tets[i][2];
-        tets_after[i][3] = out_tets[i][3];
-
-        const bool fl0 = tet_face_on_input_surface[4 * i + 0]; // opp v0
-        const bool fl1 = tet_face_on_input_surface[4 * i + 1]; // opp v1
-        const bool fl2 = tet_face_on_input_surface[4 * i + 2]; // opp v2
-        const bool fl3 = tet_face_on_input_surface[4 * i + 3]; // opp v3
-
-        // WMTK local face order:
-        //   local_f0: (v0, v1, v2) = opposite v3
-        //   local_f1: (v0, v2, v3) = opposite v1
-        //   local_f2: (v0, v1, v3) = opposite v2
-        //   local_f3: (v1, v2, v3) = opposite v0
-        tet_face_on_input_surface[4 * i + 0] = fl3;
-        tet_face_on_input_surface[4 * i + 1] = fl1;
-        tet_face_on_input_surface[4 * i + 2] = fl2;
-        tet_face_on_input_surface[4 * i + 3] = fl0;
-    }
-
-    // final sanity check: every published tet must be positively
-    // oriented under the WMTK convention ((v1-v0)x(v2-v0)).(v3-v0) > 0. Exact-
-    // rational and O(#tets), so it is compiled out of release builds.
-    if (perform_sanity_checks) {
-        logger().info("Check tet orientation after insertion...");
-        for (const auto& vids : tets_after) {
-            Vector3r n = (v_rational[vids[1]] - v_rational[vids[0]])
-                             .cross(v_rational[vids[2]] - v_rational[vids[0]]);
-            Vector3r d = v_rational[vids[3]] - v_rational[vids[0]];
-            auto res = n.dot(d);
-            if (res > 0) {
-                continue;
-            }
-            logger().error("After insertion: Tet {} is inverted! res = {}", vids, res.to_double());
-            for (size_t i = 0; i < vids.size(); ++i) {
-                logger().error("v{} = {}", i, to_double(v_rational[vids[i]]).transpose());
-            }
-        }
-        logger().info("done");
-    }
+        v_rational,
+        polygon_faces,
+        polygon_faces_on_input,
+        is_v_on_input,
+        tets_after,
+        tet_face_on_input_surface,
+        opts);
 
     T_emb.resize(tets_after.size(), 4);
     for (int i = 0; i < tets_after.size(); ++i) {

--- a/components/simwild/wmtk/components/simwild/EmbedSurface.cpp
+++ b/components/simwild/wmtk/components/simwild/EmbedSurface.cpp
@@ -1,4 +1,5 @@
 #include "EmbedSurface.hpp"
+#include <wmtk/utils/DelaunayBoxMesh.hpp>
 #include <wmtk/utils/EmbedTriangles.hpp>
 
 // clang-format off
@@ -37,7 +38,6 @@ void delaunay_box_mesh(
 
     const Vector3d vertices_max = vertices.colwise().maxCoeff();
     const Vector3d vertices_min = vertices.colwise().minCoeff();
-    const double diag = (vertices_max - vertices_min).norm();
 
     ///points for delaunay
     points.resize(vertices.rows());
@@ -46,72 +46,17 @@ void delaunay_box_mesh(
             points[i][j] = vertices(i, j);
         }
     }
-    // bbox
-    double delta = diag / 15.0;
-    box_min = Vector3d(vertices_min[0] - delta, vertices_min[1] - delta, vertices_min[2] - delta);
-    box_max = Vector3d(vertices_max[0] + delta, vertices_max[1] + delta, vertices_max[2] + delta);
 
-    // add corners of domain
-    for (int i = 0; i < 8; i++) {
-        Vector3d p;
-        std::bitset<sizeof(int) * 8> a(i);
-        for (int j = 0; j < 3; j++) {
-            if (a.test(j)) {
-                p[j] = box_max[j];
-            } else {
-                p[j] = box_min[j];
-            }
-        }
-        points.push_back({{p[0], p[1], p[2]}});
-    }
-
-    const double voxel_resolution = diag / 20.0;
-    std::array<int, 3> N; // number of grid points per dimension
-    std::array<double, 3> h; // distance between grid points per dimension
-    for (int i = 0; i < 3; i++) {
-        const double D = box_max[i] - box_min[i];
-        N[i] = (D / voxel_resolution) + 1;
-        h[i] = D / N[i];
-    }
-
-    std::array<std::vector<double>, 3> ds;
-    for (int i = 0; i < 3; i++) {
-        ds[i].push_back(box_min[i]);
-        for (int j = 0; j < N[i] - 1; j++) {
-            ds[i].push_back(box_min[i] + h[i] * (j + 1));
-        }
-        ds[i].push_back(box_max[i]);
-    }
-
-    const double min_dis = voxel_resolution * voxel_resolution / 4;
-    //    double min_dis = state.target_edge_len * state.target_edge_len;//epsilon*2
-    for (int i = 0; i < ds[0].size(); i++) {
-        for (int j = 0; j < ds[1].size(); j++) {
-            for (int k = 0; k < ds[2].size(); k++) {
-                if ((i == 0 || i == ds[0].size() - 1) && (j == 0 || j == ds[1].size() - 1) &&
-                    (k == 0 || k == ds[2].size() - 1)) {
-                    continue;
-                }
-                const Vector3d p(ds[0][i], ds[1][j], ds[2][k]);
-
-                Eigen::Vector3d n;
-                const double sqd = envelope.nearest_point(p, n);
-
-                if (sqd < min_dis) {
-                    continue;
-                }
-                points.push_back({{ds[0][i], ds[1][j], ds[2][k]}});
-            }
-        }
-    }
-
-    ///delaunay
-    std::vector<wmtk::delaunay::Point3D> unused_points;
-    std::tie(unused_points, tets) = wmtk::delaunay::delaunay3D(points);
-    wmtk::logger().info(
-        "after delauney tets.size() = {} | points.size() = {}",
-        tets.size(),
-        points.size());
+    // Unlike tetwild, the box is grown from the bounding box of the very vertices handed in.
+    wmtk::utils::delaunay_box_mesh(
+        envelope,
+        vertices_min,
+        vertices_max,
+        (vertices_max - vertices_min).norm(),
+        points,
+        tets,
+        box_min,
+        box_max);
 }
 
 void embed_surface(

--- a/components/simwild/wmtk/components/simwild/Parameters.h
+++ b/components/simwild/wmtk/components/simwild/Parameters.h
@@ -1,17 +1,26 @@
 #pragma once
+
+#include <wmtk/OptimizerParameters.h>
 #include <nlohmann/json.hpp>
 #include <wmtk/Types.hpp>
 
 namespace wmtk::components::simwild {
-struct Parameters
+/// The fields shared with tetwild and triwild live in wmtk::OptimizerParameters.
+struct Parameters : public wmtk::OptimizerParameters
 {
-    // parameters set by user
-    double epsr = 2e-3; // relative error bound (wrt diagonal)
-    double eps = -1.; // absolute error bound
-    double lr = 5e-2; // target edge length (relative)
-    double l = -1.; // target edge length (absolute)
-    double l_min = -1;
-    bool preserve_topology = true;
+    /**
+     * The four shared fields where simwild deliberately differs from tetwild/triwild. Set here
+     * rather than in the base so the divergence is visible in one place; each matches the
+     * default in simwild_spec.json.
+     */
+    Parameters()
+    {
+        epsr = 2e-3; // tetwild/triwild: 1e-3
+        stop_energy = 10; // tetwild/triwild: 100
+        preserve_topology = true; // tetwild/triwild: false
+        w_envelope = 0; // derived as 1 - w_amips in the mesh constructor
+    }
+
     std::string output_path;
 
     // Allow the 3->2 edge swap to operate on surface edges (a surface diagonal
@@ -23,69 +32,6 @@ struct Parameters
     // across each swap pass. Off by default (used by tests / debugging).
     bool check_surface_topology = false;
 
-    // ---- Stuck-element sizing refinement --------------------------------
-    // Trigger threshold: fire when the last iteration's improvement is small compared
-    // with the distance the max energy still has to cover, i.e. refine when
-    //     (prev_max - max) <= stall_eps * (max - target).
-    // Equivalently: refine unless the mesh is on course to reach the target within
-    // about 1/stall_eps more iterations. 0 => only when it does not improve at all.
-    //
-    // The denominator is the remaining distance, not prev_max, and that is the whole
-    // point. Measured against prev_max, a mesh grinding down at a steady 1.3% per
-    // iteration toward a target far below clears a 1% bar every single iteration and so
-    // never looks stalled -- even though at that rate it needs on the order of a hundred
-    // more iterations and the operations have in fact deadlocked. The escape hatch then
-    // never fires, which is exactly the regime it exists for.
-    double stuck_refine_stall_eps = 0.1;
-    // Cooldown: after a refinement, skip this many improvement iterations before
-    // refining again, so the operations get full passes to act on the new sizing
-    // field before more refinement is added. 0 => may refine every iteration.
-    //
-    // 0 by default: measured over 468 triwild20k models, a cooldown of 1 costs ~13% wall
-    // time for exactly the same mesh sizes (identical median and p90 vertex counts). The
-    // idea that the operations need an idle iteration to act on the new field does not
-    // survive contact with the data -- the trigger already declines to fire while the mesh
-    // is converging, so a separate cooldown only delays the next escape.
-    int stuck_refine_cooldown = 0;
-    // Number of worst tets (by energy) whose neighborhoods are refined.
-    int stuck_refine_num_worst = 0;
-    // Graph rings around each worst tet's vertices included in the refinement.
-    int stuck_refine_rings = 0;
-    // Multiplicative reduction of m_sizing_scalar per refinement (0.5 => /2).
-    double stuck_refine_factor = 0.5;
-    // Lower bound on m_sizing_scalar. Much smaller than the old l_min/l floor;
-    // still far above the position-rounding scale so it stays numerically safe.
-    double stuck_refine_min_scalar = 1e-3;
-    // Gradation cap for the monotone sizing smoothing: neighboring sizings may
-    // differ by at most this factor. The smoothing only ever *lowers* sizings
-    // (spreads refinement outward), never raises the refined values, avoiding
-    // sharp resolution jumps that make operations ill-conditioned.
-    double stuck_refine_gradation = 2.0;
-    // Force-split: when the max energy stalls, split each worst tet's longest edge
-    // once, bypassing the split length gate. This unsticks a sliver whose edges are
-    // too short to be split-eligible, WITHOUT touching the sizing field (which the
-    // *factor ratchet above still drives). Adds at most one split per worst tet per
-    // stall, so it does not bloat the tet count.
-    bool stuck_refine_force_split = true;
-    // When a split's rounded (double) midpoint would invert an incident tet, the
-    // split is normally rejected. If this is on, splits of edges that belong to
-    // the current worst-tet set (the seeds used by refine_sizing_around_worst)
-    // instead fall back to the EXACT rational midpoint (never inverts) and keep
-    // the new vertex un-rounded, so the worst region can still be refined.
-
-    // ---- Skip good regions ----------------------------------------------
-    // Only smooth vertices incident to a tet whose energy is >=
-    // skip_good_regions_margin * stop_energy. Smoothing a vertex surrounded by
-    // good tets does nothing, so skipping it is free (14-16x faster smooth
-    // passes). Only smoothing is gated: gating the topology/sizing ops
-    // (split/collapse/swap) starves the optimizer and blows up the element
-    // count, so those always run over the whole mesh.
-    bool skip_good_regions = false;
-    // Safety margin on the "active" threshold: a tet is active when its energy
-    // (cbrt of m_quality) is >= this fraction of stop_energy, so vertices near
-    // tets sitting just below the target are still smoothed.
-    double skip_good_regions_margin = 0.9;
-
 
     double epsr_simplify = 2e-4; // relative error bound (wrt diagonal) for simplification
     /// Order-2 (open boundary / non-manifold edge) envelope thickness, as a fraction of the
@@ -93,20 +39,9 @@ struct Parameters
     /// see the doc on /order2_envelope_ratio in the spec for the measurement behind 0.5.
     double order2_envelope_ratio = 0.5;
     double eps_simplify = -1.; // absolute error bound for simplification
-
-    // parameters set in `init` function based on mesh bbox
-    double diag_l = -1.;
     VectorXd box_min;
     VectorXd box_max;
-    double splitting_l2 = -1.; // the lower bound length (squared) for edge split
-    double collapsing_l2 =
-        std::numeric_limits<double>::max(); // the upper bound length (squared) for edge collapse
-
-    double stop_energy = 10;
     bool stop_at_float = false;
-
-    bool debug_output = false;
-    bool perform_sanity_checks = false;
 
     /**
      * Verify at init that every surface edge starts inside the envelope (2D remeshing only).
@@ -121,10 +56,6 @@ struct Parameters
      */
     bool check_envelope_at_init = false;
 
-    // weighting terms for the optimization
-    double w_amips = 1e-4;
-    double w_envelope = 0;
-
     std::string operation = "remeshing";
 
     bool skip_simplify = false;
@@ -133,7 +64,6 @@ struct Parameters
     bool write_vtu = false;
     bool write_envelope = true;
 
-    Parameters() = default;
 
     Parameters(const nlohmann::json& json_params)
     {
@@ -186,19 +116,7 @@ struct Parameters
     {
         box_min = min_;
         box_max = max_;
-        diag_l = (box_max - box_min).norm();
-        if (l > 0)
-            lr = l / diag_l;
-        else
-            l = lr * diag_l;
-        splitting_l2 = l * l * (16 / 9.);
-        collapsing_l2 = l * l * (16 / 25.);
-
-        if (eps > 0) {
-            epsr = eps / diag_l;
-        } else {
-            eps = epsr * diag_l;
-        }
+        init_lengths_from_diagonal((box_max - box_min).norm());
 
         if (eps_simplify > 0) {
             epsr_simplify = eps_simplify / diag_l;

--- a/components/simwild/wmtk/components/simwild/SimWildMesh.h
+++ b/components/simwild/wmtk/components/simwild/SimWildMesh.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <igl/Timer.h>
+#include <wmtk/SurfaceTagAttributes.h>
 #include <wmtk/TetMesh.h>
 #include <wmtk/utils/PartitionMesh.h>
 #include <polysolve/nonlinear/Problem.hpp>
@@ -71,37 +72,7 @@ public:
 //     bool m_is_on_open_boundary = false;
 // };
 
-class FaceAttributes
-{
-public:
-    /**
-     * Is this face a part of the surface.
-     */
-    bool m_is_surface_fs = false;
-
-    /**
-     * Keep track which bbox side the face is on
-     * -1: none
-     * 0/1: x min/max
-     * 2/3: y min/max
-     * 4/5: z min/max
-     *
-     * This bbox side ID is used to keep the bbox from collapsing.
-     */
-    int m_is_bbox_fs = -1; //-1; 0~5
-
-    void reset()
-    {
-        m_is_surface_fs = false;
-        m_is_bbox_fs = -1;
-    }
-
-    void merge(const FaceAttributes& attr)
-    {
-        m_is_surface_fs = m_is_surface_fs || attr.m_is_surface_fs;
-        if (attr.m_is_bbox_fs >= 0) m_is_bbox_fs = attr.m_is_bbox_fs;
-    }
-};
+using FaceAttributes = wmtk::SurfaceTagAttributes;
 
 class TetAttributes
 {

--- a/components/simwild/wmtk/components/simwild/SimWildMeshTri.hpp
+++ b/components/simwild/wmtk/components/simwild/SimWildMeshTri.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <wmtk/SurfaceTagAttributes.h>
 #include <limits>
 #include <unordered_set>
 
@@ -57,35 +58,7 @@ struct VertexAttributes
     {}
 };
 
-class EdgeAttributes
-{
-public:
-    double tag; // TODO: is this used?
-
-    bool m_is_surface_fs = false; // 0; 1
-    /**
-     * Keep track which bbox side the face is on
-     * -1: none
-     * 0/1: x min/max
-     * 2/3: y min/max
-     * 4/5: z min/max
-     *
-     * This bbox side ID is used to keep the bbox from collapsing.
-     */
-    int m_is_bbox_fs = -1; //-1; 0~5
-
-    void reset()
-    {
-        m_is_surface_fs = false;
-        m_is_bbox_fs = -1;
-    }
-
-    void merge(const EdgeAttributes& attr)
-    {
-        m_is_surface_fs = m_is_surface_fs || attr.m_is_surface_fs;
-        if (attr.m_is_bbox_fs >= 0) m_is_bbox_fs = attr.m_is_bbox_fs;
-    }
-};
+using EdgeAttributes = wmtk::SurfaceTagAttributes;
 
 class FaceAttributes
 {

--- a/components/simwild/wmtk/components/simwild/simwild.cpp
+++ b/components/simwild/wmtk/components/simwild/simwild.cpp
@@ -222,7 +222,7 @@ void run_3D(const nlohmann::json& json_params, const InputData& input_data)
     if (!report_file.empty()) {
         std::ofstream fout(report_file);
         nlohmann::json report;
-        report["#t"] = mesh.get_faces().size();
+        report["#t"] = mesh.get_tets().size();
         report["#v"] = mesh.get_vertices().size();
         report["max_energy"] = max_energy;
         report["avg_energy"] = avg_energy;

--- a/components/simwild/wmtk/components/simwild/simwild.cpp
+++ b/components/simwild/wmtk/components/simwild/simwild.cpp
@@ -1,4 +1,5 @@
 #include "simwild.hpp"
+#include <wmtk/utils/DriverPrologue.hpp>
 
 
 #include <memory>
@@ -328,34 +329,11 @@ void simwild(nlohmann::json json_params)
 {
     using wmtk::utils::resolve_path;
 
-    // verify input and inject defaults
-    {
-        const auto spec = jse::embed::wmtk_simwild_spec::simwild_spec::spec();
-        jse::JSE spec_engine;
-        spec_engine.strict = true; // detect unknown parameters in the input json
-        bool r = spec_engine.verify_json(json_params, spec);
-        if (!r) {
-            log_and_throw_error(spec_engine.log2str());
-        }
-        json_params = spec_engine.inject_defaults(json_params, spec);
-    }
-
-    const std::filesystem::path root = json_params["input_dir"];
-
-    // logger settings
-    {
-        std::string log_file_name = json_params["log_file"];
-        if (!log_file_name.empty()) {
-            log_file_name = resolve_path(root, log_file_name).string();
-            wmtk::set_file_logger(log_file_name);
-            logger().flush_on(spdlog::level::info);
-        }
-    }
-
-    std::vector<std::string> input_paths = json_params["input"];
-    for (std::string& p : input_paths) {
-        p = resolve_path(root, p).string();
-    }
+    const std::filesystem::path root = utils::verify_and_setup_logger(
+        json_params,
+        jse::embed::wmtk_simwild_spec::simwild_spec::spec(),
+        true);
+    const std::vector<std::string> input_paths = utils::resolve_input_paths(json_params, root);
 
     // std::filesystem::path output_filename = resolve_path(root, json_params["output"]);
     std::filesystem::path output_filename = json_params["output"];

--- a/components/tetwild/wmtk/components/tetwild/DelaunayBoxMesh.cpp
+++ b/components/tetwild/wmtk/components/tetwild/DelaunayBoxMesh.cpp
@@ -1,3 +1,4 @@
+#include <wmtk/utils/DelaunayBoxMesh.hpp>
 #include <wmtk/utils/Rational.hpp>
 #include "TetWildMesh.h"
 
@@ -28,71 +29,24 @@ void TetWildMesh::init_from_delaunay_box_mesh(const std::vector<Eigen::Vector3d>
         for (int j = 0; j < 3; j++) points[i][j] = vertices[i][j];
     }
 
-    // bbox
-    double delta = m_params.diag_l / 15.0;
-    Vector3d box_min(m_params.min[0] - delta, m_params.min[1] - delta, m_params.min[2] - delta);
-    Vector3d box_max(m_params.max[0] + delta, m_params.max[1] + delta, m_params.max[2] + delta);
-
-    // add corners of domain
-    for (int i = 0; i < 8; i++) {
-        Vector3d p;
-        std::bitset<sizeof(int) * 8> a(i);
-        for (int j = 0; j < 3; j++) {
-            if (a.test(j)) {
-                p[j] = box_max[j];
-            } else {
-                p[j] = box_min[j];
-            }
-        }
-        points.push_back({{p[0], p[1], p[2]}});
-    }
-
-    const double voxel_resolution = m_params.diag_l / 20.0;
-    std::array<int, 3> N; // number of grid points per dimension
-    std::array<double, 3> h; // distance between grid points per dimension
-    for (int i = 0; i < 3; i++) {
-        const double D = box_max[i] - box_min[i];
-        N[i] = (D / voxel_resolution) + 1;
-        h[i] = D / N[i];
-    }
-
-    std::array<std::vector<double>, 3> ds;
-    for (int i = 0; i < 3; i++) {
-        ds[i].push_back(box_min[i]);
-        for (int j = 0; j < N[i] - 1; j++) {
-            ds[i].push_back(box_min[i] + h[i] * (j + 1));
-        }
-        ds[i].push_back(box_max[i]);
-    }
-
-    const double min_dis = voxel_resolution * voxel_resolution / 4;
-    //    double min_dis = state.target_edge_len * state.target_edge_len;//epsilon*2
-    for (int i = 0; i < ds[0].size(); i++) {
-        for (int j = 0; j < ds[1].size(); j++) {
-            for (int k = 0; k < ds[2].size(); k++) {
-                if ((i == 0 || i == ds[0].size() - 1) && (j == 0 || j == ds[1].size() - 1) &&
-                    (k == 0 || k == ds[2].size() - 1)) {
-                    continue;
-                }
-                const Vector3d p(ds[0][i], ds[1][j], ds[2][k]);
-
-                Eigen::Vector3d n;
-                const double sqd = m_envelope->nearest_point(p, n);
-
-                if (sqd < min_dis) {
-                    continue;
-                }
-                points.push_back({{ds[0][i], ds[1][j], ds[2][k]}});
-            }
-        }
-    }
+    // The box is grown from the ORIGINAL input bbox (m_params.min/max), not from `vertices`,
+    // which are the SIMPLIFIED surface -- so it is deliberately larger than the point set
+    // being triangulated. m_params.box_min/box_max then hold the padded box, which is what
+    // bbox-face tagging compares vertex coordinates against.
+    std::vector<wmtk::delaunay::Tetrahedron> tets;
+    Vector3d box_min, box_max;
+    wmtk::utils::delaunay_box_mesh(
+        *m_envelope,
+        m_params.min,
+        m_params.max,
+        m_params.diag_l,
+        points,
+        tets,
+        box_min,
+        box_max);
 
     m_params.box_min = box_min;
     m_params.box_max = box_max;
-
-    ///delaunay
-    auto [unused_points, tets] = delaunay::delaunay3D(points);
-    logger().info("after delauney tets.size() {}  points.size() {}", tets.size(), points.size());
 
     // conn
     init(points.size(), tets);

--- a/components/tetwild/wmtk/components/tetwild/Parameters.h
+++ b/components/tetwild/wmtk/components/tetwild/Parameters.h
@@ -1,23 +1,19 @@
 #pragma once
 
+#include <wmtk/OptimizerParameters.h>
+
 namespace wmtk::components::tetwild {
-struct Parameters
+/// The fields shared with triwild and simwild live in wmtk::OptimizerParameters.
+struct Parameters : public wmtk::OptimizerParameters
 {
-    double epsr = 1e-3; // relative error bound (wrt diagonal)
-    double eps = -1.; // absolute error bound
-    double lr = 5e-2; // target edge length (relative)
     /// Order-2 (open boundary / non-manifold edge) envelope thickness, as a fraction of the
     /// surface envelope's. Deliberately below 1 where the surface envelope uses the full eps;
     /// see the doc on /order2_envelope_ratio in the spec for the measurement behind 0.5.
     double order2_envelope_ratio = 0.5;
-    double l = -1.;
-    double l_min = -1;
-    double diag_l = -1.;
     Vector3d min = Vector3d::Zero();
     Vector3d max = Vector3d::Ones();
     Vector3d box_min = Vector3d::Zero();
     Vector3d box_max = Vector3d::Ones();
-    bool preserve_topology = false;
 
     // Allow the edge swaps (3->2, 4-4, 5-6) to operate on surface edges as a
     // topology-preserving surface diagonal flip, instead of forbidding them
@@ -28,75 +24,6 @@ struct Parameters
     // (connected components, Euler characteristic, boundary loops) is unchanged
     // across each swap pass. Off by default (used by tests / debugging).
     bool check_surface_topology = false;
-
-    // ---- Stuck-element sizing refinement --------------------------------
-    // Trigger threshold: fire when the last iteration's improvement is small compared
-    // with the distance the max energy still has to cover, i.e. refine when
-    //     (prev_max - max) <= stall_eps * (max - target).
-    // Equivalently: refine unless the mesh is on course to reach the target within
-    // about 1/stall_eps more iterations. 0 => only when it does not improve at all.
-    //
-    // The denominator is the remaining distance, not prev_max, and that is the whole
-    // point. Measured against prev_max, a mesh grinding down at a steady 1.3% per
-    // iteration toward a target far below clears a 1% bar every single iteration and so
-    // never looks stalled -- even though at that rate it needs on the order of a hundred
-    // more iterations and the operations have in fact deadlocked. The escape hatch then
-    // never fires, which is exactly the regime it exists for.
-    double stuck_refine_stall_eps = 0.1;
-    // Cooldown: after a refinement, skip this many improvement iterations before
-    // refining again, so the operations get full passes to act on the new sizing
-    // field before more refinement is added. 0 => may refine every iteration.
-    //
-    // 0 by default: measured over 468 triwild20k models, a cooldown of 1 costs ~13% wall
-    // time for exactly the same mesh sizes (identical median and p90 vertex counts). The
-    // idea that the operations need an idle iteration to act on the new field does not
-    // survive contact with the data -- the trigger already declines to fire while the mesh
-    // is converging, so a separate cooldown only delays the next escape.
-    int stuck_refine_cooldown = 0;
-    // Number of worst tets (by energy) whose neighborhoods are refined.
-    int stuck_refine_num_worst = 0;
-    // Graph rings around each worst tet's vertices included in the refinement.
-    int stuck_refine_rings = 0;
-    // Multiplicative reduction of m_sizing_scalar per refinement (0.5 => /2).
-    double stuck_refine_factor = 0.5;
-    // Lower bound on m_sizing_scalar. Much smaller than the old l_min/l floor;
-    // still far above the position-rounding scale so it stays numerically safe.
-    double stuck_refine_min_scalar = 1e-3;
-    // Gradation cap for the monotone sizing smoothing: neighboring sizings may
-    // differ by at most this factor. The smoothing only ever *lowers* sizings
-    // (spreads refinement outward), never raises the refined values, avoiding
-    // sharp resolution jumps that make operations ill-conditioned.
-    double stuck_refine_gradation = 2.0;
-    // Force-split: when the max energy stalls, split each worst tet's longest edge
-    // once, bypassing the split length gate. This unsticks a sliver whose edges are
-    // too short to be split-eligible, WITHOUT touching the sizing field (which the
-    // *factor ratchet above still drives). Adds at most one split per worst tet per
-    // stall, so it does not bloat the tet count.
-    bool stuck_refine_force_split = true;
-    // When a split's rounded (double) midpoint would invert an incident tet, the
-    // split is normally rejected. If this is on, splits of edges that belong to
-    // the current worst-tet set (the seeds used by refine_sizing_around_worst)
-    // instead fall back to the EXACT rational midpoint (never inverts) and keep
-    // the new vertex un-rounded, so the worst region can still be refined.
-
-    // ---- Skip good regions ----------------------------------------------
-    // Only smooth vertices incident to a tet whose energy is >=
-    // skip_good_regions_margin * stop_energy. Smoothing a vertex surrounded by
-    // good tets does nothing, so skipping it is free (14-16x faster smooth
-    // passes). Only smoothing is gated: gating the topology/sizing ops
-    // (split/collapse/swap) starves the optimizer and blows up the element
-    // count, so those always run over the whole mesh.
-    bool skip_good_regions = false;
-    // Safety margin on the "active" threshold: a tet is active when its energy
-    // (cbrt of m_quality) is >= this fraction of stop_energy, so vertices near
-    // tets sitting just below the target are still smoothed.
-    double skip_good_regions_margin = 0.9;
-
-    double splitting_l2 = -1.; // the lower bound length (squared) for edge split
-    double collapsing_l2 =
-        std::numeric_limits<double>::max(); // the upper bound length (squared) for edge collapse
-
-    double stop_energy = 100;
 
     /**
      * Incident-tet count above which a vertex is treated as pathological, or 0 to
@@ -113,15 +40,6 @@ struct Parameters
      * vertex in the edge's link, so the gate is applied to the link, not the endpoints.
      */
     int split_high_valence_threshold = 200;
-
-    /**
-     * Relative weight of the AMIPS (quality) term against the envelope (stay-on-surface)
-     * term during smoothing. w_envelope is derived as 1 - w_amips in the TetWildMesh
-     * constructor, so the small default means the envelope dominates and AMIPS acts as a
-     * light quality preference. Matches simwild.
-     */
-    double w_amips = 1e-4;
-    double w_envelope = 1. - 1e-4; // derived; not read from json
 
     /**
      * How many smoothing passes each optimization iteration runs.
@@ -145,26 +63,11 @@ struct Parameters
     bool interleaved_smoothing = true;
     int interleaved_smoothing_passes = 1;
 
-    bool debug_output = false;
-    bool perform_sanity_checks = false;
-
     void init(const Vector3d& min_, const Vector3d& max_)
     {
         min = min_;
         max = max_;
-        diag_l = (max - min).norm();
-        if (l > 0)
-            lr = l / diag_l;
-        else
-            l = lr * diag_l;
-        splitting_l2 = l * l * (16 / 9.);
-        collapsing_l2 = l * l * (16 / 25.);
-
-        if (eps > 0)
-            epsr = eps / diag_l;
-        else
-            eps = epsr * diag_l;
-
+        init_lengths_from_diagonal((max - min).norm());
         l_min = eps;
     }
     void init(

--- a/components/tetwild/wmtk/components/tetwild/TetWildMesh.h
+++ b/components/tetwild/wmtk/components/tetwild/TetWildMesh.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <igl/Timer.h>
+#include <wmtk/SurfaceTagAttributes.h>
 #include <wmtk/TetMesh.h>
 #include <wmtk/utils/PartitionMesh.h>
 #include <algorithm>
@@ -66,25 +67,7 @@ public:
 //     bool m_is_on_open_boundary = false;
 // };
 
-// TODO: missing comments on what these attributes are
-class FaceAttributes
-{
-public:
-    bool m_is_surface_fs = false; // 0; 1
-    int m_is_bbox_fs = -1; //-1; 0~5
-
-    void reset()
-    {
-        m_is_surface_fs = false;
-        m_is_bbox_fs = -1;
-    }
-
-    void merge(const FaceAttributes& attr)
-    {
-        m_is_surface_fs = m_is_surface_fs || attr.m_is_surface_fs;
-        if (attr.m_is_bbox_fs >= 0) m_is_bbox_fs = attr.m_is_bbox_fs;
-    }
-};
+using FaceAttributes = wmtk::SurfaceTagAttributes;
 
 // TODO: missing comments on what these attributes are
 class TetAttributes

--- a/components/tetwild/wmtk/components/tetwild/VolumemesherInsertion.cpp
+++ b/components/tetwild/wmtk/components/tetwild/VolumemesherInsertion.cpp
@@ -3,6 +3,7 @@
 #include <set>
 #include <wmtk/Types.hpp>
 #include <wmtk/threading/parallel_for.hpp>
+#include <wmtk/utils/EmbedTriangles.hpp>
 #include <wmtk/utils/predicates.hpp>
 
 #include "TetWildMesh.h"
@@ -110,318 +111,26 @@ void TetWildMesh::insertion_by_volumeremesher(
         triangle_indices[3 * i + 1] = (int)faces[i][1];
         triangle_indices[3 * i + 2] = (int)faces[i][2];
     }
-
-    // Remesher outputs. The tet-based ones are what this consumes: out_tets (the
-    // remesher's tetrahedra), final_tets_parent (parent polyhedral cell of each
-    // tet), cells_with_faces_on_input (per-cell flag) and final_tets_parent_faces
-    // (the parent faces bounding each tet). embedded_cells is not decoded.
-    std::vector<vol_rem::bigrational> embedded_vertices;
-    std::vector<uint32_t> embedded_facets;
-    std::vector<uint32_t> embedded_cells;
-    std::vector<uint32_t> embedded_facets_on_input;
-
-    std::vector<std::array<uint32_t, 4>> out_tets;
-    std::vector<uint32_t> final_tets_parent;
-    std::vector<bool> cells_with_faces_on_input;
-    std::vector<std::vector<uint32_t>> final_tets_parent_faces;
-
-    // Warn about degenerate (collinear) input triangles before embedding.
-    if (m_params.perform_sanity_checks) {
-        logger().warn("Check collinearity before embedding");
-        for (int i = 0; i < triangle_indices.size(); i += 3) {
-            int id0 = triangle_indices[i + 0];
-            int id1 = triangle_indices[i + 1];
-            int id2 = triangle_indices[i + 2];
-            Vector3d v0(
-                tri_vrt_coord[3 * id0 + 0],
-                tri_vrt_coord[3 * id0 + 1],
-                tri_vrt_coord[3 * id0 + 2]);
-            Vector3d v1(
-                tri_vrt_coord[3 * id1 + 0],
-                tri_vrt_coord[3 * id1 + 1],
-                tri_vrt_coord[3 * id1 + 2]);
-            Vector3d v2(
-                tri_vrt_coord[3 * id2 + 0],
-                tri_vrt_coord[3 * id2 + 1],
-                tri_vrt_coord[3 * id2 + 2]);
-
-            if (utils::predicates::is_degenerate(v0, v1, v2)) {
-                logger().error(
-                    "Face ({}, {}, {}) is collinear!",
-                    v0.transpose(),
-                    v1.transpose(),
-                    v2.transpose());
-            }
-        }
-        logger().warn("Check done");
-    }
-
-    // Step 3: run the exact arrangement.
-    // volumeremesher embed
-    std::vector<double> vr_edge_coords, vr_point_coords;
-    std::vector<uint32_t> vr_edge_indexes;
-    std::vector<std::vector<std::array<uint32_t, 4>>> vr_tri_provenance;
-    std::vector<std::vector<std::array<uint32_t, 3>>> vr_edge_provenance;
-    std::vector<std::array<uint32_t, 2>> vr_point_provenance;
-    vol_rem::embed_tri_in_poly_mesh(
+    // Steps 3-5: the exact arrangement and everything that has to happen to its output --
+    // bigrational conversion, facet decoding, surface tracking, vertex compaction and the
+    // per-tet face-flag reorder. Shared with simwild, which does the same from matrices.
+    std::vector<bool> polygon_faces_on_input;
+    utils::EmbedTrianglesOptions opts;
+    opts.check_collinear_input = m_params.perform_sanity_checks;
+    opts.check_orientation = m_params.perform_sanity_checks;
+    utils::embed_triangles_in_tets(
         tri_vrt_coord,
         triangle_indices,
         tet_vrt_coord,
         tet_indices,
-        embedded_vertices,
-        embedded_facets,
-        embedded_cells,
-        out_tets,
-        final_tets_parent,
-        embedded_facets_on_input,
-        cells_with_faces_on_input,
-        final_tets_parent_faces,
-        vr_edge_coords,
-        vr_edge_indexes,
-        vr_point_coords,
-        vr_tri_provenance,
-        vr_edge_provenance,
-        vr_point_provenance,
-        true);
+        v_rational,
+        polygon_faces,
+        polygon_faces_on_input,
+        is_v_on_input,
+        tets_after,
+        tet_face_on_input_surface,
+        opts);
 
-    // Step 4a: copy the arrangement vertices to exact rational Vector3r. No
-    // compaction yet -- unused vertices are pruned near the end.
-    for (int i = 0; i < embedded_vertices.size() / 3; i++) {
-        v_rational.push_back(Vector3r());
-#ifdef USE_GNU_GMP_CLASSES
-        v_rational.back()[0].init(embedded_vertices[3 * i + 0].get_mpq_t());
-        v_rational.back()[1].init(embedded_vertices[3 * i + 1].get_mpq_t());
-        v_rational.back()[2].init(embedded_vertices[3 * i + 2].get_mpq_t());
-#else
-        v_rational.back()[0].init_from_bin(embedded_vertices[3 * i + 0].get_str());
-        v_rational.back()[1].init_from_bin(embedded_vertices[3 * i + 1].get_str());
-        v_rational.back()[2].init_from_bin(embedded_vertices[3 * i + 2].get_str());
-#endif
-    }
-
-    // Debug-only sanity check: the remesher now returns tets already in the WMTK
-    // orientation ((v1-v0)x(v2-v0).(v3-v0) > 0), so out_tets is used directly (no
-    // orientation fix-up when filling tets_after below). This verification is
-    // exact-rational and O(#tets) -- prohibitively expensive on large meshes --
-    // so it is compiled out of release builds.
-    if (m_params.perform_sanity_checks) {
-        logger().info("Check tet orientation after embedding...");
-        for (const auto& vids : out_tets) {
-            Vector3r n = (v_rational[vids[1]] - v_rational[vids[0]])
-                             .cross(v_rational[vids[2]] - v_rational[vids[0]]);
-            Vector3r d = v_rational[vids[3]] - v_rational[vids[0]];
-            auto res = n.dot(d);
-            if (res > 0) {
-                continue;
-            }
-            logger().error(
-                "After embed_tri_in_poly_mesh: Tet {} is inverted! res = {}",
-                vids,
-                res.to_double());
-            for (size_t i = 0; i < vids.size(); ++i) {
-                logger().error("v{} = {}", i, to_double(v_rational[vids[i]]).transpose());
-            }
-        }
-        logger().info("done");
-    }
-
-
-    // Step 4b: decode embedded_facets into triangles.
-    // here every facet must already be a triangle, so the array has a fixed
-    // stride of 4 (1 size prefix + 3 vertex ids). If the remesher ever returns a
-    // non-triangular facet this throws rather than triangulating it.
-    logger().info("Facets loop...");
-    polygon_faces.reserve(embedded_facets.size() / 4);
-    for (size_t i = 0; i < embedded_facets.size(); i += 4) {
-        const size_t polysize = embedded_facets[i];
-        if (polysize != 3) {
-            log_and_throw_error("Facets must be triangles!");
-        }
-        std::array<size_t, 3> polygon;
-        for (size_t j = 0; j < 3; ++j) {
-            polygon[j] = embedded_facets[j + i + 1];
-        }
-        polygon_faces.push_back(polygon);
-    }
-    logger().info("done");
-
-    // Per-face on-input-surface flags.
-    logger().info("Tags loop...");
-    std::vector<bool> polygon_faces_on_input(polygon_faces.size(), false);
-    for (size_t i = 0; i < embedded_facets_on_input.size(); ++i) {
-        polygon_faces_on_input[embedded_facets_on_input[i]] = true;
-    }
-    logger().info("done");
-
-    // Step 4c: surface tracking, from the remesher-provided metadata. For each
-    // output tet it looks at its parent cell (final_tets_parent) and the parent
-    // polygon faces bounding it (final_tets_parent_faces), and marks the
-    // corresponding local tet face.
-    logger().info("tracking surface...");
-    assert(final_tets_parent_faces.size() == out_tets.size());
-    for (size_t i = 0; i < out_tets.size(); ++i) {
-        const auto& tetra = out_tets[i];
-        const uint32_t tetra_parent = final_tets_parent[i];
-
-        // Fast path: if the parent cell has no faces on the input surface, none
-        // of this tet's faces can either -- push four false flags and move on.
-        if (!cells_with_faces_on_input[tetra_parent]) {
-            for (int i = 0; i < 4; ++i) {
-                tet_face_on_input_surface.push_back(false);
-            }
-            continue;
-        }
-
-        // The tet's four faces as sorted vertex sets, opposite each local vertex:
-        // f0 opposite v0, f1 opposite v1, f2 opposite v2, f3 opposite v3. Sorting
-        // lets us compare against each (also sorted) parent face by equality.
-        // vector of std array and sort
-        std::array<size_t, 3> local_f0{{tetra[1], tetra[2], tetra[3]}};
-        std::sort(local_f0.begin(), local_f0.end());
-        std::array<size_t, 3> local_f1{{tetra[0], tetra[2], tetra[3]}};
-        std::sort(local_f1.begin(), local_f1.end());
-        std::array<size_t, 3> local_f2{{tetra[0], tetra[1], tetra[3]}};
-        std::sort(local_f2.begin(), local_f2.end());
-        std::array<size_t, 3> local_f3{{tetra[0], tetra[1], tetra[2]}};
-        std::sort(local_f3.begin(), local_f3.end());
-
-        // For each parent face bounding this tet, find which local face it is and
-        // copy that face's on-input flag into the matching slot.
-        // track surface
-        std::array<bool, 4> tet_face_on_input{{false, false, false, false}};
-        for (const auto& f : final_tets_parent_faces[i]) {
-            assert(polygon_faces[f].size() == 3);
-
-            std::array<size_t, 3> f_vs = polygon_faces[f];
-            std::sort(f_vs.begin(), f_vs.end());
-
-            int64_t local_f_idx = -1;
-
-            // decide which face it is
-
-            if (f_vs == local_f0) {
-                local_f_idx = 0;
-            } else if (f_vs == local_f1) {
-                local_f_idx = 1;
-            } else if (f_vs == local_f2) {
-                local_f_idx = 2;
-            } else if (f_vs == local_f3) {
-                local_f_idx = 3;
-            }
-            if (local_f_idx == -1) {
-                log_and_throw_error("Could not find local index for tracked surface.");
-            }
-
-            tet_face_on_input[local_f_idx] = polygon_faces_on_input[f];
-        }
-
-        for (int k = 0; k < 4; k++) {
-            tet_face_on_input_surface.push_back(tet_face_on_input[k]);
-        }
-    }
-
-    // A vertex is on the input surface iff it is a corner of an on-input facet
-
-    // track vertices on input
-    is_v_on_input.resize(v_rational.size(), false);
-    for (int i = 0; i < polygon_faces.size(); i++) {
-        if (polygon_faces_on_input[i]) {
-            is_v_on_input[polygon_faces[i][0]] = true;
-            is_v_on_input[polygon_faces[i][1]] = true;
-            is_v_on_input[polygon_faces[i][2]] = true;
-        }
-    }
-    logger().info("done");
-
-    // Step 4d: compact the vertex set. The arrangement may contain vertices not
-    // referenced by any output tet, so drop the unused ones: build v_map (old id
-    // -> new id) over the used vertices, rebuild the coord and on-input arrays in
-    // the new numbering, then remap tets and facets.
-    logger().info("removing unreferenced vertices...");
-    std::vector<bool> v_is_used_in_tet(v_rational.size(), false);
-    for (const auto& t : out_tets) {
-        for (const auto& v : t) {
-            v_is_used_in_tet[v] = true;
-        }
-    }
-    std::vector<int64_t> v_map(v_rational.size(), -1);
-    std::vector<Vector3r> v_coords_final;
-    std::vector<bool> is_v_on_input_buffer;
-
-    for (size_t i = 0; i < v_rational.size(); ++i) {
-        if (v_is_used_in_tet[i]) {
-            v_map[i] = v_coords_final.size();
-            v_coords_final.emplace_back(v_rational[i]);
-            is_v_on_input_buffer.emplace_back(is_v_on_input[i]);
-        }
-    }
-    // update vertices
-    v_rational = v_coords_final;
-    is_v_on_input = is_v_on_input_buffer;
-    // update tets (in place, into the compacted numbering)
-    for (auto& t : out_tets) {
-        for (int i = 0; i < 4; ++i) {
-            assert(v_map[t[i]] >= 0);
-            t[i] = v_map[t[i]];
-        }
-    }
-    // update polygon_faces (in place, into the compacted numbering)
-    for (auto& t : polygon_faces) {
-        for (int i = 0; i < 3; ++i) {
-            assert(v_map[t[i]] >= 0);
-            t[i] = v_map[t[i]];
-        }
-    }
-    logger().info("done");
-
-    // Step 5: publish the tets. makeTetrahedra already emits WMTK-positively
-    // oriented tets, so the vertices are copied straight through -- no swap. Only
-    // the per-tet face flags need reordering: the tracking loop stored them in
-    // "opposite-vertex" order (fl[k] = flag of the face opposite out_tets[i][k]),
-    // which we map to WMTK's local face order.
-    tets_after.resize(out_tets.size());
-    for (size_t i = 0; i < out_tets.size(); ++i) {
-        tets_after[i][0] = out_tets[i][0];
-        tets_after[i][1] = out_tets[i][1];
-        tets_after[i][2] = out_tets[i][2];
-        tets_after[i][3] = out_tets[i][3];
-
-        const bool fl0 = tet_face_on_input_surface[4 * i + 0]; // opp v0
-        const bool fl1 = tet_face_on_input_surface[4 * i + 1]; // opp v1
-        const bool fl2 = tet_face_on_input_surface[4 * i + 2]; // opp v2
-        const bool fl3 = tet_face_on_input_surface[4 * i + 3]; // opp v3
-
-        // WMTK local face order:
-        //   local_f0: (v0, v1, v2) = opposite v3
-        //   local_f1: (v0, v2, v3) = opposite v1
-        //   local_f2: (v0, v1, v3) = opposite v2
-        //   local_f3: (v1, v2, v3) = opposite v0
-        tet_face_on_input_surface[4 * i + 0] = fl3;
-        tet_face_on_input_surface[4 * i + 1] = fl1;
-        tet_face_on_input_surface[4 * i + 2] = fl2;
-        tet_face_on_input_surface[4 * i + 3] = fl0;
-    }
-
-    // final sanity check: every published tet must be positively
-    // oriented under the WMTK convention ((v1-v0)x(v2-v0)).(v3-v0) > 0. Exact-
-    // rational and O(#tets), so it is compiled out of release builds.
-    if (m_params.perform_sanity_checks) {
-        logger().info("Check tet orientation after insertion...");
-        for (const auto& vids : tets_after) {
-            Vector3r n = (v_rational[vids[1]] - v_rational[vids[0]])
-                             .cross(v_rational[vids[2]] - v_rational[vids[0]]);
-            Vector3r d = v_rational[vids[3]] - v_rational[vids[0]];
-            auto res = n.dot(d);
-            if (res > 0) {
-                continue;
-            }
-            logger().error("After insertion: Tet {} is inverted! res = {}", vids, res.to_double());
-            for (size_t i = 0; i < vids.size(); ++i) {
-                logger().error("v{} = {}", i, to_double(v_rational[vids[i]]).transpose());
-            }
-        }
-        logger().info("done");
-    }
 
     // TODO this is a sanity check, but it is checked all the time for now, until insertion is
     // stable.

--- a/components/tetwild/wmtk/components/tetwild/tetwild.cpp
+++ b/components/tetwild/wmtk/components/tetwild/tetwild.cpp
@@ -630,26 +630,10 @@ TetWildMesh::ExportStruct tetwild_with_export(nlohmann::json json_params)
             const int n_samples = 100000;
 
             SampleEnvelope env_in(true);
-            {
-                std::vector<Eigen::Vector3d> v_in;
-                std::vector<Eigen::Vector3i> f_in;
-                v_in.reserve(V.rows());
-                f_in.reserve(F.rows());
-                for (int i = 0; i < V.rows(); ++i) v_in.push_back(V.row(i));
-                for (int i = 0; i < F.rows(); ++i) f_in.push_back(F.row(i));
-                env_in.init(v_in, f_in, params.eps);
-            }
+            env_in.init(V, F, params.eps);
 
             SampleEnvelope env_out(true);
-            {
-                std::vector<Eigen::Vector3d> v_out;
-                std::vector<Eigen::Vector3i> f_out;
-                v_out.reserve(matV.rows());
-                f_out.reserve(matF.rows());
-                for (int i = 0; i < matV.rows(); ++i) v_out.push_back(matV.row(i));
-                for (int i = 0; i < matF.rows(); ++i) f_out.push_back(matF.row(i));
-                env_out.init(v_out, f_out, params.eps);
-            }
+            env_out.init(matV, matF, params.eps);
 
             // Max distance from points sampled on (Vs,Fs) to the surface behind `target`.
             const auto max_deviation = [&](const Eigen::MatrixXd& Vs,

--- a/components/tetwild/wmtk/components/tetwild/tetwild.cpp
+++ b/components/tetwild/wmtk/components/tetwild/tetwild.cpp
@@ -1,4 +1,5 @@
 #include "tetwild.hpp"
+#include <wmtk/utils/DriverPrologue.hpp>
 #include <wmtk/utils/Preallocation.hpp>
 
 #include "Parameters.h"
@@ -87,32 +88,11 @@ TetWildMesh::ExportStruct tetwild_with_export(nlohmann::json json_params)
 {
     using wmtk::utils::resolve_path;
 
-    // verify input and inject defaults
-    {
-        const auto spec = jse::embed::wmtk_tetwild_spec::tetwild_spec::spec();
-        jse::JSE spec_engine;
-        bool r = spec_engine.verify_json(json_params, spec);
-        if (!r) {
-            log_and_throw_error(spec_engine.log2str());
-        }
-        json_params = spec_engine.inject_defaults(json_params, spec);
-    }
-    const std::filesystem::path root = json_params["input_dir"];
-
-    // logger settings
-    {
-        std::string log_file_name = json_params["log_file"];
-        if (!log_file_name.empty()) {
-            log_file_name = resolve_path(root, log_file_name).string();
-            wmtk::set_file_logger(log_file_name);
-            logger().flush_on(spdlog::level::info);
-        }
-    }
-
-    std::vector<std::string> input_paths = json_params["input"];
-    for (std::string& p : input_paths) {
-        p = resolve_path(root, p).string();
-    }
+    const std::filesystem::path root = utils::verify_and_setup_logger(
+        json_params,
+        jse::embed::wmtk_tetwild_spec::tetwild_spec::spec(),
+        false);
+    const std::vector<std::string> input_paths = utils::resolve_input_paths(json_params, root);
 
     tetwild::Parameters params;
 

--- a/components/triwild/wmtk/components/triwild/Parameters.h
+++ b/components/triwild/wmtk/components/triwild/Parameters.h
@@ -1,19 +1,15 @@
 #pragma once
 
+#include <wmtk/OptimizerParameters.h>
+
 #include <nlohmann/json.hpp>
 
 namespace wmtk::components::triwild {
-struct Parameters
+/// The fields shared with tetwild and simwild live in wmtk::OptimizerParameters.
+struct Parameters : public wmtk::OptimizerParameters
 {
-    double epsr = 1e-3; // relative error bound (wrt diagonal)
-    double eps = -1.; // absolute error bound
-    double lr = 5e-2; // target edge length (relative)
-    double l = -1.;
-    double l_min = -1;
-    double diag_l = -1.;
     Vector2d box_min = Vector2d::Zero();
     Vector2d box_max = Vector2d::Ones();
-    bool preserve_topology = false;
 
     /**
      * Keep the curve network's 0-dimensional features -- open polyline endpoints and
@@ -24,15 +20,6 @@ struct Parameters
      * which nothing else refuses. Off only for A/B against the old behaviour.
      */
     bool preserve_feature_points = true;
-
-    double splitting_l2 = -1.; // the lower bound length (squared) for edge split
-    double collapsing_l2 =
-        std::numeric_limits<double>::max(); // the upper bound length (squared) for edge collapse
-
-    double stop_energy = 100;
-
-    bool debug_output = false;
-    bool perform_sanity_checks = false;
 
     /**
      * Verify at init that every constrained edge starts inside the envelope.
@@ -74,15 +61,6 @@ struct Parameters
     int split_high_valence_threshold = 200;
 
     /**
-     * Relative weight of the AMIPS (quality) term against the envelope (stay-on-curve) term
-     * during smoothing. w_envelope is derived as 1 - w_amips in the TriWildMesh constructor,
-     * so the small default means the envelope dominates and AMIPS acts as a light quality
-     * preference. Matches tetwild and simwild.
-     */
-    double w_amips = 1e-4;
-    double w_envelope = 1. - 1e-4; // derived; not read from json
-
-    /**
      * How many smoothing passes each optimization iteration runs.
      *
      * This is ops[3] in local_operations({{split, collapse, swap, smooth}}), which was
@@ -103,78 +81,6 @@ struct Parameters
     // plateaus where split, collapse and swap simply undo each other.
     bool interleaved_smoothing = true;
     int interleaved_smoothing_passes = 1;
-
-    // ---- Stuck-element sizing refinement --------------------------------
-    // Same names, defaults and meaning as tetwild/simwild -- see the specs.
-    //
-    // Trigger threshold: fire when the last iteration's improvement is small compared
-    // with the distance the max energy still has to cover, i.e. refine when
-    //     (prev_max - max) <= stall_eps * (max - stop_energy).
-    // Equivalently: refine unless the mesh is on course to reach the target within
-    // about 1/stall_eps more iterations. 0 => only when it does not improve at all.
-    //
-    // The denominator is the remaining distance, not prev_max, and that is the whole
-    // point. Measured against prev_max, a mesh grinding down at a steady 1.3% per
-    // iteration from 27 toward a target of 5 clears a 1% bar every single iteration and
-    // so never looks stalled -- even though at that rate it needs ~130 more iterations
-    // and the operations have in fact deadlocked. The escape hatch then never fires,
-    // which is exactly the regime it exists for.
-    double stuck_refine_stall_eps = 0.1;
-    // Cooldown: after a refinement, skip this many improvement iterations before
-    // refining again, so the operations get full passes to act on the new sizing
-    // field before more refinement is added. 0 => may refine every iteration.
-    //
-    // 0 by default: measured over 468 triwild20k models, a cooldown of 1 costs ~13% wall
-    // time for exactly the same mesh sizes (identical median and p90 vertex counts). The
-    // idea that the operations need an idle iteration to act on the new field does not
-    // survive contact with the data -- the trigger already declines to fire while the mesh
-    // is converging, so a separate cooldown only delays the next escape.
-    int stuck_refine_cooldown = 0;
-    // Number of worst triangles (by energy) whose neighborhoods are refined.
-    // 0 => every triangle above the filter energy, max(max_energy / 100, stop_energy).
-    // Beware in 2D: the AMIPS2D energy of an equilateral triangle is 2, so a stop_energy
-    // close to that makes the filter catch nearly the whole mesh, and with force_split on
-    // that means thousands of gate-bypassing splits per stall.
-    int stuck_refine_num_worst = 0;
-    // Graph rings around each worst triangle's vertices included in the refinement.
-    int stuck_refine_rings = 0;
-    // Multiplicative reduction of m_sizing_scalar per refinement (0.5 => /2).
-    double stuck_refine_factor = 0.5;
-    // Lower bound on m_sizing_scalar.
-    double stuck_refine_min_scalar = 1e-3;
-    // Gradation cap for the monotone sizing smoothing: neighboring sizings may
-    // differ by at most this factor. The smoothing only ever *lowers* sizings
-    // (spreads refinement outward), never raises the refined values, avoiding
-    // sharp resolution jumps that make operations ill-conditioned.
-    double stuck_refine_gradation = 2.0;
-    // Force-split: when the max energy stalls, split each worst triangle's longest edge
-    // once, bypassing the split length gate. This unsticks a sliver whose edges are
-    // too short to be split-eligible, WITHOUT touching the sizing field.
-    bool stuck_refine_force_split = true;
-    // When a split's rounded (double) midpoint would invert an incident triangle, the
-    // split is normally rejected. If this is on, splits of edges that belong to the
-    // current worst-triangle set instead fall back to the EXACT rational midpoint
-    // (never inverts) and keep the new vertex un-rounded, so the worst region can
-    // still be refined.
-
-    // ---- Skip good regions ----------------------------------------------
-    // Only smooth vertices incident to a triangle whose energy is >=
-    // skip_good_regions_margin * stop_energy. Smoothing a vertex surrounded by
-    // good triangles does nothing, so skipping it is free. Only smoothing is
-    // gated: gating the topology/sizing ops (split/collapse/swap) starves the
-    // optimizer and blows up the element count, so those always run over the
-    // whole mesh.
-    // Off: gating on element quality also skips SURFACE vertices, whose smoothing is driven
-    // almost entirely by the envelope term (w_amips 1e-4), not by the quality of the elements
-    // around them. On 122839 the filtered run exhausted 60 iterations at max energy 21.03
-    // while the unfiltered one converged to 19.9998 in 54 -- and did so in LESS wall time
-    // (875s vs 947s), because needing fewer iterations more than paid for the extra vertices
-    // per pass.
-    bool skip_good_regions = false;
-    // Safety margin on the "active" threshold: a triangle is active when its
-    // energy is >= this fraction of stop_energy, so vertices near triangles
-    // sitting just below the target are still smoothed.
-    double skip_good_regions_margin = 0.9;
 
     Parameters() = default;
 
@@ -221,21 +127,7 @@ struct Parameters
     {
         box_min = min_;
         box_max = max_;
-        diag_l = (box_max - box_min).norm();
-        if (l > 0) {
-            lr = l / diag_l;
-        } else {
-            l = lr * diag_l;
-        }
-        splitting_l2 = l * l * (16 / 9.);
-        collapsing_l2 = l * l * (16 / 25.);
-
-        if (eps > 0) {
-            epsr = eps / diag_l;
-        } else {
-            eps = epsr * diag_l;
-        }
-
+        init_lengths_from_diagonal((box_max - box_min).norm());
         l_min = eps;
     }
     void init(

--- a/components/triwild/wmtk/components/triwild/TriWildMesh.h
+++ b/components/triwild/wmtk/components/triwild/TriWildMesh.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <wmtk/SurfaceTagAttributes.h>
 #include <cstdlib>
 
 #include <wmtk/utils/PartitionMesh.h>
@@ -66,34 +67,7 @@ public:
     VertexAttributes(const Vector2r& p);
 };
 
-class EdgeAttributes
-{
-public:
-    double tag; // TODO: is this used?
-
-    bool m_is_surface_fs = false; // 0; 1
-    /**
-     * Keep track which bbox side the face is on
-     * -1: none
-     * 0/1: x min/max
-     * 2/3: y min/max
-     *
-     * This bbox side ID is used to keep the bbox from collapsing.
-     */
-    int m_is_bbox_fs = -1; //-1; 0~3
-
-    void reset()
-    {
-        m_is_surface_fs = false;
-        m_is_bbox_fs = -1;
-    }
-
-    void merge(const EdgeAttributes& attr)
-    {
-        m_is_surface_fs = m_is_surface_fs || attr.m_is_surface_fs;
-        if (attr.m_is_bbox_fs >= 0) m_is_bbox_fs = attr.m_is_bbox_fs;
-    }
-};
+using EdgeAttributes = wmtk::SurfaceTagAttributes;
 
 class FaceAttributes
 {

--- a/components/triwild/wmtk/components/triwild/triwild.cpp
+++ b/components/triwild/wmtk/components/triwild/triwild.cpp
@@ -1,4 +1,5 @@
 #include "triwild.hpp"
+#include <wmtk/utils/DriverPrologue.hpp>
 #include <wmtk/utils/Preallocation.hpp>
 
 #include <igl/Timer.h>
@@ -167,32 +168,11 @@ void triwild(nlohmann::json json_params)
 {
     using wmtk::utils::resolve_path;
 
-    // verify input and inject defaults
-    {
-        const auto spec = jse::embed::wmtk_triwild_spec::triwild_spec::spec();
-        jse::JSE spec_engine;
-        bool r = spec_engine.verify_json(json_params, spec);
-        if (!r) {
-            log_and_throw_error(spec_engine.log2str());
-        }
-        json_params = spec_engine.inject_defaults(json_params, spec);
-    }
-    const std::filesystem::path root = json_params["input_dir"];
-
-    // logger settings
-    {
-        std::string log_file_name = json_params["log_file"];
-        if (!log_file_name.empty()) {
-            log_file_name = resolve_path(root, log_file_name).string();
-            wmtk::set_file_logger(log_file_name);
-            logger().flush_on(spdlog::level::info);
-        }
-    }
-
-    std::vector<std::string> input_paths = json_params["input"];
-    for (std::string& p : input_paths) {
-        p = resolve_path(root, p).string();
-    }
+    const std::filesystem::path root = utils::verify_and_setup_logger(
+        json_params,
+        jse::embed::wmtk_triwild_spec::triwild_spec::spec(),
+        false);
+    const std::vector<std::string> input_paths = utils::resolve_input_paths(json_params, root);
 
     triwild::Parameters params(json_params);
 

--- a/components/triwild/wmtk/components/triwild/triwild.cpp
+++ b/components/triwild/wmtk/components/triwild/triwild.cpp
@@ -276,17 +276,7 @@ void triwild(nlohmann::json json_params)
         logger().info("skip simplification");
     } else {
         SampleEnvelope simplify_envelope(!simplify_use_sample_envelope);
-        {
-            std::vector<Vector2d> v(V_in.rows());
-            for (int i = 0; i < V_in.rows(); ++i) {
-                v[i] = V_in.row(i);
-            }
-            std::vector<Vector2i> e(E_in.rows());
-            for (int i = 0; i < E_in.rows(); ++i) {
-                e[i] = E_in.row(i);
-            }
-            simplify_envelope.init(v, e, simplify_eps);
-        }
+        simplify_envelope.init(V_in, E_in, simplify_eps);
         const size_t removed = wmtk::utils::simplify_segments(
             V_simp,
             E_simp,

--- a/docs/simwild-adopted-behaviours.md
+++ b/docs/simwild-adopted-behaviours.md
@@ -169,3 +169,20 @@ unit tests do — ran a different configuration than every driver run:
 The spec is authoritative: it is what every driver run injects. **No integration output moved**,
 which is the expected result — the configs all go through jse. ctest 107/107, so the unit tests
 that construct `Parameters` directly either set these explicitly or are insensitive to them.
+
+---
+
+## Stage 2 — extractions
+
+### `report["#t"]` counted faces, not tets, in simwild 3D
+
+| | |
+|---|---|
+| **was** | `report["#t"] = mesh.get_faces().size();` in `run_3D` — on a `TetMesh` that is the number of **faces** |
+| **now** | `mesh.get_tets().size()` |
+| **source** | tetwild reports `tet_size()`, triwild reports `tri_capacity()`; both mean *cells* |
+| **measured** | The 6 simwild 3D configs report `#t` roughly halved — e.g. `simwild_double_sphere_3d` 22456 -> 10897, a ratio of 2.06, which is what a closed tet mesh gives since each interior face is shared by two tets. **The mesh is unchanged**; only the reported number was wrong. |
+
+`run_2D` was already correct: on a `TriMesh` the faces *are* the cells.
+
+Note for future baselines: simwild 3D `#t` values recorded before this change are face counts.

--- a/src/wmtk/OptimizerParameters.h
+++ b/src/wmtk/OptimizerParameters.h
@@ -1,0 +1,139 @@
+#pragma once
+
+#include <limits>
+
+namespace wmtk {
+
+/**
+ * @brief The parameters tetwild, triwild and simwild all share.
+ *
+ * Moved here from tetwild's Parameters.h, which had the fullest field set and the
+ * measurements written down. Each application derives its own Parameters from this and adds
+ * what is genuinely its own.
+ *
+ * Two things deliberately stay in the applications:
+ *
+ *   * **The bounding box.** Its type differs by dimension (Vector3d / Vector2d / VectorXd) and,
+ *     more importantly, so does its MEANING: tetwild's box_min/box_max are the *padded Delaunay
+ *     box* while simwild's are the raw input bbox, and both are compared with `==` against
+ *     vertex coordinates to tag bbox faces. Sharing one field would silently break the tagging
+ *     in one of them. tetwild additionally keeps `min`/`max` for the input bbox.
+ *   * **`l_min`.** tetwild and triwild set it to `eps`, simwild to `0.5 * eps`.
+ *
+ * Defaults here are tetwild's and triwild's, which agree on 20 of the 26 fields below; simwild
+ * overrides the four it differs on, in its own struct, where the divergence is visible.
+ */
+struct OptimizerParameters
+{
+    double epsr = 1e-3; // relative error bound (wrt diagonal)
+    double eps = -1.; // absolute error bound
+    double lr = 5e-2; // target edge length (relative)
+    double l = -1.;
+    double l_min = -1;
+    double diag_l = -1.;
+
+    bool preserve_topology = false;
+
+    // ---- Stuck-element sizing refinement --------------------------------
+    // Trigger threshold: fire when the last iteration's improvement is small compared
+    // with the distance the max energy still has to cover, i.e. refine when
+    //     (prev_max - max) <= stall_eps * (max - target).
+    // Equivalently: refine unless the mesh is on course to reach the target within
+    // about 1/stall_eps more iterations. 0 => only when it does not improve at all.
+    //
+    // The denominator is the remaining distance, not prev_max, and that is the whole
+    // point. Measured against prev_max, a mesh grinding down at a steady 1.3% per
+    // iteration toward a target far below clears a 1% bar every single iteration and so
+    // never looks stalled -- even though at that rate it needs on the order of a hundred
+    // more iterations and the operations have in fact deadlocked. The escape hatch then
+    // never fires, which is exactly the regime it exists for.
+    double stuck_refine_stall_eps = 0.1;
+    // Cooldown: after a refinement, skip this many improvement iterations before
+    // refining again, so the operations get full passes to act on the new sizing
+    // field before more refinement is added. 0 => may refine every iteration.
+    //
+    // 0 by default: measured over 468 triwild20k models, a cooldown of 1 costs ~13% wall
+    // time for exactly the same mesh sizes (identical median and p90 vertex counts). The
+    // idea that the operations need an idle iteration to act on the new field does not
+    // survive contact with the data -- the trigger already declines to fire while the mesh
+    // is converging, so a separate cooldown only delays the next escape.
+    int stuck_refine_cooldown = 0;
+    // Number of worst cells (by energy) whose neighborhoods are refined.
+    int stuck_refine_num_worst = 0;
+    // Graph rings around each worst cell's vertices included in the refinement.
+    int stuck_refine_rings = 0;
+    // Multiplicative reduction of m_sizing_scalar per refinement (0.5 => /2).
+    double stuck_refine_factor = 0.5;
+    // Lower bound on m_sizing_scalar. Much smaller than the old l_min/l floor;
+    // still far above the position-rounding scale so it stays numerically safe.
+    double stuck_refine_min_scalar = 1e-3;
+    // Gradation cap for the monotone sizing smoothing: neighboring sizings may
+    // differ by at most this factor. The smoothing only ever *lowers* sizings
+    // (spreads refinement outward), never raises the refined values, avoiding
+    // sharp resolution jumps that make operations ill-conditioned.
+    double stuck_refine_gradation = 2.0;
+    // Force-split: when the max energy stalls, split each worst cell's longest edge
+    // once, bypassing the split length gate. This unsticks a sliver whose edges are
+    // too short to be split-eligible, WITHOUT touching the sizing field (which the
+    // *factor ratchet above still drives). Adds at most one split per worst cell per
+    // stall, so it does not bloat the element count.
+    bool stuck_refine_force_split = true;
+
+    // ---- Skip good regions ----------------------------------------------
+    // Only smooth vertices incident to a cell whose energy is >=
+    // skip_good_regions_margin * stop_energy. Smoothing a vertex surrounded by
+    // good cells does nothing, so skipping it is free (14-16x faster smooth
+    // passes). Only smoothing is gated: gating the topology/sizing ops
+    // (split/collapse/swap) starves the optimizer and blows up the element
+    // count, so those always run over the whole mesh.
+    bool skip_good_regions = false;
+    // Safety margin on the "active" threshold: a cell is active when its energy is >= this
+    // fraction of stop_energy, so vertices near cells sitting just below the target are
+    // still smoothed.
+    double skip_good_regions_margin = 0.9;
+
+    double splitting_l2 = -1.; // the lower bound length (squared) for edge split
+    double collapsing_l2 =
+        std::numeric_limits<double>::max(); // the upper bound length (squared) for edge collapse
+
+    double stop_energy = 100;
+
+    /**
+     * Relative weight of the AMIPS (quality) term against the envelope (stay-on-surface)
+     * term during smoothing. w_envelope is derived as 1 - w_amips in each mesh's
+     * constructor, so the small default means the envelope dominates and AMIPS acts as a
+     * light quality preference.
+     */
+    double w_amips = 1e-4;
+    double w_envelope = 1. - 1e-4; // derived; not read from json
+
+    bool debug_output = false;
+    bool perform_sanity_checks = false;
+
+    /**
+     * @brief Derive the edge-length and envelope quantities from the bounding-box diagonal.
+     *
+     * The identical algebra in all three applications' init(). The caller computes diag_l from
+     * its own bounding box (whose type and meaning differ -- see the class comment) and sets
+     * its own l_min afterwards.
+     */
+    void init_lengths_from_diagonal(const double diag)
+    {
+        diag_l = diag;
+        if (l > 0) {
+            lr = l / diag_l;
+        } else {
+            l = lr * diag_l;
+        }
+        splitting_l2 = l * l * (16 / 9.);
+        collapsing_l2 = l * l * (16 / 25.);
+
+        if (eps > 0) {
+            epsr = eps / diag_l;
+        } else {
+            eps = epsr * diag_l;
+        }
+    }
+};
+
+} // namespace wmtk

--- a/src/wmtk/SurfaceTagAttributes.h
+++ b/src/wmtk/SurfaceTagAttributes.h
@@ -1,0 +1,35 @@
+#pragma once
+
+namespace wmtk {
+
+/**
+ * @brief Whether a codimension-1 simplex is tracked surface, and which bbox side it lies on.
+ *
+ * The 3D meshes attach this to faces, the 2D meshes to edges; the four copies were
+ * character-identical, `reset()` and `merge()` included.
+ *
+ * `m_is_bbox_fs` is the bbox side the simplex lies on, or -1 for none: 0/1 = x min/max,
+ * 2/3 = y min/max, 4/5 = z min/max. Tagging it is what keeps the bounding box from collapsing.
+ */
+class SurfaceTagAttributes
+{
+public:
+    /// Is this simplex part of the tracked surface.
+    bool m_is_surface_fs = false;
+    /// Which bbox side this simplex is on; -1 for none.
+    int m_is_bbox_fs = -1;
+
+    void reset()
+    {
+        m_is_surface_fs = false;
+        m_is_bbox_fs = -1;
+    }
+
+    void merge(const SurfaceTagAttributes& attr)
+    {
+        m_is_surface_fs = m_is_surface_fs || attr.m_is_surface_fs;
+        if (attr.m_is_bbox_fs >= 0) m_is_bbox_fs = attr.m_is_bbox_fs;
+    }
+};
+
+} // namespace wmtk

--- a/src/wmtk/envelope/Envelope.cpp
+++ b/src/wmtk/envelope/Envelope.cpp
@@ -462,4 +462,35 @@ double SampleEnvelope::squared_distance(const Eigen::Vector2d& p) const
     return d2;
 }
 
+
+void SampleEnvelope::init(const Eigen::MatrixXd& V, const Eigen::MatrixXi& F, const double eps)
+{
+    if (V.cols() == 3 && F.cols() == 3) {
+        std::vector<Eigen::Vector3d> v(V.rows());
+        std::vector<Eigen::Vector3i> f(F.rows());
+        for (int i = 0; i < V.rows(); ++i) v[i] = V.row(i);
+        for (int i = 0; i < F.rows(); ++i) f[i] = F.row(i);
+        init(v, f, eps);
+    } else if (V.cols() == 3 && F.cols() == 2) {
+        std::vector<Eigen::Vector3d> v(V.rows());
+        std::vector<Eigen::Vector2i> e(F.rows());
+        for (int i = 0; i < V.rows(); ++i) v[i] = V.row(i);
+        for (int i = 0; i < F.rows(); ++i) e[i] = F.row(i);
+        init(v, e, eps);
+    } else if (V.cols() == 2 && F.cols() == 2) {
+        std::vector<Eigen::Vector2d> v(V.rows());
+        std::vector<Eigen::Vector2i> e(F.rows());
+        for (int i = 0; i < V.rows(); ++i) v[i] = V.row(i);
+        for (int i = 0; i < F.rows(); ++i) e[i] = F.row(i);
+        init(v, e, eps);
+    } else {
+        log_and_throw_error(
+            "SampleEnvelope::init: unsupported shape V {}x{}, F {}x{}",
+            V.rows(),
+            V.cols(),
+            F.rows(),
+            F.cols());
+    }
+}
+
 } // namespace wmtk

--- a/src/wmtk/envelope/Envelope.hpp
+++ b/src/wmtk/envelope/Envelope.hpp
@@ -123,6 +123,18 @@ public:
         const std::vector<Eigen::Vector2d>& m_ver,
         const std::vector<Eigen::Vector2i>& m_edges,
         const double);
+
+    /**
+     * @brief Same, from Eigen matrices, dispatching on the column counts.
+     *
+     *   V Nx3, F Mx3 -> a 3D triangle envelope
+     *   V Nx3, F Mx2 -> a 3D edge envelope
+     *   V Nx2, F Mx2 -> a 2D edge envelope
+     *
+     * Marshals into the vector form above. Most callers already hold matrices and were each
+     * writing the same ten-line copy loop; this is that loop, once.
+     */
+    void init(const Eigen::MatrixXd& V, const Eigen::MatrixXi& F, const double eps);
     bool is_outside(const std::array<Eigen::Vector3d, 3>& tris) const;
     bool is_outside(const std::array<Eigen::Vector3d, 2>& edge) const;
     bool is_outside(const std::array<Eigen::Vector2d, 2>& edge) const;

--- a/src/wmtk/utils/DelaunayBoxMesh.cpp
+++ b/src/wmtk/utils/DelaunayBoxMesh.cpp
@@ -1,0 +1,87 @@
+#include <wmtk/utils/DelaunayBoxMesh.hpp>
+
+#include <wmtk/utils/Logger.hpp>
+
+#include <bitset>
+
+namespace wmtk::utils {
+
+void delaunay_box_mesh(
+    const SampleEnvelope& envelope,
+    const Vector3d& bbox_min,
+    const Vector3d& bbox_max,
+    const double diag,
+    std::vector<delaunay::Point3D>& points,
+    std::vector<delaunay::Tetrahedron>& tets,
+    Vector3d& box_min,
+    Vector3d& box_max)
+{
+    // bbox
+    const double delta = diag / 15.0;
+    box_min = Vector3d(bbox_min[0] - delta, bbox_min[1] - delta, bbox_min[2] - delta);
+    box_max = Vector3d(bbox_max[0] + delta, bbox_max[1] + delta, bbox_max[2] + delta);
+
+    // add corners of domain
+    for (int i = 0; i < 8; i++) {
+        Vector3d p;
+        std::bitset<sizeof(int) * 8> a(i);
+        for (int j = 0; j < 3; j++) {
+            if (a.test(j)) {
+                p[j] = box_max[j];
+            } else {
+                p[j] = box_min[j];
+            }
+        }
+        points.push_back({{p[0], p[1], p[2]}});
+    }
+
+    const double voxel_resolution = diag / 20.0;
+    std::array<int, 3> N; // number of grid points per dimension
+    std::array<double, 3> h; // distance between grid points per dimension
+    for (int i = 0; i < 3; i++) {
+        const double D = box_max[i] - box_min[i];
+        N[i] = (D / voxel_resolution) + 1;
+        h[i] = D / N[i];
+    }
+
+    std::array<std::vector<double>, 3> ds;
+    for (int i = 0; i < 3; i++) {
+        ds[i].push_back(box_min[i]);
+        for (int j = 0; j < N[i] - 1; j++) {
+            ds[i].push_back(box_min[i] + h[i] * (j + 1));
+        }
+        ds[i].push_back(box_max[i]);
+    }
+
+    const double min_dis = voxel_resolution * voxel_resolution / 4;
+    //    double min_dis = state.target_edge_len * state.target_edge_len;//epsilon*2
+    for (int i = 0; i < ds[0].size(); i++) {
+        for (int j = 0; j < ds[1].size(); j++) {
+            for (int k = 0; k < ds[2].size(); k++) {
+                if ((i == 0 || i == ds[0].size() - 1) && (j == 0 || j == ds[1].size() - 1) &&
+                    (k == 0 || k == ds[2].size() - 1)) {
+                    continue;
+                }
+                const Vector3d p(ds[0][i], ds[1][j], ds[2][k]);
+
+                Eigen::Vector3d n;
+                const double sqd = envelope.nearest_point(p, n);
+
+                if (sqd < min_dis) {
+                    continue;
+                }
+                points.push_back({{ds[0][i], ds[1][j], ds[2][k]}});
+            }
+        }
+    }
+
+
+    std::vector<delaunay::Point3D> unused_points;
+    std::tie(unused_points, tets) = delaunay::delaunay3D(points);
+    logger().info(
+        "after delaunay tets.size() = {} | points.size() = {}",
+        tets.size(),
+        points.size());
+}
+
+} // namespace wmtk::utils

--- a/src/wmtk/utils/DelaunayBoxMesh.hpp
+++ b/src/wmtk/utils/DelaunayBoxMesh.hpp
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <wmtk/Types.hpp>
+#include <wmtk/envelope/Envelope.hpp>
+#include <wmtk/utils/Delaunay.hpp>
+
+#include <vector>
+
+namespace wmtk::utils {
+
+/**
+ * @brief Build the Delaunay background mesh the triangle insertion embeds into.
+ *
+ * Seeds a voxel lattice over the input's bounding box grown by diag/15, drops lattice points
+ * that crowd the input surface, and Delaunay-triangulates the result.
+ *
+ * The bounding box is a **parameter, not derived from `points`**, because the two callers grow
+ * it from different things and both are load-bearing:
+ *
+ *   * tetwild passes `m_params.min/max` and `m_params.diag_l`, which come from the ORIGINAL
+ *     input surface -- but calls this with the SIMPLIFIED vertices, so the box is deliberately
+ *     larger than the point set it is triangulating. It then copies the padded box back into
+ *     `m_params.box_min/box_max`, which is what its bbox-face tagging compares against.
+ *   * simwild passes the bounding box of the very vertices it hands in.
+ *
+ * @param envelope   used only to reject lattice points closer than voxel_resolution^2/4 to the
+ *                   input surface; they would crowd constraints the arrangement is about to
+ *                   refine anyway
+ * @param bbox_min, bbox_max  the UNPADDED box to grow from
+ * @param diag       the diagonal driving both the padding (diag/15) and the voxel size (diag/20)
+ * @param[in,out] points  in: the input vertices as Point3D. out: those plus the 8 box corners
+ *                   and the surviving lattice points
+ * @param[out] tets  the Delaunay tetrahedralization of `points`
+ * @param[out] box_min, box_max  the PADDED box actually used
+ */
+void delaunay_box_mesh(
+    const SampleEnvelope& envelope,
+    const Vector3d& bbox_min,
+    const Vector3d& bbox_max,
+    double diag,
+    std::vector<delaunay::Point3D>& points,
+    std::vector<delaunay::Tetrahedron>& tets,
+    Vector3d& box_min,
+    Vector3d& box_max);
+
+} // namespace wmtk::utils

--- a/src/wmtk/utils/DriverPrologue.hpp
+++ b/src/wmtk/utils/DriverPrologue.hpp
@@ -1,0 +1,68 @@
+#pragma once
+
+#include <wmtk/utils/Logger.hpp>
+#include <wmtk/utils/resolve_path.hpp>
+
+#include <jse/jse.h>
+#include <nlohmann/json.hpp>
+#include <spdlog/common.h>
+
+#include <filesystem>
+#include <string>
+#include <vector>
+
+namespace wmtk::utils {
+
+/**
+ * @brief Verify a driver's json against its spec, inject the defaults, and set up the logger.
+ *
+ * The first thing tetwild, triwild and simwild each do, and they did it with 28 of 29
+ * identical lines.
+ *
+ * @param[in,out] json_params  verified against `spec`, then replaced by the defaults-injected
+ *                             version -- so the caller sees every optional key filled in
+ * @param spec    the component's embedded jse spec
+ * @param strict  reject unknown keys (simwild does; tetwild and triwild do not)
+ * @return the resolved input directory, i.e. json_params["input_dir"]
+ */
+inline std::filesystem::path verify_and_setup_logger(
+    nlohmann::json& json_params,
+    const nlohmann::json& spec,
+    const bool strict = false)
+{
+    {
+        jse::JSE spec_engine;
+        spec_engine.strict = strict;
+        if (!spec_engine.verify_json(json_params, spec)) {
+            log_and_throw_error(spec_engine.log2str());
+        }
+        json_params = spec_engine.inject_defaults(json_params, spec);
+    }
+
+    const std::filesystem::path root = json_params["input_dir"];
+
+    {
+        std::string log_file_name = json_params["log_file"];
+        if (!log_file_name.empty()) {
+            log_file_name = resolve_path(root, log_file_name).string();
+            wmtk::set_file_logger(log_file_name);
+            logger().flush_on(spdlog::level::info);
+        }
+    }
+
+    return root;
+}
+
+/// Resolve every entry of json_params["input"] against `root`.
+inline std::vector<std::string> resolve_input_paths(
+    const nlohmann::json& json_params,
+    const std::filesystem::path& root)
+{
+    std::vector<std::string> input_paths = json_params["input"];
+    for (std::string& p : input_paths) {
+        p = resolve_path(root, p).string();
+    }
+    return input_paths;
+}
+
+} // namespace wmtk::utils

--- a/src/wmtk/utils/DriverPrologue.hpp
+++ b/src/wmtk/utils/DriverPrologue.hpp
@@ -4,8 +4,8 @@
 #include <wmtk/utils/resolve_path.hpp>
 
 #include <jse/jse.h>
-#include <nlohmann/json.hpp>
 #include <spdlog/common.h>
+#include <nlohmann/json.hpp>
 
 #include <filesystem>
 #include <string>

--- a/src/wmtk/utils/EmbedSegments.cpp
+++ b/src/wmtk/utils/EmbedSegments.cpp
@@ -86,17 +86,7 @@ void append_background_grid(const MatrixXd& V, const MatrixXi& E, std::vector<do
     }
 
     SampleEnvelope envelope;
-    {
-        std::vector<Vector2d> V_envelope;
-        std::vector<Vector2i> E_envelope;
-        for (int i = 0; i < E.rows(); i++) {
-            E_envelope.push_back(Vector2i(E(i, 0), E(i, 1)));
-        }
-        for (int i = 0; i < V.rows(); i++) {
-            V_envelope.push_back(V.row(i));
-        }
-        envelope.init(V_envelope, E_envelope, 0);
-    }
+    envelope.init(V, E, 0);
 
     const double min_dis = voxel_resolution * voxel_resolution / 4;
     for (size_t i = 0; i < ds[0].size(); i++) {

--- a/src/wmtk/utils/EmbedTriangles.cpp
+++ b/src/wmtk/utils/EmbedTriangles.cpp
@@ -1,0 +1,343 @@
+#include <wmtk/utils/EmbedTriangles.hpp>
+
+#include <wmtk/utils/Logger.hpp>
+#include <wmtk/utils/predicates.hpp>
+
+// clang-format off
+#include <wmtk/utils/DisableWarnings.hpp>
+#include <VolumeRemesher/embed.h>
+#include <wmtk/utils/EnableWarnings.hpp>
+// clang-format on
+
+#include <set>
+
+namespace wmtk::utils {
+
+void embed_triangles_in_tets(
+    const std::vector<double>& tri_vrt_coord,
+    const std::vector<uint32_t>& triangle_indices,
+    const std::vector<double>& tet_vrt_coord,
+    const std::vector<uint32_t>& tet_indices,
+    std::vector<Vector3r>& v_rational,
+    std::vector<std::array<size_t, 3>>& polygon_faces,
+    std::vector<bool>& polygon_faces_on_input,
+    std::vector<bool>& is_v_on_input,
+    std::vector<std::array<size_t, 4>>& tets_after,
+    std::vector<bool>& tet_face_on_input_surface,
+    const EmbedTrianglesOptions& opts)
+{
+
+    // Remesher outputs. The tet-based ones are what this consumes: out_tets (the
+    // remesher's tetrahedra), final_tets_parent (parent polyhedral cell of each
+    // tet), cells_with_faces_on_input (per-cell flag) and final_tets_parent_faces
+    // (the parent faces bounding each tet). embedded_cells is not decoded.
+    std::vector<vol_rem::bigrational> embedded_vertices;
+    std::vector<uint32_t> embedded_facets;
+    std::vector<uint32_t> embedded_cells;
+    std::vector<uint32_t> embedded_facets_on_input;
+
+    std::vector<std::array<uint32_t, 4>> out_tets;
+    std::vector<uint32_t> final_tets_parent;
+    std::vector<bool> cells_with_faces_on_input;
+    std::vector<std::vector<uint32_t>> final_tets_parent_faces;
+
+    // Warn about degenerate (collinear) input triangles before embedding.
+    if (opts.check_collinear_input) {
+        logger().warn("Check collinearity before embedding");
+        for (int i = 0; i < triangle_indices.size(); i += 3) {
+            int id0 = triangle_indices[i + 0];
+            int id1 = triangle_indices[i + 1];
+            int id2 = triangle_indices[i + 2];
+            Vector3d v0(
+                tri_vrt_coord[3 * id0 + 0],
+                tri_vrt_coord[3 * id0 + 1],
+                tri_vrt_coord[3 * id0 + 2]);
+            Vector3d v1(
+                tri_vrt_coord[3 * id1 + 0],
+                tri_vrt_coord[3 * id1 + 1],
+                tri_vrt_coord[3 * id1 + 2]);
+            Vector3d v2(
+                tri_vrt_coord[3 * id2 + 0],
+                tri_vrt_coord[3 * id2 + 1],
+                tri_vrt_coord[3 * id2 + 2]);
+
+            if (utils::predicates::is_degenerate(v0, v1, v2)) {
+                logger().error(
+                    "Face ({}, {}, {}) is collinear!",
+                    v0.transpose(),
+                    v1.transpose(),
+                    v2.transpose());
+            }
+        }
+        logger().warn("Check done");
+    }
+
+    // Step 3: run the exact arrangement.
+    // volumeremesher embed
+    std::vector<double> vr_edge_coords, vr_point_coords;
+    std::vector<uint32_t> vr_edge_indexes;
+    std::vector<std::vector<std::array<uint32_t, 4>>> vr_tri_provenance;
+    std::vector<std::vector<std::array<uint32_t, 3>>> vr_edge_provenance;
+    std::vector<std::array<uint32_t, 2>> vr_point_provenance;
+    vol_rem::embed_tri_in_poly_mesh(
+        tri_vrt_coord,
+        triangle_indices,
+        tet_vrt_coord,
+        tet_indices,
+        embedded_vertices,
+        embedded_facets,
+        embedded_cells,
+        out_tets,
+        final_tets_parent,
+        embedded_facets_on_input,
+        cells_with_faces_on_input,
+        final_tets_parent_faces,
+        vr_edge_coords,
+        vr_edge_indexes,
+        vr_point_coords,
+        vr_tri_provenance,
+        vr_edge_provenance,
+        vr_point_provenance,
+        true);
+
+    // Step 4a: copy the arrangement vertices to exact rational Vector3r. No
+    // compaction yet -- unused vertices are pruned near the end.
+    for (int i = 0; i < embedded_vertices.size() / 3; i++) {
+        v_rational.push_back(Vector3r());
+#ifdef USE_GNU_GMP_CLASSES
+        v_rational.back()[0].init(embedded_vertices[3 * i + 0].get_mpq_t());
+        v_rational.back()[1].init(embedded_vertices[3 * i + 1].get_mpq_t());
+        v_rational.back()[2].init(embedded_vertices[3 * i + 2].get_mpq_t());
+#else
+        v_rational.back()[0].init_from_bin(embedded_vertices[3 * i + 0].get_str());
+        v_rational.back()[1].init_from_bin(embedded_vertices[3 * i + 1].get_str());
+        v_rational.back()[2].init_from_bin(embedded_vertices[3 * i + 2].get_str());
+#endif
+    }
+
+    // Debug-only sanity check: the remesher now returns tets already in the WMTK
+    // orientation ((v1-v0)x(v2-v0).(v3-v0) > 0), so out_tets is used directly (no
+    // orientation fix-up when filling tets_after below). This verification is
+    // exact-rational and O(#tets) -- prohibitively expensive on large meshes --
+    // so it is compiled out of release builds.
+    if (opts.check_orientation) {
+        logger().info("Check tet orientation after embedding...");
+        for (const auto& vids : out_tets) {
+            Vector3r n = (v_rational[vids[1]] - v_rational[vids[0]])
+                             .cross(v_rational[vids[2]] - v_rational[vids[0]]);
+            Vector3r d = v_rational[vids[3]] - v_rational[vids[0]];
+            auto res = n.dot(d);
+            if (res > 0) {
+                continue;
+            }
+            logger().error(
+                "After embed_tri_in_poly_mesh: Tet {} is inverted! res = {}",
+                vids,
+                res.to_double());
+            for (size_t i = 0; i < vids.size(); ++i) {
+                logger().error("v{} = {}", i, to_double(v_rational[vids[i]]).transpose());
+            }
+        }
+        logger().info("done");
+    }
+
+
+    // Step 4b: decode embedded_facets into triangles.
+    // here every facet must already be a triangle, so the array has a fixed
+    // stride of 4 (1 size prefix + 3 vertex ids). If the remesher ever returns a
+    // non-triangular facet this throws rather than triangulating it.
+    logger().info("Facets loop...");
+    polygon_faces.reserve(embedded_facets.size() / 4);
+    for (size_t i = 0; i < embedded_facets.size(); i += 4) {
+        const size_t polysize = embedded_facets[i];
+        if (polysize != 3) {
+            log_and_throw_error("Facets must be triangles!");
+        }
+        std::array<size_t, 3> polygon;
+        for (size_t j = 0; j < 3; ++j) {
+            polygon[j] = embedded_facets[j + i + 1];
+        }
+        polygon_faces.push_back(polygon);
+    }
+    logger().info("done");
+
+    // Per-face on-input-surface flags.
+    logger().info("Tags loop...");
+    polygon_faces_on_input.assign(polygon_faces.size(), false);
+    for (size_t i = 0; i < embedded_facets_on_input.size(); ++i) {
+        polygon_faces_on_input[embedded_facets_on_input[i]] = true;
+    }
+    logger().info("done");
+
+    // Step 4c: surface tracking, from the remesher-provided metadata. For each
+    // output tet it looks at its parent cell (final_tets_parent) and the parent
+    // polygon faces bounding it (final_tets_parent_faces), and marks the
+    // corresponding local tet face.
+    logger().info("tracking surface...");
+    assert(final_tets_parent_faces.size() == out_tets.size());
+    for (size_t i = 0; i < out_tets.size(); ++i) {
+        const auto& tetra = out_tets[i];
+        const uint32_t tetra_parent = final_tets_parent[i];
+
+        // Fast path: if the parent cell has no faces on the input surface, none
+        // of this tet's faces can either -- push four false flags and move on.
+        if (!cells_with_faces_on_input[tetra_parent]) {
+            for (int i = 0; i < 4; ++i) {
+                tet_face_on_input_surface.push_back(false);
+            }
+            continue;
+        }
+
+        // The tet's four faces as sorted vertex sets, opposite each local vertex:
+        // f0 opposite v0, f1 opposite v1, f2 opposite v2, f3 opposite v3. Sorting
+        // lets us compare against each (also sorted) parent face by equality.
+        // vector of std array and sort
+        std::array<size_t, 3> local_f0{{tetra[1], tetra[2], tetra[3]}};
+        std::sort(local_f0.begin(), local_f0.end());
+        std::array<size_t, 3> local_f1{{tetra[0], tetra[2], tetra[3]}};
+        std::sort(local_f1.begin(), local_f1.end());
+        std::array<size_t, 3> local_f2{{tetra[0], tetra[1], tetra[3]}};
+        std::sort(local_f2.begin(), local_f2.end());
+        std::array<size_t, 3> local_f3{{tetra[0], tetra[1], tetra[2]}};
+        std::sort(local_f3.begin(), local_f3.end());
+
+        // For each parent face bounding this tet, find which local face it is and
+        // copy that face's on-input flag into the matching slot.
+        // track surface
+        std::array<bool, 4> tet_face_on_input{{false, false, false, false}};
+        for (const auto& f : final_tets_parent_faces[i]) {
+            assert(polygon_faces[f].size() == 3);
+
+            std::array<size_t, 3> f_vs = polygon_faces[f];
+            std::sort(f_vs.begin(), f_vs.end());
+
+            int64_t local_f_idx = -1;
+
+            // decide which face it is
+
+            if (f_vs == local_f0) {
+                local_f_idx = 0;
+            } else if (f_vs == local_f1) {
+                local_f_idx = 1;
+            } else if (f_vs == local_f2) {
+                local_f_idx = 2;
+            } else if (f_vs == local_f3) {
+                local_f_idx = 3;
+            }
+            if (local_f_idx == -1) {
+                log_and_throw_error("Could not find local index for tracked surface.");
+            }
+
+            tet_face_on_input[local_f_idx] = polygon_faces_on_input[f];
+        }
+
+        for (int k = 0; k < 4; k++) {
+            tet_face_on_input_surface.push_back(tet_face_on_input[k]);
+        }
+    }
+
+    // A vertex is on the input surface iff it is a corner of an on-input facet
+
+    // track vertices on input
+    is_v_on_input.resize(v_rational.size(), false);
+    for (int i = 0; i < polygon_faces.size(); i++) {
+        if (polygon_faces_on_input[i]) {
+            is_v_on_input[polygon_faces[i][0]] = true;
+            is_v_on_input[polygon_faces[i][1]] = true;
+            is_v_on_input[polygon_faces[i][2]] = true;
+        }
+    }
+    logger().info("done");
+
+    // Step 4d: compact the vertex set. The arrangement may contain vertices not
+    // referenced by any output tet, so drop the unused ones: build v_map (old id
+    // -> new id) over the used vertices, rebuild the coord and on-input arrays in
+    // the new numbering, then remap tets and facets.
+    logger().info("removing unreferenced vertices...");
+    std::vector<bool> v_is_used_in_tet(v_rational.size(), false);
+    for (const auto& t : out_tets) {
+        for (const auto& v : t) {
+            v_is_used_in_tet[v] = true;
+        }
+    }
+    std::vector<int64_t> v_map(v_rational.size(), -1);
+    std::vector<Vector3r> v_coords_final;
+    std::vector<bool> is_v_on_input_buffer;
+
+    for (size_t i = 0; i < v_rational.size(); ++i) {
+        if (v_is_used_in_tet[i]) {
+            v_map[i] = v_coords_final.size();
+            v_coords_final.emplace_back(v_rational[i]);
+            is_v_on_input_buffer.emplace_back(is_v_on_input[i]);
+        }
+    }
+    // update vertices
+    v_rational = v_coords_final;
+    is_v_on_input = is_v_on_input_buffer;
+    // update tets (in place, into the compacted numbering)
+    for (auto& t : out_tets) {
+        for (int i = 0; i < 4; ++i) {
+            assert(v_map[t[i]] >= 0);
+            t[i] = v_map[t[i]];
+        }
+    }
+    // update polygon_faces (in place, into the compacted numbering)
+    for (auto& t : polygon_faces) {
+        for (int i = 0; i < 3; ++i) {
+            assert(v_map[t[i]] >= 0);
+            t[i] = v_map[t[i]];
+        }
+    }
+    logger().info("done");
+
+    // Step 5: publish the tets. makeTetrahedra already emits WMTK-positively
+    // oriented tets, so the vertices are copied straight through -- no swap. Only
+    // the per-tet face flags need reordering: the tracking loop stored them in
+    // "opposite-vertex" order (fl[k] = flag of the face opposite out_tets[i][k]),
+    // which we map to WMTK's local face order.
+    tets_after.resize(out_tets.size());
+    for (size_t i = 0; i < out_tets.size(); ++i) {
+        tets_after[i][0] = out_tets[i][0];
+        tets_after[i][1] = out_tets[i][1];
+        tets_after[i][2] = out_tets[i][2];
+        tets_after[i][3] = out_tets[i][3];
+
+        const bool fl0 = tet_face_on_input_surface[4 * i + 0]; // opp v0
+        const bool fl1 = tet_face_on_input_surface[4 * i + 1]; // opp v1
+        const bool fl2 = tet_face_on_input_surface[4 * i + 2]; // opp v2
+        const bool fl3 = tet_face_on_input_surface[4 * i + 3]; // opp v3
+
+        // WMTK local face order:
+        //   local_f0: (v0, v1, v2) = opposite v3
+        //   local_f1: (v0, v2, v3) = opposite v1
+        //   local_f2: (v0, v1, v3) = opposite v2
+        //   local_f3: (v1, v2, v3) = opposite v0
+        tet_face_on_input_surface[4 * i + 0] = fl3;
+        tet_face_on_input_surface[4 * i + 1] = fl1;
+        tet_face_on_input_surface[4 * i + 2] = fl2;
+        tet_face_on_input_surface[4 * i + 3] = fl0;
+    }
+
+    // final sanity check: every published tet must be positively
+    // oriented under the WMTK convention ((v1-v0)x(v2-v0)).(v3-v0) > 0. Exact-
+    // rational and O(#tets), so it is compiled out of release builds.
+    if (opts.check_orientation) {
+        logger().info("Check tet orientation after insertion...");
+        for (const auto& vids : tets_after) {
+            Vector3r n = (v_rational[vids[1]] - v_rational[vids[0]])
+                             .cross(v_rational[vids[2]] - v_rational[vids[0]]);
+            Vector3r d = v_rational[vids[3]] - v_rational[vids[0]];
+            auto res = n.dot(d);
+            if (res > 0) {
+                continue;
+            }
+            logger().error("After insertion: Tet {} is inverted! res = {}", vids, res.to_double());
+            for (size_t i = 0; i < vids.size(); ++i) {
+                logger().error("v{} = {}", i, to_double(v_rational[vids[i]]).transpose());
+            }
+        }
+        logger().info("done");
+    }
+}
+
+} // namespace wmtk::utils

--- a/src/wmtk/utils/EmbedTriangles.cpp
+++ b/src/wmtk/utils/EmbedTriangles.cpp
@@ -3,6 +3,10 @@
 #include <wmtk/utils/Logger.hpp>
 #include <wmtk/utils/predicates.hpp>
 
+// MatrixBase::cross is declared by Eigen/Core but only DEFINED in Eigen/Geometry, so without
+// this the two normal computations below compile and then fail to link.
+#include <Eigen/Geometry>
+
 // clang-format off
 #include <wmtk/utils/DisableWarnings.hpp>
 #include <VolumeRemesher/embed.h>
@@ -26,7 +30,6 @@ void embed_triangles_in_tets(
     std::vector<bool>& tet_face_on_input_surface,
     const EmbedTrianglesOptions& opts)
 {
-
     // Remesher outputs. The tet-based ones are what this consumes: out_tets (the
     // remesher's tetrahedra), final_tets_parent (parent polyhedral cell of each
     // tet), cells_with_faces_on_input (per-cell flag) and final_tets_parent_faces

--- a/src/wmtk/utils/EmbedTriangles.hpp
+++ b/src/wmtk/utils/EmbedTriangles.hpp
@@ -1,0 +1,70 @@
+#pragma once
+
+#include <wmtk/Types.hpp>
+
+#include <array>
+#include <cstdint>
+#include <vector>
+
+namespace wmtk::utils {
+
+/**
+ * @brief Options for embed_triangles_in_tets. All checks are off by default.
+ */
+struct EmbedTrianglesOptions
+{
+    /// Report input triangles that are collinear, before handing them to the remesher.
+    bool check_collinear_input = false;
+    /// Check every output tet's orientation in exact arithmetic, after embedding and again
+    /// after the vertex compaction.
+    bool check_orientation = false;
+};
+
+/**
+ * @brief Conformally insert a triangle soup into a background tet mesh, exactly.
+ *
+ * Wraps vol_rem::embed_tri_in_poly_mesh (the exact arrangement) and everything that has to
+ * happen to its output before a mesh can be built from it:
+ *
+ *   1. run the arrangement;
+ *   2. convert the remesher's bigrational coordinates to Vector3r;
+ *   3. decode embedded_facets into triangles (fixed stride of 4: one size prefix + 3 vertex
+ *      ids) and recover which are on the input surface;
+ *   4. track the surface onto the output tets, using the remesher's own metadata --
+ *      final_tets_parent (which polyhedral cell each tet came from), final_tets_parent_faces
+ *      (which polygon faces bound it) and cells_with_faces_on_input;
+ *   5. compact away vertices left unreferenced by out_tets and remap every index;
+ *   6. reorder the per-tet face flags into WMTK's local face order.
+ *
+ * Tets come straight from the remesher, so no centroid Steiner points are added and the output
+ * has no extra interior vertices. Orientation is passed through: the remesher already emits
+ * WMTK-positively oriented tets.
+ *
+ * Inputs are flat arrays so the caller marshals from whatever it holds -- tetwild has vectors
+ * of Vector3d, simwild has Eigen matrices -- and only this middle is shared.
+ *
+ * @param tri_vrt_coord      input surface vertices, 3 doubles each, xyz-interleaved
+ * @param triangle_indices   input surface triangles, 3 vertex ids each
+ * @param tet_vrt_coord      background mesh vertices, 3 doubles each
+ * @param tet_indices        background mesh tets, 4 vertex ids each
+ * @param[out] v_rational    arrangement vertices, exact
+ * @param[out] polygon_faces output triangular facets
+ * @param[out] polygon_faces_on_input  per facet: does it lie on the input surface
+ * @param[out] is_v_on_input per vertex: is it a corner of an on-input facet
+ * @param[out] tets_after    output tets
+ * @param[out] tet_face_on_input_surface  4 flags per tet, in WMTK local face order
+ */
+void embed_triangles_in_tets(
+    const std::vector<double>& tri_vrt_coord,
+    const std::vector<uint32_t>& triangle_indices,
+    const std::vector<double>& tet_vrt_coord,
+    const std::vector<uint32_t>& tet_indices,
+    std::vector<Vector3r>& v_rational,
+    std::vector<std::array<size_t, 3>>& polygon_faces,
+    std::vector<bool>& polygon_faces_on_input,
+    std::vector<bool>& is_v_on_input,
+    std::vector<std::array<size_t, 4>>& tets_after,
+    std::vector<bool>& tet_face_on_input_surface,
+    const EmbedTrianglesOptions& opts = {});
+
+} // namespace wmtk::utils


### PR DESCRIPTION
Third of four stacked PRs de-duplicating tetwild, triwild and simwild. Stacks on #1005.

Everything here is **independent of the mesh type**, so it needs no class hierarchy and no templates — it can move to `wmtk::` as plain functions and structs. Doing it before the base classes keeps that PR to the part that genuinely needs inheritance.

### What moves

| new | replaces | note |
|---|---|---|
| `wmtk::OptimizerParameters` | the 26 fields common to all three `Parameters.h`, plus the identical length/epsilon algebra as `init_lengths_from_diagonal` | `box_min`/`box_max` and `l_min` deliberately stay per-app — see the trap below |
| `wmtk::utils::embed_triangles_in_tets` | `tetwild/VolumemesherInsertion.cpp` and `simwild/EmbedSurface.cpp` — 291 of ~360 lines identical, including one **182-line byte-identical run**, comments included | takes flat arrays so each caller marshals from what it holds |
| `wmtk::utils::delaunay_box_mesh` | two copies, 59/88 identical | |
| `SampleEnvelope::init(MatrixXd, MatrixXi, double)` | the marshalling loop appeared at 19 sites; **5** actually start from Eigen matrices and are converted | the survey said 12; it was measured |
| `wmtk::utils::verify_and_setup_logger` + `resolve_input_paths` | the driver prologue, **28 of 29 identical lines** across all three drivers | |
| `wmtk::SurfaceTagAttributes` | four character-identical structs (`m_is_surface_fs`, `m_is_bbox_fs`, `reset()`, `merge()`) | |

### The trap worth knowing about

`delaunay_box_mesh` takes the bounding box as a **parameter rather than deriving it from the points**, and that is load-bearing. tetwild passes a box grown from the ORIGINAL input surface while calling the function with the SIMPLIFIED vertices — so the box is deliberately larger than the point set being triangulated — and then copies the padded box back into `m_params.box_min/box_max`, which is what its bbox-face tagging compares against. Deriving the box inside the shared function would have silently changed tetwild's box and, with it, which faces get tagged. simwild passes the bounding box of the very vertices it hands in. Both callers are correct; only a parameter serves both.

### One deliberate output change (simwild only)

`report["#t"]` in simwild's `run_3D` used `mesh.get_faces().size()` — on a `TetMesh` that counts **faces**, where tetwild and triwild both report *cells*. Now `get_tets().size()`. The six simwild 3D configs report roughly half what they did (`simwild_double_sphere_3d` 22456 → 10897, a ratio of 2.06, which is what a closed tet mesh gives since each interior face is shared by two tets). **The mesh is unchanged**; only the reported number was wrong. `run_2D` was already right, since on a `TriMesh` the faces are the cells.

Recorded in `docs/simwild-adopted-behaviours.md`, including the note that simwild 3D `#t` values in any baseline captured before this commit are face counts.

### Verification

ctest 107/107. All 53 registered configs and all 30 hidden `[challenging]` models byte-identical apart from the `#t` correction above. crown/octocat compared separately at `num_threads: 0` against a base-commit build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
