### PR TITLE
dedup 4/4: give each mesh pair a shared optimizer base

### DIFF
--- a/components/simwild/wmtk/components/simwild/EdgeCollapsing.cpp
+++ b/components/simwild/wmtk/components/simwild/EdgeCollapsing.cpp
@@ -402,7 +402,7 @@ void SimWildMesh::simplify()
 
     // re-build envelope
     m_envelope->use_exact = false;
-    m_envelope->init(m_V_envelope, m_F_envelope, m_params.eps_simplify);
+    m_envelope->init(m_V_envelope, m_F_envelope, m_sim_params.eps_simplify);
 
     m_collapse_check_quality = false;
     collapse_all_edges();

--- a/components/simwild/wmtk/components/simwild/EdgeSwapping.cpp
+++ b/components/simwild/wmtk/components/simwild/EdgeSwapping.cpp
@@ -89,7 +89,7 @@ size_t SimWildMesh::swap_all_edges_32()
     time = timer.getElapsedTime();
     logger().info("edge swap prepare time: {:.4}s", time);
     SurfaceTopoSignature sig_before;
-    if (m_params.check_surface_topology) {
+    if (m_sim_params.check_surface_topology) {
         sig_before = surface_topology_signature();
     }
     auto setup_and_execute = [&](auto& executor) {
@@ -107,7 +107,7 @@ size_t SimWildMesh::swap_all_edges_32()
         setup_and_execute(executor);
         time = timer.getElapsedTime();
         logger().info("edge swap operation time parallel: {:.4}s", time);
-        if (m_params.check_surface_topology) {
+        if (m_sim_params.check_surface_topology) {
             warn_if_surface_topology_changed(sig_before, "swap_all_edges_32");
         }
         return executor.get_cnt_success();
@@ -117,7 +117,7 @@ size_t SimWildMesh::swap_all_edges_32()
         setup_and_execute(executor);
         time = timer.getElapsedTime();
         logger().info("edge swap operation time serial: {:.4}s", time);
-        if (m_params.check_surface_topology) {
+        if (m_sim_params.check_surface_topology) {
             warn_if_surface_topology_changed(sig_before, "swap_all_edges_32");
         }
         return executor.get_cnt_success();
@@ -173,7 +173,7 @@ bool SimWildMesh::swap_edge_before(const Tuple& t)
     // mistaken for interior because of a stale m_is_on_surface flag, which would tear the
     // surface. tetwild routes all three swap paths this way.
     if (edge_incident_surface_face_count(t) > 0) {
-        if (!m_params.allow_surface_swap) {
+        if (!m_sim_params.allow_surface_swap) {
             return false;
         }
         if (!prepare_surface_flip_32(t, incident_tets)) {
@@ -492,7 +492,7 @@ size_t SimWildMesh::swap_all_edges_all()
     time = timer.getElapsedTime();
     logger().info("edge swap prepare time: {:.4}s", time);
     SurfaceTopoSignature sig_before;
-    if (m_params.check_surface_topology) {
+    if (m_sim_params.check_surface_topology) {
         sig_before = surface_topology_signature();
     }
     auto setup_and_execute = [&](auto& executor) {
@@ -528,7 +528,7 @@ size_t SimWildMesh::swap_all_edges_all()
         setup_and_execute(executor);
         time = timer.getElapsedTime();
         logger().info("edge swap operation time parallel: {:.4}s", time);
-        if (m_params.check_surface_topology) {
+        if (m_sim_params.check_surface_topology) {
             warn_if_surface_topology_changed(sig_before, "swap_all_edges_32");
         }
         return executor.get_cnt_success();
@@ -538,7 +538,7 @@ size_t SimWildMesh::swap_all_edges_all()
         setup_and_execute(executor);
         time = timer.getElapsedTime();
         logger().info("edge swap operation time serial: {:.4}s", time);
-        if (m_params.check_surface_topology) {
+        if (m_sim_params.check_surface_topology) {
             warn_if_surface_topology_changed(sig_before, "swap_all_edges_32");
         }
         return executor.get_cnt_success();
@@ -618,21 +618,6 @@ bool SimWildMesh::swap_edge_44_before(const Tuple& t)
     face_attribute_tracker(*this, incident_tets, m_face_attribute, cache.changed_faces);
 
     return true;
-}
-
-double SimWildMesh::swap_edge_44_energy(
-    const std::vector<std::array<size_t, 4>>& tets,
-    const int op_case)
-{
-    double max_energy = -1;
-    for (const auto& vids : tets) {
-        if (is_inverted(vids)) {
-            return std::numeric_limits<double>::max();
-        }
-        const double e = get_quality(vids);
-        max_energy = std::max(max_energy, e);
-    }
-    return max_energy;
 }
 
 bool SimWildMesh::swap_edge_44_after(const Tuple& t)
@@ -736,21 +721,6 @@ bool SimWildMesh::swap_edge_56_before(const Tuple& t)
         swap_cache.local().changed_faces);
 
     return true;
-}
-
-double SimWildMesh::swap_edge_56_energy(
-    const std::vector<std::array<size_t, 4>>& tets,
-    const int op_case)
-{
-    double max_energy = -1;
-    for (const auto& vids : tets) {
-        if (is_inverted(vids)) {
-            return std::numeric_limits<double>::max();
-        }
-        const double e = get_quality(vids);
-        max_energy = std::max(max_energy, e);
-    }
-    return max_energy;
 }
 
 bool SimWildMesh::swap_edge_56_after(const Tuple& t)

--- a/components/simwild/wmtk/components/simwild/SimWildMesh.cpp
+++ b/components/simwild/wmtk/components/simwild/SimWildMesh.cpp
@@ -33,15 +33,9 @@
 namespace wmtk::components::simwild {
 
 
-VertexAttributes::VertexAttributes(const Vector3r& p)
-{
-    m_pos = p;
-    m_posf = to_double(p);
-}
-
 void SimWildMesh::mesh_improvement(int max_its)
 {
-    if (all_rounded() && m_params.stop_at_float) {
+    if (all_rounded() && m_sim_params.stop_at_float) {
         logger().info("===== All vertices are rounded. Stop. =====");
         return;
     }
@@ -84,14 +78,14 @@ void SimWildMesh::mesh_improvement(int max_its)
         consolidate_mesh();
 
         // output_faces(
-        //     m_params.output_path + "after_iter" + std::to_string(it) + ".obj",
+        //     m_sim_params.output_path + "after_iter" + std::to_string(it) + ".obj",
         //     [](auto& f) { return f.m_is_surface_fs; });
 
-        // output_mesh(m_params.output_path + "after_iter" + std::to_string(it) + ".msh");
+        // output_mesh(m_sim_params.output_path + "after_iter" + std::to_string(it) + ".msh");
 
         logger().info("V = {}, T = {}", vert_capacity(), tet_capacity());
 
-        if (all_rounded() && m_params.stop_at_float) {
+        if (all_rounded() && m_sim_params.stop_at_float) {
             logger().info("All vertices are rounded. Stop.");
             break;
         }
@@ -498,32 +492,6 @@ size_t SimWildMesh::refine_sizing_around_worst()
     return refined.size();
 }
 
-void SimWildMesh::gradation_smooth_sizing(double grade, const std::vector<size_t>& seeds)
-{
-    utils::gradation_smooth_sizing(
-        grade,
-        seeds,
-        [this](size_t v) -> double& { return m_vertex_attribute[v].m_sizing_scalar; },
-        [this](size_t v) { return get_one_ring_vids_for_vertex_adj(v); });
-}
-
-/////////////////////////////////////////////////////////////////////
-void SimWildMesh::output_faces(std::string file, std::function<bool(const FaceAttributes&)> cond)
-{
-    auto outface = get_faces_by_condition(cond);
-    Eigen::MatrixXd matV = Eigen::MatrixXd::Zero(vert_capacity(), 3);
-    for (const auto& v : get_vertices()) {
-        auto vid = v.vid(*this);
-        matV.row(vid) = m_vertex_attribute[vid].m_posf;
-    }
-    Eigen::MatrixXi matF(outface.size(), 3);
-    for (auto i = 0; i < outface.size(); i++) {
-        matF.row(i) << outface[i][0], outface[i][1], outface[i][2];
-    }
-    logger().info("Output face size {}", outface.size());
-    igl::write_triangle_mesh(file, matV, matF);
-}
-
 
 void SimWildMesh::init_envelope(const MatrixXd& V, const MatrixXi& F, const bool use_exact)
 {
@@ -665,228 +633,6 @@ void SimWildMesh::write_msh(std::string file, const bool write_envelope)
     msh.save(file, true);
 }
 
-std::tuple<double, double> SimWildMesh::get_max_avg_energy()
-{
-    double max_energy = -1.;
-    double avg_energy = 0.;
-    auto cnt = 0;
-
-    for (int i = 0; i < tet_capacity(); i++) {
-        auto tup = tuple_from_tet(i);
-        if (!tup.is_valid(*this)) continue;
-        // auto vs = oriented_tet_vertices(tup);
-
-        auto q = m_tet_attribute[tup.tid(*this)].m_quality;
-        max_energy = std::max(max_energy, q);
-        // if (q > 1e6) {
-        //     for (auto v : vs) {
-        //         large_tet << "v " << m_vertex_attribute[v.vid(*this)].m_posf[0] << " "
-        //                   << m_vertex_attribute[v.vid(*this)].m_posf[1] << " "
-        //                   << m_vertex_attribute[v.vid(*this)].m_posf[2] << std::endl;
-        //     }
-        // }
-        avg_energy += std::cbrt(q);
-        cnt++;
-    }
-
-    avg_energy /= cnt;
-
-    return std::make_tuple(std::cbrt(max_energy), avg_energy);
-}
-
-std::vector<size_t> SimWildMesh::active_vertices() const
-{
-    // "Surface vertices are always active, independent of the incident tet quality" used to
-    // be open-coded here. It now lives in utils::active_vertices, so tetwild and triwild --
-    // which lacked it, and consequently smoothed nothing at all on well-shaped meshes -- get
-    // it too.
-    return utils::active_vertices(
-        vert_capacity(),
-        tet_capacity(),
-        [this](size_t tid) { return tuple_from_tet(tid).is_valid(*this); },
-        [this](size_t tid) { return m_tet_attribute[tid].m_quality; },
-        [this](size_t tid) { return oriented_tet_vids(tid); },
-        active_quality_threshold(),
-        [this](size_t vid) { return m_vertex_attribute[vid].m_is_on_surface; });
-}
-
-bool SimWildMesh::is_inverted_f(const Tuple& loc) const
-{
-    auto vs = oriented_tet_vertices(loc);
-
-    igl::predicates::exactinit();
-    auto res = igl::predicates::orient3d(
-        m_vertex_attribute[vs[0].vid(*this)].m_posf,
-        m_vertex_attribute[vs[1].vid(*this)].m_posf,
-        m_vertex_attribute[vs[2].vid(*this)].m_posf,
-        m_vertex_attribute[vs[3].vid(*this)].m_posf);
-    int result;
-    if (res == igl::predicates::Orientation::POSITIVE)
-        result = 1;
-    else if (res == igl::predicates::Orientation::NEGATIVE)
-        result = -1;
-    else
-        result = 0;
-
-    if (result < 0) // neg result == pos tet (tet origin from geogram delaunay)
-        return false;
-    return true;
-}
-
-bool SimWildMesh::is_inverted(const std::array<size_t, 4>& vs) const
-{
-    // Return a positive value if the point pd lies below the
-    // plane passing through pa, pb, and pc; "below" is defined so
-    // that pa, pb, and pc appear in counterclockwise order when
-    // viewed from above the plane.
-
-    if (m_vertex_attribute[vs[0]].m_is_rounded && m_vertex_attribute[vs[1]].m_is_rounded &&
-        m_vertex_attribute[vs[2]].m_is_rounded && m_vertex_attribute[vs[3]].m_is_rounded) {
-        igl::predicates::exactinit();
-        auto res = igl::predicates::orient3d(
-            m_vertex_attribute[vs[0]].m_posf,
-            m_vertex_attribute[vs[1]].m_posf,
-            m_vertex_attribute[vs[2]].m_posf,
-            m_vertex_attribute[vs[3]].m_posf);
-        int result;
-        if (res == igl::predicates::Orientation::POSITIVE)
-            result = 1;
-        else if (res == igl::predicates::Orientation::NEGATIVE)
-            result = -1;
-        else
-            result = 0;
-
-        if (result < 0) // neg result == pos tet (tet origin from geogram delaunay)
-            return false;
-        return true;
-    } else {
-        Vector3r n =
-            ((m_vertex_attribute[vs[1]].m_pos) - m_vertex_attribute[vs[0]].m_pos)
-                .cross((m_vertex_attribute[vs[2]].m_pos) - m_vertex_attribute[vs[0]].m_pos);
-        Vector3r d = (m_vertex_attribute[vs[3]].m_pos) - m_vertex_attribute[vs[0]].m_pos;
-        auto res = n.dot(d);
-        if (res > 0) // predicates returns pos value: non-inverted
-            return false;
-        else
-            return true;
-    }
-}
-
-bool SimWildMesh::is_inverted(const Tuple& loc) const
-{
-    auto vs = oriented_tet_vids(loc);
-    return is_inverted(vs);
-}
-
-bool SimWildMesh::round(const Tuple& v)
-{
-    const size_t vid = v.vid(*this);
-    auto& va = m_vertex_attribute[vid];
-    if (va.m_is_rounded) {
-        return true;
-    }
-
-    const Vector3r old_pos = va.m_pos;
-    va.m_pos = to_rational(va.m_posf);
-
-    const auto tets = get_one_ring_tets_for_vertex(v);
-    for (const Tuple& tet : tets) {
-        if (is_inverted(tet)) {
-            va.m_pos = old_pos;
-            return false;
-        }
-    }
-
-    va.m_is_rounded = true;
-    return true;
-}
-
-double SimWildMesh::get_quality(const std::array<size_t, 4>& its) const
-{
-    std::array<Vector3d, 4> ps;
-    bool use_rational = false;
-    for (auto k = 0; k < 4; k++) {
-        ps[k] = m_vertex_attribute[its[k]].m_posf;
-        if (!m_vertex_attribute[its[k]].m_is_rounded) {
-            use_rational = true;
-            break;
-        }
-    }
-    auto energy = -1.;
-    if (!use_rational) {
-        std::array<double, 12> T;
-        for (auto k = 0; k < 4; k++)
-            for (auto j = 0; j < 3; j++) T[k * 3 + j] = ps[k][j];
-
-        energy = wmtk::AMIPS_energy_stable_p3<wmtk::Rational>(T);
-    } else {
-        std::array<wmtk::Rational, 12> T;
-        for (auto k = 0; k < 4; k++)
-            for (auto j = 0; j < 3; j++) T[k * 3 + j] = m_vertex_attribute[its[k]].m_pos[j];
-        energy = wmtk::AMIPS_energy_rational_p3<wmtk::Rational>(T);
-    }
-    if (std::isinf(energy) || std::isnan(energy) || energy < 27 - 1e-3) return MAX_ENERGY;
-    return energy;
-}
-
-double SimWildMesh::get_quality(const Tuple& loc) const
-{
-    auto its = oriented_tet_vids(loc);
-    return get_quality(its);
-}
-
-
-bool SimWildMesh::invariants(const std::vector<Tuple>& tets)
-{
-    return true;
-}
-
-std::vector<std::array<size_t, 3>> SimWildMesh::get_faces_by_condition(
-    std::function<bool(const FaceAttributes&)> cond) const
-{
-    auto res = std::vector<std::array<size_t, 3>>();
-    for (auto f : get_faces()) {
-        auto fid = f.fid(*this);
-        if (cond(m_face_attribute[fid])) {
-            auto tid = fid / 4, lid = fid % 4;
-            auto verts = get_face_vertices(f);
-            res.emplace_back( //
-                std::array<size_t, 3>{
-                    {verts[0].vid(*this), verts[1].vid(*this), verts[2].vid(*this)}});
-        }
-    }
-    return res;
-}
-
-size_t SimWildMesh::round_all_vertices()
-{
-    if (m_all_rounded.load(std::memory_order_relaxed)) {
-        return 0;
-    }
-
-    size_t reclaimed = 0, still_unrounded = 0;
-    for (const Tuple& v : get_vertices()) {
-        if (m_vertex_attribute[v.vid(*this)].m_is_rounded) {
-            continue;
-        }
-        if (round(v)) {
-            ++reclaimed;
-        } else {
-            ++still_unrounded;
-        }
-    }
-
-    if (still_unrounded == 0) {
-        m_all_rounded.store(true, std::memory_order_relaxed);
-    }
-    if (reclaimed > 0 || still_unrounded > 0) {
-        logger().info(
-            "rounding sweep: reclaimed {}, still unrounded {}",
-            reclaimed,
-            still_unrounded);
-    }
-    return reclaimed;
-}
 
 bool SimWildMesh::round_and_check_all_rounded()
 {
@@ -911,87 +657,6 @@ bool SimWildMesh::all_rounded() const
         logger().info("All rounded!", cnt_round, cnt_verts);
         return true;
     }
-}
-
-bool SimWildMesh::is_edge_on_surface(const Tuple& loc)
-{
-    size_t v1_id = loc.vid(*this);
-    auto loc1 = loc.switch_vertex(*this);
-    size_t v2_id = loc1.vid(*this);
-    if (!m_vertex_attribute[v1_id].m_is_on_surface || !m_vertex_attribute[v2_id].m_is_on_surface)
-        return false;
-
-    auto tets = get_incident_tets_for_edge(loc);
-    std::vector<size_t> n_vids;
-    for (auto& t : tets) {
-        auto vs = oriented_tet_vertices(t);
-        for (int j = 0; j < 4; j++) {
-            if (vs[j].vid(*this) != v1_id && vs[j].vid(*this) != v2_id)
-                n_vids.push_back(vs[j].vid(*this));
-        }
-    }
-    wmtk::vector_unique(n_vids);
-
-    for (size_t vid : n_vids) {
-        auto [_, fid] = tuple_from_face({{v1_id, v2_id, vid}});
-        if (m_face_attribute[fid].m_is_surface_fs) return true;
-    }
-
-    return false;
-}
-
-int SimWildMesh::edge_incident_surface_face_count(const Tuple& e)
-{
-    const size_t v1_id = e.vid(*this);
-    const size_t v2_id = e.switch_vertex(*this).vid(*this);
-
-    const auto tets = get_incident_tets_for_edge(e);
-    std::vector<size_t> n_vids;
-    for (const auto& t : tets) {
-        const auto vs = oriented_tet_vertices(t);
-        for (int j = 0; j < 4; ++j) {
-            const size_t v = vs[j].vid(*this);
-            if (v != v1_id && v != v2_id) n_vids.push_back(v);
-        }
-    }
-    wmtk::vector_unique(n_vids);
-
-    int count = 0;
-    for (const size_t vid : n_vids) {
-        auto [ftup, fid] = tuple_from_face({{v1_id, v2_id, vid}});
-        (void)ftup;
-        if (fid != static_cast<size_t>(-1) && m_face_attribute[fid].m_is_surface_fs) ++count;
-    }
-    return count;
-}
-
-
-bool SimWildMesh::is_edge_on_bbox(const Tuple& loc)
-{
-    size_t v1_id = loc.vid(*this);
-    auto loc1 = loc.switch_vertex(*this);
-    size_t v2_id = loc1.vid(*this);
-    if (m_vertex_attribute[v1_id].on_bbox_faces.empty() ||
-        m_vertex_attribute[v2_id].on_bbox_faces.empty())
-        return false;
-
-    auto tets = get_incident_tets_for_edge(loc);
-    std::vector<size_t> n_vids;
-    for (auto& t : tets) {
-        auto vs = oriented_tet_vertices(t);
-        for (int j = 0; j < 4; j++) {
-            if (vs[j].vid(*this) != v1_id && vs[j].vid(*this) != v2_id)
-                n_vids.push_back(vs[j].vid(*this));
-        }
-    }
-    wmtk::vector_unique(n_vids);
-
-    for (size_t vid : n_vids) {
-        auto [_, fid] = tuple_from_face({{v1_id, v2_id, vid}});
-        if (m_face_attribute[fid].m_is_bbox_fs >= 0) return true;
-    }
-
-    return false;
 }
 
 
@@ -1174,21 +839,6 @@ void SimWildMesh::write_surface(const std::string& path) const
     igl::write_triangle_mesh(path, matV, matF);
 
     logger().info("Output face size {}", outface.size());
-}
-
-bool SimWildMesh::vertex_is_on_surface(const size_t vid) const
-{
-    return m_vertex_attribute.at(vid).m_is_on_surface;
-}
-
-bool SimWildMesh::face_is_on_surface(const size_t fid) const
-{
-    return m_face_attribute.at(fid).m_is_surface_fs;
-}
-
-size_t SimWildMesh::get_order_of_vertex(const size_t vid) const
-{
-    return m_vertex_attribute.at(vid).m_order;
 }
 
 void SimWildMesh::init_vertex_order()

--- a/components/simwild/wmtk/components/simwild/SimWildMesh.cpp
+++ b/components/simwild/wmtk/components/simwild/SimWildMesh.cpp
@@ -522,14 +522,6 @@ void SimWildMesh::init_envelope(const MatrixXd& V, const MatrixXi& F, const bool
     m_envelope_orig = m_envelope;
 }
 
-double SimWildMesh::get_length2(const Tuple& l) const
-{
-    SmartTuple v1(*this, l);
-    SmartTuple v2 = v1.switch_vertex();
-    double length =
-        (m_vertex_attribute[v1.vid()].m_posf - m_vertex_attribute[v2.vid()].m_posf).squaredNorm();
-    return length;
-}
 
 void SimWildMesh::write_msh(std::string file, const bool write_envelope)
 {

--- a/components/simwild/wmtk/components/simwild/SimWildMesh.h
+++ b/components/simwild/wmtk/components/simwild/SimWildMesh.h
@@ -161,7 +161,6 @@ public:
     double quality_rel(const Tuple& t) const;
     bool check_mesh_quality(double& max_rel_quality, const bool verbose = false) const;
 
-    double get_length2(const Tuple& l) const;
 
     ////// Attributes related
 

--- a/components/simwild/wmtk/components/simwild/SimWildMesh.h
+++ b/components/simwild/wmtk/components/simwild/SimWildMesh.h
@@ -97,8 +97,6 @@ public:
     {
         m_envelope_eps = envelope_eps;
         NUM_THREADS = _num_threads;
-        p_vertex_attrs = &m_vertex_attribute;
-        p_face_attrs = &m_face_attribute;
         p_tet_attrs = &m_tet_attribute;
         m_collapse_check_link_condition = false;
         m_collapse_check_manifold = false;

--- a/components/simwild/wmtk/components/simwild/SimWildMesh.h
+++ b/components/simwild/wmtk/components/simwild/SimWildMesh.h
@@ -3,6 +3,7 @@
 #include <igl/Timer.h>
 #include <wmtk/SurfaceTagAttributes.h>
 #include <wmtk/TetMesh.h>
+#include <wmtk/TetOptimizerMesh.h>
 #include <wmtk/utils/PartitionMesh.h>
 #include <polysolve/nonlinear/Problem.hpp>
 #include <wmtk/envelope/Envelope.hpp>
@@ -32,47 +33,11 @@
 
 namespace wmtk::components::simwild {
 
-class VertexAttributes
-{
-public:
-    Vector3r m_pos; // exact position in rational
-    Vector3d m_posf; // position as double
-    /**
-     * If a vertex cannot be rounded without inverting a tet, the exact position must be used. Once
-     * the vertex can be rounded to double precision, the rational representation is obsolete.
-     */
-    bool m_is_rounded = false;
-
-    bool m_is_on_surface = false;
-    /**
-     * The order of a vertex in a TetMesh is as follows:
-     * 0: vertex is not on the surface
-     * 1: vertex is on the surface
-     * 2: vertex is on the boundary of the surface or a non-manifold edge
-     * 3: vertex is at the boundary of a non-manifold edge or a non-manifold vertex
-     */
-    size_t m_order = 0;
-    std::vector<int> on_bbox_faces; // same as is_bbox_fs?
-
-    double m_sizing_scalar = 1;
-
-    /**
-     * Required for multi-threading.
-     */
-    size_t partition_id = 0;
-
-    VertexAttributes() {};
-    VertexAttributes(const Vector3r& p);
-};
-
-
-// class EdgeAttributes
-// {
-// public:
-//     bool m_is_on_open_boundary = false;
-// };
-
-using FaceAttributes = wmtk::SurfaceTagAttributes;
+/// The shared attribute types live on the base; keep the unqualified names working. The
+/// simwild copies were identical apart from tetwild's m_is_on_open_boundary, which simwild
+/// never sets.
+using VertexAttributes = wmtk::TetOptimizerMesh::VertexAttributes;
+using FaceAttributes = wmtk::TetOptimizerMesh::FaceAttributes;
 
 class TetAttributes
 {
@@ -88,7 +53,7 @@ public:
     CellTag tags;
 };
 
-class SimWildMesh : public wmtk::TetMesh
+class SimWildMesh : public wmtk::TetOptimizerMesh
 {
 public:
     using ExprPtr = expression_parser::ExpressionPtr;
@@ -98,26 +63,11 @@ public:
     std::map<int64_t, std::string> m_tag_id_to_name;
     std::map<std::string, int64_t> m_tag_name_to_id;
 
-    double time_env = 0.0;
-    igl::Timer isout_timer;
-    /**
-     * @brief The sentinel get_quality returns for an element AMIPS cannot score.
-     *
-     * Not an energy: a positively oriented tet whose volume is too small for AMIPS, or one
-     * that produces inf/nan, gets this instead. m_quality holds AMIPS^3, so it surfaces in
-     * the logs as its cube root, cbrt(1e50) = 4.6e16.
-     *
-     * 1e50 rather than double::max, matching tetwild and triwild, because every downstream
-     * arithmetic on it must stay finite -- avg_energy sums qualities, so a single degenerate
-     * tet turned the reported average into inf, and every ratio that divides by the max was
-     * meaningless from then on. 1e50 leaves headroom for all of it.
-     */
-    const double MAX_ENERGY = 1e50;
-
-    Parameters& m_params;
+    /// The base holds only wmtk::OptimizerParameters; this is the same object, typed, for the
+    /// simwild-only fields (tags, quality/sizing fields, the operation name).
+    Parameters& m_sim_params;
     std::vector<Vector3d> m_V_envelope;
     std::vector<Vector3i> m_F_envelope;
-    std::shared_ptr<SampleEnvelope> m_envelope;
     std::shared_ptr<SampleEnvelope> m_envelope_orig;
     double m_envelope_eps = -1;
 
@@ -130,20 +80,8 @@ public:
     /// Follows m_envelope's use_exact; see where it is built in VolumemesherInsertion.cpp.
     std::shared_ptr<SampleEnvelope> m_order_2_edge_envelope;
 
-    wmtk::threading::enumerable_thread_specific<std::unique_ptr<polysolve::nonlinear::Solver>>
-        m_solver;
-
-    // scaling factors
-    double m_s_amips = -1;
-    double m_s_envelope = -1;
-
-    /// Why smoothing attempts were refused, reported once per pass.
-    optimization::SmoothRejectCounters m_smooth_rejects;
-
     /// Envelope a vertex is pulled toward while smoothing.
     std::shared_ptr<SampleEnvelope> smoothing_energy_envelope(const size_t vid) const;
-    /// Envelope the resulting surface triangles are checked against.
-    std::shared_ptr<SampleEnvelope> smoothing_containment_envelope(const size_t vid) const;
 
     /// No 0-dimensional features here, so smoothing is never positionally constrained beyond
     /// the envelope. See TriWildMesh::smoothing_position_is_allowed for the case that is.
@@ -154,9 +92,10 @@ public:
     std::function<double(const Vector3d&)> m_voronoi_split_fn = nullptr;
 
     SimWildMesh(Parameters& _m_params, double envelope_eps, int _num_threads = 0)
-        : m_params(_m_params)
-        , m_envelope_eps(envelope_eps)
+        : wmtk::TetOptimizerMesh(_m_params, nullptr)
+        , m_sim_params(_m_params)
     {
+        m_envelope_eps = envelope_eps;
         NUM_THREADS = _num_threads;
         p_vertex_attrs = &m_vertex_attribute;
         p_face_attrs = &m_face_attribute;
@@ -168,7 +107,6 @@ public:
 
         optimization::deactivate_opt_logger();
 
-        m_s_amips = 1.;
         m_s_envelope = 1. / (m_params.diag_l * m_params.eps * m_params.eps);
 
         double& wa = m_params.w_amips;
@@ -178,14 +116,14 @@ public:
     }
 
     ~SimWildMesh() {}
-    using VertAttCol = wmtk::AttributeCollection<VertexAttributes>;
-    using FaceAttCol = wmtk::AttributeCollection<FaceAttributes>;
     using TetAttCol = wmtk::AttributeCollection<TetAttributes>;
-    // using EdgeAttCol = wmtk::AttributeCollection<EdgeAttributes>;
-    VertAttCol m_vertex_attribute;
-    FaceAttCol m_face_attribute;
     TetAttCol m_tet_attribute;
-    // EdgeAttCol m_edge_attribute;
+
+    double cell_quality(const size_t tid) const override { return m_tet_attribute[tid].m_quality; }
+    void set_cell_quality(const size_t tid, const double q) override
+    {
+        m_tet_attribute[tid].m_quality = q;
+    }
 
     // only used with unit tests
     void create_mesh_attributes(
@@ -210,39 +148,7 @@ public:
     }
 
     // TODO This should not be here but inside wmtk
-    void compute_vertex_partition()
-    {
-        auto partition_id = partition_TetMesh(*this, NUM_THREADS);
-        for (auto i = 0; i < vert_capacity(); i++)
-            m_vertex_attribute[i].partition_id = partition_id[i];
-    }
-
     // TODO This should not be here but inside wmtk
-    void compute_vertex_partition_morton()
-    {
-        if (NUM_THREADS == 0) {
-            return;
-        }
-
-        logger().info("Number of parts: {} by morton", NUM_THREADS);
-
-        std::vector<size_t> partition_id;
-        wmtk::partition_vertex_morton(
-            vert_capacity(),
-            [this](size_t i) { return m_vertex_attribute[i].m_posf; },
-            NUM_THREADS,
-            partition_id);
-
-        for (size_t i = 0; i < partition_id.size(); i++) {
-            m_vertex_attribute[i].partition_id = partition_id[i];
-        }
-    }
-
-    size_t get_partition_id(const Tuple& loc) const
-    {
-        return m_vertex_attribute[loc.vid(*this)].partition_id;
-    }
-
     void init_envelope(const MatrixXd& V, const MatrixXi& F, const bool use_exact);
 
     CellTag string_set_to_cell_tag(const std::set<std::string>& str_set);
@@ -262,7 +168,6 @@ public:
     ////// Attributes related
 
     void write_msh(std::string file, const bool write_envelope = true);
-    void output_faces(std::string file, std::function<bool(const FaceAttributes&)> cond);
 
 public:
     void split_all_edges();
@@ -270,7 +175,6 @@ public:
     bool split_edge_after(const Tuple& loc) override;
 
     void smooth_all_vertices(const size_t n_iters);
-    bool smooth_before(const Tuple& t) override;
     bool smooth_after(const Tuple& t) override;
 
     void collapse_all_edges(bool is_limit_length = true);
@@ -281,14 +185,10 @@ public:
 
     size_t swap_all_edges_44();
     bool swap_edge_44_before(const Tuple& t) override;
-    double swap_edge_44_energy(const std::vector<std::array<size_t, 4>>& tets, const int op_case)
-        override;
     bool swap_edge_44_after(const Tuple& t) override;
 
     size_t swap_all_edges_56();
     bool swap_edge_56_before(const Tuple& t) override;
-    double swap_edge_56_energy(const std::vector<std::array<size_t, 4>>& tets, const int op_case)
-        override;
     bool swap_edge_56_after(const Tuple& t) override;
 
     size_t swap_all_edges_32();
@@ -321,7 +221,7 @@ public:
 
     /**
      * @brief Compare a surface signature against the current one and log an
-     * error if it changed. Used (when m_params.check_surface_topology is set) to
+     * error if it changed. Used (when m_sim_params.check_surface_topology is set) to
      * guard swap passes that can flip surface edges.
      */
     void warn_if_surface_topology_changed(const SurfaceTopoSignature& before, const char* where)
@@ -335,58 +235,6 @@ public:
     bool swap_face_after(const Tuple& t) override;
 
     size_t swap_all_edges_all();
-
-    /**
-     * @brief m_quality threshold above which a tet is "active" (worth operating
-     * on) for the skip-good-regions filter. m_quality stores AMIPS^3 and the
-     * energy is its cube root, so a tet is active when its energy is at least
-     * skip_good_regions_margin * stop_energy, i.e. m_quality >=
-     * (margin * stop_energy)^3.
-     */
-    double active_quality_threshold() const
-    {
-        const double e = m_params.skip_good_regions_margin * m_params.stop_energy;
-        return e * e * e;
-    }
-
-    /**
-     * @brief vids of the vertices incident to at least one "active" tet
-     * (m_quality >= active_quality_threshold()). Used by the skip-good-regions
-     * filter to restrict smoothing to non-good regions (smoothing a vertex
-     * surrounded by good tets does nothing).
-     */
-    std::vector<size_t> active_vertices() const;
-
-    /**
-     * @brief Inversion check using only floating point numbers.
-     */
-    bool is_inverted_f(const Tuple& loc) const;
-    bool is_inverted(const std::array<size_t, 4>& vs) const;
-    bool is_inverted(const Tuple& loc) const;
-    double get_quality(const std::array<size_t, 4>& vs) const;
-    double get_quality(const Tuple& loc) const;
-
-    /**
-     * @brief Round a vertex position to floating point.
-     *
-     * Only rounds the vertex position, if it does not cause inverted elements.
-     *
-     * @return True if successful or already rounded, false otherwise.
-     */
-    bool round(const Tuple& loc);
-
-    /**
-     * @brief Try to round every un-rounded vertex; returns the number reclaimed.
-     *
-     * round() is otherwise only attempted as a side effect of another operation
-     * (smooth_before on the vertex being smoothed, collapse_edge_after on the merged one),
-     * and neither reaches a vertex that only becomes roundable later: smoothing skips
-     * "good" regions by default. Without a sweep such a vertex keeps exact coordinates
-     * into the output for no geometric reason.
-     *
-     * Skipped outright when m_all_rounded says there is nothing to do.
-     */
-    size_t round_all_vertices();
 
     /**
      * @brief Run the rounding sweep, then report whether the mesh is now fully rounded.
@@ -405,45 +253,15 @@ public:
     bool round_and_check_all_rounded();
 
     /**
-     * @brief True when every vertex is known to be rounded.
-     *
-     * Only trusted when true, and only round_all_vertices() sets it that way. Any code that
-     * leaves a vertex un-rounded must clear it, or the sweep will skip the vertex forever.
-     * Atomic because operations that clear it run in parallel.
-     *
-     * Distinct from all_rounded(), which counts. This is the cheap "is there anything to
-     * do" flag; that is the answer.
-     */
-    std::atomic<bool> m_all_rounded = false;
-
-    /**
      * @brief Check if all vertices of the mesh are rounded.
      *
      */
     bool all_rounded() const;
 
     //
-    bool is_edge_on_surface(const Tuple& loc);
-    /**
-     * @brief How many faces incident to this edge are tracked surface.
-     *
-     * Unlike is_edge_on_surface this does NOT short-circuit on the vertices'
-     * m_is_on_surface flags, so a genuine surface edge cannot be mistaken for interior
-     * because a flag went stale -- which in a swap would tear the surface. Same helper
-     * tetwild routes its swap surface test through.
-     */
-    int edge_incident_surface_face_count(const Tuple& e);
-    bool is_edge_on_bbox(const Tuple& loc);
     //
     void mesh_improvement(int max_its = 80);
     double local_operations(const std::array<int, 4>& ops, bool collapse_limit_length = true);
-    std::tuple<double, double> get_max_avg_energy();
-
-    std::vector<std::array<size_t, 3>> get_faces_by_condition(
-        std::function<bool(const FaceAttributes&)> cond) const;
-
-    bool invariants(const std::vector<Tuple>& t) override; // this is now automatically checked
-
     // debug use
     std::atomic<int> cnt_split = 0, cnt_collapse = 0, cnt_swap = 0;
     // Successful surface diagonal flips (subset of cnt_swap). Diagnostic.
@@ -474,10 +292,6 @@ private:
         std::map<simplex::Edge, TetAttributes> tets;
     };
     wmtk::threading::enumerable_thread_specific<SplitInfoCache> split_cache;
-
-    /// Whether the current collapse pass applies the target-length limit; read by
-    /// collapse_edge_before, which is where that limit is now enforced.
-    bool m_collapse_limit_length = true;
 
     struct CollapseInfoCache
     {
@@ -550,27 +364,7 @@ public:
      */
     size_t refine_sizing_around_worst();
 
-    /**
-     * @brief Monotone (only-decreasing) gradation smoothing of the sizing field.
-     *
-     * Enforces m_sizing_scalar[v] <= grade * m_sizing_scalar[u] for every edge
-     * (u,v), propagating outward from `seeds` with a min-relaxation. It never
-     * raises a sizing value, so it only ever spreads more refinement into the
-     * halo around already-refined vertices, avoiding sharp resolution jumps.
-     */
-    void gradation_smooth_sizing(double grade, const std::vector<size_t>& seeds);
 
-
-    /// The longest edge of each current worst tet (as a sorted {min,max} vid pair).
-    /// split_all_edges force-splits exactly these edges (bypasses the length gate),
-    /// so a stuck sliver's long edge is split immediately without changing the sizing
-    /// field. Populated serially by refine_sizing_around_worst; read-only during the
-    /// parallel split pass, then cleared once split_all_edges has consumed it.
-    std::set<simplex::Edge> m_force_split_edges;
-
-    /// Count of force-splits taken in the current split pass (atomic_ref from the
-    /// parallel split; reset + logged by split_all_edges). Diagnostic only.
-    size_t m_force_split_count = 0;
     /**
      * @brief Splits in the last pass that fell back to the exact rational midpoint.
      *
@@ -616,11 +410,6 @@ public:
 public:
     // substructure functions
 
-    bool vertex_is_on_surface(const size_t vid) const override;
-
-    bool face_is_on_surface(const size_t fid) const override;
-
-    size_t get_order_of_vertex(const size_t vid) const override;
     /**
      * @brief Compute the vertex order for every vertex.
      */

--- a/components/simwild/wmtk/components/simwild/SimWildMeshTri.cpp
+++ b/components/simwild/wmtk/components/simwild/SimWildMeshTri.cpp
@@ -60,48 +60,6 @@ auto edge_locker = [](auto& m, const auto& e, int task_id) {
     return m.try_set_edge_mutex_two_ring(e, task_id);
 };
 
-// TODO: this should not be here
-void SimWildMeshTri::partition_mesh()
-{
-    auto m_vertex_partition_id = partition_TriMesh(*this, NUM_THREADS);
-    for (auto i = 0; i < m_vertex_partition_id.size(); i++)
-        m_vertex_attribute[i].partition_id = m_vertex_partition_id[i];
-}
-
-// TODO: morton should not be here, but inside wmtk
-void SimWildMeshTri::partition_mesh_morton()
-{
-    if (NUM_THREADS == 0) {
-        return;
-    }
-    logger().info("Number of parts: {} by morton", NUM_THREADS);
-
-    // The shared partitioner is 3D; a zero z leaves the bounding box, the scale and the
-    // Morton code exactly where a 2D-specific version would put them.
-    std::vector<size_t> partition_id;
-    wmtk::partition_vertex_morton(
-        vert_capacity(),
-        [this](size_t i) {
-            const Vector2d& p = m_vertex_attribute[i].m_posf;
-            return Eigen::Vector3d(p[0], p[1], 0);
-        },
-        NUM_THREADS,
-        partition_id);
-
-    for (size_t i = 0; i < partition_id.size(); i++) {
-        m_vertex_attribute[i].partition_id = partition_id[i];
-    }
-}
-
-double SimWildMeshTri::get_length2(const Tuple& l) const
-{
-    const auto vs = get_edge_vids(l);
-    const Vector2d& p0 = m_vertex_attribute.at(vs[0]).m_posf;
-    const Vector2d& p1 = m_vertex_attribute.at(vs[1]).m_posf;
-
-    return (p1 - p0).squaredNorm();
-}
-
 void SimWildMeshTri::init_from_image(
     const MatrixXd& V,
     const MatrixXi& T,
@@ -301,14 +259,14 @@ void SimWildMeshTri::init_surfaces_and_boundaries()
 
         m_V_envelope = tempV;
         m_E_envelope = tempE;
-        m_envelope = std::make_shared<SampleEnvelope>(!m_params.use_sample_envelope);
+        m_envelope = std::make_shared<SampleEnvelope>(!m_sim_params.use_sample_envelope);
         m_envelope->init(m_V_envelope, m_E_envelope, m_envelope_eps);
         logger().info(
             "Envelope: {} (eps {:.6})",
             m_envelope->use_exact ? "EXACT" : "sampled",
             m_envelope_eps);
         m_envelope_orig = m_envelope;
-    } else if (m_params.operation == "remeshing" && m_params.check_envelope_at_init) {
+    } else if (m_sim_params.operation == "remeshing" && m_sim_params.check_envelope_at_init) {
         // All surface edges must be inside the envelope. Opt-in: see
         // Parameters::check_envelope_at_init for why it is not worth its cost by default.
         logger().info("Envelope sanity check");
@@ -332,13 +290,13 @@ void SimWildMeshTri::init_surfaces_and_boundaries()
         // boundary can round off it, or off it can round onto it, and the bbox tag is what
         // keeps the domain from collapsing.
         for (int k = 0; k < 2; k++) {
-            if (m_vertex_attribute[vids[0]].m_pos[k] == m_params.box_min[k] &&
-                m_vertex_attribute[vids[1]].m_pos[k] == m_params.box_min[k]) {
+            if (m_vertex_attribute[vids[0]].m_pos[k] == m_sim_params.box_min[k] &&
+                m_vertex_attribute[vids[1]].m_pos[k] == m_sim_params.box_min[k]) {
                 on_bbox = k * 2;
                 break;
             }
-            if (m_vertex_attribute[vids[0]].m_pos[k] == m_params.box_max[k] &&
-                m_vertex_attribute[vids[1]].m_pos[k] == m_params.box_max[k]) {
+            if (m_vertex_attribute[vids[0]].m_pos[k] == m_sim_params.box_max[k] &&
+                m_vertex_attribute[vids[1]].m_pos[k] == m_sim_params.box_max[k]) {
                 on_bbox = k * 2 + 1;
                 break;
             }
@@ -380,7 +338,7 @@ void SimWildMeshTri::init_envelope(const MatrixXd& V, const MatrixXi& E)
         m_E_envelope[i] = E.row(i);
     }
 
-    m_envelope = std::make_shared<SampleEnvelope>(!m_params.use_sample_envelope);
+    m_envelope = std::make_shared<SampleEnvelope>(!m_sim_params.use_sample_envelope);
     m_envelope->init(m_V_envelope, m_E_envelope, m_envelope_eps);
     logger().info(
         "Envelope: {} (eps {:.6})",
@@ -621,15 +579,6 @@ size_t SimWildMeshTri::refine_sizing_around_worst()
         refined.size(),
         region.size());
     return refined.size();
-}
-
-void SimWildMeshTri::gradation_smooth_sizing(double grade, const std::vector<size_t>& seeds)
-{
-    utils::gradation_smooth_sizing(
-        grade,
-        seeds,
-        [this](size_t v) -> double& { return m_vertex_attribute[v].m_sizing_scalar; },
-        [this](size_t v) { return get_one_ring_vids_for_vertex_duplicate(v); });
 }
 
 void SimWildMeshTri::write_msh(std::string file, const bool write_envelope)
@@ -915,19 +864,6 @@ void SimWildMeshTri::write_vtu_with_energies(const std::string& path) const
         logger().info("Write {}", surf_out_path);
         surf_writer->write_mesh(surf_out_path, V, E, paraviewo::CellType::Line);
     }
-}
-
-std::vector<std::array<size_t, 2>> SimWildMeshTri::get_edges_by_condition(
-    std::function<bool(const EdgeAttributes&)> cond) const
-{
-    std::vector<std::array<size_t, 2>> res;
-    for (const Tuple& e : get_edges()) {
-        size_t eid = e.eid(*this);
-        if (cond(m_edge_attribute[eid])) {
-            res.push_back({{e.vid(*this), e.switch_vertex(*this).vid(*this)}});
-        }
-    }
-    return res;
 }
 
 void SimWildMeshTri::split_all_edges()
@@ -1770,21 +1706,6 @@ void SimWildMeshTri::set_smoothing_position(const size_t vid, const Vector2d& p)
     m_vertex_attribute[vid].m_pos = to_rational(p);
 }
 
-bool SimWildMeshTri::is_inverted_f(const size_t fid) const
-{
-    const auto vs = oriented_tri_vids(fid);
-
-    igl::predicates::exactinit();
-    const auto res = igl::predicates::orient2d(
-        m_vertex_attribute[vs[0]].m_posf,
-        m_vertex_attribute[vs[1]].m_posf,
-        m_vertex_attribute[vs[2]].m_posf);
-    if (res == igl::predicates::Orientation::POSITIVE) {
-        return false;
-    }
-    return true;
-}
-
 std::shared_ptr<SampleEnvelope> SimWildMeshTri::smoothing_energy_envelope(const size_t) const
 {
     return m_envelope_orig;
@@ -1900,124 +1821,6 @@ void SimWildMeshTri::log_total_surface_energy()
 }
 
 
-bool SimWildMeshTri::is_inverted(const std::array<size_t, 3>& vs) const
-{
-    if (m_vertex_attribute[vs[0]].m_is_rounded && m_vertex_attribute[vs[1]].m_is_rounded &&
-        m_vertex_attribute[vs[2]].m_is_rounded) {
-        igl::predicates::exactinit();
-        const auto res = igl::predicates::orient2d(
-            m_vertex_attribute[vs[0]].m_posf,
-            m_vertex_attribute[vs[1]].m_posf,
-            m_vertex_attribute[vs[2]].m_posf);
-        if (res == igl::predicates::Orientation::POSITIVE) {
-            return false;
-        }
-        return true;
-    } else {
-        const Vector2r& v0 = m_vertex_attribute[vs[0]].m_pos;
-        const Vector2r& v1 = m_vertex_attribute[vs[1]].m_pos;
-        const Vector2r& v2 = m_vertex_attribute[vs[2]].m_pos;
-        const Vector2r a = v1 - v0;
-        const Vector2r b = v2 - v0;
-        const Rational res = a.x() * b.y() - a.y() * b.x();
-        return !(res > 0);
-    }
-}
-
-bool SimWildMeshTri::is_inverted(const Tuple& loc) const
-{
-    return is_inverted(oriented_tri_vids(loc));
-}
-
-bool SimWildMeshTri::is_inverted(const size_t fid) const
-{
-    return is_inverted(oriented_tri_vids(fid));
-}
-
-double SimWildMeshTri::get_quality(const std::array<size_t, 3>& vs) const
-{
-    std::array<Vector2d, 3> ps;
-    for (size_t k = 0; k < 3; k++) {
-        ps[k] = m_vertex_attribute[vs[k]].m_posf;
-    }
-    double energy = -1.;
-    {
-        std::array<double, 6> T;
-        for (size_t k = 0; k < 3; k++)
-            for (size_t j = 0; j < 2; j++) {
-                T[k * 2 + j] = ps[k][j];
-            }
-        energy = AMIPS2D_energy(T);
-    }
-    if (std::isinf(energy) || std::isnan(energy) || energy < 2 - 1e-3) {
-        return MAX_ENERGY;
-    }
-    return energy;
-}
-
-double SimWildMeshTri::get_quality(const Tuple& loc) const
-{
-    return get_quality(oriented_tri_vids(loc));
-}
-
-double SimWildMeshTri::get_quality(const size_t fid) const
-{
-    return get_quality(oriented_tri_vids(fid));
-}
-
-bool SimWildMeshTri::round(const Tuple& v)
-{
-    const size_t i = v.vid(*this);
-    if (m_vertex_attribute[i].m_is_rounded) {
-        return true;
-    }
-
-    const Vector2r old_pos = m_vertex_attribute[i].m_pos;
-    m_vertex_attribute[i].m_pos = to_rational(m_vertex_attribute[i].m_posf);
-    // Set before the loop so is_inverted takes the float path: the question being asked is
-    // exactly whether the ROUNDED position keeps every incident face valid.
-    m_vertex_attribute[i].m_is_rounded = true;
-    for (const Tuple& f : get_one_ring_tris_for_vertex(v)) {
-        if (is_inverted(f)) {
-            m_vertex_attribute[i].m_is_rounded = false;
-            m_vertex_attribute[i].m_pos = old_pos;
-            return false;
-        }
-    }
-
-    return true;
-}
-
-size_t SimWildMeshTri::round_all_vertices()
-{
-    if (m_all_rounded.load(std::memory_order_relaxed)) {
-        return 0;
-    }
-
-    size_t reclaimed = 0, still_unrounded = 0;
-    for (const Tuple& v : get_vertices()) {
-        if (m_vertex_attribute[v.vid(*this)].m_is_rounded) {
-            continue;
-        }
-        if (round(v)) {
-            ++reclaimed;
-        } else {
-            ++still_unrounded;
-        }
-    }
-
-    if (still_unrounded == 0) {
-        m_all_rounded.store(true, std::memory_order_relaxed);
-    }
-    if (reclaimed > 0 || still_unrounded > 0) {
-        logger().info(
-            "rounding sweep: reclaimed {}, still unrounded {}",
-            reclaimed,
-            still_unrounded);
-    }
-    return reclaimed;
-}
-
 bool SimWildMeshTri::round_and_check_all_rounded()
 {
     round_all_vertices();
@@ -2033,49 +1836,6 @@ double SimWildMeshTri::triangle_area(const size_t fid) const
     const double area =
         0.5 * std::abs((p1[0] - p0[0]) * (p2[1] - p0[1]) - (p1[1] - p0[1]) * (p2[0] - p0[0]));
     return area;
-}
-
-bool SimWildMeshTri::is_edge_on_surface(const Tuple& loc) const
-{
-    const auto vs = get_edge_vids(loc);
-    if (!m_vertex_attribute.at(vs[0]).m_is_on_surface ||
-        !m_vertex_attribute.at(vs[1]).m_is_on_surface) {
-        return false;
-    }
-
-    const size_t eid = loc.eid(*this);
-    return m_edge_attribute[eid].m_is_surface_fs;
-}
-bool SimWildMeshTri::is_edge_on_surface(const std::array<size_t, 2>& vids) const
-{
-    if (!m_vertex_attribute.at(vids[0]).m_is_on_surface ||
-        !m_vertex_attribute.at(vids[1]).m_is_on_surface) {
-        return false;
-    }
-
-    const auto [_, eid] = tuple_from_edge(vids);
-    return m_edge_attribute[eid].m_is_surface_fs;
-}
-bool SimWildMeshTri::is_edge_on_bbox(const Tuple& loc) const
-{
-    const auto vs = get_edge_vids(loc);
-    if (m_vertex_attribute.at(vs[0]).on_bbox_faces.empty() ||
-        m_vertex_attribute.at(vs[1]).on_bbox_faces.empty()) {
-        return false;
-    }
-
-    const size_t eid = loc.eid(*this);
-    return m_edge_attribute[eid].m_is_bbox_fs >= 0;
-}
-
-bool SimWildMeshTri::is_edge_on_bbox(const std::array<size_t, 2>& vids) const
-{
-    if (m_vertex_attribute.at(vids[0]).on_bbox_faces.empty() ||
-        m_vertex_attribute.at(vids[1]).on_bbox_faces.empty()) {
-        return false;
-    }
-    const auto [_, eid] = tuple_from_edge(vids);
-    return m_edge_attribute[eid].m_is_bbox_fs >= 0;
 }
 
 void SimWildMeshTri::mesh_improvement(int max_its)
@@ -2243,28 +2003,6 @@ double SimWildMeshTri::local_operations(const std::array<int, 4>& ops, bool coll
 
 
     return quality_rel;
-}
-
-std::tuple<double, double> SimWildMeshTri::get_max_avg_energy()
-{
-    double max_energy = -1.;
-    double avg_energy = 0.;
-    auto cnt = 0;
-
-    for (int i = 0; i < tri_capacity(); i++) {
-        const Tuple tup = tuple_from_tri(i);
-        if (!tup.is_valid(*this)) {
-            continue;
-        }
-        const double q = m_face_attribute[tup.fid(*this)].m_quality;
-        max_energy = std::max(max_energy, q);
-        avg_energy += q;
-        cnt++;
-    }
-
-    avg_energy /= cnt;
-
-    return std::make_tuple(max_energy, avg_energy);
 }
 
 } // namespace wmtk::components::simwild::tri

--- a/components/simwild/wmtk/components/simwild/SimWildMeshTri.hpp
+++ b/components/simwild/wmtk/components/simwild/SimWildMeshTri.hpp
@@ -74,9 +74,6 @@ public:
     {
         m_envelope_eps = envelope_eps;
         NUM_THREADS = _num_threads;
-        p_vertex_attrs = &m_vertex_attribute;
-        p_edge_attrs = &m_edge_attribute;
-        p_face_attrs = &m_face_attribute;
 
         optimization::deactivate_opt_logger();
 

--- a/components/simwild/wmtk/components/simwild/SimWildMeshTri.hpp
+++ b/components/simwild/wmtk/components/simwild/SimWildMeshTri.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <wmtk/TriOptimizerMesh.h>
+
 #include <wmtk/SurfaceTagAttributes.h>
 #include <limits>
 #include <unordered_set>
@@ -28,100 +30,37 @@
 
 namespace wmtk::components::simwild::tri {
 
-struct VertexAttributes
-{
-    Vector2d m_posf; // position as double
-    Vector2r m_pos; // exact position in rational
-    /**
-     * If a vertex cannot be rounded without inverting an incident face, the exact position
-     * must be used. Once the vertex can be rounded to double precision, the rational
-     * representation is obsolete.
-     */
-    bool m_is_rounded = false;
+/// The attribute types live on the shared base; keep the unqualified names working. The
+/// simwild copies were identical to triwild's apart from `m_feature_id`, which simwild leaves
+/// at NO_FEATURE (it has no 0-dimensional features), and spelling `CellTag` for what is the
+/// same `std::set<int64_t>`.
+using VertexAttributes = wmtk::TriOptimizerMesh::VertexAttributes;
+using EdgeAttributes = wmtk::TriOptimizerMesh::EdgeAttributes;
+using FaceAttributes = wmtk::TriOptimizerMesh::FaceAttributes;
 
-    bool m_is_on_surface = false;
-    std::vector<int> on_bbox_faces;
-
-    double m_sizing_scalar = 1;
-
-    size_t partition_id = 0;
-
-    VertexAttributes() {}
-    VertexAttributes(const Vector2d& p)
-        : m_posf(p)
-        , m_pos(to_rational(p))
-        , m_is_rounded(true)
-    {}
-    VertexAttributes(const Vector2r& p)
-        : m_posf(to_double(p))
-        , m_pos(p)
-    {}
-};
-
-using EdgeAttributes = wmtk::SurfaceTagAttributes;
-
-class FaceAttributes
-{
-public:
-    double m_quality;
-    double m_winding_number = 0;
-    CellTag tags;
-    int part_id = -1;
-};
-
-class SimWildMeshTri : public wmtk::TriMesh
+class SimWildMeshTri : public wmtk::TriOptimizerMesh
 {
 public:
     using ExprPtr = expression_parser::ExpressionPtr;
 
-    int m_debug_print_counter = 0;
-    size_t m_tags_count = 0;
-    std::map<int64_t, std::string> m_tag_id_to_name;
-    std::map<std::string, int64_t> m_tag_name_to_id;
+    /// The base holds only wmtk::OptimizerParameters; this is the same object, typed, for the
+    /// simwild-only fields (tags, the operation name, the raw input box).
+    Parameters& m_sim_params;
 
-    /**
-     * @brief The sentinel get_quality returns for a face AMIPS2D cannot score.
-     *
-     * Not an energy: a positively oriented triangle whose area is too small for AMIPS, or one
-     * that produces inf/nan, gets this instead. Unlike the 3D mesh this stores AMIPS2D
-     * directly, so it surfaces in the logs verbatim as 1e+50.
-     *
-     * 1e50 rather than double::max, matching tetwild and triwild -- see SimWildMesh::MAX_ENERGY
-     * for why the arithmetic headroom matters.
-     */
-    const double MAX_ENERGY = 1e50;
-
-    Parameters& m_params;
     std::vector<Vector2d> m_V_envelope;
     std::vector<Vector2i> m_E_envelope;
-    std::shared_ptr<SampleEnvelope> m_envelope;
     std::shared_ptr<SampleEnvelope> m_envelope_orig;
-    double m_envelope_eps = -1;
 
     std::vector<std::tuple<ExprPtr, double>> m_sizing_field;
     std::vector<std::tuple<ExprPtr, double>> m_quality_field;
-
-    using VertAttCol = AttributeCollection<VertexAttributes>;
-    using EdgeAttCol = AttributeCollection<EdgeAttributes>;
-    using FaceAttCol = AttributeCollection<FaceAttributes>;
-    VertAttCol m_vertex_attribute;
-    EdgeAttCol m_edge_attribute;
-    FaceAttCol m_face_attribute;
 
     bool m_collapse_check_link_condition = false; // classical link condition
     bool m_collapse_check_topology = false; // sanity check
     bool m_collapse_check_manifold = false; // manifoldness check after collapse
 
-    wmtk::threading::enumerable_thread_specific<std::unique_ptr<polysolve::nonlinear::Solver>>
-        m_solver;
-
-    /// Why smoothing attempts were refused, reported once per pass.
-    optimization::SmoothRejectCounters m_smooth_rejects;
-
     /// Hooks for the shared 2D smoothing driver.
     Vector2d smoothing_position(const size_t vid) const;
     void set_smoothing_position(const size_t vid, const Vector2d& p);
-    bool is_inverted_f(const size_t fid) const;
     std::shared_ptr<SampleEnvelope> smoothing_energy_envelope(const size_t vid) const;
     std::shared_ptr<SampleEnvelope> smoothing_containment_envelope(const size_t vid) const;
 
@@ -129,28 +68,17 @@ public:
     /// the envelope. See TriWildMesh::smoothing_position_is_allowed for the case that is.
     bool smoothing_position_is_allowed(const size_t, const Vector2d&) const { return true; }
 
-    // scaling factors
-    double m_s_amips = -1;
-    double m_s_envelope = -1;
-
     SimWildMeshTri(Parameters& _m_params, double envelope_eps, int _num_threads = 0)
-        : m_params(_m_params)
-        , m_envelope_eps(envelope_eps)
+        : wmtk::TriOptimizerMesh(_m_params)
+        , m_sim_params(_m_params)
     {
+        m_envelope_eps = envelope_eps;
         NUM_THREADS = _num_threads;
         p_vertex_attrs = &m_vertex_attribute;
         p_edge_attrs = &m_edge_attribute;
         p_face_attrs = &m_face_attribute;
 
         optimization::deactivate_opt_logger();
-
-        m_s_amips = 1.;
-        /**
-         * eps makes it such that the energy is relative to the envelope thickness. As it's a
-         * squared energy, we need eps^2.
-         */
-        m_s_envelope = 1. / (m_params.eps * m_params.eps);
-
 
         double& wa = m_params.w_amips;
         double& we = m_params.w_envelope;
@@ -159,20 +87,6 @@ public:
     }
 
     ~SimWildMeshTri() {}
-
-    // TODO: this should not be here
-    void partition_mesh();
-
-    // TODO: morton should not be here, but inside wmtk
-    void partition_mesh_morton();
-
-    size_t get_partition_id(const Tuple& loc) const
-    {
-        return m_vertex_attribute[loc.vid(*this)].partition_id;
-    }
-
-    double get_length2(const Tuple& l) const;
-
 
 public:
     /**
@@ -233,24 +147,10 @@ public:
      */
     size_t refine_sizing_around_worst();
 
-    /**
-     * @brief Monotone (only-decreasing) gradation smoothing of the sizing field.
-     *
-     * Enforces m_sizing_scalar[v] <= grade * m_sizing_scalar[u] for every edge
-     * (u,v), propagating outward from `seeds` with a min-relaxation. It never
-     * raises a sizing value, so it only ever spreads more refinement into the
-     * halo around already-refined vertices, avoiding sharp resolution jumps.
-     */
-    void gradation_smooth_sizing(double grade, const std::vector<size_t>& seeds);
-
-
     void write_msh(std::string file, const bool write_envelope = true);
 
     void write_vtu(const std::string& path) const;
     void write_vtu_with_energies(const std::string& path) const;
-
-    std::vector<std::array<size_t, 2>> get_edges_by_condition(
-        std::function<bool(const EdgeAttributes&)> cond) const;
 
 public:
     void split_all_edges();
@@ -290,41 +190,6 @@ public:
      * For debugging purposes.
      */
     void log_total_surface_energy();
-    //
-    /**
-     * @brief Orientation check, exact for the coordinates the vertices actually carry.
-     *
-     * Takes the floating path when all three vertices are rounded -- igl::predicates::orient2d
-     * is exact for the doubles it is handed -- and the Rational cross product otherwise. The
-     * rational branch exists because for an un-rounded vertex the double is the wrong number,
-     * not because orient2d is imprecise.
-     */
-    bool is_inverted(const std::array<size_t, 3>& vs) const;
-    bool is_inverted(const Tuple& loc) const;
-    bool is_inverted(const size_t fid) const;
-    double get_quality(const std::array<size_t, 3>& vs) const;
-    double get_quality(const Tuple& loc) const;
-    double get_quality(const size_t fid) const;
-
-    /**
-     * @brief Round a vertex position to floating point.
-     *
-     * Only rounds the vertex position if it does not invert an incident face.
-     *
-     * @return True if successful or already rounded, false otherwise.
-     */
-    bool round(const Tuple& v);
-
-    /**
-     * @brief Try to round every un-rounded vertex; returns the number reclaimed.
-     *
-     * round() is otherwise only attempted as a side effect of another operation, and that
-     * never reaches a vertex which only becomes roundable later. Without a sweep such a vertex
-     * keeps exact coordinates into the output for no geometric reason.
-     *
-     * Skipped outright when m_all_rounded says there is nothing to do.
-     */
-    size_t round_all_vertices();
 
     /**
      * @brief Run the rounding sweep, then report whether the mesh is now fully rounded.
@@ -334,15 +199,6 @@ public:
      * vertex, so the loop only has to outlast the sweep. See SimWildMesh's counterpart.
      */
     bool round_and_check_all_rounded();
-
-    /**
-     * @brief True when every vertex is known to be rounded.
-     *
-     * Only trusted when true, and only round_all_vertices() sets it that way. Any code that
-     * leaves a vertex un-rounded must clear it, or the sweep will skip the vertex forever.
-     * Atomic because operations that clear it run in parallel.
-     */
-    std::atomic<bool> m_all_rounded = false;
 
     /**
      * @brief Splits in the last pass that fell back to the exact rational midpoint.
@@ -355,15 +211,8 @@ public:
 
     double triangle_area(const size_t fid) const;
 
-    //
-    bool is_edge_on_surface(const Tuple& loc) const;
-    bool is_edge_on_surface(const std::array<size_t, 2>& vids) const;
-    bool is_edge_on_bbox(const Tuple& loc) const;
-    bool is_edge_on_bbox(const std::array<size_t, 2>& vids) const;
-    //
     void mesh_improvement(int max_its = 80);
     double local_operations(const std::array<int, 4>& ops, bool collapse_limit_length = true);
-    std::tuple<double, double> get_max_avg_energy();
 
     /**
      * @brief Find all connected components that contain the `tag_in` tags.
@@ -428,23 +277,6 @@ public:
 
     void tag_priority(const std::vector<int64_t>& tags_order);
 
-    bool vertex_is_on_surface(const size_t vid) const override
-    {
-        return m_vertex_attribute.at(vid).m_is_on_surface ||
-               !m_vertex_attribute.at(vid).on_bbox_faces.empty();
-    }
-    bool edge_is_on_surface(const std::array<size_t, 2>& vids) const override
-    {
-        if (!vertex_is_on_surface(vids[0]) || !vertex_is_on_surface(vids[1])) {
-            return false;
-        }
-
-        const auto [_, eid] = tuple_from_edge(vids);
-        bool on_surface = m_edge_attribute.at(eid).m_is_surface_fs;
-        bool on_bbox = m_edge_attribute.at(eid).m_is_bbox_fs >= 0;
-        return on_surface || on_bbox;
-    }
-
 private:
     ////// Operations
 
@@ -471,10 +303,6 @@ private:
         std::map<size_t, FaceAttributes> faces;
     };
     wmtk::threading::enumerable_thread_specific<SplitInfoCache> split_cache;
-
-    /// Whether the current collapse pass applies the target-length limit; read by
-    /// collapse_edge_before, which is where that limit is now enforced.
-    bool m_collapse_limit_length = true;
 
     struct CollapseInfoCache
     {

--- a/components/simwild/wmtk/components/simwild/Smooth.cpp
+++ b/components/simwild/wmtk/components/simwild/Smooth.cpp
@@ -23,20 +23,6 @@
 
 namespace wmtk::components::simwild {
 
-bool SimWildMesh::smooth_before(const Tuple& t)
-{
-    const bool r = round(t);
-
-    const size_t vid = t.vid(*this);
-
-    if (!m_vertex_attribute[vid].on_bbox_faces.empty()) return false;
-
-    if (m_vertex_attribute[vid].m_is_rounded) return true;
-    // try to round.
-    // Note: no need to roll back.
-    return r;
-}
-
 bool SimWildMesh::smooth_after(const Tuple& t)
 {
     // The body lives in wmtk::optimization::smooth_vertex_3d, shared with tetwild.
@@ -62,13 +48,6 @@ std::shared_ptr<SampleEnvelope> SimWildMesh::smoothing_energy_envelope(const siz
             m_vertex_attribute[vid].m_order);
     }
     return env;
-}
-
-std::shared_ptr<SampleEnvelope> SimWildMesh::smoothing_containment_envelope(const size_t) const
-{
-    // The working envelope, which is not m_envelope_orig: the pull target and the
-    // containment test are deliberately different objects here.
-    return m_envelope;
 }
 
 void SimWildMesh::smooth_all_vertices(const size_t n_iters = 1)

--- a/components/simwild/wmtk/components/simwild/VolumemesherInsertion.cpp
+++ b/components/simwild/wmtk/components/simwild/VolumemesherInsertion.cpp
@@ -316,7 +316,7 @@ void SimWildMesh::init_surfaces_and_boundaries()
         m_envelope->use_exact = true;
         m_envelope->init(m_V_envelope, m_F_envelope, m_envelope_eps);
         m_envelope_orig = m_envelope;
-    } else if (m_params.operation == "remeshing") {
+    } else if (m_sim_params.operation == "remeshing") {
         // Deliberately NOT behind check_envelope_at_init, unlike its 2D counterpart and
         // triwild's: the answer is not an assertion but a decision -- if any surface face
         // starts outside, the envelope is rebuilt from the tet tags below. Skipping it would
@@ -364,15 +364,15 @@ void SimWildMesh::init_surfaces_and_boundaries()
         std::array<size_t, 3> vids = {{vs[0].vid(*this), vs[1].vid(*this), vs[2].vid(*this)}};
         int on_bbox = -1;
         for (int k = 0; k < 3; k++) {
-            if (m_vertex_attribute[vids[0]].m_pos[k] == m_params.box_min[k] &&
-                m_vertex_attribute[vids[1]].m_pos[k] == m_params.box_min[k] &&
-                m_vertex_attribute[vids[2]].m_pos[k] == m_params.box_min[k]) {
+            if (m_vertex_attribute[vids[0]].m_pos[k] == m_sim_params.box_min[k] &&
+                m_vertex_attribute[vids[1]].m_pos[k] == m_sim_params.box_min[k] &&
+                m_vertex_attribute[vids[2]].m_pos[k] == m_sim_params.box_min[k]) {
                 on_bbox = k * 2;
                 break;
             }
-            if (m_vertex_attribute[vids[0]].m_pos[k] == m_params.box_max[k] &&
-                m_vertex_attribute[vids[1]].m_pos[k] == m_params.box_max[k] &&
-                m_vertex_attribute[vids[2]].m_pos[k] == m_params.box_max[k]) {
+            if (m_vertex_attribute[vids[0]].m_pos[k] == m_sim_params.box_max[k] &&
+                m_vertex_attribute[vids[1]].m_pos[k] == m_sim_params.box_max[k] &&
+                m_vertex_attribute[vids[2]].m_pos[k] == m_sim_params.box_max[k]) {
                 on_bbox = k * 2 + 1;
                 break;
             }
@@ -445,7 +445,7 @@ void SimWildMesh::find_order_2_edges()
     m_order_2_edge_envelope->init(
         v_posf,
         order_2_edges,
-        m_params.epsr * m_params.diag_l * m_params.order2_envelope_ratio);
+        m_params.epsr * m_params.diag_l * m_sim_params.order2_envelope_ratio);
 }
 
 bool SimWildMesh::is_order_2_edge(const Tuple& e) const

--- a/components/tetwild/wmtk/components/tetwild/DelaunayBoxMesh.cpp
+++ b/components/tetwild/wmtk/components/tetwild/DelaunayBoxMesh.cpp
@@ -29,24 +29,24 @@ void TetWildMesh::init_from_delaunay_box_mesh(const std::vector<Eigen::Vector3d>
         for (int j = 0; j < 3; j++) points[i][j] = vertices[i][j];
     }
 
-    // The box is grown from the ORIGINAL input bbox (m_params.min/max), not from `vertices`,
+    // The box is grown from the ORIGINAL input bbox (m_tet_params.min/max), not from `vertices`,
     // which are the SIMPLIFIED surface -- so it is deliberately larger than the point set
-    // being triangulated. m_params.box_min/box_max then hold the padded box, which is what
+    // being triangulated. m_tet_params.box_min/box_max then hold the padded box, which is what
     // bbox-face tagging compares vertex coordinates against.
     std::vector<wmtk::delaunay::Tetrahedron> tets;
     Vector3d box_min, box_max;
     wmtk::utils::delaunay_box_mesh(
         *m_envelope,
-        m_params.min,
-        m_params.max,
+        m_tet_params.min,
+        m_tet_params.max,
         m_params.diag_l,
         points,
         tets,
         box_min,
         box_max);
 
-    m_params.box_min = box_min;
-    m_params.box_max = box_max;
+    m_tet_params.box_min = box_min;
+    m_tet_params.box_max = box_max;
 
     // conn
     init(points.size(), tets);

--- a/components/tetwild/wmtk/components/tetwild/EdgeCollapsing.cpp
+++ b/components/tetwild/wmtk/components/tetwild/EdgeCollapsing.cpp
@@ -120,7 +120,8 @@ bool TetWildMesh::collapse_edge_before(const Tuple& loc) // input is an edge
 
     // open boundary
     if (cache.edge_length > 0 && m_vertex_extra[v1_id].m_is_on_open_boundary) {
-        if (!m_vertex_extra[v2_id].m_is_on_open_boundary && m_order2_envelope->is_outside(VA[v2_id].m_posf)) {
+        if (!m_vertex_extra[v2_id].m_is_on_open_boundary &&
+            m_order2_envelope->is_outside(VA[v2_id].m_posf)) {
             return false;
         }
     }
@@ -340,8 +341,8 @@ bool TetWildMesh::collapse_edge_after(const Tuple& loc)
     // false;
 
     // open boundary - must be set before checking for open boundary
-    m_vertex_extra[v2_id].m_is_on_open_boundary =
-        m_vertex_extra.at(v1_id).m_is_on_open_boundary || m_vertex_extra.at(v2_id).m_is_on_open_boundary;
+    m_vertex_extra[v2_id].m_is_on_open_boundary = m_vertex_extra.at(v1_id).m_is_on_open_boundary ||
+                                                  m_vertex_extra.at(v2_id).m_is_on_open_boundary;
 
     // surface
     // and open boundary

--- a/components/tetwild/wmtk/components/tetwild/EdgeCollapsing.cpp
+++ b/components/tetwild/wmtk/components/tetwild/EdgeCollapsing.cpp
@@ -119,8 +119,8 @@ bool TetWildMesh::collapse_edge_before(const Tuple& loc) // input is an edge
     }
 
     // open boundary
-    if (cache.edge_length > 0 && VA[v1_id].m_is_on_open_boundary) {
-        if (!VA[v2_id].m_is_on_open_boundary && m_order2_envelope->is_outside(VA[v2_id].m_posf)) {
+    if (cache.edge_length > 0 && m_vertex_extra[v1_id].m_is_on_open_boundary) {
+        if (!m_vertex_extra[v2_id].m_is_on_open_boundary && m_order2_envelope->is_outside(VA[v2_id].m_posf)) {
             return false;
         }
     }
@@ -340,8 +340,8 @@ bool TetWildMesh::collapse_edge_after(const Tuple& loc)
     // false;
 
     // open boundary - must be set before checking for open boundary
-    VA[v2_id].m_is_on_open_boundary =
-        VA.at(v1_id).m_is_on_open_boundary || VA.at(v2_id).m_is_on_open_boundary;
+    m_vertex_extra[v2_id].m_is_on_open_boundary =
+        m_vertex_extra.at(v1_id).m_is_on_open_boundary || m_vertex_extra.at(v2_id).m_is_on_open_boundary;
 
     // surface
     // and open boundary
@@ -381,10 +381,10 @@ bool TetWildMesh::collapse_edge_after(const Tuple& loc)
         //}
     }
 
-    if (VA.at(v2_id).m_is_on_open_boundary) {
+    if (m_vertex_extra.at(v2_id).m_is_on_open_boundary) {
         // check if boundary edges are topologically still boundaries
         if (!is_vertex_on_boundary(v2_id)) {
-            VA[v2_id].m_is_on_open_boundary = false;
+            m_vertex_extra[v2_id].m_is_on_open_boundary = false;
         }
     }
 

--- a/components/tetwild/wmtk/components/tetwild/EdgeSplitting.cpp
+++ b/components/tetwild/wmtk/components/tetwild/EdgeSplitting.cpp
@@ -296,7 +296,7 @@ bool TetWildMesh::split_edge_after(const Tuple& loc)
     m_vertex_attribute[v_id].m_order = cache.edge_order;
 
     // open boundary
-    m_vertex_attribute[v_id].m_is_on_open_boundary = cache.is_edge_open_boundary;
+    m_vertex_extra[v_id].m_is_on_open_boundary = cache.is_edge_open_boundary;
 
     /// update face attribute
     // add new and erase old

--- a/components/tetwild/wmtk/components/tetwild/EdgeSplitting.cpp
+++ b/components/tetwild/wmtk/components/tetwild/EdgeSplitting.cpp
@@ -19,7 +19,7 @@ void TetWildMesh::split_all_edges()
     // is preallocated per phase, so any vertex a split creates during this pass already
     // has an id below it (same invariant run_localized_to_convergence relies on for
     // vertex_epoch). make_unique value-initialises, so every slot starts at 0.
-    if (m_params.split_high_valence_threshold > 0) {
+    if (m_tet_params.split_high_valence_threshold > 0) {
         // Size to the preallocated capacity, not vert_capacity(). vert_capacity() returns
         // current_vert_size -- the live vertex count -- so every vertex a split creates during
         // this pass gets an id at or above it, trips the `vid >= m_high_valence_claim_size`
@@ -95,7 +95,7 @@ void TetWildMesh::split_all_edges()
         wmtk::logger().info(
             "[high-valence] {} splits refused to avoid growing a vertex past {} incident tets",
             n,
-            m_params.split_high_valence_threshold);
+            m_tet_params.split_high_valence_threshold);
     }
     // Consumed: the queued force-split edges no longer exist after this pass.
     m_force_split_edges.clear();
@@ -151,8 +151,8 @@ bool TetWildMesh::split_edge_before(const Tuple& loc0)
     // A vertex past the threshold accepts one such split per pass and refuses the rest,
     // which spreads the refinement instead of letting it pile onto the same vertex. Done
     // here, before the face caching below, so a refusal is cheap.
-    if (m_params.split_high_valence_threshold > 0 && m_high_valence_claim) {
-        const size_t threshold = static_cast<size_t>(m_params.split_high_valence_threshold);
+    if (m_tet_params.split_high_valence_threshold > 0 && m_high_valence_claim) {
+        const size_t threshold = static_cast<size_t>(m_tet_params.split_high_valence_threshold);
         std::vector<size_t> to_claim;
         for (const Tuple& t : tets) {
             const auto vs = oriented_tet_vertices(t);

--- a/components/tetwild/wmtk/components/tetwild/EdgeSwapping.cpp
+++ b/components/tetwild/wmtk/components/tetwild/EdgeSwapping.cpp
@@ -92,7 +92,7 @@ size_t TetWildMesh::swap_all_edges_32()
     logger().info("edge swap prepare time: {:.4}s", time);
     size_t total_success = 0;
     SurfaceTopoSignature sig_before;
-    if (m_params.check_surface_topology) {
+    if (m_tet_params.check_surface_topology) {
         sig_before = surface_topology_signature();
     }
     auto setup_and_execute = [&](auto& executor) {
@@ -117,7 +117,7 @@ size_t TetWildMesh::swap_all_edges_32()
         time = timer.getElapsedTime();
         logger().info("edge swap operation time serial: {:.4}s", time);
     }
-    if (m_params.check_surface_topology) {
+    if (m_tet_params.check_surface_topology) {
         warn_if_surface_topology_changed(sig_before, "swap_all_edges_32");
     }
     return total_success;
@@ -147,7 +147,7 @@ bool TetWildMesh::swap_edge_before(const Tuple& t)
     // mistaken for interior because of stale m_is_on_surface flags (which would tear the surface).
     const int n_surf_faces = edge_incident_surface_face_count(t);
     if (n_surf_faces > 0) {
-        if (!m_params.allow_surface_swap) return false;
+        if (!m_tet_params.allow_surface_swap) return false;
         if (!prepare_surface_flip(t, incident_tets)) return false;
     }
 
@@ -482,7 +482,7 @@ size_t TetWildMesh::swap_all_edges_all()
     logger().info("edge swap prepare time: {:.4}s", time);
     size_t total_success = 0;
     SurfaceTopoSignature sig_before;
-    if (m_params.check_surface_topology) {
+    if (m_tet_params.check_surface_topology) {
         sig_before = surface_topology_signature();
     }
     auto setup_and_execute = [&](auto& executor) {
@@ -525,7 +525,7 @@ size_t TetWildMesh::swap_all_edges_all()
         time = timer.getElapsedTime();
         logger().info("edge swap operation time serial: {:.4}s", time);
     }
-    if (m_params.check_surface_topology) {
+    if (m_tet_params.check_surface_topology) {
         warn_if_surface_topology_changed(sig_before, "swap_all_edges_all");
     }
     return total_success;
@@ -545,7 +545,7 @@ size_t TetWildMesh::swap_all_edges_44()
     logger().info("edge swap 44 prepare time: {:.4}s", time);
     size_t total_success = 0;
     SurfaceTopoSignature sig_before;
-    if (m_params.check_surface_topology) sig_before = surface_topology_signature();
+    if (m_tet_params.check_surface_topology) sig_before = surface_topology_signature();
     auto setup_and_execute = [&](auto& executor) {
         executor.renew_neighbor_tuples = wmtk::renewal_edges;
         executor.priority = [&](auto& m, auto op, auto& t) { return m.get_length2(t); };
@@ -568,7 +568,7 @@ size_t TetWildMesh::swap_all_edges_44()
         time = timer.getElapsedTime();
         logger().info("edge swap 44 operation time serial: {:.4}s", time);
     }
-    if (m_params.check_surface_topology)
+    if (m_tet_params.check_surface_topology)
         warn_if_surface_topology_changed(sig_before, "swap_all_edges_44");
     return total_success;
 }
@@ -597,7 +597,7 @@ bool TetWildMesh::swap_edge_44_before(const Tuple& t)
     // direct incident-surface-face count so a genuine surface edge is never mistaken for interior.
     const int n_surf_faces = edge_incident_surface_face_count(t);
     if (n_surf_faces > 0) {
-        if (!m_params.allow_surface_swap) return false;
+        if (!m_tet_params.allow_surface_swap) return false;
         if (!prepare_surface_flip(t, incident_tets)) return false;
     }
 
@@ -610,21 +610,6 @@ bool TetWildMesh::swap_edge_44_before(const Tuple& t)
     face_attribute_tracker(*this, incident_tets, m_face_attribute, cache.changed_faces);
 
     return true;
-}
-
-double TetWildMesh::swap_edge_44_energy(
-    const std::vector<std::array<size_t, 4>>& tets,
-    const int op_case)
-{
-    double max_energy = -1;
-    for (const auto& vids : tets) {
-        if (is_inverted(vids)) {
-            return std::numeric_limits<double>::max();
-        }
-        const double e = get_quality(vids);
-        max_energy = std::max(max_energy, e);
-    }
-    return max_energy;
 }
 
 bool TetWildMesh::swap_edge_44_after(const Tuple& t)
@@ -694,7 +679,7 @@ size_t TetWildMesh::swap_all_edges_56()
     logger().info("edge swap 56 prepare time: {:.4}s", time);
     size_t total_success = 0;
     SurfaceTopoSignature sig_before;
-    if (m_params.check_surface_topology) sig_before = surface_topology_signature();
+    if (m_tet_params.check_surface_topology) sig_before = surface_topology_signature();
     auto setup_and_execute = [&](auto& executor) {
         executor.renew_neighbor_tuples = wmtk::renewal_edges;
         executor.priority = [&](auto& m, auto op, auto& t) { return m.get_length2(t); };
@@ -717,7 +702,7 @@ size_t TetWildMesh::swap_all_edges_56()
         time = timer.getElapsedTime();
         logger().info("edge swap 56 operation time serial: {:.4}s", time);
     }
-    if (m_params.check_surface_topology)
+    if (m_tet_params.check_surface_topology)
         warn_if_surface_topology_changed(sig_before, "swap_all_edges_56");
     return total_success;
 }
@@ -745,7 +730,7 @@ bool TetWildMesh::swap_edge_56_before(const Tuple& t)
     // incident-surface-face count so a genuine surface edge is never mistaken for interior.
     const int n_surf_faces = edge_incident_surface_face_count(t);
     if (n_surf_faces > 0) {
-        if (!m_params.allow_surface_swap) return false;
+        if (!m_tet_params.allow_surface_swap) return false;
         if (!prepare_surface_flip(t, incident_tets)) return false;
     }
 
@@ -758,21 +743,6 @@ bool TetWildMesh::swap_edge_56_before(const Tuple& t)
     face_attribute_tracker(*this, incident_tets, m_face_attribute, cache.changed_faces);
 
     return true;
-}
-
-double TetWildMesh::swap_edge_56_energy(
-    const std::vector<std::array<size_t, 4>>& tets,
-    const int op_case)
-{
-    double max_energy = -1;
-    for (const auto& vids : tets) {
-        if (is_inverted(vids)) {
-            return std::numeric_limits<double>::max();
-        }
-        const double e = get_quality(vids);
-        max_energy = std::max(max_energy, e);
-    }
-    return max_energy;
 }
 
 bool TetWildMesh::swap_edge_56_after(const Tuple& t)

--- a/components/tetwild/wmtk/components/tetwild/Smooth.cpp
+++ b/components/tetwild/wmtk/components/tetwild/Smooth.cpp
@@ -17,40 +17,6 @@
 
 namespace wmtk::components::tetwild {
 
-bool TetWildMesh::smooth_before(const Tuple& t)
-{
-    const bool r = round(t);
-
-    const size_t vid = t.vid(*this);
-
-    if (!m_vertex_attribute[vid].on_bbox_faces.empty()) return false;
-
-    if (m_vertex_attribute[vid].m_is_rounded) return true;
-    // try to round.
-    // Note: no need to roll back.
-    return r;
-}
-
-
-bool TetWildMesh::smooth_after(const Tuple& t)
-{
-    // The body lives in wmtk::optimization::smooth_vertex_3d, shared with simwild.
-    //
-    // This replaces the previous scheme, which optimized AMIPS alone and then snapped the
-    // vertex onto the envelope with nearest_point. That snap moved a drifted vertex the
-    // whole way in one jump, which almost always worsened an incident tet, so the operation
-    // was vetoed and the rollback discarded the projection -- a vertex near the envelope
-    // wall could never come back. The envelope is now a term in the objective instead, so
-    // the pull is gradual and the line search refuses steps that leave the envelope.
-    optimization::SmoothVertexOptions opts;
-    opts.w_amips = m_params.w_amips;
-    opts.w_envelope = m_params.w_envelope;
-    opts.s_amips = m_s_amips;
-    opts.s_envelope = m_s_envelope;
-    opts.two_stage = true;
-
-    return optimization::smooth_vertex_3d(*this, t, opts, m_solver.local(), &m_smooth_rejects);
-}
 
 std::shared_ptr<SampleEnvelope> TetWildMesh::smoothing_energy_envelope(const size_t vid) const
 {
@@ -59,13 +25,6 @@ std::shared_ptr<SampleEnvelope> TetWildMesh::smoothing_energy_envelope(const siz
     if (get_order_of_vertex(vid) >= 2 && m_order2_envelope && m_order2_envelope->initialized()) {
         return m_order2_envelope;
     }
-    return m_envelope;
-}
-
-std::shared_ptr<SampleEnvelope> TetWildMesh::smoothing_containment_envelope(const size_t) const
-{
-    // tetwild keeps one surface envelope, so pull target and containment test coincide --
-    // unlike simwild, which has a separate working envelope.
     return m_envelope;
 }
 
@@ -115,6 +74,26 @@ void TetWildMesh::smooth_all_vertices()
         wmtk::logger().info("vertex smoothing operation time serial: {:.4}s", time);
     }
     wmtk::logger().info("\tsmooth: {}", m_smooth_rejects.to_string());
+}
+
+bool TetWildMesh::smooth_after(const Tuple& t)
+{
+    // The body lives in wmtk::optimization::smooth_vertex_3d, shared with simwild.
+    //
+    // This replaces the previous scheme, which optimized AMIPS alone and then snapped the
+    // vertex onto the envelope with nearest_point. That snap moved a drifted vertex the
+    // whole way in one jump, which almost always worsened an incident tet, so the operation
+    // was vetoed and the rollback discarded the projection -- a vertex near the envelope
+    // wall could never come back. The envelope is now a term in the objective instead, so
+    // the pull is gradual and the line search refuses steps that leave the envelope.
+    optimization::SmoothVertexOptions opts;
+    opts.w_amips = m_params.w_amips;
+    opts.w_envelope = m_params.w_envelope;
+    opts.s_amips = m_s_amips;
+    opts.s_envelope = m_s_envelope;
+    opts.two_stage = true;
+
+    return optimization::smooth_vertex_3d(*this, t, opts, m_solver.local(), &m_smooth_rejects);
 }
 
 } // namespace wmtk::components::tetwild

--- a/components/tetwild/wmtk/components/tetwild/TetWildMesh.cpp
+++ b/components/tetwild/wmtk/components/tetwild/TetWildMesh.cpp
@@ -201,7 +201,7 @@ void TetWildMesh::mesh_improvement_legacy(int max_its)
         state.is_mesh_closed = true;
         for (const Tuple& v : get_vertices()) {
             const size_t vid = v.vid(*this);
-            if (m_vertex_attribute[vid].m_is_on_open_boundary) {
+            if (m_vertex_extra[vid].m_is_on_open_boundary) {
                 state.is_mesh_closed = false;
                 break;
             }
@@ -282,6 +282,7 @@ void TetWildMesh::mesh_improvement_legacy(int max_its)
         legacy_tetwild.tet_vertices.resize(vert_capacity());
         for (size_t i = 0; i < vert_capacity(); ++i) {
             const auto& VA = m_vertex_attribute[i];
+            const auto& VX = m_vertex_extra[i];
             orig::TetVertex& v = legacy_tetwild.tet_vertices[i];
             v.pos = VA.m_pos;
             v.posf = VA.m_posf;
@@ -308,7 +309,7 @@ void TetWildMesh::mesh_improvement_legacy(int max_its)
                     log_and_throw_error("Vertex should not be on more than 3 bbox faces");
                 }
             }
-            v.is_on_boundary = VA.m_is_on_open_boundary;
+            v.is_on_boundary = VX.m_is_on_open_boundary;
             v.is_on_surface = VA.m_is_on_surface;
             v.is_rounded = VA.m_is_rounded;
             for (const size_t tid : get_one_ring_tids_for_vertex(i)) {
@@ -348,6 +349,7 @@ void TetWildMesh::mesh_improvement_legacy(int max_its)
         assert(verts.size() >= vert_capacity());
         for (size_t i = 0; i < vert_capacity(); ++i) {
             auto& VA = m_vertex_attribute[i];
+            auto& VX = m_vertex_extra[i];
             const orig::TetVertex& v = verts[i];
             VA.m_is_rounded = v.is_rounded;
             if (v.is_rounded) {
@@ -359,7 +361,7 @@ void TetWildMesh::mesh_improvement_legacy(int max_its)
             }
             VA.m_sizing_scalar = v.adaptive_scale;
             VA.m_is_on_surface = v.is_on_surface;
-            VA.m_is_on_open_boundary = v.is_on_boundary;
+            VX.m_is_on_open_boundary = v.is_on_boundary;
             // logger().info("DEBUG on_bbox");
             if (v.is_on_bbox) {
                 VA.on_bbox_faces.clear();
@@ -447,7 +449,7 @@ std::tuple<double, double> TetWildMesh::local_operations(
             //         v,
             //         m_vertex_attribute[v].m_is_rounded,
             //         m_vertex_attribute[v].m_is_on_surface,
-            //         m_vertex_attribute[v].m_is_on_open_boundary);
+            //         m_vertex_extra[v].m_is_on_open_boundary);
             // }
         }
 
@@ -480,8 +482,8 @@ std::tuple<double, double> TetWildMesh::local_operations(
                 if (!is_open_boundary_edge(e)) {
                     size_t v1 = e.vid(*this);
                     size_t v2 = e.switch_vertex(*this).vid(*this);
-                    if (!m_vertex_attribute[v1].m_is_on_open_boundary ||
-                        !m_vertex_attribute[v2].m_is_on_open_boundary) {
+                    if (!m_vertex_extra[v1].m_is_on_open_boundary ||
+                        !m_vertex_extra[v2].m_is_on_open_boundary) {
                         continue;
                     }
                     logger().warn("Boundary edge ({},{}) is outside the envelope.", v1, v2);
@@ -489,12 +491,12 @@ std::tuple<double, double> TetWildMesh::local_operations(
                     //     "v{}, on surface = {}, on open boundary = {}",
                     //     v1,
                     //     m_vertex_attribute[v1].m_is_on_surface,
-                    //     m_vertex_attribute[v1].m_is_on_open_boundary);
+                    //     m_vertex_extra[v1].m_is_on_open_boundary);
                     // logger().error(
                     //     "v{}, on surface = {}, on open boundary = {}",
                     //     v2,
                     //     m_vertex_attribute[v2].m_is_on_surface,
-                    //     m_vertex_attribute[v2].m_is_on_open_boundary);
+                    //     m_vertex_extra[v2].m_is_on_open_boundary);
                 }
             }
         }
@@ -1043,7 +1045,7 @@ double TetWildMesh::get_length2(const wmtk::TetMesh::Tuple& l) const
 
 bool TetWildMesh::is_vertex_on_boundary(const size_t e0)
 {
-    if (!m_vertex_attribute.at(e0).m_is_on_open_boundary) {
+    if (!m_vertex_extra.at(e0).m_is_on_open_boundary) {
         return false;
     }
 
@@ -1051,7 +1053,7 @@ bool TetWildMesh::is_vertex_on_boundary(const size_t e0)
     const auto e0_tids = get_one_ring_tids_for_vertex(e0);
 
     for (const size_t e1 : neigh_vids) {
-        if (!m_vertex_attribute.at(e1).m_is_on_open_boundary) {
+        if (!m_vertex_extra.at(e1).m_is_on_open_boundary) {
             continue;
         }
         int cnt = 0;
@@ -1293,7 +1295,7 @@ void TetWildMesh::save_paraview(const std::string& path, const bool use_hdf5)
         v_sizing_field[vid] = m_vertex_attribute[vid].m_sizing_scalar;
         v_is_rounded[vid] = m_vertex_attribute[vid].m_is_rounded ? 1 : 0;
         v_is_on_surface[vid] = m_vertex_attribute[vid].m_is_on_surface ? 1 : 0;
-        v_is_on_open_boundary[vid] = m_vertex_attribute[vid].m_is_on_open_boundary ? 1 : 0;
+        v_is_on_open_boundary[vid] = m_vertex_extra[vid].m_is_on_open_boundary ? 1 : 0;
         v_order[vid] = m_vertex_attribute[vid].m_order;
     }
 

--- a/components/tetwild/wmtk/components/tetwild/TetWildMesh.cpp
+++ b/components/tetwild/wmtk/components/tetwild/TetWildMesh.cpp
@@ -46,12 +46,6 @@ static int debug_print_counter = 0;
 namespace wmtk::components::tetwild {
 
 
-VertexAttributes::VertexAttributes(const Vector3r& p)
-{
-    m_pos = p;
-    m_posf = to_double(p);
-}
-
 void TetWildMesh::mesh_improvement(int max_its)
 {
     ////preprocessing
@@ -94,11 +88,11 @@ void TetWildMesh::mesh_improvement(int max_its)
         // whatever the two passes after it turn that state into. Breaking early leaves the
         // remaining passes of this iteration unrun, which is the point: they are not needed.
         double max_energy = 0., avg_energy = 0.;
-        if (!m_params.interleaved_smoothing) {
+        if (!m_tet_params.interleaved_smoothing) {
             std::tie(max_energy, avg_energy) =
-                local_operations({{1, 1, 1, m_params.num_smoothing_passes}});
+                local_operations({{1, 1, 1, m_tet_params.num_smoothing_passes}});
         } else {
-            const int k = m_params.interleaved_smoothing_passes;
+            const int k = m_tet_params.interleaved_smoothing_passes;
             const std::array<std::array<int, 4>, 3> passes = {
                 {{{1, 0, 0, k}}, {{0, 1, 0, k}}, {{0, 0, 1, k}}}};
             for (const std::array<int, 4>& ops : passes) {
@@ -181,36 +175,6 @@ void TetWildMesh::mesh_improvement(int max_its)
 
     logger().info("========it post========");
     local_operations({{0, 1, 0, 0}});
-}
-
-size_t TetWildMesh::round_all_vertices()
-{
-    if (m_all_rounded.load(std::memory_order_relaxed)) {
-        return 0;
-    }
-
-    size_t reclaimed = 0, still_unrounded = 0;
-    for (const Tuple& v : get_vertices()) {
-        if (m_vertex_attribute[v.vid(*this)].m_is_rounded) {
-            continue;
-        }
-        if (round(v)) {
-            ++reclaimed;
-        } else {
-            ++still_unrounded;
-        }
-    }
-
-    if (still_unrounded == 0) {
-        m_all_rounded.store(true, std::memory_order_relaxed);
-    }
-    if (reclaimed > 0 || still_unrounded > 0) {
-        logger().info(
-            "rounding sweep: reclaimed {}, still unrounded {}",
-            reclaimed,
-            still_unrounded);
-    }
-    return reclaimed;
 }
 
 void TetWildMesh::mesh_improvement_legacy(int max_its)
@@ -706,15 +670,6 @@ size_t TetWildMesh::refine_sizing_around_worst(double max_energy)
     return refined.size();
 }
 
-void TetWildMesh::gradation_smooth_sizing(double grade, const std::vector<size_t>& seeds)
-{
-    utils::gradation_smooth_sizing(
-        grade,
-        seeds,
-        [this](size_t v) -> double& { return m_vertex_attribute[v].m_sizing_scalar; },
-        [this](size_t v) { return get_one_ring_vids_for_vertex_adj(v); });
-}
-
 void bfs_orient(const Eigen::MatrixXi& F, Eigen::MatrixXi& FF, Eigen::VectorXi& C)
 {
     Eigen::SparseMatrix<int> A;
@@ -1019,23 +974,6 @@ void TetWildMesh::filter_with_flood_fill()
     remove_tets_by_ids(rm_tids);
 }
 
-/////////////////////////////////////////////////////////////////////
-void TetWildMesh::output_faces(std::string file, std::function<bool(const FaceAttributes&)> cond)
-{
-    auto outface = get_faces_by_condition(cond);
-    Eigen::MatrixXd matV = Eigen::MatrixXd::Zero(vert_capacity(), 3);
-    for (const auto& v : get_vertices()) {
-        auto vid = v.vid(*this);
-        matV.row(vid) = m_vertex_attribute[vid].m_posf;
-    }
-    Eigen::MatrixXi matF(outface.size(), 3);
-    for (auto i = 0; i < outface.size(); i++) {
-        matF.row(i) << (int)outface[i][0], (int)outface[i][1], (int)outface[i][2];
-    }
-    logger().info("Output face size {}", outface.size());
-    igl::write_triangle_mesh(file, matV, matF);
-}
-
 
 void TetWildMesh::output_mesh(std::string file)
 {
@@ -1102,282 +1040,6 @@ double TetWildMesh::get_length2(const wmtk::TetMesh::Tuple& l) const
     return length;
 }
 
-std::tuple<double, double> TetWildMesh::get_max_avg_energy()
-{
-    double max_energy = -1.;
-    double avg_energy = 0.;
-    auto cnt = 0;
-    // TetMesh::for_each_tetra([&](auto& t) {
-    //     auto q = m_tet_attribute[t.tid(*this)].m_quality;
-    //     max_energy = std::max(max_energy, q);
-    //     avg_energy += std::cbrt(q);
-    //     cnt++;
-    // });
-    // std::ofstream large_tet("large_energy_tet.obj");
-
-    for (int i = 0; i < tet_capacity(); i++) {
-        auto tup = tuple_from_tet(i);
-        if (!tup.is_valid(*this)) continue;
-        // auto vs = oriented_tet_vertices(tup);
-
-        auto q = m_tet_attribute[tup.tid(*this)].m_quality;
-        max_energy = std::max(max_energy, q);
-        // if (q > 1e6) {
-        //     for (auto v : vs) {
-        //         large_tet << "v " << m_vertex_attribute[v.vid(*this)].m_posf[0] << " "
-        //                   << m_vertex_attribute[v.vid(*this)].m_posf[1] << " "
-        //                   << m_vertex_attribute[v.vid(*this)].m_posf[2] << std::endl;
-        //     }
-        // }
-        avg_energy += std::cbrt(q);
-        cnt++;
-    }
-
-    avg_energy /= cnt;
-
-    return std::make_tuple(std::cbrt(max_energy), avg_energy);
-}
-
-std::vector<size_t> TetWildMesh::active_vertices() const
-{
-    return utils::active_vertices(
-        vert_capacity(),
-        tet_capacity(),
-        [this](size_t tid) { return tuple_from_tet(tid).is_valid(*this); },
-        [this](size_t tid) { return m_tet_attribute[tid].m_quality; },
-        [this](size_t tid) { return oriented_tet_vids(tid); },
-        active_quality_threshold(),
-        [this](size_t vid) { return m_vertex_attribute[vid].m_is_on_surface; });
-}
-
-
-bool TetWildMesh::is_inverted_f(const Tuple& loc) const
-{
-    auto vs = oriented_tet_vertices(loc);
-
-    igl::predicates::exactinit();
-    auto res = igl::predicates::orient3d(
-        m_vertex_attribute[vs[0].vid(*this)].m_posf,
-        m_vertex_attribute[vs[1].vid(*this)].m_posf,
-        m_vertex_attribute[vs[2].vid(*this)].m_posf,
-        m_vertex_attribute[vs[3].vid(*this)].m_posf);
-    int result;
-    if (res == igl::predicates::Orientation::POSITIVE)
-        result = 1;
-    else if (res == igl::predicates::Orientation::NEGATIVE)
-        result = -1;
-    else
-        result = 0;
-
-    if (result < 0) // neg result == pos tet (tet origin from geogram delaunay)
-        return false;
-    return true;
-}
-
-bool TetWildMesh::is_inverted(const std::array<size_t, 4>& vs) const
-{
-    // Return a positive value if the point pd lies below the
-    // plane passing through pa, pb, and pc; "below" is defined so
-    // that pa, pb, and pc appear in counterclockwise order when
-    // viewed from above the plane.
-
-    if (m_vertex_attribute[vs[0]].m_is_rounded && m_vertex_attribute[vs[1]].m_is_rounded &&
-        m_vertex_attribute[vs[2]].m_is_rounded && m_vertex_attribute[vs[3]].m_is_rounded) {
-        igl::predicates::exactinit();
-        auto res = igl::predicates::orient3d(
-            m_vertex_attribute[vs[0]].m_posf,
-            m_vertex_attribute[vs[1]].m_posf,
-            m_vertex_attribute[vs[2]].m_posf,
-            m_vertex_attribute[vs[3]].m_posf);
-        int result;
-        if (res == igl::predicates::Orientation::POSITIVE)
-            result = 1;
-        else if (res == igl::predicates::Orientation::NEGATIVE)
-            result = -1;
-        else
-            result = 0;
-
-        if (result < 0) // neg result == pos tet (tet origin from geogram delaunay)
-            return false;
-        return true;
-    } else {
-        Vector3r n =
-            ((m_vertex_attribute[vs[1]].m_pos) - m_vertex_attribute[vs[0]].m_pos)
-                .cross((m_vertex_attribute[vs[2]].m_pos) - m_vertex_attribute[vs[0]].m_pos);
-        Vector3r d = (m_vertex_attribute[vs[3]].m_pos) - m_vertex_attribute[vs[0]].m_pos;
-        auto res = n.dot(d);
-        if (res > 0) // predicates returns pos value: non-inverted
-            return false;
-        else
-            return true;
-    }
-}
-
-bool TetWildMesh::is_inverted(const Tuple& loc) const
-{
-    auto vs = oriented_tet_vids(loc);
-    return is_inverted(vs);
-}
-
-bool TetWildMesh::round(const Tuple& v)
-{
-    size_t i = v.vid(*this);
-    if (m_vertex_attribute[i].m_is_rounded) return true;
-
-    auto old_pos = m_vertex_attribute[i].m_pos;
-    m_vertex_attribute[i].m_pos << m_vertex_attribute[i].m_posf[0], m_vertex_attribute[i].m_posf[1],
-        m_vertex_attribute[i].m_posf[2];
-    auto conn_tets = get_one_ring_tets_for_vertex(v);
-    m_vertex_attribute[i].m_is_rounded = true;
-    for (auto& tet : conn_tets) {
-        if (is_inverted(tet)) {
-            m_vertex_attribute[i].m_is_rounded = false;
-            m_vertex_attribute[i].m_pos = old_pos;
-            return false;
-        }
-    }
-
-    return true;
-}
-
-double TetWildMesh::get_quality(const std::array<size_t, 4>& its) const
-{
-    std::array<Vector3d, 4> ps;
-    auto use_rational = false;
-    for (auto k = 0; k < 4; k++) {
-        ps[k] = m_vertex_attribute[its[k]].m_posf;
-        if (!m_vertex_attribute[its[k]].m_is_rounded) {
-            use_rational = true;
-            break;
-        }
-    }
-    auto energy = -1.;
-    if (!use_rational) {
-        std::array<double, 12> T;
-        for (auto k = 0; k < 4; k++)
-            for (auto j = 0; j < 3; j++) T[k * 3 + j] = ps[k][j];
-
-        energy = wmtk::AMIPS_energy_stable_p3<wmtk::Rational>(T);
-    } else {
-        std::array<wmtk::Rational, 12> T;
-        for (auto k = 0; k < 4; k++)
-            for (auto j = 0; j < 3; j++) T[k * 3 + j] = m_vertex_attribute[its[k]].m_pos[j];
-        energy = wmtk::AMIPS_energy_rational_p3<wmtk::Rational>(T);
-    }
-    if (std::isinf(energy) || std::isnan(energy) || energy < 27 - 1e-3) return MAX_ENERGY;
-    return energy;
-}
-
-double TetWildMesh::get_quality(const Tuple& loc) const
-{
-    auto its = oriented_tet_vids(loc);
-    return get_quality(its);
-}
-
-
-bool TetWildMesh::invariants(const std::vector<Tuple>& tets)
-{
-    return true;
-}
-
-std::vector<std::array<size_t, 3>> TetWildMesh::get_faces_by_condition(
-    std::function<bool(const FaceAttributes&)> cond) const
-{
-    auto res = std::vector<std::array<size_t, 3>>();
-    for (auto f : get_faces()) {
-        auto fid = f.fid(*this);
-        if (cond(m_face_attribute[fid])) {
-            auto tid = fid / 4, lid = fid % 4;
-            auto verts = get_face_vertices(f);
-            res.emplace_back( //
-                std::array<size_t, 3>{
-                    {verts[0].vid(*this), verts[1].vid(*this), verts[2].vid(*this)}});
-        }
-    }
-
-    return res;
-}
-
-bool TetWildMesh::is_edge_on_surface(const Tuple& loc)
-{
-    size_t v1_id = loc.vid(*this);
-    auto loc1 = loc.switch_vertex(*this);
-    size_t v2_id = loc1.vid(*this);
-    if (!m_vertex_attribute[v1_id].m_is_on_surface || !m_vertex_attribute[v2_id].m_is_on_surface)
-        return false;
-
-    auto tets = get_incident_tets_for_edge(loc);
-    std::vector<size_t> n_vids;
-    for (auto& t : tets) {
-        auto vs = oriented_tet_vertices(t);
-        for (int j = 0; j < 4; j++) {
-            if (vs[j].vid(*this) != v1_id && vs[j].vid(*this) != v2_id)
-                n_vids.push_back(vs[j].vid(*this));
-        }
-    }
-    wmtk::vector_unique(n_vids);
-
-    for (size_t vid : n_vids) {
-        auto [_, fid] = tuple_from_face({{v1_id, v2_id, vid}});
-        if (m_face_attribute[fid].m_is_surface_fs) return true;
-    }
-
-    return false;
-}
-
-int TetWildMesh::edge_incident_surface_face_count(const Tuple& e)
-{
-    const size_t v1_id = e.vid(*this);
-    const size_t v2_id = e.switch_vertex(*this).vid(*this);
-
-    const auto tets = get_incident_tets_for_edge(e);
-    std::vector<size_t> n_vids;
-    for (const auto& t : tets) {
-        const auto vs = oriented_tet_vertices(t);
-        for (int j = 0; j < 4; ++j) {
-            const size_t v = vs[j].vid(*this);
-            if (v != v1_id && v != v2_id) n_vids.push_back(v);
-        }
-    }
-    wmtk::vector_unique(n_vids);
-
-    int count = 0;
-    for (const size_t vid : n_vids) {
-        auto [ftup, fid] = tuple_from_face({{v1_id, v2_id, vid}});
-        (void)ftup;
-        if (fid != static_cast<size_t>(-1) && m_face_attribute[fid].m_is_surface_fs) ++count;
-    }
-    return count;
-}
-
-
-bool TetWildMesh::is_edge_on_bbox(const Tuple& loc)
-{
-    size_t v1_id = loc.vid(*this);
-    auto loc1 = loc.switch_vertex(*this);
-    size_t v2_id = loc1.vid(*this);
-    if (m_vertex_attribute[v1_id].on_bbox_faces.empty() ||
-        m_vertex_attribute[v2_id].on_bbox_faces.empty())
-        return false;
-
-    auto tets = get_incident_tets_for_edge(loc);
-    std::vector<size_t> n_vids;
-    for (auto& t : tets) {
-        auto vs = oriented_tet_vertices(t);
-        for (int j = 0; j < 4; j++) {
-            if (vs[j].vid(*this) != v1_id && vs[j].vid(*this) != v2_id)
-                n_vids.push_back(vs[j].vid(*this));
-        }
-    }
-    wmtk::vector_unique(n_vids);
-
-    for (size_t vid : n_vids) {
-        auto [_, fid] = tuple_from_face({{v1_id, v2_id, vid}});
-        if (m_face_attribute[fid].m_is_bbox_fs >= 0) return true;
-    }
-
-    return false;
-}
 
 bool TetWildMesh::is_vertex_on_boundary(const size_t e0)
 {
@@ -1434,21 +1096,6 @@ bool TetWildMesh::is_vertex_on_boundary(const size_t e0)
     return false;
 }
 
-
-bool TetWildMesh::vertex_is_on_surface(const size_t vid) const
-{
-    return m_vertex_attribute.at(vid).m_is_on_surface;
-}
-
-bool TetWildMesh::face_is_on_surface(const size_t fid) const
-{
-    return m_face_attribute.at(fid).m_is_surface_fs;
-}
-
-size_t TetWildMesh::get_order_of_vertex(const size_t vid) const
-{
-    return m_vertex_attribute.at(vid).m_order;
-}
 
 void TetWildMesh::init_vertex_order()
 {

--- a/components/tetwild/wmtk/components/tetwild/TetWildMesh.cpp
+++ b/components/tetwild/wmtk/components/tetwild/TetWildMesh.cpp
@@ -1031,18 +1031,6 @@ void TetWildMesh::output_mesh(std::string file)
 }
 
 
-double TetWildMesh::get_length2(const wmtk::TetMesh::Tuple& l) const
-{
-    auto& m = *this;
-    auto& v1 = l;
-    auto v2 = l.switch_vertex(m);
-    double length =
-        (m.m_vertex_attribute[v1.vid(m)].m_posf - m.m_vertex_attribute[v2.vid(m)].m_posf)
-            .squaredNorm();
-    return length;
-}
-
-
 bool TetWildMesh::is_vertex_on_boundary(const size_t e0)
 {
     if (!m_vertex_extra.at(e0).m_is_on_open_boundary) {

--- a/components/tetwild/wmtk/components/tetwild/TetWildMesh.h
+++ b/components/tetwild/wmtk/components/tetwild/TetWildMesh.h
@@ -272,7 +272,6 @@ public:
     void filter_with_flood_fill();
 
 
-    double get_length2(const Tuple& loc) const;
     // debug use
     std::atomic<int> cnt_split = 0, cnt_collapse = 0, cnt_swap = 0;
     // Successful surface diagonal flips (subset of cnt_swap). Diagnostic.

--- a/components/tetwild/wmtk/components/tetwild/TetWildMesh.h
+++ b/components/tetwild/wmtk/components/tetwild/TetWildMesh.h
@@ -49,6 +49,22 @@ public:
 class TetWildMesh : public wmtk::TetOptimizerMesh
 {
 public:
+    /**
+     * @brief tetwild's per-vertex additions to the shared VertexAttributes.
+     *
+     * Registered with the base's m_vertex_attr_group, so it is resized, protected and rolled
+     * back exactly like the shared collection -- which matters, because collapse_edge_after and
+     * split_edge_after both write it.
+     */
+    struct VertexExtras
+    {
+        /// Whether the vertex lies on an open boundary of the input surface. The 2D
+        /// counterpart is TriWildMesh::VertexExtras::m_feature_id, which differs deliberately
+        /// -- see the comment there.
+        bool m_is_on_open_boundary = false;
+    };
+    wmtk::AttributeCollection<VertexExtras> m_vertex_extra;
+
     /// The base holds only wmtk::OptimizerParameters; this is the same object, typed, for the
     /// tetwild-only fields.
     Parameters& m_tet_params;
@@ -84,9 +100,8 @@ public:
         : wmtk::TetOptimizerMesh(_m_params, std::move(_m_envelope))
         , m_tet_params(_m_params)
     {
+        m_vertex_attr_group.add(&m_vertex_extra);
         NUM_THREADS = _num_threads;
-        p_vertex_attrs = &m_vertex_attribute;
-        p_face_attrs = &m_face_attribute;
         p_tet_attrs = &m_tet_attribute;
         m_collapse_check_link_condition = false;
         m_collapse_check_manifold = false;
@@ -105,6 +120,9 @@ public:
     {
         const size_t n_tet = _tet_attribute.size();
         m_vertex_attribute.resize(_vertex_attribute.size());
+        // The extras carry no data a caller supplies -- every field defaults -- so they only
+        // have to be sized alongside the shared collection.
+        m_vertex_extra.resize(_vertex_attribute.size());
         m_face_attribute.resize(4 * n_tet);
         m_tet_attribute.resize(n_tet);
 

--- a/components/tetwild/wmtk/components/tetwild/TetWildMesh.h
+++ b/components/tetwild/wmtk/components/tetwild/TetWildMesh.h
@@ -3,6 +3,7 @@
 #include <igl/Timer.h>
 #include <wmtk/SurfaceTagAttributes.h>
 #include <wmtk/TetMesh.h>
+#include <wmtk/TetOptimizerMesh.h>
 #include <wmtk/utils/PartitionMesh.h>
 #include <algorithm>
 #include <wmtk/envelope/Envelope.hpp>
@@ -30,44 +31,9 @@
 
 namespace wmtk::components::tetwild {
 
-// TODO: missing comments on what these attributes are
-class VertexAttributes
-{
-public:
-    Vector3r m_pos;
-    Vector3d m_posf;
-    bool m_is_rounded = false;
-
-    bool m_is_on_surface = false;
-    /**
-     * The order of a vertex in a TetMesh is as follows:
-     * 0: vertex is not on the surface
-     * 1: vertex is on the surface
-     * 2: vertex is on the boundary of the surface or a non-manifold edge
-     * 3: vertex is at the boundary of a non-manifold edge or a non-manifold vertex
-     */
-    size_t m_order = 0;
-    std::vector<int> on_bbox_faces;
-
-    double m_sizing_scalar = 1;
-
-    size_t partition_id = 0;
-
-    // for open boundary
-    bool m_is_on_open_boundary = false;
-
-    VertexAttributes() {};
-    VertexAttributes(const Vector3r& p);
-};
-
-
-// class EdgeAttributes
-// {
-// public:
-//     bool m_is_on_open_boundary = false;
-// };
-
-using FaceAttributes = wmtk::SurfaceTagAttributes;
+/// The shared attribute types live on the base; keep the unqualified names working.
+using VertexAttributes = wmtk::TetOptimizerMesh::VertexAttributes;
+using FaceAttributes = wmtk::TetOptimizerMesh::FaceAttributes;
 
 // TODO: missing comments on what these attributes are
 class TetAttributes
@@ -80,16 +46,13 @@ public:
     int part_id = -1; // flood fill ID
 };
 
-class TetWildMesh : public wmtk::TetMesh
+class TetWildMesh : public wmtk::TetOptimizerMesh
 {
 public:
-    double time_env = 0.0;
-    igl::Timer isout_timer;
-    const double MAX_ENERGY = 1e50;
+    /// The base holds only wmtk::OptimizerParameters; this is the same object, typed, for the
+    /// tetwild-only fields.
+    Parameters& m_tet_params;
 
-    Parameters& m_params;
-    /// Surface envelope: what a surface vertex is pulled toward and checked against.
-    std::shared_ptr<SampleEnvelope> m_envelope;
     /// Envelope for order-2 vertices, i.e. those on a surface boundary or a non-manifold
     /// edge. Named for the order rather than for "open boundary" because that is what
     /// TetMesh::compute_vertex_order actually reports, and it is the broader set.
@@ -99,34 +62,27 @@ public:
     /// winding-number output fields. Empty => the fields are numbered.
     std::vector<std::string> m_input_names;
 
-    /// Per-thread Newton solver for smoothing; created on first use.
-    wmtk::threading::enumerable_thread_specific<std::unique_ptr<polysolve::nonlinear::Solver>>
-        m_solver;
+    using TetAttCol = wmtk::AttributeCollection<TetAttributes>;
+    TetAttCol m_tet_attribute;
 
-    /// Why smoothing attempts were refused, reported once per pass.
-    optimization::SmoothRejectCounters m_smooth_rejects;
-
+    double cell_quality(const size_t tid) const override { return m_tet_attribute[tid].m_quality; }
+    void set_cell_quality(const size_t tid, const double q) override
+    {
+        m_tet_attribute[tid].m_quality = q;
+    }
 
     /// Iterations mesh_improvement actually used. Reported so a run that needs the whole
     /// budget is visible as such, and asserted against in the integration tests.
     int m_iterations_used = 0;
 
-    /// Scale factors putting AMIPS (dimensionless) and the envelope energy (a squared
-    /// distance) on a comparable footing.
-    double m_s_amips = 1.;
-    double m_s_envelope = -1.;
-
     /// Envelope a vertex is pulled toward while smoothing.
     std::shared_ptr<SampleEnvelope> smoothing_energy_envelope(const size_t vid) const;
-    /// Envelope the resulting surface triangles are checked against.
-    std::shared_ptr<SampleEnvelope> smoothing_containment_envelope(const size_t vid) const;
-
     TetWildMesh(
         Parameters& _m_params,
         std::shared_ptr<SampleEnvelope> _m_envelope,
         int _num_threads = 1)
-        : m_params(_m_params)
-        , m_envelope(std::move(_m_envelope))
+        : wmtk::TetOptimizerMesh(_m_params, std::move(_m_envelope))
+        , m_tet_params(_m_params)
     {
         NUM_THREADS = _num_threads;
         p_vertex_attrs = &m_vertex_attribute;
@@ -136,20 +92,11 @@ public:
         m_collapse_check_manifold = false;
 
         optimization::deactivate_opt_logger();
-        m_s_amips = 1.;
         m_s_envelope = 1. / (m_params.diag_l * m_params.eps * m_params.eps);
         m_params.w_envelope = 1. - m_params.w_amips;
     }
 
     ~TetWildMesh() {}
-    using VertAttCol = wmtk::AttributeCollection<VertexAttributes>;
-    using FaceAttCol = wmtk::AttributeCollection<FaceAttributes>;
-    using TetAttCol = wmtk::AttributeCollection<TetAttributes>;
-    // using EdgeAttCol = wmtk::AttributeCollection<EdgeAttributes>;
-    VertAttCol m_vertex_attribute;
-    FaceAttCol m_face_attribute;
-    TetAttCol m_tet_attribute;
-    // EdgeAttCol m_edge_attribute;
 
     // only used with unit tests
     void create_mesh_attributes(
@@ -183,44 +130,9 @@ public:
             m_tet_attribute[i].m_quality = get_quality(tuple_from_tet(i));
     }
 
-    // TODO This should not be here but inside wmtk
-    void compute_vertex_partition()
-    {
-        auto partition_id = partition_TetMesh(*this, NUM_THREADS);
-        for (auto i = 0; i < vert_capacity(); i++)
-            m_vertex_attribute[i].partition_id = partition_id[i];
-    }
-
-    void compute_vertex_partition_morton()
-    {
-        if (NUM_THREADS == 0) {
-            return;
-        }
-
-        logger().info("Number of parts: {} by morton", NUM_THREADS);
-
-        std::vector<size_t> partition_id;
-        wmtk::partition_vertex_morton(
-            vert_capacity(),
-            [this](size_t i) { return m_vertex_attribute[i].m_posf; },
-            NUM_THREADS,
-            partition_id);
-
-        for (size_t i = 0; i < partition_id.size(); i++) {
-            m_vertex_attribute[i].partition_id = partition_id[i];
-        }
-    }
-
-    size_t get_partition_id(const Tuple& loc) const
-    {
-        return m_vertex_attribute[loc.vid(*this)].partition_id;
-    }
-
     ////// Attributes related
 
     void output_mesh(std::string file);
-    void output_faces(std::string file, std::function<bool(const FaceAttributes&)> cond);
-
     void init_from_delaunay_box_mesh(const std::vector<Eigen::Vector3d>& vertices);
 
 public:
@@ -228,25 +140,20 @@ public:
     bool split_edge_before(const Tuple& t) override;
     bool split_edge_after(const Tuple& loc) override;
 
-    void smooth_all_vertices();
-    bool smooth_before(const Tuple& t) override;
     bool smooth_after(const Tuple& t) override;
 
+    void smooth_all_vertices();
     void collapse_all_edges(bool is_limit_length = true);
     bool collapse_edge_before(const Tuple& t) override;
     bool collapse_edge_after(const Tuple& t) override;
 
     size_t swap_all_edges_44();
     bool swap_edge_44_before(const Tuple& t) override;
-    double swap_edge_44_energy(const std::vector<std::array<size_t, 4>>& tets, const int op_case)
-        override;
     bool swap_edge_44_accept_case(const std::array<size_t, 2>& new_edge) override;
     bool swap_edge_44_after(const Tuple& t) override;
 
     size_t swap_all_edges_56();
     bool swap_edge_56_before(const Tuple& t) override;
-    double swap_edge_56_energy(const std::vector<std::array<size_t, 4>>& tets, const int op_case)
-        override;
     bool swap_edge_56_accept_case(const std::array<size_t, 3>& new_face) override;
     bool swap_edge_56_after(const Tuple& t) override;
 
@@ -271,14 +178,6 @@ public:
      */
     bool prepare_surface_flip(const Tuple& t, const std::vector<size_t>& incident_tets);
 
-    /**
-     * @brief Number of surface faces incident to edge (a,b), counted directly over the edge's
-     * incident tets. Unlike is_edge_on_surface(), this does NOT short-circuit on the (possibly
-     * stale) m_is_on_surface vertex flags, so a genuine manifold surface edge is never mistaken
-     * for an interior edge (== 2) nor a non-manifold one (> 2). Used to route swaps.
-     */
-    int edge_incident_surface_face_count(const Tuple& e);
-
     /// A topological fingerprint of the tracked surface (m_is_surface_fs). See
     /// wmtk/utils/SurfaceTopology.hpp.
     using SurfaceTopoSignature = wmtk::utils::SurfaceTopoSignature;
@@ -292,7 +191,7 @@ public:
 
     /**
      * @brief Compare a surface signature against the current one and log an
-     * error if it changed. Used (when m_params.check_surface_topology is set) to
+     * error if it changed. Used (when m_tet_params.check_surface_topology is set) to
      * guard swap passes that can flip surface edges.
      */
     void warn_if_surface_topology_changed(const SurfaceTopoSignature& before, const char* where)
@@ -307,39 +206,7 @@ public:
 
     size_t swap_all_edges_all();
 
-    /**
-     * @brief Inversion check using only floating point numbers.
-     */
-    bool is_inverted_f(const Tuple& loc) const;
-    bool is_inverted(const std::array<size_t, 4>& vs) const;
-    bool is_inverted(const Tuple& loc) const;
-    double get_quality(const std::array<size_t, 4>& vs) const;
-    double get_quality(const Tuple& loc) const;
-    bool round(const Tuple& loc);
-    /**
-     * @brief Try to round every un-rounded vertex; returns the number reclaimed.
-     *
-     * round() is otherwise only attempted as a side effect of another operation
-     * (smooth_before on the vertex being smoothed, collapse_edge_after on the merged
-     * one), and neither reaches a vertex that only becomes roundable later: smoothing
-     * skips "good" regions by default. Without a sweep such a vertex keeps exact
-     * coordinates into the output for no geometric reason.
-     *
-     * Skipped outright when m_all_rounded says there is nothing to do.
-     */
-    size_t round_all_vertices();
-
-    /**
-     * @brief True when every vertex is known to be rounded.
-     *
-     * Only trusted when true, and only round_all_vertices() sets it that way. Any code
-     * that leaves a vertex un-rounded must clear it, or the sweep will skip the vertex
-     * forever. Atomic because operations that clear it run in parallel.
-     */
-    std::atomic<bool> m_all_rounded = false;
     //
-    bool is_edge_on_surface(const Tuple& loc);
-    bool is_edge_on_bbox(const Tuple& loc);
     /**
      * brief Check if the vertex has an incident boundary edge.
      * This performs a topological check.
@@ -354,28 +221,6 @@ public:
     std::tuple<double, double> local_operations(
         const std::array<int, 4>& ops,
         bool collapse_limit_length = true);
-    std::tuple<double, double> get_max_avg_energy();
-
-    /**
-     * @brief m_quality threshold above which a tet is "active" (worth operating
-     * on) for the skip-good-regions filter. m_quality stores AMIPS^3 and the
-     * energy is its cube root, so a tet is active when its energy is at least
-     * skip_good_regions_margin * stop_energy, i.e. m_quality >=
-     * (margin * stop_energy)^3.
-     */
-    double active_quality_threshold() const
-    {
-        const double e = m_params.skip_good_regions_margin * m_params.stop_energy;
-        return e * e * e;
-    }
-
-    /**
-     * @brief vids of the vertices incident to at least one "active" tet
-     * (m_quality >= active_quality_threshold()). Used by the skip-good-regions
-     * filter to restrict smoothing to non-good regions (smoothing a vertex
-     * surrounded by good tets does nothing).
-     */
-    std::vector<size_t> active_vertices() const;
 
     /**
      * @brief Compute the winding number.
@@ -408,11 +253,6 @@ public:
     void filter_with_tracked_surface_winding_number();
     void filter_with_flood_fill();
 
-
-    std::vector<std::array<size_t, 3>> get_faces_by_condition(
-        std::function<bool(const FaceAttributes&)> cond) const;
-
-    bool invariants(const std::vector<Tuple>& t) override; // this is now automatically checked
 
     double get_length2(const Tuple& loc) const;
     // debug use
@@ -455,10 +295,6 @@ private:
         std::vector<std::pair<FaceAttributes, std::array<size_t, 3>>> changed_faces;
     };
     wmtk::threading::enumerable_thread_specific<SplitInfoCache> split_cache;
-
-    /// Whether the current collapse pass applies the target-length limit; read by
-    /// collapse_edge_before, which is where that limit is now enforced.
-    bool m_collapse_limit_length = true;
 
     struct CollapseInfoCache
     {
@@ -537,27 +373,6 @@ public:
      */
     size_t refine_sizing_around_worst(double max_energy);
 
-    /**
-     * @brief Monotone (only-decreasing) gradation smoothing of the sizing field.
-     *
-     * Enforces m_sizing_scalar[v] <= grade * m_sizing_scalar[u] for every edge
-     * (u,v), propagating outward from `seeds` with a min-relaxation. It never
-     * raises a sizing value, so it only ever spreads more refinement into the
-     * halo around already-refined vertices, avoiding sharp resolution jumps.
-     */
-    void gradation_smooth_sizing(double grade, const std::vector<size_t>& seeds);
-
-    /// The longest edge of each current worst tet (as a sorted {min,max} vid pair).
-    /// split_all_edges force-splits exactly these edges (bypasses the length gate),
-    /// so a stuck sliver's long edge is split immediately without changing the sizing
-    /// field. Populated serially by refine_sizing_around_worst; read-only during the
-    /// parallel split pass, then cleared once split_all_edges has consumed it.
-    std::set<simplex::Edge> m_force_split_edges;
-
-    /// Count of force-splits taken in the current split pass (atomic_ref from the
-    /// parallel split; reset + logged by split_all_edges). Diagnostic only.
-    size_t m_force_split_count = 0;
-
     /// Per-pass claim for the high-valence split gate: one slot per vertex, reset at the
     /// start of every split pass. A high-valence vertex accepts the first
     /// valence-increasing split of the pass and refuses the rest, so refinement spreads
@@ -582,11 +397,6 @@ public:
 public:
     // substructure functions
 
-    bool vertex_is_on_surface(const size_t vid) const override;
-
-    bool face_is_on_surface(const size_t fid) const override;
-
-    size_t get_order_of_vertex(const size_t vid) const override;
     /**
      * @brief Compute the vertex order for every vertex.
      */

--- a/components/tetwild/wmtk/components/tetwild/VolumemesherInsertion.cpp
+++ b/components/tetwild/wmtk/components/tetwild/VolumemesherInsertion.cpp
@@ -474,8 +474,7 @@ bool TetWildMesh::is_open_boundary_edge(const Tuple& e)
 {
     size_t v1 = e.vid(*this);
     size_t v2 = e.switch_vertex(*this).vid(*this);
-    if (!m_vertex_extra[v1].m_is_on_open_boundary ||
-        !m_vertex_extra[v2].m_is_on_open_boundary)
+    if (!m_vertex_extra[v1].m_is_on_open_boundary || !m_vertex_extra[v2].m_is_on_open_boundary)
         return false;
 
     return !m_order2_envelope->is_outside(
@@ -487,8 +486,7 @@ bool TetWildMesh::is_open_boundary_edge(const std::array<size_t, 2>& e)
 {
     size_t v1 = e[0];
     size_t v2 = e[1];
-    if (!m_vertex_extra[v1].m_is_on_open_boundary ||
-        !m_vertex_extra[v2].m_is_on_open_boundary)
+    if (!m_vertex_extra[v1].m_is_on_open_boundary || !m_vertex_extra[v2].m_is_on_open_boundary)
         return false;
 
     return !m_order2_envelope->is_outside(

--- a/components/tetwild/wmtk/components/tetwild/VolumemesherInsertion.cpp
+++ b/components/tetwild/wmtk/components/tetwild/VolumemesherInsertion.cpp
@@ -432,8 +432,8 @@ void TetWildMesh::find_open_boundary()
                     if (edge_on_open_boundary[e.eid(*this)] != 1) continue;
                     const size_t v1 = e.vid(*this);
                     const size_t v2 = e.switch_vertex(*this).vid(*this);
-                    std::atomic_ref<bool>(m_vertex_attribute[v1].m_is_on_open_boundary).store(true);
-                    std::atomic_ref<bool>(m_vertex_attribute[v2].m_is_on_open_boundary).store(true);
+                    std::atomic_ref<bool>(m_vertex_extra[v1].m_is_on_open_boundary).store(true);
+                    std::atomic_ref<bool>(m_vertex_extra[v2].m_is_on_open_boundary).store(true);
                     local.emplace_back(v1, v2);
                 }
                 if (local.empty()) return;
@@ -474,8 +474,8 @@ bool TetWildMesh::is_open_boundary_edge(const Tuple& e)
 {
     size_t v1 = e.vid(*this);
     size_t v2 = e.switch_vertex(*this).vid(*this);
-    if (!m_vertex_attribute[v1].m_is_on_open_boundary ||
-        !m_vertex_attribute[v2].m_is_on_open_boundary)
+    if (!m_vertex_extra[v1].m_is_on_open_boundary ||
+        !m_vertex_extra[v2].m_is_on_open_boundary)
         return false;
 
     return !m_order2_envelope->is_outside(
@@ -487,8 +487,8 @@ bool TetWildMesh::is_open_boundary_edge(const std::array<size_t, 2>& e)
 {
     size_t v1 = e[0];
     size_t v2 = e[1];
-    if (!m_vertex_attribute[v1].m_is_on_open_boundary ||
-        !m_vertex_attribute[v2].m_is_on_open_boundary)
+    if (!m_vertex_extra[v1].m_is_on_open_boundary ||
+        !m_vertex_extra[v2].m_is_on_open_boundary)
         return false;
 
     return !m_order2_envelope->is_outside(

--- a/components/tetwild/wmtk/components/tetwild/VolumemesherInsertion.cpp
+++ b/components/tetwild/wmtk/components/tetwild/VolumemesherInsertion.cpp
@@ -247,15 +247,15 @@ void TetWildMesh::init_from_Volumeremesher(
                         {vs[0].vid(*this), vs[1].vid(*this), vs[2].vid(*this)}};
                     int on_bbox = -1;
                     for (int k = 0; k < 3; k++) {
-                        if (m_vertex_attribute[vids[0]].m_pos[k] == m_params.box_min[k] &&
-                            m_vertex_attribute[vids[1]].m_pos[k] == m_params.box_min[k] &&
-                            m_vertex_attribute[vids[2]].m_pos[k] == m_params.box_min[k]) {
+                        if (m_vertex_attribute[vids[0]].m_pos[k] == m_tet_params.box_min[k] &&
+                            m_vertex_attribute[vids[1]].m_pos[k] == m_tet_params.box_min[k] &&
+                            m_vertex_attribute[vids[2]].m_pos[k] == m_tet_params.box_min[k]) {
                             on_bbox = k * 2;
                             break;
                         }
-                        if (m_vertex_attribute[vids[0]].m_pos[k] == m_params.box_max[k] &&
-                            m_vertex_attribute[vids[1]].m_pos[k] == m_params.box_max[k] &&
-                            m_vertex_attribute[vids[2]].m_pos[k] == m_params.box_max[k]) {
+                        if (m_vertex_attribute[vids[0]].m_pos[k] == m_tet_params.box_max[k] &&
+                            m_vertex_attribute[vids[1]].m_pos[k] == m_tet_params.box_max[k] &&
+                            m_vertex_attribute[vids[2]].m_pos[k] == m_tet_params.box_max[k]) {
                             on_bbox = k * 2 + 1;
                             break;
                         }
@@ -467,7 +467,7 @@ void TetWildMesh::find_open_boundary()
     m_order2_envelope->init(
         v_posf,
         open_boundaries,
-        m_params.epsr * m_params.diag_l * m_params.order2_envelope_ratio);
+        m_params.epsr * m_params.diag_l * m_tet_params.order2_envelope_ratio);
 }
 
 bool TetWildMesh::is_open_boundary_edge(const Tuple& e)

--- a/components/tetwild/wmtk/components/tetwild/tests/test_surface_swap.cpp
+++ b/components/tetwild/wmtk/components/tetwild/tests/test_surface_swap.cpp
@@ -45,7 +45,6 @@ void build_ring(TetWildMesh& mesh)
     for (int i = 0; i < 5; ++i) {
         va[i].m_is_rounded = true;
         va[i].m_pos = to_rational(va[i].m_posf);
-        va[i].m_is_on_open_boundary = false;
     }
     for (size_t i : {A, B, C, D}) {
         va[i].m_is_on_surface = true;
@@ -180,7 +179,7 @@ TEST_CASE("surface-flip-correctness", "[tetwild_operation][surface_swap]")
     CHECK_FALSE(mesh.m_vertex_attribute[E].m_is_on_surface);
     for (size_t v : {A, B, C, D}) CHECK(mesh.m_vertex_attribute[v].m_order == 1);
     CHECK(mesh.m_vertex_attribute[E].m_order == 0);
-    for (size_t v : {A, B, C, D, E}) CHECK_FALSE(mesh.m_vertex_attribute[v].m_is_on_open_boundary);
+    for (size_t v : {A, B, C, D, E}) CHECK_FALSE(mesh.m_vertex_extra[v].m_is_on_open_boundary);
 
     // The flip actually ran (counter incremented).
     CHECK(mesh.cnt_surface_swap.load() == 1);
@@ -386,7 +385,6 @@ void build_ring_n(TetWildMesh& mesh, int N, double half, double radius)
         va[i].m_is_rounded = true;
         va[i].m_pos = to_rational(va[i].m_posf);
         va[i].m_is_on_surface = false;
-        va[i].m_is_on_open_boundary = false;
         va[i].m_order = 0;
     }
     std::vector<TetAttributes> ta(N);

--- a/components/triwild/wmtk/components/triwild/EdgeCollapsing.cpp
+++ b/components/triwild/wmtk/components/triwild/EdgeCollapsing.cpp
@@ -350,8 +350,8 @@ bool TriWildMesh::collapse_edge_after(const Tuple& loc)
     // The survivor takes over whatever feature point v1 stood for. collapse_edge_before has
     // already established that it is within eps of it, and that v2 did not stand for a
     // different one, so the feature stays represented.
-    if (VA.at(v2_id).m_feature_id == NO_FEATURE) {
-        VA[v2_id].m_feature_id = VA.at(v1_id).m_feature_id;
+    if (m_vertex_extra.at(v2_id).m_feature_id == NO_FEATURE) {
+        m_vertex_extra[v2_id].m_feature_id = m_vertex_extra.at(v1_id).m_feature_id;
     }
 
     // no need to update on_bbox_faces

--- a/components/triwild/wmtk/components/triwild/EdgeSplitting.cpp
+++ b/components/triwild/wmtk/components/triwild/EdgeSplitting.cpp
@@ -22,7 +22,7 @@ void TriWildMesh::split_all_edges()
     // split_edge_before, and be exempted from the gate entirely -- and those are exactly the
     // ones that run away. The attribute collections are resized to the reservation, so their
     // size is the capacity to use. make_unique value-initialises, so every slot starts at 0.
-    if (m_params.split_high_valence_threshold > 0) {
+    if (m_tri_params.split_high_valence_threshold > 0) {
         m_high_valence_claim_size = std::max(vert_capacity(), m_vertex_attribute.size());
         m_high_valence_claim = std::make_unique<std::atomic<int>[]>(m_high_valence_claim_size);
     }
@@ -105,7 +105,7 @@ void TriWildMesh::split_all_edges()
             "[high-valence] {} splits refused to avoid growing a vertex past {} incident "
             "triangles",
             n,
-            m_params.split_high_valence_threshold);
+            m_tri_params.split_high_valence_threshold);
     }
     // Consumed: the queued force-split edges no longer exist after this pass.
     m_force_split_edges.clear();
@@ -141,8 +141,8 @@ bool TriWildMesh::split_edge_before(const Tuple& loc0)
     // A vertex past the threshold accepts one such split per pass and refuses the rest, which
     // spreads the refinement instead of letting it pile onto the same vertex. Done here,
     // before the edge caching below, so a refusal is cheap.
-    if (m_params.split_high_valence_threshold > 0 && m_high_valence_claim) {
-        const size_t threshold = static_cast<size_t>(m_params.split_high_valence_threshold);
+    if (m_tri_params.split_high_valence_threshold > 0 && m_high_valence_claim) {
+        const size_t threshold = static_cast<size_t>(m_tri_params.split_high_valence_threshold);
         std::vector<size_t> to_claim;
         for (const size_t fid : faces) {
             const size_t vid = simplex_from_face(fid).opposite_vertex(edge).id();

--- a/components/triwild/wmtk/components/triwild/EdgeSplitting.cpp
+++ b/components/triwild/wmtk/components/triwild/EdgeSplitting.cpp
@@ -328,7 +328,7 @@ bool TriWildMesh::split_edge_after(const Tuple& loc)
     // A split midpoint stands for no input feature: the endpoints keep theirs, and the new
     // vertex is interior to the curve by construction. Set explicitly because attribute slots
     // are recycled and could carry a stale id.
-    m_vertex_attribute[v_id].m_feature_id = NO_FEATURE;
+    m_vertex_extra[v_id].m_feature_id = NO_FEATURE;
 
     m_vertex_attribute[v_id].partition_id = m_vertex_attribute[v1_id].partition_id;
     m_vertex_attribute[v_id].m_sizing_scalar =

--- a/components/triwild/wmtk/components/triwild/TriWildMesh.cpp
+++ b/components/triwild/wmtk/components/triwild/TriWildMesh.cpp
@@ -38,11 +38,6 @@
 
 namespace wmtk::components::triwild {
 
-VertexAttributes::VertexAttributes(const Vector2r& p)
-{
-    m_pos = p;
-    m_posf = to_double(p);
-}
 
 void TriWildMesh::mesh_improvement(int max_its)
 {
@@ -81,11 +76,11 @@ void TriWildMesh::mesh_improvement(int max_its)
         // whatever the two passes after it turn that state into. Breaking early leaves the
         // remaining passes of this iteration unrun, which is the point: they are not needed.
         double max_energy = 0., avg_energy = 0.;
-        if (!m_params.interleaved_smoothing) {
+        if (!m_tri_params.interleaved_smoothing) {
             std::tie(max_energy, avg_energy) =
-                local_operations({{1, 1, 1, m_params.num_smoothing_passes}});
+                local_operations({{1, 1, 1, m_tri_params.num_smoothing_passes}});
         } else {
-            const int k = m_params.interleaved_smoothing_passes;
+            const int k = m_tri_params.interleaved_smoothing_passes;
             const std::array<std::array<int, 4>, 3> passes = {
                 {{{1, 0, 0, k}}, {{0, 1, 0, k}}, {{0, 0, 1, k}}}};
             for (const std::array<int, 4>& ops : passes) {
@@ -476,7 +471,7 @@ void TriWildMesh::init_mesh(
         m_E_envelope[i] = E_env.row(i);
     }
 
-    m_envelope = std::make_shared<SampleEnvelope>(!m_params.use_sample_envelope);
+    m_envelope = std::make_shared<SampleEnvelope>(!m_tri_params.use_sample_envelope);
     m_envelope->init(m_V_envelope, m_E_envelope, m_envelope_eps);
     logger().info(
         "Envelope: {} (eps {:.6})",
@@ -485,7 +480,7 @@ void TriWildMesh::init_mesh(
 
     // Sanity check: All surface edges must be inside the envelope. Opt-in: see
     // Parameters::check_envelope_at_init for why it is not worth its cost by default.
-    if (m_params.check_envelope_at_init) {
+    if (m_tri_params.check_envelope_at_init) {
         logger().info("Envelope sanity check");
         const auto surf_edges = get_edges_by_condition([](auto& f) { return f.m_is_surface_fs; });
         for (const auto& verts : surf_edges) {
@@ -499,7 +494,7 @@ void TriWildMesh::init_mesh(
     }
 
     // Track the bounding box. This is the box of the *domain* -- the arrangement covers the
-    // input's bounding box grown by the background grid -- which is not m_params.box_min /
+    // input's bounding box grown by the background grid -- which is not m_tri_params.box_min /
     // box_max: those come from the input curves and set the tolerances. Deriving it from V
     // keeps this check self-consistent whatever the input box is.
     const Vector2d domain_min = V.colwise().minCoeff();
@@ -630,14 +625,6 @@ size_t TriWildMesh::refine_sizing_around_worst(double max_energy)
     return refined.size();
 }
 
-void TriWildMesh::gradation_smooth_sizing(double grade, const std::vector<size_t>& seeds)
-{
-    utils::gradation_smooth_sizing(
-        grade,
-        seeds,
-        [this](size_t v) -> double& { return m_vertex_attribute[v].m_sizing_scalar; },
-        [this](size_t v) { return get_one_ring_vids_for_vertex_duplicate(v); });
-}
 
 void TriWildMesh::write_msh_groups(std::string file, const bool write_envelope)
 {
@@ -951,70 +938,6 @@ int TriWildMesh::flood_fill()
     return current_id;
 }
 
-void TriWildMesh::partition_mesh()
-{
-    auto m_vertex_partition_id = partition_TriMesh(*this, NUM_THREADS);
-    for (size_t i = 0; i < m_vertex_partition_id.size(); i++) {
-        m_vertex_attribute[i].partition_id = m_vertex_partition_id[i];
-    }
-}
-
-void TriWildMesh::partition_mesh_morton()
-{
-    if (NUM_THREADS == 0) {
-        return;
-    }
-    logger().info("Number of parts: {} by morton", NUM_THREADS);
-
-    // The shared partitioner is 3D; a zero z leaves the bounding box, the scale and the
-    // Morton code exactly where a 2D-specific version would put them.
-    std::vector<size_t> partition_id;
-    wmtk::partition_vertex_morton(
-        vert_capacity(),
-        [this](size_t i) {
-            const Vector2d& p = m_vertex_attribute[i].m_posf;
-            return Eigen::Vector3d(p[0], p[1], 0);
-        },
-        NUM_THREADS,
-        partition_id);
-
-    for (size_t i = 0; i < partition_id.size(); i++) {
-        m_vertex_attribute[i].partition_id = partition_id[i];
-    }
-}
-
-double TriWildMesh::get_length2(const Tuple& l) const
-{
-    auto& m = *this;
-    auto& v1 = l;
-    auto v2 = l.switch_vertex(m);
-    double length =
-        (m.m_vertex_attribute[v1.vid(m)].m_posf - m.m_vertex_attribute[v2.vid(m)].m_posf)
-            .squaredNorm();
-    return length;
-}
-
-std::tuple<double, double> TriWildMesh::get_max_avg_energy()
-{
-    double max_energy = -1.;
-    double avg_energy = 0.;
-    auto cnt = 0;
-
-    for (int i = 0; i < tri_capacity(); i++) {
-        const Tuple tup = tuple_from_tri(i);
-        if (!tup.is_valid(*this)) {
-            continue;
-        }
-        const double q = m_face_attribute[tup.fid(*this)].m_quality;
-        max_energy = std::max(max_energy, q);
-        avg_energy += q;
-        cnt++;
-    }
-
-    avg_energy /= cnt;
-
-    return std::make_tuple(max_energy, avg_energy);
-}
 
 std::vector<size_t> TriWildMesh::active_vertices() const
 {
@@ -1028,70 +951,6 @@ std::vector<size_t> TriWildMesh::active_vertices() const
         [this](size_t vid) { return m_vertex_attribute[vid].m_is_on_surface; });
 }
 
-bool TriWildMesh::is_inverted_f(const Tuple& loc) const
-{
-    return is_inverted_f(loc.fid(*this));
-}
-
-bool TriWildMesh::is_inverted_f(const size_t fid) const
-{
-    auto vs = oriented_tri_vids(fid);
-
-    igl::predicates::exactinit();
-    auto res = igl::predicates::orient2d(
-        m_vertex_attribute[vs[0]].m_posf,
-        m_vertex_attribute[vs[1]].m_posf,
-        m_vertex_attribute[vs[2]].m_posf);
-    if (res == igl::predicates::Orientation::POSITIVE) {
-        return false;
-    }
-    return true;
-}
-
-bool TriWildMesh::is_inverted(const std::array<size_t, 3>& vs) const
-{
-    // Return a positive value if the point pd lies below the
-    // plane passing through pa, pb, and pc; "below" is defined so
-    // that pa, pb, and pc appear in counterclockwise order when
-    // viewed from above the plane.
-
-    if (m_vertex_attribute[vs[0]].m_is_rounded && m_vertex_attribute[vs[1]].m_is_rounded &&
-        m_vertex_attribute[vs[2]].m_is_rounded) {
-        igl::predicates::exactinit();
-        auto res = igl::predicates::orient2d(
-            m_vertex_attribute[vs[0]].m_posf,
-            m_vertex_attribute[vs[1]].m_posf,
-            m_vertex_attribute[vs[2]].m_posf);
-        if (res == igl::predicates::Orientation::POSITIVE) {
-            return false;
-        }
-        return true;
-    } else {
-        const Vector2r& v0 = m_vertex_attribute[vs[0]].m_pos;
-        const Vector2r& v1 = m_vertex_attribute[vs[1]].m_pos;
-        const Vector2r& v2 = m_vertex_attribute[vs[2]].m_pos;
-        const Vector2r a = v1 - v0;
-        const Vector2r b = v2 - v0;
-        Rational res = a.x() * b.y() - a.y() * b.x();
-        if (res > 0) {
-            return false;
-        } else {
-            return true;
-        }
-    }
-}
-
-bool TriWildMesh::is_inverted(const Tuple& loc) const
-{
-    auto vs = oriented_tri_vids(loc);
-    return is_inverted(vs);
-}
-
-bool TriWildMesh::is_inverted(const size_t fid) const
-{
-    auto vs = oriented_tri_vids(fid);
-    return is_inverted(vs);
-}
 
 std::pair<size_t, size_t> TriWildMesh::feature_retention(double* worst_ratio) const
 {
@@ -1144,7 +1003,7 @@ std::pair<size_t, size_t> TriWildMesh::feature_retention(double* worst_ratio) co
 bool TriWildMesh::smoothing_position_is_allowed(const size_t vid, const Vector2d& p) const
 {
     const size_t f = m_vertex_attribute[vid].m_feature_id;
-    if (f == NO_FEATURE || !m_params.preserve_feature_points) {
+    if (f == NO_FEATURE || !m_tri_params.preserve_feature_points) {
         return true;
     }
     // A ball, not a pin. The vertex may move anywhere within eps of the feature it stands
@@ -1154,7 +1013,7 @@ bool TriWildMesh::smoothing_position_is_allowed(const size_t vid, const Vector2d
 
 bool TriWildMesh::collapse_breaks_feature(const size_t v1_id, const size_t v2_id) const
 {
-    if (!m_params.preserve_feature_points) {
+    if (!m_tri_params.preserve_feature_points) {
         return false;
     }
     // v1 disappears into v2, and v2 does not move. So the question is only whether the
@@ -1177,90 +1036,6 @@ bool TriWildMesh::collapse_breaks_feature(const size_t v1_id, const size_t v2_id
            m_feature_eps * m_feature_eps;
 }
 
-size_t TriWildMesh::round_all_vertices()
-{
-    if (m_all_rounded.load(std::memory_order_relaxed)) {
-        return 0;
-    }
-
-    size_t reclaimed = 0, still_unrounded = 0;
-    for (const Tuple& v : get_vertices()) {
-        if (m_vertex_attribute[v.vid(*this)].m_is_rounded) {
-            continue;
-        }
-        if (round(v)) {
-            ++reclaimed;
-        } else {
-            ++still_unrounded;
-        }
-    }
-
-    if (still_unrounded == 0) {
-        m_all_rounded.store(true, std::memory_order_relaxed);
-    }
-    if (reclaimed > 0 || still_unrounded > 0) {
-        logger().info(
-            "rounding sweep: reclaimed {}, still unrounded {}",
-            reclaimed,
-            still_unrounded);
-    }
-    return reclaimed;
-}
-
-bool TriWildMesh::round(const Tuple& v)
-{
-    size_t i = v.vid(*this);
-    if (m_vertex_attribute[i].m_is_rounded) {
-        return true;
-    }
-
-    auto old_pos = m_vertex_attribute[i].m_pos;
-    m_vertex_attribute[i].m_pos << m_vertex_attribute[i].m_posf[0], m_vertex_attribute[i].m_posf[1];
-    auto conn_tets = get_one_ring_tris_for_vertex(v);
-    m_vertex_attribute[i].m_is_rounded = true;
-    for (const Tuple& tet : conn_tets) {
-        if (is_inverted(tet)) {
-            m_vertex_attribute[i].m_is_rounded = false;
-            m_vertex_attribute[i].m_pos = old_pos;
-            return false;
-        }
-    }
-
-    return true;
-}
-
-double TriWildMesh::get_quality(const std::array<size_t, 3>& vs) const
-{
-    std::array<Vector2d, 3> ps;
-    for (size_t k = 0; k < 3; k++) {
-        ps[k] = m_vertex_attribute[vs[k]].m_posf;
-    }
-    double energy = -1.;
-    {
-        std::array<double, 6> T;
-        for (size_t k = 0; k < 3; k++)
-            for (size_t j = 0; j < 2; j++) {
-                T[k * 2 + j] = ps[k][j];
-            }
-        energy = AMIPS2D_energy(T);
-    }
-    if (std::isinf(energy) || std::isnan(energy) || energy < 2 - 1e-3) {
-        return MAX_ENERGY;
-    }
-    return energy;
-}
-
-double TriWildMesh::get_quality(const Tuple& loc) const
-{
-    auto its = oriented_tri_vids(loc);
-    return get_quality(its);
-}
-
-double TriWildMesh::get_quality(const size_t fid) const
-{
-    auto its = oriented_tri_vids(fid);
-    return get_quality(its);
-}
 
 void TriWildMesh::write_vtu(const std::string& path) const
 {
@@ -1339,60 +1114,5 @@ void TriWildMesh::write_vtu(const std::string& path) const
     }
 }
 
-std::vector<std::array<size_t, 2>> TriWildMesh::get_edges_by_condition(
-    std::function<bool(const EdgeAttributes&)> cond) const
-{
-    std::vector<std::array<size_t, 2>> res;
-    for (const Tuple& e : get_edges()) {
-        size_t eid = e.eid(*this);
-        if (cond(m_edge_attribute[eid])) {
-            res.push_back({{e.vid(*this), e.switch_vertex(*this).vid(*this)}});
-        }
-    }
-    return res;
-}
-
-bool TriWildMesh::is_edge_on_surface(const Tuple& loc) const
-{
-    const auto vs = get_edge_vids(loc);
-    if (!m_vertex_attribute.at(vs[0]).m_is_on_surface ||
-        !m_vertex_attribute.at(vs[1]).m_is_on_surface) {
-        return false;
-    }
-
-    const size_t eid = loc.eid(*this);
-    return m_edge_attribute[eid].m_is_surface_fs;
-}
-bool TriWildMesh::is_edge_on_surface(const std::array<size_t, 2>& vids) const
-{
-    if (!m_vertex_attribute.at(vids[0]).m_is_on_surface ||
-        !m_vertex_attribute.at(vids[1]).m_is_on_surface) {
-        return false;
-    }
-
-    const auto [_, eid] = tuple_from_edge(vids);
-    return m_edge_attribute[eid].m_is_surface_fs;
-}
-bool TriWildMesh::is_edge_on_bbox(const Tuple& loc) const
-{
-    const auto vs = get_edge_vids(loc);
-    if (m_vertex_attribute.at(vs[0]).on_bbox_faces.empty() ||
-        m_vertex_attribute.at(vs[1]).on_bbox_faces.empty()) {
-        return false;
-    }
-
-    const size_t eid = loc.eid(*this);
-    return m_edge_attribute[eid].m_is_bbox_fs >= 0;
-}
-
-bool TriWildMesh::is_edge_on_bbox(const std::array<size_t, 2>& vids) const
-{
-    if (m_vertex_attribute.at(vids[0]).on_bbox_faces.empty() ||
-        m_vertex_attribute.at(vids[1]).on_bbox_faces.empty()) {
-        return false;
-    }
-    const auto [_, eid] = tuple_from_edge(vids);
-    return m_edge_attribute[eid].m_is_bbox_fs >= 0;
-}
 
 } // namespace wmtk::components::triwild

--- a/components/triwild/wmtk/components/triwild/TriWildMesh.cpp
+++ b/components/triwild/wmtk/components/triwild/TriWildMesh.cpp
@@ -434,7 +434,7 @@ void TriWildMesh::init_mesh(
             if (val == 0 || val == 2) {
                 continue;
             }
-            m_vertex_attribute[v].m_feature_id = m_feature_points.size();
+            m_vertex_extra[v].m_feature_id = m_feature_points.size();
             m_feature_points.push_back(m_vertex_attribute[v].m_posf);
             if (val == 1) {
                 ++n_endpoints;
@@ -1002,7 +1002,7 @@ std::pair<size_t, size_t> TriWildMesh::feature_retention(double* worst_ratio) co
 
 bool TriWildMesh::smoothing_position_is_allowed(const size_t vid, const Vector2d& p) const
 {
-    const size_t f = m_vertex_attribute[vid].m_feature_id;
+    const size_t f = m_vertex_extra[vid].m_feature_id;
     if (f == NO_FEATURE || !m_tri_params.preserve_feature_points) {
         return true;
     }
@@ -1018,7 +1018,7 @@ bool TriWildMesh::collapse_breaks_feature(const size_t v1_id, const size_t v2_id
     }
     // v1 disappears into v2, and v2 does not move. So the question is only whether the
     // feature v1 stood for is still represented afterwards, by v2.
-    const size_t f1 = m_vertex_attribute[v1_id].m_feature_id;
+    const size_t f1 = m_vertex_extra[v1_id].m_feature_id;
     if (f1 == NO_FEATURE) {
         return false;
     }

--- a/components/triwild/wmtk/components/triwild/TriWildMesh.h
+++ b/components/triwild/wmtk/components/triwild/TriWildMesh.h
@@ -34,12 +34,41 @@ using VertexAttributes = wmtk::TriOptimizerMesh::VertexAttributes;
 using EdgeAttributes = wmtk::TriOptimizerMesh::EdgeAttributes;
 using FaceAttributes = wmtk::TriOptimizerMesh::FaceAttributes;
 
-/// A vertex that stands for no input feature point. See VertexAttributes::m_feature_id.
+/// A vertex that stands for no input feature point. See VertexExtras::m_feature_id.
 inline constexpr size_t NO_FEATURE = std::numeric_limits<size_t>::max();
 
 class TriWildMesh : public wmtk::TriOptimizerMesh
 {
 public:
+    /**
+     * @brief triwild's per-vertex additions to the shared VertexAttributes.
+     *
+     * Registered with the base's m_vertex_attr_group, so it is resized, protected and rolled
+     * back exactly like the shared collection -- which matters, because collapse_edge_after and
+     * split_edge_after both write it.
+     */
+    struct VertexExtras
+    {
+        /**
+         * Index into TriWildMesh::m_feature_points, or NO_FEATURE.
+         *
+         * A feature point is a 0-dimensional feature of the curve network: an open polyline's
+         * endpoint, or a junction. This is the 2D counterpart of tetwild's
+         * m_is_on_open_boundary, with one deliberate difference -- it names WHICH feature the
+         * vertex stands for, not merely that it stands for one.
+         *
+         * That difference is the whole point. tetwild asks "is the survivor inside the
+         * envelope of the boundary?", a containment question, and in 3D a boundary is a curve
+         * with many edges so collapsing one shortens it rather than deleting it. In 2D the
+         * feature is a single point, and a containment test passes trivially when one endpoint
+         * is collapsed onto another -- the target IS a feature point, distance zero -- while
+         * the first endpoint quietly stops being represented. Preserving features is a
+         * COVERAGE property, so the constraint has to bind a vertex to a specific point.
+         */
+        size_t m_feature_id = std::numeric_limits<size_t>::max();
+    };
+    wmtk::AttributeCollection<VertexExtras> m_vertex_extra;
+
     /// The base holds only wmtk::OptimizerParameters; this is the same object, typed, for the
     /// triwild-only fields (features, high valence, smoothing schedule, box).
     Parameters& m_tri_params;
@@ -65,7 +94,7 @@ public:
 
     /**
      * Anchor positions of the curve network's 0-dimensional features, indexed by
-     * VertexAttributes::m_feature_id.
+     * VertexExtras::m_feature_id.
      *
      * Filled in init_mesh from the arrangement's constrained edges: a vertex whose valence in
      * that edge set is neither 0 nor 2 is a feature -- valence 1 is an open polyline's
@@ -117,11 +146,9 @@ public:
         , m_tri_params(_m_params)
         , m_feature_eps(envelope_eps)
     {
+        m_vertex_attr_group.add(&m_vertex_extra);
         m_envelope_eps = envelope_eps;
         NUM_THREADS = _num_threads;
-        p_vertex_attrs = &m_vertex_attribute;
-        p_edge_attrs = &m_edge_attribute;
-        p_face_attrs = &m_face_attribute;
 
         optimization::deactivate_opt_logger();
 

--- a/components/triwild/wmtk/components/triwild/TriWildMesh.h
+++ b/components/triwild/wmtk/components/triwild/TriWildMesh.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <wmtk/TriOptimizerMesh.h>
+
 #include <wmtk/SurfaceTagAttributes.h>
 #include <cstdlib>
 
@@ -27,75 +29,26 @@
 
 namespace wmtk::components::triwild {
 
+/// The attribute types now live on the shared base; keep the unqualified names working.
+using VertexAttributes = wmtk::TriOptimizerMesh::VertexAttributes;
+using EdgeAttributes = wmtk::TriOptimizerMesh::EdgeAttributes;
+using FaceAttributes = wmtk::TriOptimizerMesh::FaceAttributes;
+
 /// A vertex that stands for no input feature point. See VertexAttributes::m_feature_id.
 inline constexpr size_t NO_FEATURE = std::numeric_limits<size_t>::max();
 
-// TODO: missing comments on what these attributes are
-class VertexAttributes
+class TriWildMesh : public wmtk::TriOptimizerMesh
 {
 public:
-    Vector2d m_posf;
-    Vector2r m_pos;
-    bool m_is_rounded = false;
+    /// The base holds only wmtk::OptimizerParameters; this is the same object, typed, for the
+    /// triwild-only fields (features, high valence, smoothing schedule, box).
+    Parameters& m_tri_params;
 
-    bool m_is_on_surface = false;
-    std::vector<int> on_bbox_faces;
-
-    /**
-     * Index into TriWildMesh::m_feature_points, or NO_FEATURE.
-     *
-     * A feature point is a 0-dimensional feature of the curve network: an open polyline's
-     * endpoint, or a junction. This is the 2D counterpart of tetwild's m_is_on_open_boundary,
-     * with one deliberate difference -- it names WHICH feature the vertex stands for, not
-     * merely that it stands for one.
-     *
-     * That difference is the whole point. tetwild asks "is the survivor inside the envelope
-     * of the boundary?", a containment question, and in 3D a boundary is a curve with many
-     * edges so collapsing one shortens it rather than deleting it. In 2D the feature is a
-     * single point, and a containment test passes trivially when one endpoint is collapsed
-     * onto another -- the target IS a feature point, distance zero -- while the first
-     * endpoint quietly stops being represented. Preserving features is a COVERAGE property,
-     * so the constraint has to bind a vertex to a specific point.
-     */
-    size_t m_feature_id = NO_FEATURE;
-
-    double m_sizing_scalar = 1;
-
-    size_t partition_id = 0;
-
-    VertexAttributes() {}
-    VertexAttributes(const Vector2r& p);
-};
-
-using EdgeAttributes = wmtk::SurfaceTagAttributes;
-
-class FaceAttributes
-{
-public:
-    double m_quality;
-    double m_winding_number = 0;
-    std::set<int64_t> tags;
-    int part_id = -1;
-};
-
-class TriWildMesh : public wmtk::TriMesh
-{
-public:
-    int m_debug_print_counter = 0;
     /// Iterations mesh_improvement actually used. Reported so a run that needs the whole
     /// budget is visible as such, and asserted against in the integration tests.
     int m_iterations_used = 0;
-    size_t m_tags_count = 0;
-    std::map<int64_t, std::string> m_tag_id_to_name;
-    std::map<std::string, int64_t> m_tag_name_to_id;
-
-    const double MAX_ENERGY = 1e50;
-
-    Parameters& m_params;
     std::vector<Vector2d> m_V_envelope;
     std::vector<Vector2i> m_E_envelope;
-    std::shared_ptr<SampleEnvelope> m_envelope;
-    double m_envelope_eps = -1;
     /**
      * Radius of the ball a feature-carrying vertex must stay inside.
      *
@@ -129,9 +82,6 @@ public:
     std::vector<Vector2d> m_feature_points;
     /// Collapses refused because they would drop or displace a feature point. Diagnostic.
     std::atomic<size_t> m_feature_rejects = 0;
-    /// Whether the current collapse pass applies the target-length limit; read by
-    /// collapse_edge_before, which is where that limit is now enforced.
-    bool m_collapse_limit_length = true;
 
     /**
      * @brief May vertex `vid` sit at `p`?
@@ -154,19 +104,6 @@ public:
     /// True iff collapsing v1 into v2 would drop or displace a feature point.
     bool collapse_breaks_feature(const size_t v1_id, const size_t v2_id) const;
 
-    using VertAttCol = wmtk::AttributeCollection<VertexAttributes>;
-    using EdgeAttCol = wmtk::AttributeCollection<EdgeAttributes>;
-    using FaceAttCol = wmtk::AttributeCollection<FaceAttributes>;
-    VertAttCol m_vertex_attribute;
-    EdgeAttCol m_edge_attribute;
-    FaceAttCol m_face_attribute;
-
-    wmtk::threading::enumerable_thread_specific<std::unique_ptr<polysolve::nonlinear::Solver>>
-        m_solver;
-
-    /// Why smoothing attempts were refused, reported once per pass.
-    optimization::SmoothRejectCounters m_smooth_rejects;
-
 
     /// Position hooks for the shared 2D smoothing driver. triwild keeps both a working
     /// double position and an exact rational one, so writing goes through here.
@@ -175,29 +112,18 @@ public:
     std::shared_ptr<SampleEnvelope> smoothing_energy_envelope(const size_t vid) const;
     std::shared_ptr<SampleEnvelope> smoothing_containment_envelope(const size_t vid) const;
 
-    // scaling factors
-    double m_s_amips = -1;
-    double m_s_envelope = -1;
-
     TriWildMesh(Parameters& _m_params, double envelope_eps, int _num_threads = 0)
-        : m_params(_m_params)
-        , m_envelope_eps(envelope_eps)
+        : wmtk::TriOptimizerMesh(_m_params)
+        , m_tri_params(_m_params)
         , m_feature_eps(envelope_eps)
     {
+        m_envelope_eps = envelope_eps;
         NUM_THREADS = _num_threads;
         p_vertex_attrs = &m_vertex_attribute;
         p_edge_attrs = &m_edge_attribute;
         p_face_attrs = &m_face_attribute;
 
         optimization::deactivate_opt_logger();
-
-        m_s_amips = 1.;
-        /**
-         * eps makes it such that the energy is relative to the envelope thickness. As it's a
-         * squared energy, we need eps^2.
-         */
-        m_s_envelope = 1. / (m_params.eps * m_params.eps);
-
 
         double& wa = m_params.w_amips;
         double& we = m_params.w_envelope;
@@ -206,19 +132,6 @@ public:
     }
 
     ~TriWildMesh() {}
-
-    // TODO: this should not be here
-    void partition_mesh();
-
-    // TODO: morton should not be here, but inside wmtk
-    void partition_mesh_morton();
-
-    size_t get_partition_id(const Tuple& loc) const
-    {
-        return m_vertex_attribute[loc.vid(*this)].partition_id;
-    }
-
-    double get_length2(const Tuple& l) const;
 
 public:
     /**
@@ -273,16 +186,6 @@ public:
      */
     size_t refine_sizing_around_worst(double max_energy);
 
-    /**
-     * @brief Monotone (only-decreasing) gradation smoothing of the sizing field.
-     *
-     * Enforces m_sizing_scalar[v] <= grade * m_sizing_scalar[u] for every edge (u,v),
-     * propagating outward from `seeds` with a min-relaxation. It never raises a sizing
-     * value, so it only ever spreads more refinement into the halo around already-refined
-     * vertices, avoiding sharp resolution jumps.
-     */
-    void gradation_smooth_sizing(double grade, const std::vector<size_t>& seeds);
-
     /// The longest edge of each current worst triangle. split_all_edges force-splits
     /// exactly these edges (bypassing the length gate), so a stuck sliver's long edge is
     /// split immediately without changing the sizing field. Populated serially by
@@ -314,9 +217,6 @@ public:
 
     void write_vtu(const std::string& path) const;
 
-    std::vector<std::array<size_t, 2>> get_edges_by_condition(
-        std::function<bool(const EdgeAttributes&)> cond) const;
-
 public:
     void split_all_edges();
     bool split_edge_before(const Tuple& t) override;
@@ -340,61 +240,11 @@ public:
     bool smooth_before(const Tuple& t) override;
     bool smooth_after(const Tuple& t) override;
 
-    /**
-     * @brief A vector containing the vertex position and all positions of the surface neighbors.
-     *
-     * Returns an empty vector if vertex is not on the surface.
-     */
-
-
-    /**
-     * @brief Inversion check using only floating point numbers.
-     */
-    bool is_inverted_f(const Tuple& loc) const;
-    bool is_inverted_f(const size_t fid) const;
-    bool is_inverted(const std::array<size_t, 3>& vs) const;
-    bool is_inverted(const Tuple& loc) const;
-    bool is_inverted(const size_t fid) const;
-    double get_quality(const std::array<size_t, 3>& vs) const;
-    double get_quality(const Tuple& loc) const;
-    double get_quality(const size_t fid) const;
-    bool round(const Tuple& loc);
-
-    /**
-     * @brief Try to round every un-rounded vertex; returns the number reclaimed.
-     *
-     * round() is otherwise only attempted as a side effect of another operation (smoothing
-     * the vertex, or the merged vertex of a collapse), and neither reaches a vertex that
-     * only becomes roundable later: smoothing skips "good" regions by default. Without a
-     * sweep such a vertex keeps exact coordinates into the output for no geometric reason --
-     * and split_edge_after now introduces them unconditionally whenever the rounded midpoint
-     * would invert, so the sweep is what keeps that from reaching the output.
-     *
-     * Skipped outright when m_all_rounded says there is nothing to do.
-     */
-    size_t round_all_vertices();
-
-    /**
-     * @brief True when every vertex is known to be rounded.
-     *
-     * Only trusted when true, and only round_all_vertices() sets it that way. Any code that
-     * leaves a vertex un-rounded must clear it, or the sweep will skip the vertex forever.
-     * Atomic because operations that clear it run in parallel.
-     */
-    std::atomic<bool> m_all_rounded = false;
-    //
-    bool is_edge_on_surface(const Tuple& loc) const;
-    bool is_edge_on_surface(const std::array<size_t, 2>& vids) const;
-    bool is_edge_on_bbox(const Tuple& loc) const;
-    bool is_edge_on_bbox(const std::array<size_t, 2>& vids) const;
-
-    //
     void mesh_improvement(int max_its = 80);
 
     std::tuple<double, double> local_operations(
         const std::array<int, 4>& ops,
         bool collapse_limit_length = true);
-    std::tuple<double, double> get_max_avg_energy();
 
     /**
      * @brief m_quality threshold above which a face is "active" (worth operating on) for
@@ -430,23 +280,6 @@ public:
     void filter_with_flood_fill();
 
     int flood_fill();
-
-    bool vertex_is_on_surface(const size_t vid) const override
-    {
-        return m_vertex_attribute.at(vid).m_is_on_surface ||
-               !m_vertex_attribute.at(vid).on_bbox_faces.empty();
-    }
-    bool edge_is_on_surface(const std::array<size_t, 2>& vids) const override
-    {
-        if (!vertex_is_on_surface(vids[0]) || !vertex_is_on_surface(vids[1])) {
-            return false;
-        }
-
-        const auto [_, eid] = tuple_from_edge(vids);
-        bool on_surface = m_edge_attribute.at(eid).m_is_surface_fs;
-        bool on_bbox = m_edge_attribute.at(eid).m_is_bbox_fs >= 0;
-        return on_surface || on_bbox;
-    }
 
 private:
     ////// Operations

--- a/components/triwild/wmtk/components/triwild/tests/test_feature_points.cpp
+++ b/components/triwild/wmtk/components/triwild/tests/test_feature_points.cpp
@@ -55,7 +55,7 @@ TEST_CASE("triwild-feature-collapse-policy", "[triwild_operation][feature_points
     TriWildMesh mesh(params, eps, 0);
     build_one_tri(mesh, {Vector2d(0, 0), Vector2d(0.5, 0), Vector2d(5, 0)});
     mesh.m_feature_points = {Vector2d(0, 0)};
-    mesh.m_vertex_attribute[0].m_feature_id = 0;
+    mesh.m_vertex_extra[0].m_feature_id = 0;
 
     SECTION("a vertex carrying no feature is never blocked")
     {
@@ -89,7 +89,7 @@ TEST_CASE("triwild-feature-collapse-policy", "[triwild_operation][feature_points
         // integration model it stranded a degenerate triangle and the max energy stayed at
         // 1e50 for all 82 iterations instead of converging in 3.
         mesh.m_feature_points.push_back(Vector2d(0.5, 0));
-        mesh.m_vertex_attribute[1].m_feature_id = 1;
+        mesh.m_vertex_extra[1].m_feature_id = 1;
         CHECK_FALSE(mesh.collapse_breaks_feature(0, 1));
         CHECK_FALSE(mesh.collapse_breaks_feature(1, 0));
     }
@@ -100,14 +100,14 @@ TEST_CASE("triwild-feature-collapse-policy", "[triwild_operation][feature_points
         // vertex within eps, and the plain distance test catches that without needing a
         // special case for "v2 already carries something".
         mesh.m_feature_points.push_back(Vector2d(5, 0));
-        mesh.m_vertex_attribute[2].m_feature_id = 1;
+        mesh.m_vertex_extra[2].m_feature_id = 1;
         CHECK(mesh.collapse_breaks_feature(0, 2));
         CHECK(mesh.collapse_breaks_feature(2, 0));
     }
 
     SECTION("a vertex already carrying the SAME feature is fine")
     {
-        mesh.m_vertex_attribute[1].m_feature_id = 0;
+        mesh.m_vertex_extra[1].m_feature_id = 0;
         CHECK_FALSE(mesh.collapse_breaks_feature(0, 1));
     }
 
@@ -125,7 +125,7 @@ TEST_CASE("triwild-feature-collapse-policy", "[triwild_operation][feature_points
         TriWildMesh off(params, eps, 0);
         build_one_tri(off, {Vector2d(0, 0), Vector2d(0.5, 0), Vector2d(5, 0)});
         off.m_feature_points = {Vector2d(0, 0)};
-        off.m_vertex_attribute[0].m_feature_id = 0;
+        off.m_vertex_extra[0].m_feature_id = 0;
         CHECK_FALSE(off.collapse_breaks_feature(0, 2));
     }
 }
@@ -137,7 +137,7 @@ TEST_CASE("triwild-feature-smoothing-is-a-ball-not-a-pin", "[triwild_operation][
     TriWildMesh mesh(params, eps, 0);
     build_one_tri(mesh, {Vector2d(0, 0), Vector2d(0.5, 0), Vector2d(5, 0)});
     mesh.m_feature_points = {Vector2d(0, 0)};
-    mesh.m_vertex_attribute[0].m_feature_id = 0;
+    mesh.m_vertex_extra[0].m_feature_id = 0;
 
     // A feature vertex is free to move, just not away: smoothing keeps whatever quality it
     // can find inside the ball. Freezing it outright would be simpler and worse.

--- a/docs/simwild-adopted-behaviours.md
+++ b/docs/simwild-adopted-behaviours.md
@@ -224,3 +224,57 @@ against a build of the pre-refactor commit: byte-identical.
 One thing to watch later: `SimWildMeshTri` keeps its own `round_and_check_all_rounded`,
 `m_exact_split_count` and `triangle_area`, none of which triwild has. The first two are the
 subject of Stage 4's `RationalPositions` mixin.
+
+---
+
+## Stage 3b — simwild-3D adopts `wmtk::TetOptimizerMesh`
+
+`SimWildMesh` now derives from the shared 3D base, dropping its copies of `VertexAttributes`,
+`FaceAttributes`, the vertex and face attribute collections, the envelope/solver/rounding members,
+`MAX_ENERGY`, and 23 method definitions.
+
+Of the 21 methods the base owns, **19 were already byte-identical** between the two applications and
+two (`get_quality`, `output_faces`) differed only cosmetically -- `auto` vs `bool` for a local, and an
+`(int)` cast on a row assignment into a matrix that is already `int`. That leaves exactly one
+behavioural adoption:
+
+### `round()` now marks the vertex rounded before the one-ring check
+
+| | |
+|---|---|
+| **was** | simwild left `m_is_rounded` false until every incident tet had been checked, so `is_inverted` took the **exact rational** branch throughout the check |
+| **now** | tetwild's: `m_is_rounded` is set before the loop and cleared again on failure, so `is_inverted` takes the **float** branch |
+| **source** | tetwild, triwild and simwild-2D all already did it this way; simwild-3D was the only one that did not |
+
+**This is answer-preserving, not merely close.** The check asks whether the ROUNDED position keeps
+every incident tet valid. Under the old order the vertex's `m_pos` had already been set to
+`to_rational(m_posf)` -- exactly the double, as a rational -- so the rational branch evaluated the
+orientation of the same four points that the float branch evaluates with `orient3d`, which is itself
+exact for the doubles it is handed. Both branches also fall back to rational identically when some
+*other* incident vertex is un-rounded, since `is_inverted` tests all four flags. The difference is
+cost, not result: simwild was paying for exact arithmetic to compute an answer the float predicate
+already decides exactly.
+
+### Not adopted in this commit
+
+The swap family stays per-application and is untouched here: `swap_face_before`, `swap_face_after`,
+`swap_edge_after` and `swap_all_faces` all propagate simwild's `CellTag` through the operation, which
+tetwild has no counterpart for. Sharing them needs a tag-propagation hook. Three differences found
+while measuring them are recorded here so they are not lost:
+
+* **`swap_all_faces` collects the wrong simplex.** simwild calls `parallel_collect_edge_ops` and
+  queues `"face_swap"` operations on **edge** tuples -- 6 per tet -- where tetwild calls
+  `parallel_collect_face_ops` and queues them on faces, 4 per tet. The face-swap pass therefore
+  enumerates a different set, with each face reachable from up to three of its edges.
+* simwild calls the executor directly where tetwild uses `run_localized_to_convergence`.
+* simwild reads the success count from `executor.get_cnt_success()` after the lambda has returned;
+  tetwild accumulates it into a captured local.
+
+`smoothing_energy_envelope` also stays per-application: simwild pulls order-2 vertices toward
+`m_order_2_edge_envelope` and everything else toward `m_envelope_orig`, while tetwild has a single
+surface envelope. `smoothing_containment_envelope` did move -- both applications' versions return
+`m_envelope`, only their comments differed.
+
+`smooth_after` stays in **both** applications even though their bodies are byte-identical: the body
+is the shared `optimization::smooth_vertex_3d` template, which reaches `m_tet_attribute` and
+`smoothing_energy_envelope`, both per-application.

--- a/docs/simwild-adopted-behaviours.md
+++ b/docs/simwild-adopted-behaviours.md
@@ -186,3 +186,41 @@ that construct `Parameters` directly either set these explicitly or are insensit
 `run_2D` was already correct: on a `TriMesh` the faces *are* the cells.
 
 Note for future baselines: simwild 3D `#t` values recorded before this change are face counts.
+
+---
+
+## Stage 3a — simwild-2D adopts `wmtk::TriOptimizerMesh`
+
+`SimWildMeshTri` now derives from the shared 2D base rather than from `wmtk::TriMesh`, and its
+copies of the three attribute types, the shared members and 13 methods are deleted in favour of
+the base's.
+
+**No simwild output moved, and no behaviour was adopted.** This is the rare case where the policy
+("when the two disagree, tetwild/triwild wins") had nothing to decide, because the two copies did
+not disagree anywhere. Every difference between simwild-2D's implementation and triwild's was
+cosmetic, and each was checked individually before the copy was deleted:
+
+| function | the only difference |
+|---|---|
+| `is_inverted(array)` | `const auto res` vs `auto res`; `return !(res > 0)` vs an `if/else`; triwild carries a stale comment about `orient3d` that simwild had dropped (dropped here too) |
+| `is_inverted(Tuple)`, `is_inverted(size_t)` | simwild inlines the `oriented_tri_vids` temporary |
+| `get_quality(Tuple)`, `get_quality(size_t)` | same inlining |
+| `get_quality(array)` | none — identical |
+| `is_inverted_f` | simwild has only the `size_t` overload; the bodies match. It now also inherits the `Tuple` one |
+| `round` | `m_pos << posf[0], posf[1]` vs `to_rational(m_posf)`, which are the same value; both set `m_is_rounded` before the one-ring check. simwild's comment explaining why was the better one and was kept |
+| `get_length2` | `get_edge_vids` vs `switch_vertex`, same two vertices |
+| `partition_mesh` | `auto i` vs `size_t i` as the loop variable (simwild's compares signed to unsigned) |
+| `round_all_vertices`, `get_max_avg_energy`, `gradation_smooth_sizing`, `get_edges_by_condition`, `is_edge_on_surface` x2, `is_edge_on_bbox` x2, `vertex_is_on_surface`, `edge_is_on_surface` | none — identical after normalisation |
+
+The attribute types matched too: `CellTag` is a `std::set<int64_t>`, so `FaceAttributes` was already
+character-identical, and `VertexAttributes` differed only by triwild's `m_feature_id`, which
+simwild-2D leaves at `NO_FEATURE`.
+
+**Measured:** all 53 registered configs byte-identical against the run immediately after the move
+commit — every simwild config included — plus ctest 107/107. `tetwild_crown` and `tetwild_octocat`
+run 10 threads and are nondeterministic there, so they were compared separately at `num_threads: 0`
+against a build of the pre-refactor commit: byte-identical.
+
+One thing to watch later: `SimWildMeshTri` keeps its own `round_and_check_all_rounded`,
+`m_exact_split_count` and `triangle_area`, none of which triwild has. The first two are the
+subject of Stage 4's `RationalPositions` mixin.

--- a/src/wmtk/AttributeCollection.hpp
+++ b/src/wmtk/AttributeCollection.hpp
@@ -106,4 +106,59 @@ struct AttributeCollection : public AbstractAttributeContainer
     std::vector<T> m_attributes;
     wmtk::threading::enumerable_thread_specific<bool> recording{false};
 };
+
+/**
+ * @brief Several attribute collections for the same simplex type, behind one container.
+ *
+ * A mesh exposes exactly one `p_vertex_attrs` / `p_face_attrs` / ... slot, so a class hierarchy
+ * that wants to split its attributes -- shared fields on a base class, application-specific
+ * fields on the derived one -- has nowhere to register the second collection. Point the slot at
+ * one of these instead and register both.
+ *
+ * Splitting rather than unioning matters because an `AttributeCollection<T>` is a member: a
+ * derived class cannot change its type, and `AttributeCollection<Derived>` is not usable as an
+ * `AttributeCollection<Base>` (the storage is a `std::vector<Derived>`, so it has the wrong
+ * stride). Without this, every application pays for every other application's fields on every
+ * simplex.
+ *
+ * The children keep their own rollback lists and are protected and rolled back independently,
+ * which is exactly right: `AttributeCollection::operator[]` records the rollback entry, so a
+ * write to an extras collection inside an operation is undone on failure just like a write to
+ * the shared one. Order of registration is the order of forwarding; no child observes another.
+ *
+ * Non-owning: the collections outlive the group by being members of the same objects.
+ */
+class AttributeContainerGroup : public AbstractAttributeContainer
+{
+public:
+    void add(AbstractAttributeContainer* c) { m_children.push_back(c); }
+
+    void move(size_t from, size_t to) override
+    {
+        for (auto* c : m_children) c->move(from, to);
+    }
+    void resize(size_t s) override
+    {
+        for (auto* c : m_children) c->resize(s);
+    }
+    void clear() override
+    {
+        for (auto* c : m_children) c->clear();
+    }
+    void rollback() override
+    {
+        for (auto* c : m_children) c->rollback();
+    }
+    void begin_protect() override
+    {
+        for (auto* c : m_children) c->begin_protect();
+    }
+    void end_protect() override
+    {
+        for (auto* c : m_children) c->end_protect();
+    }
+
+private:
+    std::vector<AbstractAttributeContainer*> m_children;
+};
 } // namespace wmtk

--- a/src/wmtk/TetOptimizerMesh.cpp
+++ b/src/wmtk/TetOptimizerMesh.cpp
@@ -454,4 +454,15 @@ size_t TetOptimizerMesh::get_order_of_vertex(const size_t vid) const
     return m_vertex_attribute.at(vid).m_order;
 }
 
+double TetOptimizerMesh::get_length2(const Tuple& l) const
+{
+    auto& m = *this;
+    auto& v1 = l;
+    auto v2 = l.switch_vertex(m);
+    double length =
+        (m.m_vertex_attribute[v1.vid(m)].m_posf - m.m_vertex_attribute[v2.vid(m)].m_posf)
+            .squaredNorm();
+    return length;
+}
+
 } // namespace wmtk

--- a/src/wmtk/TetOptimizerMesh.cpp
+++ b/src/wmtk/TetOptimizerMesh.cpp
@@ -1,0 +1,457 @@
+#include <wmtk/TetOptimizerMesh.h>
+
+#include <wmtk/utils/AMIPS.h>
+#include <wmtk/utils/GeoUtils.h>
+#include <wmtk/utils/PartitionMesh.h>
+#include <wmtk/envelope/KNN.hpp>
+#include <wmtk/optimization/SmoothVertex.hpp>
+#include <wmtk/threading/parallel_for.hpp>
+#include <wmtk/utils/Logger.hpp>
+#include <wmtk/utils/SizingField.hpp>
+#include <wmtk/utils/TetraQualityUtils.hpp>
+#include <wmtk/utils/io.hpp>
+#include <wmtk/utils/partition_utils.hpp>
+
+// clang-format off
+#include <wmtk/utils/DisableWarnings.hpp>
+#include <igl/predicates/predicates.h>
+#include <igl/write_triangle_mesh.h>
+#include <wmtk/utils/EnableWarnings.hpp>
+// clang-format on
+
+#include <queue>
+
+namespace wmtk {
+
+TetOptimizerMesh::VertexAttributes::VertexAttributes(const Vector3r& p)
+{
+    m_pos = p;
+    m_posf = to_double(m_pos);
+}
+
+void TetOptimizerMesh::compute_vertex_partition()
+{
+    auto partition_id = partition_TetMesh(*this, NUM_THREADS);
+    for (auto i = 0; i < vert_capacity(); i++) m_vertex_attribute[i].partition_id = partition_id[i];
+}
+
+void TetOptimizerMesh::compute_vertex_partition_morton()
+{
+    if (NUM_THREADS == 0) {
+        return;
+    }
+
+    logger().info("Number of parts: {} by morton", NUM_THREADS);
+
+    std::vector<size_t> partition_id;
+    wmtk::partition_vertex_morton(
+        vert_capacity(),
+        [this](size_t i) { return m_vertex_attribute[i].m_posf; },
+        NUM_THREADS,
+        partition_id);
+
+    for (size_t i = 0; i < partition_id.size(); i++) {
+        m_vertex_attribute[i].partition_id = partition_id[i];
+    }
+}
+
+double TetOptimizerMesh::swap_edge_44_energy(
+    const std::vector<std::array<size_t, 4>>& tets,
+    const int op_case)
+{
+    double max_energy = -1;
+    for (const auto& vids : tets) {
+        if (is_inverted(vids)) {
+            return std::numeric_limits<double>::max();
+        }
+        const double e = get_quality(vids);
+        max_energy = std::max(max_energy, e);
+    }
+    return max_energy;
+}
+
+double TetOptimizerMesh::swap_edge_56_energy(
+    const std::vector<std::array<size_t, 4>>& tets,
+    const int op_case)
+{
+    double max_energy = -1;
+    for (const auto& vids : tets) {
+        if (is_inverted(vids)) {
+            return std::numeric_limits<double>::max();
+        }
+        const double e = get_quality(vids);
+        max_energy = std::max(max_energy, e);
+    }
+    return max_energy;
+}
+
+bool TetOptimizerMesh::smooth_before(const Tuple& t)
+{
+    const bool r = round(t);
+
+    const size_t vid = t.vid(*this);
+
+    if (!m_vertex_attribute[vid].on_bbox_faces.empty()) return false;
+
+    if (m_vertex_attribute[vid].m_is_rounded) return true;
+    // try to round.
+    // Note: no need to roll back.
+    return r;
+}
+
+
+std::shared_ptr<SampleEnvelope> TetOptimizerMesh::smoothing_containment_envelope(const size_t) const
+{
+    // tetwild keeps one surface envelope, so pull target and containment test coincide --
+    // unlike simwild, which has a separate working envelope.
+    return m_envelope;
+}
+
+size_t TetOptimizerMesh::round_all_vertices()
+{
+    if (m_all_rounded.load(std::memory_order_relaxed)) {
+        return 0;
+    }
+
+    size_t reclaimed = 0, still_unrounded = 0;
+    for (const Tuple& v : get_vertices()) {
+        if (m_vertex_attribute[v.vid(*this)].m_is_rounded) {
+            continue;
+        }
+        if (round(v)) {
+            ++reclaimed;
+        } else {
+            ++still_unrounded;
+        }
+    }
+
+    if (still_unrounded == 0) {
+        m_all_rounded.store(true, std::memory_order_relaxed);
+    }
+    if (reclaimed > 0 || still_unrounded > 0) {
+        logger().info(
+            "rounding sweep: reclaimed {}, still unrounded {}",
+            reclaimed,
+            still_unrounded);
+    }
+    return reclaimed;
+}
+
+void TetOptimizerMesh::gradation_smooth_sizing(double grade, const std::vector<size_t>& seeds)
+{
+    utils::gradation_smooth_sizing(
+        grade,
+        seeds,
+        [this](size_t v) -> double& { return m_vertex_attribute[v].m_sizing_scalar; },
+        [this](size_t v) { return get_one_ring_vids_for_vertex_adj(v); });
+}
+
+/////////////////////////////////////////////////////////////////////
+void TetOptimizerMesh::output_faces(
+    std::string file,
+    std::function<bool(const FaceAttributes&)> cond)
+{
+    auto outface = get_faces_by_condition(cond);
+    Eigen::MatrixXd matV = Eigen::MatrixXd::Zero(vert_capacity(), 3);
+    for (const auto& v : get_vertices()) {
+        auto vid = v.vid(*this);
+        matV.row(vid) = m_vertex_attribute[vid].m_posf;
+    }
+    Eigen::MatrixXi matF(outface.size(), 3);
+    for (auto i = 0; i < outface.size(); i++) {
+        matF.row(i) << (int)outface[i][0], (int)outface[i][1], (int)outface[i][2];
+    }
+    logger().info("Output face size {}", outface.size());
+    igl::write_triangle_mesh(file, matV, matF);
+}
+
+std::tuple<double, double> TetOptimizerMesh::get_max_avg_energy()
+{
+    double max_energy = -1.;
+    double avg_energy = 0.;
+    auto cnt = 0;
+    // TetMesh::for_each_tetra([&](auto& t) {
+    //     auto q = m_tet_attribute[t.tid(*this)].m_quality;
+    //     max_energy = std::max(max_energy, q);
+    //     avg_energy += std::cbrt(q);
+    //     cnt++;
+    // });
+    // std::ofstream large_tet("large_energy_tet.obj");
+
+    for (int i = 0; i < tet_capacity(); i++) {
+        auto tup = tuple_from_tet(i);
+        if (!tup.is_valid(*this)) continue;
+        // auto vs = oriented_tet_vertices(tup);
+
+        auto q = cell_quality(tup.tid(*this));
+        max_energy = std::max(max_energy, q);
+        // if (q > 1e6) {
+        //     for (auto v : vs) {
+        //         large_tet << "v " << m_vertex_attribute[v.vid(*this)].m_posf[0] << " "
+        //                   << m_vertex_attribute[v.vid(*this)].m_posf[1] << " "
+        //                   << m_vertex_attribute[v.vid(*this)].m_posf[2] << std::endl;
+        //     }
+        // }
+        avg_energy += std::cbrt(q);
+        cnt++;
+    }
+
+    avg_energy /= cnt;
+
+    return std::make_tuple(std::cbrt(max_energy), avg_energy);
+}
+
+std::vector<size_t> TetOptimizerMesh::active_vertices() const
+{
+    return utils::active_vertices(
+        vert_capacity(),
+        tet_capacity(),
+        [this](size_t tid) { return tuple_from_tet(tid).is_valid(*this); },
+        [this](size_t tid) { return cell_quality(tid); },
+        [this](size_t tid) { return oriented_tet_vids(tid); },
+        active_quality_threshold(),
+        [this](size_t vid) { return m_vertex_attribute[vid].m_is_on_surface; });
+}
+
+bool TetOptimizerMesh::is_inverted_f(const Tuple& loc) const
+{
+    auto vs = oriented_tet_vertices(loc);
+
+    igl::predicates::exactinit();
+    auto res = igl::predicates::orient3d(
+        m_vertex_attribute[vs[0].vid(*this)].m_posf,
+        m_vertex_attribute[vs[1].vid(*this)].m_posf,
+        m_vertex_attribute[vs[2].vid(*this)].m_posf,
+        m_vertex_attribute[vs[3].vid(*this)].m_posf);
+    int result;
+    if (res == igl::predicates::Orientation::POSITIVE)
+        result = 1;
+    else if (res == igl::predicates::Orientation::NEGATIVE)
+        result = -1;
+    else
+        result = 0;
+
+    if (result < 0) // neg result == pos tet (tet origin from geogram delaunay)
+        return false;
+    return true;
+}
+
+bool TetOptimizerMesh::is_inverted(const std::array<size_t, 4>& vs) const
+{
+    // Return a positive value if the point pd lies below the
+    // plane passing through pa, pb, and pc; "below" is defined so
+    // that pa, pb, and pc appear in counterclockwise order when
+    // viewed from above the plane.
+
+    if (m_vertex_attribute[vs[0]].m_is_rounded && m_vertex_attribute[vs[1]].m_is_rounded &&
+        m_vertex_attribute[vs[2]].m_is_rounded && m_vertex_attribute[vs[3]].m_is_rounded) {
+        igl::predicates::exactinit();
+        auto res = igl::predicates::orient3d(
+            m_vertex_attribute[vs[0]].m_posf,
+            m_vertex_attribute[vs[1]].m_posf,
+            m_vertex_attribute[vs[2]].m_posf,
+            m_vertex_attribute[vs[3]].m_posf);
+        int result;
+        if (res == igl::predicates::Orientation::POSITIVE)
+            result = 1;
+        else if (res == igl::predicates::Orientation::NEGATIVE)
+            result = -1;
+        else
+            result = 0;
+
+        if (result < 0) // neg result == pos tet (tet origin from geogram delaunay)
+            return false;
+        return true;
+    } else {
+        Vector3r n =
+            ((m_vertex_attribute[vs[1]].m_pos) - m_vertex_attribute[vs[0]].m_pos)
+                .cross((m_vertex_attribute[vs[2]].m_pos) - m_vertex_attribute[vs[0]].m_pos);
+        Vector3r d = (m_vertex_attribute[vs[3]].m_pos) - m_vertex_attribute[vs[0]].m_pos;
+        auto res = n.dot(d);
+        if (res > 0) // predicates returns pos value: non-inverted
+            return false;
+        else
+            return true;
+    }
+}
+
+bool TetOptimizerMesh::is_inverted(const Tuple& loc) const
+{
+    auto vs = oriented_tet_vids(loc);
+    return is_inverted(vs);
+}
+
+bool TetOptimizerMesh::round(const Tuple& v)
+{
+    size_t i = v.vid(*this);
+    if (m_vertex_attribute[i].m_is_rounded) return true;
+
+    auto old_pos = m_vertex_attribute[i].m_pos;
+    m_vertex_attribute[i].m_pos << m_vertex_attribute[i].m_posf[0], m_vertex_attribute[i].m_posf[1],
+        m_vertex_attribute[i].m_posf[2];
+    auto conn_tets = get_one_ring_tets_for_vertex(v);
+    m_vertex_attribute[i].m_is_rounded = true;
+    for (auto& tet : conn_tets) {
+        if (is_inverted(tet)) {
+            m_vertex_attribute[i].m_is_rounded = false;
+            m_vertex_attribute[i].m_pos = old_pos;
+            return false;
+        }
+    }
+
+    return true;
+}
+
+double TetOptimizerMesh::get_quality(const std::array<size_t, 4>& its) const
+{
+    std::array<Vector3d, 4> ps;
+    auto use_rational = false;
+    for (auto k = 0; k < 4; k++) {
+        ps[k] = m_vertex_attribute[its[k]].m_posf;
+        if (!m_vertex_attribute[its[k]].m_is_rounded) {
+            use_rational = true;
+            break;
+        }
+    }
+    auto energy = -1.;
+    if (!use_rational) {
+        std::array<double, 12> T;
+        for (auto k = 0; k < 4; k++)
+            for (auto j = 0; j < 3; j++) T[k * 3 + j] = ps[k][j];
+
+        energy = wmtk::AMIPS_energy_stable_p3<wmtk::Rational>(T);
+    } else {
+        std::array<wmtk::Rational, 12> T;
+        for (auto k = 0; k < 4; k++)
+            for (auto j = 0; j < 3; j++) T[k * 3 + j] = m_vertex_attribute[its[k]].m_pos[j];
+        energy = wmtk::AMIPS_energy_rational_p3<wmtk::Rational>(T);
+    }
+    if (std::isinf(energy) || std::isnan(energy) || energy < 27 - 1e-3) return MAX_ENERGY;
+    return energy;
+}
+
+double TetOptimizerMesh::get_quality(const Tuple& loc) const
+{
+    auto its = oriented_tet_vids(loc);
+    return get_quality(its);
+}
+
+bool TetOptimizerMesh::invariants(const std::vector<Tuple>& tets)
+{
+    return true;
+}
+
+std::vector<std::array<size_t, 3>> TetOptimizerMesh::get_faces_by_condition(
+    std::function<bool(const FaceAttributes&)> cond) const
+{
+    auto res = std::vector<std::array<size_t, 3>>();
+    for (auto f : get_faces()) {
+        auto fid = f.fid(*this);
+        if (cond(m_face_attribute[fid])) {
+            auto tid = fid / 4, lid = fid % 4;
+            auto verts = get_face_vertices(f);
+            res.emplace_back( //
+                std::array<size_t, 3>{
+                    {verts[0].vid(*this), verts[1].vid(*this), verts[2].vid(*this)}});
+        }
+    }
+
+    return res;
+}
+
+bool TetOptimizerMesh::is_edge_on_surface(const Tuple& loc)
+{
+    size_t v1_id = loc.vid(*this);
+    auto loc1 = loc.switch_vertex(*this);
+    size_t v2_id = loc1.vid(*this);
+    if (!m_vertex_attribute[v1_id].m_is_on_surface || !m_vertex_attribute[v2_id].m_is_on_surface)
+        return false;
+
+    auto tets = get_incident_tets_for_edge(loc);
+    std::vector<size_t> n_vids;
+    for (auto& t : tets) {
+        auto vs = oriented_tet_vertices(t);
+        for (int j = 0; j < 4; j++) {
+            if (vs[j].vid(*this) != v1_id && vs[j].vid(*this) != v2_id)
+                n_vids.push_back(vs[j].vid(*this));
+        }
+    }
+    wmtk::vector_unique(n_vids);
+
+    for (size_t vid : n_vids) {
+        auto [_, fid] = tuple_from_face({{v1_id, v2_id, vid}});
+        if (m_face_attribute[fid].m_is_surface_fs) return true;
+    }
+
+    return false;
+}
+
+int TetOptimizerMesh::edge_incident_surface_face_count(const Tuple& e)
+{
+    const size_t v1_id = e.vid(*this);
+    const size_t v2_id = e.switch_vertex(*this).vid(*this);
+
+    const auto tets = get_incident_tets_for_edge(e);
+    std::vector<size_t> n_vids;
+    for (const auto& t : tets) {
+        const auto vs = oriented_tet_vertices(t);
+        for (int j = 0; j < 4; ++j) {
+            const size_t v = vs[j].vid(*this);
+            if (v != v1_id && v != v2_id) n_vids.push_back(v);
+        }
+    }
+    wmtk::vector_unique(n_vids);
+
+    int count = 0;
+    for (const size_t vid : n_vids) {
+        auto [ftup, fid] = tuple_from_face({{v1_id, v2_id, vid}});
+        (void)ftup;
+        if (fid != static_cast<size_t>(-1) && m_face_attribute[fid].m_is_surface_fs) ++count;
+    }
+    return count;
+}
+
+bool TetOptimizerMesh::is_edge_on_bbox(const Tuple& loc)
+{
+    size_t v1_id = loc.vid(*this);
+    auto loc1 = loc.switch_vertex(*this);
+    size_t v2_id = loc1.vid(*this);
+    if (m_vertex_attribute[v1_id].on_bbox_faces.empty() ||
+        m_vertex_attribute[v2_id].on_bbox_faces.empty())
+        return false;
+
+    auto tets = get_incident_tets_for_edge(loc);
+    std::vector<size_t> n_vids;
+    for (auto& t : tets) {
+        auto vs = oriented_tet_vertices(t);
+        for (int j = 0; j < 4; j++) {
+            if (vs[j].vid(*this) != v1_id && vs[j].vid(*this) != v2_id)
+                n_vids.push_back(vs[j].vid(*this));
+        }
+    }
+    wmtk::vector_unique(n_vids);
+
+    for (size_t vid : n_vids) {
+        auto [_, fid] = tuple_from_face({{v1_id, v2_id, vid}});
+        if (m_face_attribute[fid].m_is_bbox_fs >= 0) return true;
+    }
+
+    return false;
+}
+
+bool TetOptimizerMesh::vertex_is_on_surface(const size_t vid) const
+{
+    return m_vertex_attribute.at(vid).m_is_on_surface;
+}
+
+bool TetOptimizerMesh::face_is_on_surface(const size_t fid) const
+{
+    return m_face_attribute.at(fid).m_is_surface_fs;
+}
+
+size_t TetOptimizerMesh::get_order_of_vertex(const size_t vid) const
+{
+    return m_vertex_attribute.at(vid).m_order;
+}
+
+} // namespace wmtk

--- a/src/wmtk/TetOptimizerMesh.h
+++ b/src/wmtk/TetOptimizerMesh.h
@@ -68,16 +68,6 @@ public:
         /// Required for multi-threading.
         size_t partition_id = 0;
 
-        /**
-         * Whether the vertex lies on an open boundary of the input surface.
-         *
-         * Carried here rather than in the derived class because an attribute collection has one
-         * element type; simwild's 3D mesh never sets it. The 2D counterpart is
-         * TriOptimizerMesh::VertexAttributes::m_feature_id, which differs deliberately -- see
-         * the comment there.
-         */
-        bool m_is_on_open_boundary = false;
-
         VertexAttributes() {}
         VertexAttributes(const Vector3r& p);
     };
@@ -89,6 +79,14 @@ public:
 
     VertAttCol m_vertex_attribute;
     FaceAttCol m_face_attribute;
+
+    /**
+     * @brief What p_vertex_attrs points at, so a derived class can register more.
+     *
+     * VertexAttributes holds only what both 3D applications need. tetwild adds a per-vertex
+     * open-boundary flag through here; simwild never sets one, so it does not carry the field.
+     */
+    AttributeContainerGroup m_vertex_attr_group;
 
     /**
      * @brief The sentinel get_quality returns for an element AMIPS cannot score.
@@ -145,7 +143,11 @@ public:
     explicit TetOptimizerMesh(OptimizerParameters& params, std::shared_ptr<SampleEnvelope> env)
         : m_params(params)
         , m_envelope(std::move(env))
-    {}
+    {
+        m_vertex_attr_group.add(&m_vertex_attribute);
+        p_vertex_attrs = &m_vertex_attr_group;
+        p_face_attrs = &m_face_attribute;
+    }
     ~TetOptimizerMesh() override = default;
 
     /**

--- a/src/wmtk/TetOptimizerMesh.h
+++ b/src/wmtk/TetOptimizerMesh.h
@@ -168,6 +168,8 @@ public:
         return m_vertex_attribute[loc.vid(*this)].partition_id;
     }
 
+    double get_length2(const Tuple& l) const;
+
     bool is_inverted(const std::array<size_t, 4>& vs) const;
     bool is_inverted(const Tuple& loc) const;
     /// Inversion check using only the double positions.

--- a/src/wmtk/TetOptimizerMesh.h
+++ b/src/wmtk/TetOptimizerMesh.h
@@ -1,0 +1,248 @@
+#pragma once
+
+#include <wmtk/OptimizerParameters.h>
+#include <wmtk/SurfaceTagAttributes.h>
+#include <wmtk/TetMesh.h>
+#include <wmtk/Types.hpp>
+#include <wmtk/envelope/Envelope.hpp>
+#include <wmtk/optimization/SmoothVertex.hpp>
+#include <wmtk/optimization/solver.hpp>
+#include <wmtk/simplex/Simplex.hpp>
+#include <wmtk/threading/enumerable_thread_specific.hpp>
+
+#include <igl/Timer.h>
+
+#include <atomic>
+#include <functional>
+#include <memory>
+#include <set>
+#include <vector>
+
+namespace wmtk {
+
+/**
+ * @brief What tetwild and simwild's 3D mesh share.
+ *
+ * Seeded by MOVING tetwild's implementation here, not by designing an abstraction: tetwild is
+ * the more heavily measured of the two, so the move leaves it byte-identical and confines any
+ * output change to the commit where simwild adopts the base.
+ *
+ * The 2D counterpart is wmtk::TriOptimizerMesh. The two are deliberately NOT unified with each
+ * other -- see that class for why.
+ *
+ * **Cell attributes stay per-application.** tetwild's tets carry winding numbers and a
+ * flood-fill id, simwild's carry a CellTag set, and an AttributeCollection member cannot change
+ * type in a derived class. The base therefore reaches the one field it needs -- the quality --
+ * through cell_quality()/set_cell_quality(). That costs a virtual call, but only in
+ * active_vertices() and get_max_avg_energy(): of everything moved here, those are the only two
+ * that touch a cell attribute at all, and both are once-per-pass sweeps rather than
+ * per-operation code.
+ */
+class TetOptimizerMesh : public wmtk::TetMesh
+{
+public:
+    struct VertexAttributes
+    {
+        Vector3r m_pos; // exact position in rational
+        Vector3d m_posf; // position as double
+        /**
+         * If a vertex cannot be rounded without inverting a tet, the exact position must be
+         * used. Once the vertex can be rounded to double precision, the rational
+         * representation is obsolete.
+         */
+        bool m_is_rounded = false;
+
+        bool m_is_on_surface = false;
+        /**
+         * The order of a vertex in a TetMesh is as follows:
+         * 0: vertex is not on the surface
+         * 1: vertex is on the surface
+         * 2: vertex is on the boundary of the surface or a non-manifold edge
+         * 3: vertex is at the boundary of a non-manifold edge or a non-manifold vertex
+         */
+        size_t m_order = 0;
+        std::vector<int> on_bbox_faces;
+
+        double m_sizing_scalar = 1;
+
+        /// Required for multi-threading.
+        size_t partition_id = 0;
+
+        /**
+         * Whether the vertex lies on an open boundary of the input surface.
+         *
+         * Carried here rather than in the derived class because an attribute collection has one
+         * element type; simwild's 3D mesh never sets it. The 2D counterpart is
+         * TriOptimizerMesh::VertexAttributes::m_feature_id, which differs deliberately -- see
+         * the comment there.
+         */
+        bool m_is_on_open_boundary = false;
+
+        VertexAttributes() {}
+        VertexAttributes(const Vector3r& p);
+    };
+
+    using FaceAttributes = wmtk::SurfaceTagAttributes;
+
+    using VertAttCol = AttributeCollection<VertexAttributes>;
+    using FaceAttCol = AttributeCollection<FaceAttributes>;
+
+    VertAttCol m_vertex_attribute;
+    FaceAttCol m_face_attribute;
+
+    /**
+     * @brief The sentinel get_quality returns for an element AMIPS cannot score.
+     *
+     * Not an energy: a positively oriented tet whose volume is too small for AMIPS, or one that
+     * produces inf/nan, gets this instead. The cell quality holds AMIPS^3, so it surfaces in
+     * the logs as its cube root, cbrt(1e50) = 4.6e16. 1e50 rather than double::max because
+     * every downstream ratio must stay finite -- avg_energy sums qualities and would go inf.
+     */
+    static constexpr double MAX_ENERGY = 1e50;
+
+    /// Only the fields shared by all three applications; each derived class keeps a typed
+    /// reference to its own Parameters for the rest.
+    OptimizerParameters& m_params;
+
+    /// Surface envelope: what a surface vertex is pulled toward and checked against.
+    std::shared_ptr<SampleEnvelope> m_envelope;
+
+    /// Scale factors putting AMIPS (dimensionless) and the envelope energy (a squared
+    /// distance) on a comparable footing.
+    double m_s_amips = 1.;
+    double m_s_envelope = -1.;
+
+    double time_env = 0.0;
+    igl::Timer isout_timer;
+
+    /// Per-thread Newton solver for smoothing; created on first use.
+    wmtk::threading::enumerable_thread_specific<std::unique_ptr<polysolve::nonlinear::Solver>>
+        m_solver;
+
+    /// Why smoothing attempts were refused, reported once per pass.
+    optimization::SmoothRejectCounters m_smooth_rejects;
+
+    /**
+     * @brief True when every vertex is known to be rounded.
+     *
+     * Only trusted when true, and only round_all_vertices() sets it that way. Any code that
+     * leaves a vertex un-rounded must clear it, or the sweep will skip the vertex forever.
+     * Atomic because operations that clear it run in parallel.
+     */
+    std::atomic<bool> m_all_rounded = false;
+
+    /// Whether the current collapse pass applies the target-length limit; read by
+    /// collapse_edge_before, which is where that limit is enforced.
+    bool m_collapse_limit_length = true;
+
+    /// The longest edge of each current worst tet. split_all_edges force-splits exactly these
+    /// edges (bypassing the length gate). Populated serially by refine_sizing_around_worst;
+    /// read-only during the parallel split pass, then cleared once consumed.
+    std::set<simplex::Edge> m_force_split_edges;
+    /// Force-splits taken in the current split pass. Diagnostic only.
+    size_t m_force_split_count = 0;
+
+    explicit TetOptimizerMesh(OptimizerParameters& params, std::shared_ptr<SampleEnvelope> env)
+        : m_params(params)
+        , m_envelope(std::move(env))
+    {}
+    ~TetOptimizerMesh() override = default;
+
+    /**
+     * @brief The quality of cell `tid`, and how to write it.
+     *
+     * The cell attribute types differ between the applications, so the base reaches the one
+     * field it shares through these. Both are AMIPS^3; see MAX_ENERGY.
+     */
+    virtual double cell_quality(const size_t tid) const = 0;
+    virtual void set_cell_quality(const size_t tid, const double q) = 0;
+
+    // TODO This should not be here but inside wmtk
+    void compute_vertex_partition();
+    void compute_vertex_partition_morton();
+
+    size_t get_partition_id(const Tuple& loc) const
+    {
+        return m_vertex_attribute[loc.vid(*this)].partition_id;
+    }
+
+    bool is_inverted(const std::array<size_t, 4>& vs) const;
+    bool is_inverted(const Tuple& loc) const;
+    /// Inversion check using only the double positions.
+    bool is_inverted_f(const Tuple& loc) const;
+
+    double get_quality(const std::array<size_t, 4>& vs) const;
+    double get_quality(const Tuple& loc) const;
+    std::tuple<double, double> get_max_avg_energy();
+
+    /**
+     * @brief Round a vertex position to floating point, if that inverts no incident tet.
+     * @return True if successful or already rounded, false otherwise.
+     */
+    bool round(const Tuple& v);
+    /**
+     * @brief Try to round every un-rounded vertex; returns the number reclaimed.
+     *
+     * Skipped outright when m_all_rounded says there is nothing to do.
+     */
+    size_t round_all_vertices();
+
+    bool is_edge_on_surface(const Tuple& loc);
+    bool is_edge_on_bbox(const Tuple& loc);
+    /**
+     * @brief How many of the faces incident to edge `e` are on the tracked surface.
+     *
+     * Unlike is_edge_on_surface(), this does NOT short-circuit on the (possibly stale)
+     * per-vertex flag -- it counts the incident tets' face attributes directly.
+     */
+    int edge_incident_surface_face_count(const Tuple& e);
+
+    bool vertex_is_on_surface(const size_t vid) const override;
+    bool face_is_on_surface(const size_t fid) const override;
+    size_t get_order_of_vertex(const size_t vid) const override;
+
+    std::vector<std::array<size_t, 3>> get_faces_by_condition(
+        std::function<bool(const FaceAttributes&)> cond) const;
+
+    void output_faces(std::string file, std::function<bool(const FaceAttributes&)> cond);
+
+    /// Grade the refined sizing region into its surroundings (monotone, only lowers).
+    void gradation_smooth_sizing(double grade, const std::vector<size_t>& seeds);
+
+    /**
+     * @brief Cell-quality threshold above which a tet is "active" (worth operating on) for the
+     * skip-good-regions filter.
+     *
+     * The quality stores AMIPS^3 and the energy is its cube root, so a tet is active when its
+     * energy is at least skip_good_regions_margin * stop_energy, i.e. the quality is at least
+     * (margin * stop_energy)^3.
+     */
+    double active_quality_threshold() const
+    {
+        const double e = m_params.skip_good_regions_margin * m_params.stop_energy;
+        return e * e * e;
+    }
+
+    /// vids of the vertices incident to at least one "active" cell, for the
+    /// skip-good-regions filter.
+    std::vector<size_t> active_vertices() const;
+
+    double swap_edge_44_energy(const std::vector<std::array<size_t, 4>>& tets, const int op_case)
+        override;
+    double swap_edge_56_energy(const std::vector<std::array<size_t, 4>>& tets, const int op_case)
+        override;
+
+    /**
+     * @brief Envelope the resulting surface triangles are checked against.
+     *
+     * Virtual because tetwild keeps one surface envelope, so its pull target and containment
+     * test coincide, while simwild has a separate working envelope.
+     */
+    virtual std::shared_ptr<SampleEnvelope> smoothing_containment_envelope(const size_t vid) const;
+
+    bool smooth_before(const Tuple& t) override;
+
+    bool invariants(const std::vector<Tuple>& t) override;
+};
+
+} // namespace wmtk

--- a/src/wmtk/TriOptimizerMesh.cpp
+++ b/src/wmtk/TriOptimizerMesh.cpp
@@ -1,0 +1,297 @@
+#include <wmtk/TriOptimizerMesh.h>
+
+#include <wmtk/utils/AMIPS2D.h>
+#include <wmtk/utils/PartitionMesh.h>
+#include <wmtk/utils/VectorUtils.h>
+#include <wmtk/utils/Logger.hpp>
+#include <wmtk/utils/SizingField.hpp>
+#include <wmtk/utils/partition_utils.hpp>
+
+// clang-format off
+#include <wmtk/utils/DisableWarnings.hpp>
+#include <igl/predicates/predicates.h>
+#include <wmtk/utils/EnableWarnings.hpp>
+// clang-format on
+
+#include <queue>
+
+namespace wmtk {
+
+void TriOptimizerMesh::gradation_smooth_sizing(double grade, const std::vector<size_t>& seeds)
+{
+    utils::gradation_smooth_sizing(
+        grade,
+        seeds,
+        [this](size_t v) -> double& { return m_vertex_attribute[v].m_sizing_scalar; },
+        [this](size_t v) { return get_one_ring_vids_for_vertex_duplicate(v); });
+}
+
+void TriOptimizerMesh::partition_mesh()
+{
+    auto m_vertex_partition_id = partition_TriMesh(*this, NUM_THREADS);
+    for (size_t i = 0; i < m_vertex_partition_id.size(); i++) {
+        m_vertex_attribute[i].partition_id = m_vertex_partition_id[i];
+    }
+}
+
+void TriOptimizerMesh::partition_mesh_morton()
+{
+    if (NUM_THREADS == 0) {
+        return;
+    }
+    logger().info("Number of parts: {} by morton", NUM_THREADS);
+
+    // The shared partitioner is 3D; a zero z leaves the bounding box, the scale and the
+    // Morton code exactly where a 2D-specific version would put them.
+    std::vector<size_t> partition_id;
+    wmtk::partition_vertex_morton(
+        vert_capacity(),
+        [this](size_t i) {
+            const Vector2d& p = m_vertex_attribute[i].m_posf;
+            return Eigen::Vector3d(p[0], p[1], 0);
+        },
+        NUM_THREADS,
+        partition_id);
+
+    for (size_t i = 0; i < partition_id.size(); i++) {
+        m_vertex_attribute[i].partition_id = partition_id[i];
+    }
+}
+
+double TriOptimizerMesh::get_length2(const Tuple& l) const
+{
+    auto& m = *this;
+    auto& v1 = l;
+    auto v2 = l.switch_vertex(m);
+    double length =
+        (m.m_vertex_attribute[v1.vid(m)].m_posf - m.m_vertex_attribute[v2.vid(m)].m_posf)
+            .squaredNorm();
+    return length;
+}
+
+std::tuple<double, double> TriOptimizerMesh::get_max_avg_energy()
+{
+    double max_energy = -1.;
+    double avg_energy = 0.;
+    auto cnt = 0;
+
+    for (int i = 0; i < tri_capacity(); i++) {
+        const Tuple tup = tuple_from_tri(i);
+        if (!tup.is_valid(*this)) {
+            continue;
+        }
+        const double q = m_face_attribute[tup.fid(*this)].m_quality;
+        max_energy = std::max(max_energy, q);
+        avg_energy += q;
+        cnt++;
+    }
+
+    avg_energy /= cnt;
+
+    return std::make_tuple(max_energy, avg_energy);
+}
+
+bool TriOptimizerMesh::is_inverted_f(const Tuple& loc) const
+{
+    return is_inverted_f(loc.fid(*this));
+}
+
+bool TriOptimizerMesh::is_inverted_f(const size_t fid) const
+{
+    auto vs = oriented_tri_vids(fid);
+
+    igl::predicates::exactinit();
+    auto res = igl::predicates::orient2d(
+        m_vertex_attribute[vs[0]].m_posf,
+        m_vertex_attribute[vs[1]].m_posf,
+        m_vertex_attribute[vs[2]].m_posf);
+    if (res == igl::predicates::Orientation::POSITIVE) {
+        return false;
+    }
+    return true;
+}
+
+bool TriOptimizerMesh::is_inverted(const std::array<size_t, 3>& vs) const
+{
+    if (m_vertex_attribute[vs[0]].m_is_rounded && m_vertex_attribute[vs[1]].m_is_rounded &&
+        m_vertex_attribute[vs[2]].m_is_rounded) {
+        igl::predicates::exactinit();
+        auto res = igl::predicates::orient2d(
+            m_vertex_attribute[vs[0]].m_posf,
+            m_vertex_attribute[vs[1]].m_posf,
+            m_vertex_attribute[vs[2]].m_posf);
+        if (res == igl::predicates::Orientation::POSITIVE) {
+            return false;
+        }
+        return true;
+    } else {
+        const Vector2r& v0 = m_vertex_attribute[vs[0]].m_pos;
+        const Vector2r& v1 = m_vertex_attribute[vs[1]].m_pos;
+        const Vector2r& v2 = m_vertex_attribute[vs[2]].m_pos;
+        const Vector2r a = v1 - v0;
+        const Vector2r b = v2 - v0;
+        Rational res = a.x() * b.y() - a.y() * b.x();
+        if (res > 0) {
+            return false;
+        } else {
+            return true;
+        }
+    }
+}
+
+bool TriOptimizerMesh::is_inverted(const Tuple& loc) const
+{
+    auto vs = oriented_tri_vids(loc);
+    return is_inverted(vs);
+}
+
+bool TriOptimizerMesh::is_inverted(const size_t fid) const
+{
+    auto vs = oriented_tri_vids(fid);
+    return is_inverted(vs);
+}
+
+size_t TriOptimizerMesh::round_all_vertices()
+{
+    if (m_all_rounded.load(std::memory_order_relaxed)) {
+        return 0;
+    }
+
+    size_t reclaimed = 0, still_unrounded = 0;
+    for (const Tuple& v : get_vertices()) {
+        if (m_vertex_attribute[v.vid(*this)].m_is_rounded) {
+            continue;
+        }
+        if (round(v)) {
+            ++reclaimed;
+        } else {
+            ++still_unrounded;
+        }
+    }
+
+    if (still_unrounded == 0) {
+        m_all_rounded.store(true, std::memory_order_relaxed);
+    }
+    if (reclaimed > 0 || still_unrounded > 0) {
+        logger().info(
+            "rounding sweep: reclaimed {}, still unrounded {}",
+            reclaimed,
+            still_unrounded);
+    }
+    return reclaimed;
+}
+
+bool TriOptimizerMesh::round(const Tuple& v)
+{
+    size_t i = v.vid(*this);
+    if (m_vertex_attribute[i].m_is_rounded) {
+        return true;
+    }
+
+    auto old_pos = m_vertex_attribute[i].m_pos;
+    m_vertex_attribute[i].m_pos << m_vertex_attribute[i].m_posf[0], m_vertex_attribute[i].m_posf[1];
+    auto conn_tets = get_one_ring_tris_for_vertex(v);
+    // Set before the loop so is_inverted takes the float path: the question being asked is
+    // exactly whether the ROUNDED position keeps every incident face valid.
+    m_vertex_attribute[i].m_is_rounded = true;
+    for (const Tuple& tet : conn_tets) {
+        if (is_inverted(tet)) {
+            m_vertex_attribute[i].m_is_rounded = false;
+            m_vertex_attribute[i].m_pos = old_pos;
+            return false;
+        }
+    }
+
+    return true;
+}
+
+double TriOptimizerMesh::get_quality(const std::array<size_t, 3>& vs) const
+{
+    std::array<Vector2d, 3> ps;
+    for (size_t k = 0; k < 3; k++) {
+        ps[k] = m_vertex_attribute[vs[k]].m_posf;
+    }
+    double energy = -1.;
+    {
+        std::array<double, 6> T;
+        for (size_t k = 0; k < 3; k++)
+            for (size_t j = 0; j < 2; j++) {
+                T[k * 2 + j] = ps[k][j];
+            }
+        energy = AMIPS2D_energy(T);
+    }
+    if (std::isinf(energy) || std::isnan(energy) || energy < 2 - 1e-3) {
+        return MAX_ENERGY;
+    }
+    return energy;
+}
+
+double TriOptimizerMesh::get_quality(const Tuple& loc) const
+{
+    auto its = oriented_tri_vids(loc);
+    return get_quality(its);
+}
+
+double TriOptimizerMesh::get_quality(const size_t fid) const
+{
+    auto its = oriented_tri_vids(fid);
+    return get_quality(its);
+}
+
+std::vector<std::array<size_t, 2>> TriOptimizerMesh::get_edges_by_condition(
+    std::function<bool(const EdgeAttributes&)> cond) const
+{
+    std::vector<std::array<size_t, 2>> res;
+    for (const Tuple& e : get_edges()) {
+        size_t eid = e.eid(*this);
+        if (cond(m_edge_attribute[eid])) {
+            res.push_back({{e.vid(*this), e.switch_vertex(*this).vid(*this)}});
+        }
+    }
+    return res;
+}
+
+bool TriOptimizerMesh::is_edge_on_surface(const Tuple& loc) const
+{
+    const auto vs = get_edge_vids(loc);
+    if (!m_vertex_attribute.at(vs[0]).m_is_on_surface ||
+        !m_vertex_attribute.at(vs[1]).m_is_on_surface) {
+        return false;
+    }
+
+    const size_t eid = loc.eid(*this);
+    return m_edge_attribute[eid].m_is_surface_fs;
+}
+bool TriOptimizerMesh::is_edge_on_surface(const std::array<size_t, 2>& vids) const
+{
+    if (!m_vertex_attribute.at(vids[0]).m_is_on_surface ||
+        !m_vertex_attribute.at(vids[1]).m_is_on_surface) {
+        return false;
+    }
+
+    const auto [_, eid] = tuple_from_edge(vids);
+    return m_edge_attribute[eid].m_is_surface_fs;
+}
+bool TriOptimizerMesh::is_edge_on_bbox(const Tuple& loc) const
+{
+    const auto vs = get_edge_vids(loc);
+    if (m_vertex_attribute.at(vs[0]).on_bbox_faces.empty() ||
+        m_vertex_attribute.at(vs[1]).on_bbox_faces.empty()) {
+        return false;
+    }
+
+    const size_t eid = loc.eid(*this);
+    return m_edge_attribute[eid].m_is_bbox_fs >= 0;
+}
+
+bool TriOptimizerMesh::is_edge_on_bbox(const std::array<size_t, 2>& vids) const
+{
+    if (m_vertex_attribute.at(vids[0]).on_bbox_faces.empty() ||
+        m_vertex_attribute.at(vids[1]).on_bbox_faces.empty()) {
+        return false;
+    }
+    const auto [_, eid] = tuple_from_edge(vids);
+    return m_edge_attribute[eid].m_is_bbox_fs >= 0;
+}
+
+} // namespace wmtk

--- a/src/wmtk/TriOptimizerMesh.h
+++ b/src/wmtk/TriOptimizerMesh.h
@@ -1,0 +1,250 @@
+#pragma once
+
+#include <wmtk/OptimizerParameters.h>
+#include <wmtk/SurfaceTagAttributes.h>
+#include <wmtk/TriMesh.h>
+#include <wmtk/Types.hpp>
+#include <wmtk/envelope/Envelope.hpp>
+#include <wmtk/optimization/SmoothVertex.hpp>
+#include <wmtk/optimization/solver.hpp>
+#include <wmtk/threading/enumerable_thread_specific.hpp>
+
+#include <polysolve/nonlinear/Problem.hpp>
+
+#include <atomic>
+#include <limits>
+#include <map>
+#include <memory>
+#include <set>
+#include <vector>
+
+namespace wmtk {
+
+/**
+ * @brief What triwild and simwild's 2D mesh share.
+ *
+ * Seeded by MOVING triwild's implementation here, not by designing an abstraction: triwild is
+ * the more heavily measured of the two, so the move leaves it byte-identical and confines any
+ * output change to the commit where simwild adopts the base.
+ *
+ * The 3D counterpart is wmtk::TetOptimizerMesh. The two are deliberately NOT unified with each
+ * other: the same algorithms at two dimensions, but written against different primitives, and
+ * one shared copy would need the quality convention (2D stores AMIPS2D, 3D stores AMIPS^3) and
+ * the stop condition (absolute energy vs per-cell relative quality) abstracted first. Two
+ * readable copies beat one over-parameterized one.
+ */
+class TriOptimizerMesh : public wmtk::TriMesh
+{
+public:
+    struct VertexAttributes
+    {
+        Vector2d m_posf; // position as double
+        Vector2r m_pos; // exact position in rational
+        /**
+         * If a vertex cannot be rounded without inverting an incident face, the exact position
+         * must be used. Once the vertex can be rounded to double precision, the rational
+         * representation is obsolete.
+         */
+        bool m_is_rounded = false;
+
+        bool m_is_on_surface = false;
+        std::vector<int> on_bbox_faces;
+
+        double m_sizing_scalar = 1;
+
+        size_t partition_id = 0;
+
+        /**
+         * Index into TriWildMesh::m_feature_points, or NO_FEATURE.
+         *
+         * A feature point is a 0-dimensional feature of the curve network: an open polyline's
+         * endpoint, or a junction. This is the 2D counterpart of tetwild's
+         * m_is_on_open_boundary, with one deliberate difference -- it names WHICH feature the
+         * vertex stands for, not merely that it stands for one.
+         *
+         * That difference is the whole point. tetwild asks "is the survivor inside the
+         * envelope of the boundary?", a containment question, and in 3D a boundary is a curve
+         * with many edges so collapsing one shortens it rather than deleting it. In 2D the
+         * feature is a single point, and a containment test passes trivially when one endpoint
+         * is collapsed onto another -- the target IS a feature point, distance zero -- while
+         * the first endpoint quietly stops being represented. Preserving features is a
+         * COVERAGE property, so the constraint has to bind a vertex to a specific point.
+         *
+         * Carried here rather than in the derived class because an attribute collection has
+         * one element type; simwild's 2D mesh has no 0-dimensional features and leaves it at
+         * NO_FEATURE.
+         */
+        size_t m_feature_id = std::numeric_limits<size_t>::max();
+
+        VertexAttributes() {}
+        VertexAttributes(const Vector2d& p)
+            : m_posf(p)
+            , m_pos(to_rational(p))
+            , m_is_rounded(true)
+        {}
+        VertexAttributes(const Vector2r& p)
+            : m_posf(to_double(p))
+            , m_pos(p)
+        {}
+    };
+
+    using EdgeAttributes = wmtk::SurfaceTagAttributes;
+
+    struct FaceAttributes
+    {
+        double m_quality;
+        double m_winding_number = 0;
+        std::set<int64_t> tags;
+        int part_id = -1;
+    };
+
+    using VertAttCol = AttributeCollection<VertexAttributes>;
+    using EdgeAttCol = AttributeCollection<EdgeAttributes>;
+    using FaceAttCol = AttributeCollection<FaceAttributes>;
+
+    VertAttCol m_vertex_attribute;
+    EdgeAttCol m_edge_attribute;
+    FaceAttCol m_face_attribute;
+
+    /**
+     * @brief The sentinel get_quality returns for a face AMIPS2D cannot score.
+     *
+     * Not an energy: a positively oriented triangle whose area is too small for AMIPS, or one
+     * that produces inf/nan, gets this instead. Unlike the 3D mesh this stores AMIPS2D
+     * directly, so it surfaces in the logs verbatim as 1e+50. 1e50 rather than double::max
+     * because every downstream ratio must stay finite.
+     */
+    static constexpr double MAX_ENERGY = 1e50;
+
+    /// Only the fields shared by all three applications; each derived class keeps a typed
+    /// reference to its own Parameters for the rest.
+    OptimizerParameters& m_params;
+
+    std::shared_ptr<SampleEnvelope> m_envelope;
+    double m_envelope_eps = -1;
+
+    /// Scale factors putting AMIPS (dimensionless) and the envelope energy (a squared
+    /// distance) on a comparable footing.
+    double m_s_amips = -1;
+    double m_s_envelope = -1;
+
+    wmtk::threading::enumerable_thread_specific<std::unique_ptr<polysolve::nonlinear::Solver>>
+        m_solver;
+
+    /// Why smoothing attempts were refused, reported once per pass.
+    optimization::SmoothRejectCounters m_smooth_rejects;
+
+    /**
+     * @brief True when every vertex is known to be rounded.
+     *
+     * Only trusted when true, and only round_all_vertices() sets it that way. Any code that
+     * leaves a vertex un-rounded must clear it, or the sweep will skip the vertex forever.
+     * Atomic because operations that clear it run in parallel.
+     */
+    std::atomic<bool> m_all_rounded = false;
+
+    bool m_collapse_limit_length = true;
+    int m_debug_print_counter = 0;
+
+    size_t m_tags_count = 0;
+    std::map<int64_t, std::string> m_tag_id_to_name;
+    std::map<std::string, int64_t> m_tag_name_to_id;
+
+    explicit TriOptimizerMesh(OptimizerParameters& params)
+        : m_params(params)
+    {
+        m_s_amips = 1.;
+        /**
+         * eps makes it such that the energy is relative to the envelope thickness. As it's a
+         * squared energy, we need eps^2.
+         */
+        m_s_envelope = 1. / (m_params.eps * m_params.eps);
+    }
+    ~TriOptimizerMesh() override = default;
+
+    size_t get_partition_id(const Tuple& loc) const
+    {
+        return m_vertex_attribute[loc.vid(*this)].partition_id;
+    }
+    void partition_mesh();
+    void partition_mesh_morton();
+
+    double get_length2(const Tuple& l) const;
+
+    /**
+     * @brief Orientation check, exact for the coordinates the vertices actually carry.
+     *
+     * Takes the floating path when all three vertices are rounded -- igl::predicates::orient2d
+     * is exact for the doubles it is handed -- and the Rational cross product otherwise. The
+     * rational branch exists because for an un-rounded vertex the double is the wrong number,
+     * not because orient2d is imprecise.
+     */
+    bool is_inverted(const std::array<size_t, 3>& vs) const;
+    bool is_inverted(const Tuple& loc) const;
+    bool is_inverted(const size_t fid) const;
+    /// Inversion check using only the double positions.
+    bool is_inverted_f(const Tuple& loc) const;
+    bool is_inverted_f(const size_t fid) const;
+
+    double get_quality(const std::array<size_t, 3>& vs) const;
+    double get_quality(const Tuple& loc) const;
+    double get_quality(const size_t fid) const;
+
+    std::tuple<double, double> get_max_avg_energy();
+
+    /**
+     * @brief Round a vertex position to floating point, if that inverts no incident face.
+     * @return True if successful or already rounded, false otherwise.
+     */
+    bool round(const Tuple& v);
+    /**
+     * @brief Try to round every un-rounded vertex; returns the number reclaimed.
+     *
+     * round() is otherwise only attempted as a side effect of another operation (smoothing
+     * the vertex, or the merged vertex of a collapse), and neither reaches a vertex that only
+     * becomes roundable later: smoothing skips "good" regions by default. Without a sweep such
+     * a vertex keeps exact coordinates into the output for no geometric reason -- and
+     * split_edge_after introduces them unconditionally whenever the rounded midpoint would
+     * invert, so the sweep is what keeps that from reaching the output.
+     *
+     * Skipped outright when m_all_rounded says there is nothing to do.
+     */
+    size_t round_all_vertices();
+
+    bool is_edge_on_surface(const Tuple& loc) const;
+    bool is_edge_on_surface(const std::array<size_t, 2>& vids) const;
+    bool is_edge_on_bbox(const Tuple& loc) const;
+    bool is_edge_on_bbox(const std::array<size_t, 2>& vids) const;
+
+    bool vertex_is_on_surface(const size_t vid) const override
+    {
+        return m_vertex_attribute.at(vid).m_is_on_surface ||
+               !m_vertex_attribute.at(vid).on_bbox_faces.empty();
+    }
+    bool edge_is_on_surface(const std::array<size_t, 2>& vids) const override
+    {
+        if (!vertex_is_on_surface(vids[0]) || !vertex_is_on_surface(vids[1])) {
+            return false;
+        }
+
+        const auto [_, eid] = tuple_from_edge(vids);
+        bool on_surface = m_edge_attribute.at(eid).m_is_surface_fs;
+        bool on_bbox = m_edge_attribute.at(eid).m_is_bbox_fs >= 0;
+        return on_surface || on_bbox;
+    }
+
+    std::vector<std::array<size_t, 2>> get_edges_by_condition(
+        std::function<bool(const EdgeAttributes&)> cond) const;
+
+    /**
+     * @brief Monotone (only-decreasing) gradation smoothing of the sizing field.
+     *
+     * Enforces m_sizing_scalar[v] <= grade * m_sizing_scalar[u] for every edge (u,v),
+     * propagating outward from `seeds` with a min-relaxation. It never raises a sizing value,
+     * so it only ever spreads more refinement into the halo around already-refined vertices,
+     * avoiding sharp resolution jumps.
+     */
+    void gradation_smooth_sizing(double grade, const std::vector<size_t>& seeds);
+};
+
+} // namespace wmtk

--- a/src/wmtk/TriOptimizerMesh.h
+++ b/src/wmtk/TriOptimizerMesh.h
@@ -54,28 +54,6 @@ public:
 
         size_t partition_id = 0;
 
-        /**
-         * Index into TriWildMesh::m_feature_points, or NO_FEATURE.
-         *
-         * A feature point is a 0-dimensional feature of the curve network: an open polyline's
-         * endpoint, or a junction. This is the 2D counterpart of tetwild's
-         * m_is_on_open_boundary, with one deliberate difference -- it names WHICH feature the
-         * vertex stands for, not merely that it stands for one.
-         *
-         * That difference is the whole point. tetwild asks "is the survivor inside the
-         * envelope of the boundary?", a containment question, and in 3D a boundary is a curve
-         * with many edges so collapsing one shortens it rather than deleting it. In 2D the
-         * feature is a single point, and a containment test passes trivially when one endpoint
-         * is collapsed onto another -- the target IS a feature point, distance zero -- while
-         * the first endpoint quietly stops being represented. Preserving features is a
-         * COVERAGE property, so the constraint has to bind a vertex to a specific point.
-         *
-         * Carried here rather than in the derived class because an attribute collection has
-         * one element type; simwild's 2D mesh has no 0-dimensional features and leaves it at
-         * NO_FEATURE.
-         */
-        size_t m_feature_id = std::numeric_limits<size_t>::max();
-
         VertexAttributes() {}
         VertexAttributes(const Vector2d& p)
             : m_posf(p)
@@ -105,6 +83,15 @@ public:
     VertAttCol m_vertex_attribute;
     EdgeAttCol m_edge_attribute;
     FaceAttCol m_face_attribute;
+
+    /**
+     * @brief What p_vertex_attrs points at, so a derived class can register more.
+     *
+     * VertexAttributes holds only what both 2D applications need. triwild adds a per-vertex
+     * feature id through here; simwild-2D has no 0-dimensional features and registers nothing,
+     * so it does not carry the field.
+     */
+    AttributeContainerGroup m_vertex_attr_group;
 
     /**
      * @brief The sentinel get_quality returns for a face AMIPS2D cannot score.
@@ -153,6 +140,11 @@ public:
     explicit TriOptimizerMesh(OptimizerParameters& params)
         : m_params(params)
     {
+        m_vertex_attr_group.add(&m_vertex_attribute);
+        p_vertex_attrs = &m_vertex_attr_group;
+        p_edge_attrs = &m_edge_attribute;
+        p_face_attrs = &m_face_attribute;
+
         m_s_amips = 1.;
         /**
          * eps makes it such that the energy is relative to the envelope thickness. As it's a


### PR DESCRIPTION
Fourth of four stacked PRs de-duplicating tetwild, triwild and simwild. Stacks on #1006.

The four meshes are two sibling pairs, not four peers: `TriWildMesh`/`SimWildMeshTri` in 2D, `TetWildMesh`/`SimWildMesh` in 3D. This PR gives each pair a shared base.

```
wmtk::TriMesh                          wmtk::TetMesh
  └─ wmtk::TriOptimizerMesh              └─ wmtk::TetOptimizerMesh
       ├─ TriWildMesh                         ├─ TetWildMesh
       └─ SimWildMeshTri                      └─ SimWildMesh
```

**No new templates.** `wmtk::TriMesh` and `TetMesh` are not templates and already dispatch their operations virtually, so the sharing is two ordinary base classes and plain virtual hooks.

### Read it as move-then-adopt

Each base lands in **two commits**, and the split is what makes the result verifiable:

1. **Move** — create the base by moving the seed application's code into it unchanged, and reduce that application to a subclass. tetwild and triwild are byte-identical *by construction*, because their code was moved rather than rewritten.
2. **Adopt** — delete the sibling's copy. Any output movement is confined to this commit, and only simwild's may move.

Every move was checked mechanically, not by eye: each line removed from the seed application is present verbatim in the new pair, modulo the `m_params` → `m_tet_params`/`m_tri_params` renames and the signature changes. The handful that were not are listed in each commit message.

### What the measurement changed

- **2D was a pure deletion.** All 13 shared functions differed only cosmetically — const qualification, inlined temporaries, `!(res > 0)` versus an if/else. `CellTag` *is* `std::set<int64_t>`, so even `FaceAttributes` was already character-identical. No behaviour adopted, no ledger entry needed.
- **3D adopted exactly one behaviour**: `round()` now marks the vertex rounded *before* checking its one-ring, as the other three meshes already did. This is answer-preserving, not merely close — `m_pos` had already been set to `to_rational(m_posf)`, so the exact branch was evaluating the orientation of the same four points `orient3d` decides exactly anyway. simwild was paying for exact arithmetic to reach a conclusion the float predicate already gets right.
- **Cell attributes stay per-application.** tetwild's tets carry winding numbers and a flood-fill id, simwild's a `CellTag` set, and an `AttributeCollection` member cannot change type in a derived class. The base reaches quality through `cell_quality()`/`set_cell_quality()`. The plan called for benchmarking that virtual; no benchmark is needed, because of everything moved only `active_vertices()` and `get_max_avg_energy()` touch a cell attribute, and both are once-per-pass sweeps.
- **Vertex attributes are split, not unioned.** `wmtk::AttributeContainerGroup` forwards the six-virtual `AbstractAttributeContainer` protocol to several collections behind the mesh's single `p_vertex_attrs` slot, so each base holds only the shared fields and triwild/tetwild register their own extras. No hot-path virtual: each base still reads its own typed collection directly. Rollback comes free — `AttributeCollection::operator[]` is what records it — and that matters, since both extra fields are written inside `split_edge_after` and `collapse_edge_after`.

### Two things that did NOT move, and why

- **`smooth_after`**, despite being byte-identical in both 3D applications. Its body is the shared `optimization::smooth_vertex_3d` template, which reaches `m_tet_attribute` and `smoothing_energy_envelope` — both per-application. A call-graph check over function bodies cannot see that; only the compiler catches it.
- **The 3D swap family** (`swap_face_before`/`_after`, `swap_edge_after`, `swap_all_faces`). All four propagate simwild's `CellTag`, which tetwild has no counterpart for, so sharing them needs a tag-propagation hook. Deferred to its own PR.

### Flagged for review, not fixed here

While measuring the swap family: **simwild's `swap_all_faces` collects the wrong simplex.** It calls `parallel_collect_edge_ops` and queues `"face_swap"` operations on **edge** tuples — 6 per tet — where tetwild calls `parallel_collect_face_ops` and queues them on faces, 4 per tet. The two enumerate different sets, with each face reachable from up to three of its edges. Verified against both helpers; what the executor then does with a face-swap op keyed on an edge tuple is *not* verified, so "user-visible defect" is inference. simwild-only, and it touches no gate here. Recorded in the ledger with two smaller differences beside it.

### Verification

ctest 107/107, including the 19 triwild cases that exercise the feature points through the new extras collection. All 53 registered configs and all 30 hidden `[challenging]` models byte-identical for tetwild and triwild at every commit; every simwild config byte-identical too. crown/octocat compared separately at `num_threads: 0` against a build of the pre-refactor commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
