### PR TITLE
De-dup 5/5: fold the 24 executor-pass shells into wmtk::run_pass

### DIFF
--- a/components/simwild/wmtk/components/simwild/EdgeCollapsing.cpp
+++ b/components/simwild/wmtk/components/simwild/EdgeCollapsing.cpp
@@ -3,12 +3,12 @@
 
 #include <igl/Timer.h>
 #include <algorithm>
-#include <wmtk/ExecutionScheduler.hpp>
 #include <wmtk/threading/collector.hpp>
 #include <wmtk/utils/ExecutorUtils.hpp>
 #include <wmtk/utils/LocalizedRetry.hpp>
 #include <wmtk/utils/Logger.hpp>
 #include <wmtk/utils/ParallelCollect.hpp>
+#include <wmtk/utils/RunPass.hpp>
 
 namespace wmtk::components::simwild {
 
@@ -30,53 +30,40 @@ void SimWildMesh::collapse_all_edges(bool is_limit_length)
     logger().info("#edges = {}", all_ops.size() / 2);
     logger().info("edge collapse prepare time: {:.4}s", time);
 
-    auto setup_and_execute = [&](auto& executor) {
-        executor.renew_neighbor_tuples = [](const auto& m, auto op, const auto& newts) {
-            std::vector<std::pair<std::string, wmtk::TetMesh::Tuple>> op_tups;
-            for (const Tuple& t : newts) {
-                op_tups.emplace_back(op, t);
-                op_tups.emplace_back(op, t.switch_vertex(m));
-            }
-            return op_tups;
-        };
-        executor.priority = [](const SimWildMesh& m, Op op, const Tuple& t) {
-            return -m.get_length2(t);
-        };
-        executor.num_threads = NUM_THREADS;
-        executor.is_weight_up_to_date = [&](const SimWildMesh& m,
-                                            const std::tuple<double, Op, Tuple>& ele) {
-            auto& VA = m_vertex_attribute;
-            auto& [weight, op, tup] = ele;
-            auto length = m.get_length2(tup);
-            if (length != -weight) {
-                return false;
-            }
-            // Deliberately NOT filtered on length here. An over-length edge stays a
-            // candidate and collapse_edge_before decides it on quality instead: it is kept
-            // only if it STRICTLY improves the worst element of the ring. See there.
-            return true;
-        };
+    wmtk::run_pass(
+        *this,
+        wmtk::PassLock::EdgeTwoRing,
+        "edge collapse operation",
+        [&](auto& executor, auto& mesh) {
+            executor.renew_neighbor_tuples = [](const auto& m, auto op, const auto& newts) {
+                std::vector<std::pair<std::string, wmtk::TetMesh::Tuple>> op_tups;
+                for (const Tuple& t : newts) {
+                    op_tups.emplace_back(op, t);
+                    op_tups.emplace_back(op, t.switch_vertex(m));
+                }
+                return op_tups;
+            };
+            executor.priority = [](const wmtk::TetOptimizerMesh& m, Op op, const Tuple& t) {
+                return -m.get_length2(t);
+            };
+            executor.is_weight_up_to_date = [&](const wmtk::TetOptimizerMesh& m,
+                                                const std::tuple<double, Op, Tuple>& ele) {
+                auto& VA = m_vertex_attribute;
+                auto& [weight, op, tup] = ele;
+                auto length = m.get_length2(tup);
+                if (length != -weight) {
+                    return false;
+                }
+                // Deliberately NOT filtered on length here. An over-length edge stays a
+                // candidate and collapse_edge_before decides it on quality instead: it is kept
+                // only if it STRICTLY improves the worst element of the ring. See there.
+                return true;
+            };
 
-        // Retry a failed collapse only where the mesh actually changed this round
-        // (dirty-epoch localized retry), instead of re-testing every failure every pass.
-        wmtk::run_localized_to_convergence(*this, executor, all_ops);
-    };
-    if (NUM_THREADS > 0) {
-        timer.start();
-        auto executor = ExecutePass<SimWildMesh>(ExecutionPolicy::kPartition);
-        executor.lock_vertices = [](SimWildMesh& m, const Tuple& e, int task_id) -> bool {
-            return m.try_set_edge_mutex_two_ring(e, task_id);
-        };
-        setup_and_execute(executor);
-        time = timer.getElapsedTime();
-        wmtk::logger().info("edge collapse operation time parallel: {:.4}s", time);
-    } else {
-        timer.start();
-        auto executor = ExecutePass<SimWildMesh>(ExecutionPolicy::kSeq);
-        setup_and_execute(executor);
-        time = timer.getElapsedTime();
-        wmtk::logger().info("edge collapse operation time serial: {:.4}s", time);
-    }
+            // Retry a failed collapse only where the mesh actually changed this round
+            // (dirty-epoch localized retry), instead of re-testing every failure every pass.
+            wmtk::run_localized_to_convergence(mesh, executor, all_ops);
+        });
 }
 
 bool SimWildMesh::collapse_edge_before(const Tuple& loc) // input is an edge

--- a/components/simwild/wmtk/components/simwild/EdgeSplitting.cpp
+++ b/components/simwild/wmtk/components/simwild/EdgeSplitting.cpp
@@ -1,9 +1,9 @@
 #include "SimWildMesh.h"
 
 #include <igl/Timer.h>
-#include <wmtk/ExecutionScheduler.hpp>
 #include <wmtk/utils/ExecutorUtils.hpp>
 #include <wmtk/utils/Logger.hpp>
+#include <wmtk/utils/RunPass.hpp>
 
 namespace wmtk::components::simwild {
 
@@ -20,57 +20,44 @@ void SimWildMesh::split_all_edges()
     }
     time = timer.getElapsedTime();
     wmtk::logger().info("edge split prepare time: {:.4}s", time);
-    auto setup_and_execute = [&](auto& executor) {
-        executor.renew_neighbor_tuples = wmtk::renewal_edges;
+    wmtk::run_pass(
+        *this,
+        wmtk::PassLock::EdgeTwoRing,
+        "edge split operation",
+        [&](auto& executor, auto& mesh) {
+            executor.renew_neighbor_tuples = wmtk::renewal_edges;
 
-        executor.priority = [&](const SimWildMesh& m, std::string op, const Tuple& t) {
-            return m.get_length2(t);
-        };
-        executor.num_threads = NUM_THREADS;
-        executor.is_weight_up_to_date = [&](const SimWildMesh& m,
-                                            const std::tuple<double, std::string, Tuple>& ele) {
-            auto [weight, op, tup] = ele;
-            auto length = m.get_length2(tup);
-            if (length != weight) {
-                return false;
-            }
-            //
-            size_t v1_id = tup.vid(*this);
-            size_t v2_id = tup.switch_vertex(*this).vid(*this);
-            // Force-split: a worst tet's longest edge (queued by
-            // refine_sizing_around_worst when the max energy stalls) is split once
-            // regardless of the length gate, to unstick a sliver without changing the
-            // sizing field. The new midpoint is not in m_force_split_edges, so the
-            // two halves are NOT force-split again -- exactly one split per edge.
-            if (is_force_split_edge(v1_id, v2_id)) {
+            executor.priority = [&](const wmtk::TetOptimizerMesh& m,
+                                    std::string op,
+                                    const Tuple& t) { return m.get_length2(t); };
+            executor.is_weight_up_to_date = [&](const wmtk::TetOptimizerMesh& m,
+                                                const std::tuple<double, std::string, Tuple>& ele) {
+                auto [weight, op, tup] = ele;
+                auto length = m.get_length2(tup);
+                if (length != weight) {
+                    return false;
+                }
+                //
+                size_t v1_id = tup.vid(*this);
+                size_t v2_id = tup.switch_vertex(*this).vid(*this);
+                // Force-split: a worst tet's longest edge (queued by
+                // refine_sizing_around_worst when the max energy stalls) is split once
+                // regardless of the length gate, to unstick a sliver without changing the
+                // sizing field. The new midpoint is not in m_force_split_edges, so the
+                // two halves are NOT force-split again -- exactly one split per edge.
+                if (is_force_split_edge(v1_id, v2_id)) {
+                    return true;
+                }
+                double sizing_ratio = (m_vertex_attribute[v1_id].m_sizing_scalar +
+                                       m_vertex_attribute[v2_id].m_sizing_scalar) /
+                                      2;
+                if (length < m_params.splitting_l2 * sizing_ratio * sizing_ratio) {
+                    return false;
+                }
                 return true;
-            }
-            double sizing_ratio = (m_vertex_attribute[v1_id].m_sizing_scalar +
-                                   m_vertex_attribute[v2_id].m_sizing_scalar) /
-                                  2;
-            if (length < m_params.splitting_l2 * sizing_ratio * sizing_ratio) {
-                return false;
-            }
-            return true;
-        };
-        executor(*this, collect_all_ops);
-    };
-    if (NUM_THREADS > 0) {
-        timer.start();
-        auto executor = wmtk::ExecutePass<SimWildMesh>(wmtk::ExecutionPolicy::kPartition);
-        executor.lock_vertices = [&](auto& m, const auto& e, int task_id) -> bool {
-            return m.try_set_edge_mutex_two_ring(e, task_id);
-        };
-        setup_and_execute(executor);
-        time = timer.getElapsedTime();
-        wmtk::logger().info("edge split operation time parallel: {:.4}s", time);
-    } else {
-        timer.start();
-        auto executor = wmtk::ExecutePass<SimWildMesh>(wmtk::ExecutionPolicy::kSeq);
-        setup_and_execute(executor);
-        time = timer.getElapsedTime();
-        wmtk::logger().info("edge split operation time serial: {:.4}s", time);
-    }
+            };
+            executor(mesh, collect_all_ops);
+        });
     if (m_force_split_count > 0) {
         wmtk::logger().info(
             "[force-split] {} worst-tet longest edges force-split",

--- a/components/simwild/wmtk/components/simwild/EdgeSwapping.cpp
+++ b/components/simwild/wmtk/components/simwild/EdgeSwapping.cpp
@@ -2,10 +2,10 @@
 
 #include <igl/Timer.h>
 #include <wmtk/TetMesh.h>
-#include <wmtk/ExecutionScheduler.hpp>
 #include <wmtk/utils/ExecutorUtils.hpp>
 #include <wmtk/utils/Logger.hpp>
 #include <wmtk/utils/ParallelCollect.hpp>
+#include <wmtk/utils/RunPass.hpp>
 #include "spdlog/spdlog.h"
 #include "wmtk/utils/TupleUtils.hpp"
 
@@ -92,36 +92,21 @@ size_t SimWildMesh::swap_all_edges_32()
     if (m_sim_params.check_surface_topology) {
         sig_before = surface_topology_signature();
     }
-    auto setup_and_execute = [&](auto& executor) {
-        executor.renew_neighbor_tuples = wmtk::renewal_edges;
-        executor.priority = [&](auto& m, auto op, auto& t) { return m.get_length2(t); };
-        executor.num_threads = NUM_THREADS;
-        executor(*this, collect_all_ops);
-    };
-    if (NUM_THREADS > 0) {
-        timer.start();
-        auto executor = wmtk::ExecutePass<SimWildMesh>(wmtk::ExecutionPolicy::kPartition);
-        executor.lock_vertices = [](auto& m, const auto& e, int task_id) -> bool {
-            return m.try_set_edge_mutex_two_ring(e, task_id);
-        };
-        setup_and_execute(executor);
-        time = timer.getElapsedTime();
-        logger().info("edge swap operation time parallel: {:.4}s", time);
-        if (m_sim_params.check_surface_topology) {
-            warn_if_surface_topology_changed(sig_before, "swap_all_edges_32");
-        }
-        return executor.get_cnt_success();
-    } else {
-        timer.start();
-        auto executor = wmtk::ExecutePass<SimWildMesh>(wmtk::ExecutionPolicy::kSeq);
-        setup_and_execute(executor);
-        time = timer.getElapsedTime();
-        logger().info("edge swap operation time serial: {:.4}s", time);
-        if (m_sim_params.check_surface_topology) {
-            warn_if_surface_topology_changed(sig_before, "swap_all_edges_32");
-        }
-        return executor.get_cnt_success();
+    size_t total_success = 0;
+    wmtk::run_pass(
+        *this,
+        wmtk::PassLock::EdgeTwoRing,
+        "edge swap operation",
+        [&](auto& executor, auto& mesh) {
+            executor.renew_neighbor_tuples = wmtk::renewal_edges;
+            executor.priority = [&](auto& m, auto op, auto& t) { return m.get_length2(t); };
+            executor(mesh, collect_all_ops);
+            total_success = executor.get_cnt_success();
+        });
+    if (m_sim_params.check_surface_topology) {
+        warn_if_surface_topology_changed(sig_before, "swap_all_edges_32");
     }
+    return total_success;
 }
 
 bool SimWildMesh::swap_edge_before(const Tuple& t)
@@ -374,30 +359,18 @@ size_t SimWildMesh::swap_all_faces()
         });
     time = timer.getElapsedTime();
     logger().info("face swap prepare time: {:.4}s", time);
-    auto setup_and_execute = [&](auto& executor) {
-        executor.renew_neighbor_tuples = wmtk::renewal_faces;
-        executor.priority = [](auto& m, auto op, auto& t) { return m.get_length2(t); };
-        executor.num_threads = NUM_THREADS;
-        executor(*this, collect_all_ops);
-    };
-    if (NUM_THREADS > 0) {
-        timer.start();
-        auto executor = wmtk::ExecutePass<SimWildMesh>(wmtk::ExecutionPolicy::kPartition);
-        executor.lock_vertices = [](auto& m, const auto& e, int task_id) -> bool {
-            return m.try_set_face_mutex_two_ring(e, task_id);
-        };
-        setup_and_execute(executor);
-        time = timer.getElapsedTime();
-        logger().info("face swap operation time parallel: {:.4}s", time);
-        return executor.get_cnt_success();
-    } else {
-        timer.start();
-        auto executor = wmtk::ExecutePass<SimWildMesh>(wmtk::ExecutionPolicy::kSeq);
-        setup_and_execute(executor);
-        time = timer.getElapsedTime();
-        logger().info("face swap operation time serial: {:.4}s", time);
-        return executor.get_cnt_success();
-    }
+    size_t total_success = 0;
+    wmtk::run_pass(
+        *this,
+        wmtk::PassLock::FaceTwoRing,
+        "face swap operation",
+        [&](auto& executor, auto& mesh) {
+            executor.renew_neighbor_tuples = wmtk::renewal_faces;
+            executor.priority = [](auto& m, auto op, auto& t) { return m.get_length2(t); };
+            executor(mesh, collect_all_ops);
+            total_success = executor.get_cnt_success();
+        });
+    return total_success;
 }
 
 bool SimWildMesh::swap_face_before(const Tuple& t)
@@ -495,54 +468,39 @@ size_t SimWildMesh::swap_all_edges_all()
     if (m_sim_params.check_surface_topology) {
         sig_before = surface_topology_signature();
     }
-    auto setup_and_execute = [&](auto& executor) {
-        // executor.renew_neighbor_tuples = wmtk::renewal_edges;
-        executor.renew_neighbor_tuples =
-            [](const TetMesh& m, const std::string& op, const std::vector<Tuple>& newt) {
-                std::vector<std::pair<std::string, TetMesh::Tuple>> op_tups;
-                std::vector<TetMesh::Tuple> new_edges;
-                for (const TetMesh::Tuple& ti : newt) {
-                    for (auto j = 0; j < 6; j++) {
-                        new_edges.push_back(m.tuple_from_edge(ti.tid(m), j));
+    size_t total_success = 0;
+    wmtk::run_pass(
+        *this,
+        wmtk::PassLock::EdgeTwoRing,
+        "edge swap operation",
+        [&](auto& executor, auto& mesh) {
+            // executor.renew_neighbor_tuples = wmtk::renewal_edges;
+            executor.renew_neighbor_tuples =
+                [](const TetMesh& m, const std::string& op, const std::vector<Tuple>& newt) {
+                    std::vector<std::pair<std::string, TetMesh::Tuple>> op_tups;
+                    std::vector<TetMesh::Tuple> new_edges;
+                    for (const TetMesh::Tuple& ti : newt) {
+                        for (auto j = 0; j < 6; j++) {
+                            new_edges.push_back(m.tuple_from_edge(ti.tid(m), j));
+                        }
+                    };
+                    wmtk::unique_edge_tuples(m, new_edges);
+                    op_tups.reserve(new_edges.size() * 3);
+                    for (const Tuple& loc : new_edges) {
+                        op_tups.emplace_back("edge_swap", loc);
+                        op_tups.emplace_back("edge_swap_44", loc);
+                        op_tups.emplace_back("edge_swap_56", loc);
                     }
+                    return op_tups;
                 };
-                wmtk::unique_edge_tuples(m, new_edges);
-                op_tups.reserve(new_edges.size() * 3);
-                for (const Tuple& loc : new_edges) {
-                    op_tups.emplace_back("edge_swap", loc);
-                    op_tups.emplace_back("edge_swap_44", loc);
-                    op_tups.emplace_back("edge_swap_56", loc);
-                }
-                return op_tups;
-            };
-        executor.priority = [&](auto& m, auto op, auto& t) { return m.get_length2(t); };
-        executor.num_threads = NUM_THREADS;
-        executor(*this, collect_all_ops);
-    };
-    if (NUM_THREADS > 0) {
-        timer.start();
-        auto executor = wmtk::ExecutePass<SimWildMesh>(wmtk::ExecutionPolicy::kPartition);
-        executor.lock_vertices = [](auto& m, const auto& e, int task_id) -> bool {
-            return m.try_set_edge_mutex_two_ring(e, task_id);
-        };
-        setup_and_execute(executor);
-        time = timer.getElapsedTime();
-        logger().info("edge swap operation time parallel: {:.4}s", time);
-        if (m_sim_params.check_surface_topology) {
-            warn_if_surface_topology_changed(sig_before, "swap_all_edges_32");
-        }
-        return executor.get_cnt_success();
-    } else {
-        timer.start();
-        auto executor = wmtk::ExecutePass<SimWildMesh>(wmtk::ExecutionPolicy::kSeq);
-        setup_and_execute(executor);
-        time = timer.getElapsedTime();
-        logger().info("edge swap operation time serial: {:.4}s", time);
-        if (m_sim_params.check_surface_topology) {
-            warn_if_surface_topology_changed(sig_before, "swap_all_edges_32");
-        }
-        return executor.get_cnt_success();
+            executor.priority = [&](auto& m, auto op, auto& t) { return m.get_length2(t); };
+            executor(mesh, collect_all_ops);
+            total_success = executor.get_cnt_success();
+        });
+    if (m_sim_params.check_surface_topology) {
+        warn_if_surface_topology_changed(sig_before, "swap_all_edges_32");
     }
+    return total_success;
 }
 
 
@@ -557,30 +515,18 @@ size_t SimWildMesh::swap_all_edges_44()
         });
     time = timer.getElapsedTime();
     logger().info("edge swap 44 prepare time: {:.4}s", time);
-    auto setup_and_execute = [&](auto& executor) {
-        executor.renew_neighbor_tuples = wmtk::renewal_edges;
-        executor.priority = [&](auto& m, auto op, auto& t) { return m.get_length2(t); };
-        executor.num_threads = NUM_THREADS;
-        executor(*this, collect_all_ops);
-    };
-    if (NUM_THREADS > 0) {
-        timer.start();
-        auto executor = wmtk::ExecutePass<SimWildMesh>(wmtk::ExecutionPolicy::kPartition);
-        executor.lock_vertices = [](auto& m, const auto& e, int task_id) -> bool {
-            return m.try_set_edge_mutex_two_ring(e, task_id);
-        };
-        setup_and_execute(executor);
-        time = timer.getElapsedTime();
-        logger().info("edge swap 44 operation time parallel: {:.4}s", time);
-        return executor.get_cnt_success();
-    } else {
-        timer.start();
-        auto executor = wmtk::ExecutePass<SimWildMesh>(wmtk::ExecutionPolicy::kSeq);
-        setup_and_execute(executor);
-        time = timer.getElapsedTime();
-        logger().info("edge swap 44 operation time serial: {:.4}s", time);
-        return executor.get_cnt_success();
-    }
+    size_t total_success = 0;
+    wmtk::run_pass(
+        *this,
+        wmtk::PassLock::EdgeTwoRing,
+        "edge swap 44 operation",
+        [&](auto& executor, auto& mesh) {
+            executor.renew_neighbor_tuples = wmtk::renewal_edges;
+            executor.priority = [&](auto& m, auto op, auto& t) { return m.get_length2(t); };
+            executor(mesh, collect_all_ops);
+            total_success = executor.get_cnt_success();
+        });
+    return total_success;
 }
 
 bool SimWildMesh::swap_edge_44_before(const Tuple& t)
@@ -657,30 +603,18 @@ size_t SimWildMesh::swap_all_edges_56()
         });
     time = timer.getElapsedTime();
     logger().info("edge swap 56 prepare time: {:.4}s", time);
-    auto setup_and_execute = [&](auto& executor) {
-        executor.renew_neighbor_tuples = wmtk::renewal_edges;
-        executor.priority = [&](auto& m, auto op, auto& t) { return m.get_length2(t); };
-        executor.num_threads = NUM_THREADS;
-        executor(*this, collect_all_ops);
-    };
-    if (NUM_THREADS > 0) {
-        timer.start();
-        auto executor = wmtk::ExecutePass<SimWildMesh>(wmtk::ExecutionPolicy::kPartition);
-        executor.lock_vertices = [](auto& m, const auto& e, int task_id) -> bool {
-            return m.try_set_edge_mutex_two_ring(e, task_id);
-        };
-        setup_and_execute(executor);
-        time = timer.getElapsedTime();
-        logger().info("edge swap 56 operation time parallel: {:.4}s", time);
-        return executor.get_cnt_success();
-    } else {
-        timer.start();
-        auto executor = wmtk::ExecutePass<SimWildMesh>(wmtk::ExecutionPolicy::kSeq);
-        setup_and_execute(executor);
-        time = timer.getElapsedTime();
-        logger().info("edge swap 56 operation time serial: {:.4}s", time);
-        return executor.get_cnt_success();
-    }
+    size_t total_success = 0;
+    wmtk::run_pass(
+        *this,
+        wmtk::PassLock::EdgeTwoRing,
+        "edge swap 56 operation",
+        [&](auto& executor, auto& mesh) {
+            executor.renew_neighbor_tuples = wmtk::renewal_edges;
+            executor.priority = [&](auto& m, auto op, auto& t) { return m.get_length2(t); };
+            executor(mesh, collect_all_ops);
+            total_success = executor.get_cnt_success();
+        });
+    return total_success;
 }
 
 bool SimWildMesh::swap_edge_56_before(const Tuple& t)

--- a/components/simwild/wmtk/components/simwild/SimWildMeshTri.cpp
+++ b/components/simwild/wmtk/components/simwild/SimWildMeshTri.cpp
@@ -17,7 +17,6 @@
 #include <paraviewo/VTUWriter.hpp>
 #include <set>
 #include <unordered_map>
-#include <wmtk/ExecutionScheduler.hpp>
 #include <wmtk/envelope/KNN.hpp>
 #include <wmtk/optimization/AMIPSEnergy.hpp>
 #include <wmtk/optimization/DirichletEnergy.hpp>
@@ -26,6 +25,7 @@
 #include <wmtk/optimization/solver.hpp>
 #include <wmtk/utils/LocalizedRetry.hpp>
 #include <wmtk/utils/ParallelCollect.hpp>
+#include <wmtk/utils/RunPass.hpp>
 #include <wmtk/utils/SizingField.hpp>
 #include <wmtk/utils/TetraQualityUtils.hpp>
 #include <wmtk/utils/TupleUtils.hpp>
@@ -36,7 +36,7 @@
 
 namespace wmtk::components::simwild::tri {
 
-auto renew = [](const SimWildMeshTri& m, auto op, auto& tris) {
+auto renew = [](const wmtk::TriOptimizerMesh& m, auto op, auto& tris) {
     using Tuple = TriMesh::Tuple;
     std::vector<Tuple> edges;
     for (const auto& t : tris) {
@@ -54,11 +54,6 @@ auto renew = [](const SimWildMeshTri& m, auto op, auto& tris) {
     return optup;
 };
 
-
-auto edge_locker = [](auto& m, const auto& e, int task_id) {
-    // TODO: this should not be here
-    return m.try_set_edge_mutex_two_ring(e, task_id);
-};
 
 void SimWildMeshTri::init_from_image(
     const MatrixXd& V,
@@ -878,56 +873,43 @@ void SimWildMeshTri::split_all_edges()
     }
     time = timer.getElapsedTime();
     wmtk::logger().info("edge split prepare time: {:.4}s", time);
-    auto setup_and_execute = [&](auto& executor) {
-        executor.renew_neighbor_tuples =
-            [](const SimWildMeshTri& m, std::string op, const auto& newts) {
-                std::vector<std::pair<std::string, TriMesh::Tuple>> op_tups;
-                for (const auto& t : newts) {
-                    op_tups.emplace_back(op, t);
-                    op_tups.emplace_back(op, t.switch_edge(m));
-                    op_tups.emplace_back(op, t.switch_vertex(m).switch_edge(m));
-                }
-                return op_tups;
-            };
+    wmtk::run_pass(
+        *this,
+        wmtk::PassLock::EdgeTwoRing,
+        "edge split operation",
+        [&](auto& executor, auto& mesh) {
+            executor.renew_neighbor_tuples =
+                [](const wmtk::TriOptimizerMesh& m, std::string op, const auto& newts) {
+                    std::vector<std::pair<std::string, TriMesh::Tuple>> op_tups;
+                    for (const auto& t : newts) {
+                        op_tups.emplace_back(op, t);
+                        op_tups.emplace_back(op, t.switch_edge(m));
+                        op_tups.emplace_back(op, t.switch_vertex(m).switch_edge(m));
+                    }
+                    return op_tups;
+                };
 
-        executor.priority = [&](const SimWildMeshTri& m, std::string op, const Tuple& t) {
-            return m.get_length2(t);
-        };
-        executor.num_threads = NUM_THREADS;
-        executor.is_weight_up_to_date = [&](const SimWildMeshTri& m, const auto& ele) {
-            auto [weight, op, tup] = ele;
-            auto length = m.get_length2(tup);
-            if (length != weight) {
-                return false;
-            }
-            //
-            size_t v1_id = tup.vid(*this);
-            size_t v2_id = tup.switch_vertex(*this).vid(*this);
-            const auto& VA = m_vertex_attribute;
-            double sizing_ratio = 0.5 * (VA[v1_id].m_sizing_scalar + VA[v2_id].m_sizing_scalar);
-            if (length < m_params.splitting_l2 * sizing_ratio * sizing_ratio) {
-                return false;
-            }
-            return true;
-        };
-        executor(*this, collect_all_ops);
-    };
-    if (NUM_THREADS > 0) {
-        timer.start();
-        auto executor = ExecutePass<SimWildMeshTri>(ExecutionPolicy::kPartition);
-        executor.lock_vertices = [&](auto& m, const auto& e, int task_id) -> bool {
-            return m.try_set_edge_mutex_two_ring(e, task_id);
-        };
-        setup_and_execute(executor);
-        time = timer.getElapsedTime();
-        wmtk::logger().info("edge split operation time parallel: {:.4}s", time);
-    } else {
-        timer.start();
-        auto executor = ExecutePass<SimWildMeshTri>(ExecutionPolicy::kSeq);
-        setup_and_execute(executor);
-        time = timer.getElapsedTime();
-        wmtk::logger().info("edge split operation time serial: {:.4}s", time);
-    }
+            executor.priority = [&](const wmtk::TriOptimizerMesh& m,
+                                    std::string op,
+                                    const Tuple& t) { return m.get_length2(t); };
+            executor.is_weight_up_to_date = [&](const wmtk::TriOptimizerMesh& m, const auto& ele) {
+                auto [weight, op, tup] = ele;
+                auto length = m.get_length2(tup);
+                if (length != weight) {
+                    return false;
+                }
+                //
+                size_t v1_id = tup.vid(*this);
+                size_t v2_id = tup.switch_vertex(*this).vid(*this);
+                const auto& VA = m_vertex_attribute;
+                double sizing_ratio = 0.5 * (VA[v1_id].m_sizing_scalar + VA[v2_id].m_sizing_scalar);
+                if (length < m_params.splitting_l2 * sizing_ratio * sizing_ratio) {
+                    return false;
+                }
+                return true;
+            };
+            executor(mesh, collect_all_ops);
+        });
     if (m_exact_split_count > 0) {
         wmtk::logger().info(
             "{} splits fell back to the exact rational midpoint",
@@ -1177,57 +1159,45 @@ void SimWildMeshTri::collapse_all_edges(bool is_limit_length)
     m_collapse_limit_length = is_limit_length;
     std::vector<std::pair<std::string, Tuple>> all_ops;
 
-    auto setup_and_execute = [&](auto& executor) {
-        executor.priority = [](const SimWildMeshTri& m, Op op, const Tuple& t) {
-            return -m.get_length2(t);
-        };
-        executor.num_threads = NUM_THREADS;
-        executor.is_weight_up_to_date = [&](const SimWildMeshTri& m,
-                                            const std::tuple<double, Op, Tuple>& ele) {
-            const auto& VA = m_vertex_attribute;
-            auto& [weight, op, tup] = ele;
-            const double length = m.get_length2(tup);
-            if (length != -weight) {
-                return false;
-            }
-            // Deliberately NOT filtered on length here. An over-length edge stays a
-            // candidate and collapse_edge_before decides it on quality instead: it is kept
-            // only if it STRICTLY improves the worst element of the ring. See there.
-            return true;
-        };
+    wmtk::run_pass(
+        *this,
+        wmtk::PassLock::EdgeTwoRing,
+        "edge collapse",
+        [&](auto& executor, auto& mesh) {
+            executor.priority = [](const wmtk::TriOptimizerMesh& m, Op op, const Tuple& t) {
+                return -m.get_length2(t);
+            };
+            executor.is_weight_up_to_date = [&](const wmtk::TriOptimizerMesh& m,
+                                                const std::tuple<double, Op, Tuple>& ele) {
+                const auto& VA = m_vertex_attribute;
+                auto& [weight, op, tup] = ele;
+                const double length = m.get_length2(tup);
+                if (length != -weight) {
+                    return false;
+                }
+                // Deliberately NOT filtered on length here. An over-length edge stays a
+                // candidate and collapse_edge_before decides it on quality instead: it is kept
+                // only if it STRICTLY improves the worst element of the ring. See there.
+                return true;
+            };
 
-        // Execute!!
-        do {
-            all_ops.clear();
-            const auto all_edges = get_edges();
-            logger().info("#E = {}", all_edges.size());
-            for (const Tuple& loc : all_edges) {
-                // collect all edges. Filtering too long edges happens in `is_weight_up_to_date`
-                all_ops.emplace_back("edge_collapse", loc);
-                all_ops.emplace_back("edge_collapse", loc.switch_vertex(*this));
-            }
-            executor(*this, all_ops);
-            logger().info(
-                "success: {}, failed: {}",
-                executor.get_cnt_success(),
-                executor.get_cnt_fail());
-        } while (executor.get_cnt_success() > 0);
-    };
-
-    igl::Timer timer;
-    timer.start();
-    if (NUM_THREADS > 0) {
-        auto executor = ExecutePass<SimWildMeshTri>(ExecutionPolicy::kPartition);
-        executor.lock_vertices = [](SimWildMeshTri& m, const Tuple& e, int task_id) -> bool {
-            return m.try_set_edge_mutex_two_ring(e, task_id);
-        };
-        setup_and_execute(executor);
-        wmtk::logger().info("edge collapse time parallel: {:.4}s", timer.getElapsedTimeInSec());
-    } else {
-        auto executor = ExecutePass<SimWildMeshTri>(ExecutionPolicy::kSeq);
-        setup_and_execute(executor);
-        wmtk::logger().info("edge collapse time serial: {:.4}s", timer.getElapsedTimeInSec());
-    }
+            // Execute!!
+            do {
+                all_ops.clear();
+                const auto all_edges = get_edges();
+                logger().info("#E = {}", all_edges.size());
+                for (const Tuple& loc : all_edges) {
+                    // collect all edges. Filtering too long edges happens in `is_weight_up_to_date`
+                    all_ops.emplace_back("edge_collapse", loc);
+                    all_ops.emplace_back("edge_collapse", loc.switch_vertex(*this));
+                }
+                executor(mesh, all_ops);
+                logger().info(
+                    "success: {}, failed: {}",
+                    executor.get_cnt_success(),
+                    executor.get_cnt_fail());
+            } while (executor.get_cnt_success() > 0);
+        });
 }
 
 bool SimWildMeshTri::collapse_edge_before(const Tuple& loc)
@@ -1497,30 +1467,23 @@ size_t SimWildMeshTri::swap_all_edges()
     logger().info("edge swap prepare time: {:.4}s", timer.getElapsedTimeInSec());
 
     size_t total_success = 0;
-    auto setup_and_execute = [&](auto& executor) {
+    wmtk::run_pass(*this, wmtk::PassLock::EdgeTwoRing, "", [&](auto& executor, auto& mesh) {
         executor.renew_neighbor_tuples = renew;
-        executor.num_threads = NUM_THREADS;
-        executor.priority = [](const SimWildMeshTri& m, std::string op, const Tuple& e) {
-            return m.swap_weight(e);
+        // `swap_weight` is simwild's own, so reach it through `this` rather than through the
+        // executor's mesh argument, which is the shared base.
+        executor.priority = [this](const wmtk::TriOptimizerMesh&, std::string op, const Tuple& e) {
+            return swap_weight(e);
         };
         executor.should_renew = [](auto val) { return (val > 0); };
-        executor.is_weight_up_to_date = [](const SimWildMeshTri& m, auto& ele) {
+        executor.is_weight_up_to_date = [this](const wmtk::TriOptimizerMesh&, auto& ele) {
             auto& [val, _, e] = ele;
-            const double w = m.swap_weight(e);
+            const double w = swap_weight(e);
             return (w > 1e-5) && ((w - val) * (w - val) < 1e-8);
         };
         // Retry a failed swap only where the mesh actually changed this round
         // (dirty-epoch localized retry).
-        total_success = wmtk::run_localized_to_convergence(*this, executor, collect_all_ops);
-    };
-    if (NUM_THREADS > 0) {
-        auto executor = ExecutePass<SimWildMeshTri>(ExecutionPolicy::kPartition);
-        executor.lock_vertices = edge_locker;
-        setup_and_execute(executor);
-    } else {
-        auto executor = ExecutePass<SimWildMeshTri>(ExecutionPolicy::kSeq);
-        setup_and_execute(executor);
-    }
+        total_success = wmtk::run_localized_to_convergence(mesh, executor, collect_all_ops);
+    });
 
     // The caller (local_operations) stops the swap loop once a pass changes nothing, so this
     // has to be the real count -- it used to return `true`, i.e. always 1, which meant the
@@ -1640,21 +1603,11 @@ void SimWildMeshTri::smooth_all_vertices(const size_t n_iters)
         }
         logger().info("vertex smoothing prepare time: {:.4}s", timer.getElapsedTimeInSec());
         logger().info("#V = {}", collect_all_ops.size());
-        if (NUM_THREADS > 0) {
-            timer.start();
-            ExecutePass<SimWildMeshTri> executor(ExecutionPolicy::kPartition);
-            executor.lock_vertices = [](auto& m, const auto& e, int task_id) -> bool {
-                return m.try_set_vertex_mutex_one_ring(e, task_id);
-            };
-            executor.num_threads = NUM_THREADS;
-            executor(*this, collect_all_ops);
-            logger().info("vertex smoothing time parallel: {:.4}s", timer.getElapsedTimeInSec());
-        } else {
-            timer.start();
-            ExecutePass<SimWildMeshTri> executor(ExecutionPolicy::kSeq);
-            executor(*this, collect_all_ops);
-            logger().info("vertex smoothing time serial: {:.4}s", timer.getElapsedTimeInSec());
-        }
+        wmtk::run_pass(
+            *this,
+            wmtk::PassLock::VertexOneRing,
+            "vertex smoothing",
+            [&](auto& executor, auto& mesh) { executor(mesh, collect_all_ops); });
         logger().info("\tsmooth: {}", m_smooth_rejects.to_string());
         if (m_params.debug_output) {
             write_vtu(fmt::format("debug_{}", m_debug_print_counter++));

--- a/components/simwild/wmtk/components/simwild/Smooth.cpp
+++ b/components/simwild/wmtk/components/simwild/Smooth.cpp
@@ -2,7 +2,7 @@
 #include "SimWildMesh.h"
 
 #include <wmtk/optimization/SmoothVertex.hpp>
-#include "wmtk/ExecutionScheduler.hpp"
+#include <wmtk/utils/RunPass.hpp>
 
 #include <Eigen/src/Core/util/Constants.h>
 #include <igl/Timer.h>
@@ -74,23 +74,11 @@ void SimWildMesh::smooth_all_vertices(const size_t n_iters = 1)
         time = timer.getElapsedTime();
         wmtk::logger().info("vertex smoothing prepare time: {:.4}s", time);
         wmtk::logger().debug("Num verts {}", collect_all_ops.size());
-        if (NUM_THREADS > 0) {
-            timer.start();
-            auto executor = wmtk::ExecutePass<SimWildMesh>(wmtk::ExecutionPolicy::kPartition);
-            executor.lock_vertices = [](auto& m, const auto& e, int task_id) -> bool {
-                return m.try_set_vertex_mutex_one_ring(e, task_id);
-            };
-            executor.num_threads = NUM_THREADS;
-            executor(*this, collect_all_ops);
-            time = timer.getElapsedTime();
-            wmtk::logger().info("vertex smoothing operation time parallel: {:.4}s", time);
-        } else {
-            timer.start();
-            auto executor = wmtk::ExecutePass<SimWildMesh>(wmtk::ExecutionPolicy::kSeq);
-            executor(*this, collect_all_ops);
-            time = timer.getElapsedTime();
-            wmtk::logger().info("vertex smoothing operation time serial: {:.4}s", time);
-        }
+        wmtk::run_pass(
+            *this,
+            wmtk::PassLock::VertexOneRing,
+            "vertex smoothing operation",
+            [&](auto& executor, auto& mesh) { executor(mesh, collect_all_ops); });
         logger().info("\tsmooth: {}", m_smooth_rejects.to_string());
         if (m_params.debug_output) {
             write_vtu(fmt::format("debug_{}", m_debug_print_counter++));

--- a/components/tetwild/wmtk/components/tetwild/EdgeCollapsing.cpp
+++ b/components/tetwild/wmtk/components/tetwild/EdgeCollapsing.cpp
@@ -7,12 +7,12 @@
 #include <atomic>
 #include <mutex>
 #include <unordered_set>
-#include <wmtk/ExecutionScheduler.hpp>
 #include <wmtk/threading/collector.hpp>
 #include <wmtk/utils/ExecutorUtils.hpp>
 #include <wmtk/utils/LocalizedRetry.hpp>
 #include <wmtk/utils/Logger.hpp>
 #include <wmtk/utils/ParallelCollect.hpp>
+#include <wmtk/utils/RunPass.hpp>
 
 namespace wmtk::components::tetwild {
 
@@ -35,46 +35,33 @@ void TetWildMesh::collapse_all_edges(bool is_limit_length)
     logger().info("#edges = {}", collect_all_ops.size() / 2);
     time = timer.getElapsedTime();
     logger().info("edge collapse prepare time: {:.4}s", time);
-    auto setup_and_execute = [&](auto& executor) {
-        executor.renew_neighbor_tuples = [](const auto& m, auto op, const auto& newts) {
-            std::vector<std::pair<std::string, wmtk::TetMesh::Tuple>> op_tups;
-            for (const Tuple& t : newts) {
-                op_tups.emplace_back(op, t);
-                op_tups.emplace_back(op, t.switch_vertex(m));
-            }
-            return op_tups;
-        };
-        executor.priority = [&](auto& m, auto op, auto& t) { return -m.get_length2(t); };
-        executor.num_threads = NUM_THREADS;
-        executor.is_weight_up_to_date = [&](const auto& m, const auto& ele) {
-            auto& [weight, op, tup] = ele;
-            auto length = m.get_length2(tup);
-            if (length != -weight) return false;
-            // Deliberately NOT filtered on length here. An over-length edge stays a
-            // candidate and collapse_edge_before decides it on quality instead: it is kept
-            // only if it STRICTLY improves the worst element of the ring. See there.
-            return true;
-        };
-        // Retry a failed collapse only where the mesh actually changed this round
-        // (dirty-epoch localized retry), instead of re-testing every failure every pass.
-        wmtk::run_localized_to_convergence(*this, executor, collect_all_ops);
-    };
-    if (NUM_THREADS > 0) {
-        timer.start();
-        auto executor = wmtk::ExecutePass<TetWildMesh>(wmtk::ExecutionPolicy::kPartition);
-        executor.lock_vertices = [](auto& m, const auto& e, int task_id) -> bool {
-            return m.try_set_edge_mutex_two_ring(e, task_id);
-        };
-        setup_and_execute(executor);
-        time = timer.getElapsedTime();
-        wmtk::logger().info("edge collapse operation time parallel: {:.4}s", time);
-    } else {
-        timer.start();
-        auto executor = wmtk::ExecutePass<TetWildMesh>(wmtk::ExecutionPolicy::kSeq);
-        setup_and_execute(executor);
-        time = timer.getElapsedTime();
-        wmtk::logger().info("edge collapse operation time serial: {:.4}s", time);
-    }
+    wmtk::run_pass(
+        *this,
+        wmtk::PassLock::EdgeTwoRing,
+        "edge collapse operation",
+        [&](auto& executor, auto& mesh) {
+            executor.renew_neighbor_tuples = [](const auto& m, auto op, const auto& newts) {
+                std::vector<std::pair<std::string, wmtk::TetMesh::Tuple>> op_tups;
+                for (const Tuple& t : newts) {
+                    op_tups.emplace_back(op, t);
+                    op_tups.emplace_back(op, t.switch_vertex(m));
+                }
+                return op_tups;
+            };
+            executor.priority = [&](auto& m, auto op, auto& t) { return -m.get_length2(t); };
+            executor.is_weight_up_to_date = [&](const auto& m, const auto& ele) {
+                auto& [weight, op, tup] = ele;
+                auto length = m.get_length2(tup);
+                if (length != -weight) return false;
+                // Deliberately NOT filtered on length here. An over-length edge stays a
+                // candidate and collapse_edge_before decides it on quality instead: it is kept
+                // only if it STRICTLY improves the worst element of the ring. See there.
+                return true;
+            };
+            // Retry a failed collapse only where the mesh actually changed this round
+            // (dirty-epoch localized retry), instead of re-testing every failure every pass.
+            wmtk::run_localized_to_convergence(mesh, executor, collect_all_ops);
+        });
 }
 
 bool TetWildMesh::collapse_edge_before(const Tuple& loc) // input is an edge

--- a/components/tetwild/wmtk/components/tetwild/EdgeSplitting.cpp
+++ b/components/tetwild/wmtk/components/tetwild/EdgeSplitting.cpp
@@ -1,11 +1,11 @@
 #include "TetWildMesh.h"
 
 #include <igl/Timer.h>
-#include <wmtk/ExecutionScheduler.hpp>
 #include <wmtk/utils/ExecutorUtils.hpp>
 #include <wmtk/utils/LocalizedRetry.hpp>
 #include <wmtk/utils/Logger.hpp>
 #include <wmtk/utils/ParallelCollect.hpp>
+#include <wmtk/utils/RunPass.hpp>
 
 namespace wmtk::components::tetwild {
 
@@ -40,52 +40,39 @@ void TetWildMesh::split_all_edges()
         [](TetWildMesh&, const Tuple& e, auto& out) { out.emplace_back("edge_split", e); });
     time = timer.getElapsedTime();
     wmtk::logger().info("edge split prepare time: {:.4}s", time);
-    auto setup_and_execute = [&](auto& executor) {
-        executor.renew_neighbor_tuples = wmtk::renewal_simple;
+    wmtk::run_pass(
+        *this,
+        wmtk::PassLock::EdgeTwoRing,
+        "edge split operation",
+        [&](auto& executor, auto& mesh) {
+            executor.renew_neighbor_tuples = wmtk::renewal_simple;
 
-        executor.priority = [&](auto& m, auto op, auto& t) { return m.get_length2(t); };
-        executor.num_threads = NUM_THREADS;
-        executor.is_weight_up_to_date = [&](const auto& m, const auto& ele) {
-            auto [weight, op, tup] = ele;
-            auto length = m.get_length2(tup);
-            if (length != weight) return false;
-            //
-            size_t v1_id = tup.vid(*this);
-            size_t v2_id = tup.switch_vertex(*this).vid(*this);
-            // Force-split: a worst tet's longest edge (queued by
-            // refine_sizing_around_worst when the max energy stalls) is split once
-            // regardless of the length gate, to unstick a sliver without changing the
-            // sizing field. The new midpoint is not in m_force_split_edges, so the
-            // two halves are NOT force-split again -- exactly one split per edge.
-            if (is_force_split_edge(v1_id, v2_id)) {
+            executor.priority = [&](auto& m, auto op, auto& t) { return m.get_length2(t); };
+            executor.is_weight_up_to_date = [&](const auto& m, const auto& ele) {
+                auto [weight, op, tup] = ele;
+                auto length = m.get_length2(tup);
+                if (length != weight) return false;
+                //
+                size_t v1_id = tup.vid(*this);
+                size_t v2_id = tup.switch_vertex(*this).vid(*this);
+                // Force-split: a worst tet's longest edge (queued by
+                // refine_sizing_around_worst when the max energy stalls) is split once
+                // regardless of the length gate, to unstick a sliver without changing the
+                // sizing field. The new midpoint is not in m_force_split_edges, so the
+                // two halves are NOT force-split again -- exactly one split per edge.
+                if (is_force_split_edge(v1_id, v2_id)) {
+                    return true;
+                }
+                double sizing_ratio = (m_vertex_attribute[v1_id].m_sizing_scalar +
+                                       m_vertex_attribute[v2_id].m_sizing_scalar) /
+                                      2;
+                if (length < m_params.splitting_l2 * sizing_ratio * sizing_ratio) {
+                    return false;
+                }
                 return true;
-            }
-            double sizing_ratio = (m_vertex_attribute[v1_id].m_sizing_scalar +
-                                   m_vertex_attribute[v2_id].m_sizing_scalar) /
-                                  2;
-            if (length < m_params.splitting_l2 * sizing_ratio * sizing_ratio) {
-                return false;
-            }
-            return true;
-        };
-        wmtk::run_localized_to_convergence(*this, executor, collect_all_ops);
-    };
-    if (NUM_THREADS > 0) {
-        timer.start();
-        auto executor = wmtk::ExecutePass<TetWildMesh>(wmtk::ExecutionPolicy::kPartition);
-        executor.lock_vertices = [&](auto& m, const auto& e, int task_id) -> bool {
-            return m.try_set_edge_mutex_two_ring(e, task_id);
-        };
-        setup_and_execute(executor);
-        time = timer.getElapsedTime();
-        wmtk::logger().info("edge split operation time parallel: {:.4}s", time);
-    } else {
-        timer.start();
-        auto executor = wmtk::ExecutePass<TetWildMesh>(wmtk::ExecutionPolicy::kSeq);
-        setup_and_execute(executor);
-        time = timer.getElapsedTime();
-        wmtk::logger().info("edge split operation time serial: {:.4}s", time);
-    }
+            };
+            wmtk::run_localized_to_convergence(mesh, executor, collect_all_ops);
+        });
     if (m_force_split_count > 0) {
         wmtk::logger().info(
             "[force-split] {} worst-tet longest edges force-split",

--- a/components/tetwild/wmtk/components/tetwild/EdgeSwapping.cpp
+++ b/components/tetwild/wmtk/components/tetwild/EdgeSwapping.cpp
@@ -2,11 +2,11 @@
 
 #include <igl/Timer.h>
 #include <wmtk/TetMesh.h>
-#include <wmtk/ExecutionScheduler.hpp>
 #include <wmtk/utils/ExecutorUtils.hpp>
 #include <wmtk/utils/LocalizedRetry.hpp>
 #include <wmtk/utils/Logger.hpp>
 #include <wmtk/utils/ParallelCollect.hpp>
+#include <wmtk/utils/RunPass.hpp>
 #include "spdlog/spdlog.h"
 #include "wmtk/utils/TupleUtils.hpp"
 
@@ -95,28 +95,15 @@ size_t TetWildMesh::swap_all_edges_32()
     if (m_tet_params.check_surface_topology) {
         sig_before = surface_topology_signature();
     }
-    auto setup_and_execute = [&](auto& executor) {
-        executor.renew_neighbor_tuples = wmtk::renewal_edges;
-        executor.priority = [&](auto& m, auto op, auto& t) { return m.get_length2(t); };
-        executor.num_threads = NUM_THREADS;
-        total_success = wmtk::run_localized_to_convergence(*this, executor, collect_all_ops);
-    };
-    if (NUM_THREADS > 0) {
-        timer.start();
-        auto executor = wmtk::ExecutePass<TetWildMesh>(wmtk::ExecutionPolicy::kPartition);
-        executor.lock_vertices = [](auto& m, const auto& e, int task_id) -> bool {
-            return m.try_set_edge_mutex_two_ring(e, task_id);
-        };
-        setup_and_execute(executor);
-        time = timer.getElapsedTime();
-        logger().info("edge swap operation time parallel: {:.4}s", time);
-    } else {
-        timer.start();
-        auto executor = wmtk::ExecutePass<TetWildMesh>(wmtk::ExecutionPolicy::kSeq);
-        setup_and_execute(executor);
-        time = timer.getElapsedTime();
-        logger().info("edge swap operation time serial: {:.4}s", time);
-    }
+    wmtk::run_pass(
+        *this,
+        wmtk::PassLock::EdgeTwoRing,
+        "edge swap operation",
+        [&](auto& executor, auto& mesh) {
+            executor.renew_neighbor_tuples = wmtk::renewal_edges;
+            executor.priority = [&](auto& m, auto op, auto& t) { return m.get_length2(t); };
+            total_success = wmtk::run_localized_to_convergence(mesh, executor, collect_all_ops);
+        });
     if (m_tet_params.check_surface_topology) {
         warn_if_surface_topology_changed(sig_before, "swap_all_edges_32");
     }
@@ -370,30 +357,16 @@ size_t TetWildMesh::swap_all_faces()
     time = timer.getElapsedTime();
     logger().info("face swap prepare time: {:.4}s", time);
     size_t total_success = 0;
-    auto setup_and_execute = [&](auto& executor) {
-        executor.renew_neighbor_tuples = wmtk::renewal_faces;
-        executor.priority = [](auto& m, auto op, auto& t) { return m.get_length2(t); };
-        executor.num_threads = NUM_THREADS;
-        total_success = wmtk::run_localized_to_convergence(*this, executor, collect_all_ops);
-    };
-    if (NUM_THREADS > 0) {
-        timer.start();
-        auto executor = wmtk::ExecutePass<TetWildMesh>(wmtk::ExecutionPolicy::kPartition);
-        executor.lock_vertices = [](auto& m, const auto& e, int task_id) -> bool {
-            return m.try_set_face_mutex_two_ring(e, task_id);
-        };
-        setup_and_execute(executor);
-        time = timer.getElapsedTime();
-        logger().info("face swap operation time parallel: {:.4}s", time);
-        return total_success;
-    } else {
-        timer.start();
-        auto executor = wmtk::ExecutePass<TetWildMesh>(wmtk::ExecutionPolicy::kSeq);
-        setup_and_execute(executor);
-        time = timer.getElapsedTime();
-        logger().info("face swap operation time serial: {:.4}s", time);
-        return total_success;
-    }
+    wmtk::run_pass(
+        *this,
+        wmtk::PassLock::FaceTwoRing,
+        "face swap operation",
+        [&](auto& executor, auto& mesh) {
+            executor.renew_neighbor_tuples = wmtk::renewal_faces;
+            executor.priority = [](auto& m, auto op, auto& t) { return m.get_length2(t); };
+            total_success = wmtk::run_localized_to_convergence(mesh, executor, collect_all_ops);
+        });
+    return total_success;
 }
 
 bool TetWildMesh::swap_face_before(const Tuple& t)
@@ -485,46 +458,33 @@ size_t TetWildMesh::swap_all_edges_all()
     if (m_tet_params.check_surface_topology) {
         sig_before = surface_topology_signature();
     }
-    auto setup_and_execute = [&](auto& executor) {
-        // executor.renew_neighbor_tuples = wmtk::renewal_edges;
-        executor.renew_neighbor_tuples =
-            [](const TetMesh& m, const std::string& op, const std::vector<Tuple>& newt) {
-                std::vector<std::pair<std::string, TetMesh::Tuple>> op_tups;
-                std::vector<TetMesh::Tuple> new_edges;
-                for (const TetMesh::Tuple& ti : newt) {
-                    for (auto j = 0; j < 6; j++) {
-                        new_edges.push_back(m.tuple_from_edge(ti.tid(m), j));
+    wmtk::run_pass(
+        *this,
+        wmtk::PassLock::EdgeTwoRing,
+        "edge swap operation",
+        [&](auto& executor, auto& mesh) {
+            // executor.renew_neighbor_tuples = wmtk::renewal_edges;
+            executor.renew_neighbor_tuples =
+                [](const TetMesh& m, const std::string& op, const std::vector<Tuple>& newt) {
+                    std::vector<std::pair<std::string, TetMesh::Tuple>> op_tups;
+                    std::vector<TetMesh::Tuple> new_edges;
+                    for (const TetMesh::Tuple& ti : newt) {
+                        for (auto j = 0; j < 6; j++) {
+                            new_edges.push_back(m.tuple_from_edge(ti.tid(m), j));
+                        }
+                    };
+                    wmtk::unique_edge_tuples(m, new_edges);
+                    op_tups.reserve(new_edges.size() * 3);
+                    for (const Tuple& loc : new_edges) {
+                        op_tups.emplace_back("edge_swap", loc);
+                        op_tups.emplace_back("edge_swap_44", loc);
+                        op_tups.emplace_back("edge_swap_56", loc);
                     }
+                    return op_tups;
                 };
-                wmtk::unique_edge_tuples(m, new_edges);
-                op_tups.reserve(new_edges.size() * 3);
-                for (const Tuple& loc : new_edges) {
-                    op_tups.emplace_back("edge_swap", loc);
-                    op_tups.emplace_back("edge_swap_44", loc);
-                    op_tups.emplace_back("edge_swap_56", loc);
-                }
-                return op_tups;
-            };
-        executor.priority = [&](auto& m, auto op, auto& t) { return m.get_length2(t); };
-        executor.num_threads = NUM_THREADS;
-        total_success = wmtk::run_localized_to_convergence(*this, executor, collect_all_ops);
-    };
-    if (NUM_THREADS > 0) {
-        timer.start();
-        auto executor = wmtk::ExecutePass<TetWildMesh>(wmtk::ExecutionPolicy::kPartition);
-        executor.lock_vertices = [](auto& m, const auto& e, int task_id) -> bool {
-            return m.try_set_edge_mutex_two_ring(e, task_id);
-        };
-        setup_and_execute(executor);
-        time = timer.getElapsedTime();
-        logger().info("edge swap operation time parallel: {:.4}s", time);
-    } else {
-        timer.start();
-        auto executor = wmtk::ExecutePass<TetWildMesh>(wmtk::ExecutionPolicy::kSeq);
-        setup_and_execute(executor);
-        time = timer.getElapsedTime();
-        logger().info("edge swap operation time serial: {:.4}s", time);
-    }
+            executor.priority = [&](auto& m, auto op, auto& t) { return m.get_length2(t); };
+            total_success = wmtk::run_localized_to_convergence(mesh, executor, collect_all_ops);
+        });
     if (m_tet_params.check_surface_topology) {
         warn_if_surface_topology_changed(sig_before, "swap_all_edges_all");
     }
@@ -546,28 +506,15 @@ size_t TetWildMesh::swap_all_edges_44()
     size_t total_success = 0;
     SurfaceTopoSignature sig_before;
     if (m_tet_params.check_surface_topology) sig_before = surface_topology_signature();
-    auto setup_and_execute = [&](auto& executor) {
-        executor.renew_neighbor_tuples = wmtk::renewal_edges;
-        executor.priority = [&](auto& m, auto op, auto& t) { return m.get_length2(t); };
-        executor.num_threads = NUM_THREADS;
-        total_success = wmtk::run_localized_to_convergence(*this, executor, collect_all_ops);
-    };
-    if (NUM_THREADS > 0) {
-        timer.start();
-        auto executor = wmtk::ExecutePass<TetWildMesh>(wmtk::ExecutionPolicy::kPartition);
-        executor.lock_vertices = [](auto& m, const auto& e, int task_id) -> bool {
-            return m.try_set_edge_mutex_two_ring(e, task_id);
-        };
-        setup_and_execute(executor);
-        time = timer.getElapsedTime();
-        logger().info("edge swap 44 operation time parallel: {:.4}s", time);
-    } else {
-        timer.start();
-        auto executor = wmtk::ExecutePass<TetWildMesh>(wmtk::ExecutionPolicy::kSeq);
-        setup_and_execute(executor);
-        time = timer.getElapsedTime();
-        logger().info("edge swap 44 operation time serial: {:.4}s", time);
-    }
+    wmtk::run_pass(
+        *this,
+        wmtk::PassLock::EdgeTwoRing,
+        "edge swap 44 operation",
+        [&](auto& executor, auto& mesh) {
+            executor.renew_neighbor_tuples = wmtk::renewal_edges;
+            executor.priority = [&](auto& m, auto op, auto& t) { return m.get_length2(t); };
+            total_success = wmtk::run_localized_to_convergence(mesh, executor, collect_all_ops);
+        });
     if (m_tet_params.check_surface_topology)
         warn_if_surface_topology_changed(sig_before, "swap_all_edges_44");
     return total_success;
@@ -680,28 +627,15 @@ size_t TetWildMesh::swap_all_edges_56()
     size_t total_success = 0;
     SurfaceTopoSignature sig_before;
     if (m_tet_params.check_surface_topology) sig_before = surface_topology_signature();
-    auto setup_and_execute = [&](auto& executor) {
-        executor.renew_neighbor_tuples = wmtk::renewal_edges;
-        executor.priority = [&](auto& m, auto op, auto& t) { return m.get_length2(t); };
-        executor.num_threads = NUM_THREADS;
-        total_success = wmtk::run_localized_to_convergence(*this, executor, collect_all_ops);
-    };
-    if (NUM_THREADS > 0) {
-        timer.start();
-        auto executor = wmtk::ExecutePass<TetWildMesh>(wmtk::ExecutionPolicy::kPartition);
-        executor.lock_vertices = [](auto& m, const auto& e, int task_id) -> bool {
-            return m.try_set_edge_mutex_two_ring(e, task_id);
-        };
-        setup_and_execute(executor);
-        time = timer.getElapsedTime();
-        logger().info("edge swap 56 operation time parallel: {:.4}s", time);
-    } else {
-        timer.start();
-        auto executor = wmtk::ExecutePass<TetWildMesh>(wmtk::ExecutionPolicy::kSeq);
-        setup_and_execute(executor);
-        time = timer.getElapsedTime();
-        logger().info("edge swap 56 operation time serial: {:.4}s", time);
-    }
+    wmtk::run_pass(
+        *this,
+        wmtk::PassLock::EdgeTwoRing,
+        "edge swap 56 operation",
+        [&](auto& executor, auto& mesh) {
+            executor.renew_neighbor_tuples = wmtk::renewal_edges;
+            executor.priority = [&](auto& m, auto op, auto& t) { return m.get_length2(t); };
+            total_success = wmtk::run_localized_to_convergence(mesh, executor, collect_all_ops);
+        });
     if (m_tet_params.check_surface_topology)
         warn_if_surface_topology_changed(sig_before, "swap_all_edges_56");
     return total_success;

--- a/components/tetwild/wmtk/components/tetwild/Smooth.cpp
+++ b/components/tetwild/wmtk/components/tetwild/Smooth.cpp
@@ -1,14 +1,13 @@
 
 #include "TetWildMesh.h"
 
-#include <cstdlib>
-#include "wmtk/ExecutionScheduler.hpp"
-
 #include <Eigen/src/Core/util/Constants.h>
 #include <igl/Timer.h>
 #include <wmtk/utils/AMIPS.h>
 #include <array>
+#include <cstdlib>
 #include <wmtk/utils/Logger.hpp>
+#include <wmtk/utils/RunPass.hpp>
 #include <wmtk/utils/TetraQualityUtils.hpp>
 
 
@@ -55,24 +54,11 @@ void TetWildMesh::smooth_all_vertices()
     time = timer.getElapsedTime();
     wmtk::logger().info("vertex smoothing prepare time: {:.4}s", time);
     wmtk::logger().debug("Num verts {}", collect_all_ops.size());
-    if (NUM_THREADS > 0) {
-        timer.start();
-        auto executor = wmtk::ExecutePass<TetWildMesh>(wmtk::ExecutionPolicy::kPartition);
-        executor.lock_vertices = [](auto& m, const auto& e, int task_id) -> bool {
-            return m.try_set_vertex_mutex_one_ring(e, task_id);
-        };
-        executor.num_threads = NUM_THREADS;
-        executor(*this, collect_all_ops);
-        time = timer.getElapsedTime();
-        wmtk::logger().info("vertex smoothing operation time parallel: {:.4}s", time);
-    } else {
-        timer.start();
-        auto executor = wmtk::ExecutePass<TetWildMesh>(wmtk::ExecutionPolicy::kSeq);
-        // executor.priority = [&](auto& m, auto op, auto& t) -> double { return rand(); };
-        executor(*this, collect_all_ops);
-        time = timer.getElapsedTime();
-        wmtk::logger().info("vertex smoothing operation time serial: {:.4}s", time);
-    }
+    wmtk::run_pass(
+        *this,
+        wmtk::PassLock::VertexOneRing,
+        "vertex smoothing operation",
+        [&](auto& executor, auto& mesh) { executor(mesh, collect_all_ops); });
     wmtk::logger().info("\tsmooth: {}", m_smooth_rejects.to_string());
 }
 

--- a/components/triwild/wmtk/components/triwild/EdgeCollapsing.cpp
+++ b/components/triwild/wmtk/components/triwild/EdgeCollapsing.cpp
@@ -7,11 +7,11 @@
 #include <algorithm>
 #include <atomic>
 #include <unordered_set>
-#include <wmtk/ExecutionScheduler.hpp>
 #include <wmtk/utils/ExecutorUtils.hpp>
 #include <wmtk/utils/LocalizedRetry.hpp>
 #include <wmtk/utils/Logger.hpp>
 #include <wmtk/utils/ParallelCollect.hpp>
+#include <wmtk/utils/RunPass.hpp>
 
 namespace wmtk::components::triwild {
 
@@ -34,62 +34,53 @@ void TriWildMesh::collapse_all_edges(bool is_limit_length)
     logger().info("#E = {}", all_ops.size() / 2);
     logger().info("edge collapse prepare time: {:.4}s", timer.getElapsedTimeInSec());
 
-    auto setup_and_execute = [&](auto& executor) {
-        executor.renew_neighbor_tuples = [](const TriWildMesh& m, Op op, const auto& newts) {
-            std::vector<std::pair<std::string, TriMesh::Tuple>> op_tups;
-            op_tups.reserve(2 * newts.size());
-            for (const Tuple& t : newts) {
-                op_tups.emplace_back(op, t);
-                op_tups.emplace_back(op, t.switch_vertex(m));
-            }
-            return op_tups;
-        };
-        executor.priority = [](const TriWildMesh& m, Op op, const Tuple& t) {
-            return -m.get_length2(t);
-        };
-        executor.num_threads = NUM_THREADS;
-        executor.is_weight_up_to_date = [&](const TriWildMesh& m,
-                                            const std::tuple<double, Op, Tuple>& ele) {
-            const auto& VA = m_vertex_attribute;
-            auto& [weight, op, tup] = ele;
-            const double length = m.get_length2(tup);
-            if (length != -weight) {
-                return false;
-            }
-            // Deliberately NOT filtered on length here. An over-length edge stays a
-            // candidate and collapse_edge_before decides it on quality instead: it is kept
-            // only if it STRICTLY improves the worst element of the ring. See there.
-            return true;
-        };
+    wmtk::run_pass(
+        *this,
+        wmtk::PassLock::EdgeTwoRing,
+        "edge collapse",
+        [&](auto& executor, auto& mesh) {
+            executor.renew_neighbor_tuples =
+                [](const wmtk::TriOptimizerMesh& m, Op op, const auto& newts) {
+                    std::vector<std::pair<std::string, TriMesh::Tuple>> op_tups;
+                    op_tups.reserve(2 * newts.size());
+                    for (const Tuple& t : newts) {
+                        op_tups.emplace_back(op, t);
+                        op_tups.emplace_back(op, t.switch_vertex(m));
+                    }
+                    return op_tups;
+                };
+            executor.priority = [](const wmtk::TriOptimizerMesh& m, Op op, const Tuple& t) {
+                return -m.get_length2(t);
+            };
+            executor.is_weight_up_to_date = [&](const wmtk::TriOptimizerMesh& m,
+                                                const std::tuple<double, Op, Tuple>& ele) {
+                const auto& VA = m_vertex_attribute;
+                auto& [weight, op, tup] = ele;
+                const double length = m.get_length2(tup);
+                if (length != -weight) {
+                    return false;
+                }
+                // Deliberately NOT filtered on length here. An over-length edge stays a
+                // candidate and collapse_edge_before decides it on quality instead: it is kept
+                // only if it STRICTLY improves the worst element of the ring. See there.
+                return true;
+            };
 
-        // Retry a failed collapse only where the mesh actually changed this round
-        // (dirty-epoch localized retry). This replaces the loop that rebuilt the whole op
-        // list from get_edges() after every pass and re-ran the expensive geometric
-        // pre-checks on every failure, even where nothing could have changed.
-        const size_t total_success = wmtk::run_localized_to_convergence(*this, executor, all_ops);
-        logger().info("collapse success: {}", total_success);
-        if (const size_t n = m_feature_rejects.load(); n > 0) {
-            logger().info(
-                "[feature] {} collapses refused to keep a polyline endpoint or junction "
-                "within {:.6} of its input position",
-                n,
-                m_envelope_eps);
-        }
-    };
-
-    timer.start();
-    if (NUM_THREADS > 0) {
-        auto executor = ExecutePass<TriWildMesh>(ExecutionPolicy::kPartition);
-        executor.lock_vertices = [](TriWildMesh& m, const Tuple& e, int task_id) -> bool {
-            return m.try_set_edge_mutex_two_ring(e, task_id);
-        };
-        setup_and_execute(executor);
-        logger().info("edge collapse time parallel: {:.4}s", timer.getElapsedTimeInSec());
-    } else {
-        auto executor = ExecutePass<TriWildMesh>(ExecutionPolicy::kSeq);
-        setup_and_execute(executor);
-        logger().info("edge collapse time serial: {:.4}s", timer.getElapsedTimeInSec());
-    }
+            // Retry a failed collapse only where the mesh actually changed this round
+            // (dirty-epoch localized retry). This replaces the loop that rebuilt the whole op
+            // list from get_edges() after every pass and re-ran the expensive geometric
+            // pre-checks on every failure, even where nothing could have changed.
+            const size_t total_success =
+                wmtk::run_localized_to_convergence(mesh, executor, all_ops);
+            logger().info("collapse success: {}", total_success);
+            if (const size_t n = m_feature_rejects.load(); n > 0) {
+                logger().info(
+                    "[feature] {} collapses refused to keep a polyline endpoint or junction "
+                    "within {:.6} of its input position",
+                    n,
+                    m_envelope_eps);
+            }
+        });
 }
 
 bool TriWildMesh::collapse_edge_before(const Tuple& loc) // input is an edge

--- a/components/triwild/wmtk/components/triwild/EdgeSplitting.cpp
+++ b/components/triwild/wmtk/components/triwild/EdgeSplitting.cpp
@@ -2,11 +2,11 @@
 
 #include <igl/Timer.h>
 #include <atomic>
-#include <wmtk/ExecutionScheduler.hpp>
 #include <wmtk/utils/ExecutorUtils.hpp>
 #include <wmtk/utils/LocalizedRetry.hpp>
 #include <wmtk/utils/Logger.hpp>
 #include <wmtk/utils/ParallelCollect.hpp>
+#include <wmtk/utils/RunPass.hpp>
 
 namespace wmtk::components::triwild {
 
@@ -35,66 +35,53 @@ void TriWildMesh::split_all_edges()
         [](TriWildMesh&, const Tuple& e, auto& out) { out.emplace_back("edge_split", e); });
     time = timer.getElapsedTime();
     logger().info("edge split prepare time: {:.4}s", time);
-    auto setup_and_execute = [&](auto& executor) {
-        executor.renew_neighbor_tuples =
-            [](const TriWildMesh& m, std::string op, const auto& newts) {
-                std::vector<std::pair<std::string, TriMesh::Tuple>> op_tups;
-                for (const auto& t : newts) {
-                    op_tups.emplace_back(op, t);
-                    op_tups.emplace_back(op, t.switch_edge(m));
-                    op_tups.emplace_back(op, t.switch_vertex(m).switch_edge(m));
-                }
-                return op_tups;
-            };
+    wmtk::run_pass(
+        *this,
+        wmtk::PassLock::EdgeTwoRing,
+        "edge split operation",
+        [&](auto& executor, auto& mesh) {
+            executor.renew_neighbor_tuples =
+                [](const wmtk::TriOptimizerMesh& m, std::string op, const auto& newts) {
+                    std::vector<std::pair<std::string, TriMesh::Tuple>> op_tups;
+                    for (const auto& t : newts) {
+                        op_tups.emplace_back(op, t);
+                        op_tups.emplace_back(op, t.switch_edge(m));
+                        op_tups.emplace_back(op, t.switch_vertex(m).switch_edge(m));
+                    }
+                    return op_tups;
+                };
 
-        executor.priority = [&](const TriWildMesh& m, std::string op, const Tuple& t) {
-            return m.get_length2(t);
-        };
-        executor.num_threads = NUM_THREADS;
-        executor.is_weight_up_to_date = [&](const TriWildMesh& m, const auto& ele) {
-            auto [weight, op, tup] = ele;
-            auto length = m.get_length2(tup);
-            if (length != weight) {
-                return false;
-            }
-            //
-            size_t v1_id = tup.vid(*this);
-            size_t v2_id = tup.switch_vertex(*this).vid(*this);
-            // Force-split: a worst triangle's longest edge (queued by
-            // refine_sizing_around_worst when the max energy stalls) is split once
-            // regardless of the length gate, to unstick a sliver without changing the
-            // sizing field. The new midpoint is not in m_force_split_edges, so the two
-            // halves are NOT force-split again -- exactly one split per edge.
-            if (is_force_split_edge(v1_id, v2_id)) {
+            executor.priority = [&](const wmtk::TriOptimizerMesh& m,
+                                    std::string op,
+                                    const Tuple& t) { return m.get_length2(t); };
+            executor.is_weight_up_to_date = [&](const wmtk::TriOptimizerMesh& m, const auto& ele) {
+                auto [weight, op, tup] = ele;
+                auto length = m.get_length2(tup);
+                if (length != weight) {
+                    return false;
+                }
+                //
+                size_t v1_id = tup.vid(*this);
+                size_t v2_id = tup.switch_vertex(*this).vid(*this);
+                // Force-split: a worst triangle's longest edge (queued by
+                // refine_sizing_around_worst when the max energy stalls) is split once
+                // regardless of the length gate, to unstick a sliver without changing the
+                // sizing field. The new midpoint is not in m_force_split_edges, so the two
+                // halves are NOT force-split again -- exactly one split per edge.
+                if (is_force_split_edge(v1_id, v2_id)) {
+                    return true;
+                }
+                const auto& VA = m_vertex_attribute;
+                double sizing_ratio = 0.5 * (VA[v1_id].m_sizing_scalar + VA[v2_id].m_sizing_scalar);
+                if (length < m_params.splitting_l2 * sizing_ratio * sizing_ratio) {
+                    return false;
+                }
                 return true;
-            }
-            const auto& VA = m_vertex_attribute;
-            double sizing_ratio = 0.5 * (VA[v1_id].m_sizing_scalar + VA[v2_id].m_sizing_scalar);
-            if (length < m_params.splitting_l2 * sizing_ratio * sizing_ratio) {
-                return false;
-            }
-            return true;
-        };
-        // Retry a failed split only where the mesh actually changed this round
-        // (dirty-epoch localized retry), instead of re-testing every failure every pass.
-        wmtk::run_localized_to_convergence(*this, executor, collect_all_ops);
-    };
-    if (NUM_THREADS > 0) {
-        timer.start();
-        auto executor = ExecutePass<TriWildMesh>(ExecutionPolicy::kPartition);
-        executor.lock_vertices = [&](auto& m, const auto& e, int task_id) -> bool {
-            return m.try_set_edge_mutex_two_ring(e, task_id);
-        };
-        setup_and_execute(executor);
-        time = timer.getElapsedTime();
-        wmtk::logger().info("edge split operation time parallel: {:.4}s", time);
-    } else {
-        timer.start();
-        auto executor = ExecutePass<TriWildMesh>(ExecutionPolicy::kSeq);
-        setup_and_execute(executor);
-        time = timer.getElapsedTime();
-        wmtk::logger().info("edge split operation time serial: {:.4}s", time);
-    }
+            };
+            // Retry a failed split only where the mesh actually changed this round
+            // (dirty-epoch localized retry), instead of re-testing every failure every pass.
+            wmtk::run_localized_to_convergence(mesh, executor, collect_all_ops);
+        });
     if (m_force_split_count > 0) {
         wmtk::logger().info(
             "[force-split] {} worst-triangle longest edges force-split",

--- a/components/triwild/wmtk/components/triwild/EdgeSwapping.cpp
+++ b/components/triwild/wmtk/components/triwild/EdgeSwapping.cpp
@@ -2,18 +2,18 @@
 
 #include <igl/Timer.h>
 #include <wmtk/TriMesh.h>
-#include <wmtk/ExecutionScheduler.hpp>
 #include <wmtk/utils/ExecutorUtils.hpp>
 #include <wmtk/utils/LocalizedRetry.hpp>
 #include <wmtk/utils/Logger.hpp>
 #include <wmtk/utils/ParallelCollect.hpp>
+#include <wmtk/utils/RunPass.hpp>
 #include "wmtk/utils/TupleUtils.hpp"
 
 #include <cassert>
 
 namespace wmtk::components::triwild {
 
-auto renew = [](const TriWildMesh& m, auto op, auto& tris) {
+auto renew = [](const wmtk::TriOptimizerMesh& m, auto op, auto& tris) {
     using Tuple = TriMesh::Tuple;
     std::vector<Tuple> edges;
     for (const auto& t : tris) {
@@ -31,11 +31,6 @@ auto renew = [](const TriWildMesh& m, auto op, auto& tris) {
     return optup;
 };
 
-auto edge_locker = [](auto& m, const auto& e, int task_id) {
-    // TODO: this should not be here
-    return m.try_set_edge_mutex_two_ring(e, task_id);
-};
-
 size_t TriWildMesh::swap_all_edges()
 {
     igl::Timer timer;
@@ -48,30 +43,23 @@ size_t TriWildMesh::swap_all_edges()
     logger().info("edge swap prepare time: {:.4}s", timer.getElapsedTimeInSec());
 
     size_t total_success = 0;
-    auto setup_and_execute = [&](auto& executor) {
+    wmtk::run_pass(*this, wmtk::PassLock::EdgeTwoRing, "", [&](auto& executor, auto& mesh) {
         executor.renew_neighbor_tuples = renew;
-        executor.num_threads = NUM_THREADS;
-        executor.priority = [](const TriWildMesh& m, std::string op, const Tuple& e) {
-            return m.swap_weight(e);
+        // `swap_weight` is triwild's own, so reach it through `this` rather than through the
+        // executor's mesh argument, which is the shared base.
+        executor.priority = [this](const wmtk::TriOptimizerMesh&, std::string op, const Tuple& e) {
+            return swap_weight(e);
         };
         executor.should_renew = [](auto val) { return (val > 0); };
-        executor.is_weight_up_to_date = [](const TriWildMesh& m, auto& ele) {
+        executor.is_weight_up_to_date = [this](const wmtk::TriOptimizerMesh&, auto& ele) {
             auto& [val, _, e] = ele;
-            const double w = m.swap_weight(e);
+            const double w = swap_weight(e);
             return (w > 1e-5) && ((w - val) * (w - val) < 1e-8);
         };
         // Retry a failed swap only where the mesh actually changed this round
         // (dirty-epoch localized retry).
-        total_success = wmtk::run_localized_to_convergence(*this, executor, collect_all_ops);
-    };
-    if (NUM_THREADS > 0) {
-        auto executor = ExecutePass<TriWildMesh>(ExecutionPolicy::kPartition);
-        executor.lock_vertices = edge_locker;
-        setup_and_execute(executor);
-    } else {
-        auto executor = ExecutePass<TriWildMesh>(ExecutionPolicy::kSeq);
-        setup_and_execute(executor);
-    }
+        total_success = wmtk::run_localized_to_convergence(mesh, executor, collect_all_ops);
+    });
 
     // The caller (local_operations) stops the swap loop once a pass changes nothing, so
     // this has to be the real count -- it used to return `true`, i.e. always 1.

--- a/components/triwild/wmtk/components/triwild/Smooth.cpp
+++ b/components/triwild/wmtk/components/triwild/Smooth.cpp
@@ -4,7 +4,7 @@
 #include <cstdlib>
 
 #include <wmtk/optimization/SmoothVertex.hpp>
-#include "wmtk/ExecutionScheduler.hpp"
+#include <wmtk/utils/RunPass.hpp>
 
 #include <igl/Timer.h>
 #include <array>
@@ -94,21 +94,11 @@ void TriWildMesh::smooth_all_vertices(const size_t n_iters)
         }
         logger().info("vertex smoothing prepare time: {:.4}s", timer.getElapsedTimeInSec());
         logger().info("#V = {}", collect_all_ops.size());
-        if (NUM_THREADS > 0) {
-            timer.start();
-            ExecutePass<TriWildMesh> executor(ExecutionPolicy::kPartition);
-            executor.lock_vertices = [](auto& m, const auto& e, int task_id) -> bool {
-                return m.try_set_vertex_mutex_one_ring(e, task_id);
-            };
-            executor.num_threads = NUM_THREADS;
-            executor(*this, collect_all_ops);
-            logger().info("vertex smoothing time parallel: {:.4}s", timer.getElapsedTimeInSec());
-        } else {
-            timer.start();
-            ExecutePass<TriWildMesh> executor(ExecutionPolicy::kSeq);
-            executor(*this, collect_all_ops);
-            logger().info("vertex smoothing time serial: {:.4}s", timer.getElapsedTimeInSec());
-        }
+        wmtk::run_pass(
+            *this,
+            wmtk::PassLock::VertexOneRing,
+            "vertex smoothing",
+            [&](auto& executor, auto& m) { executor(m, collect_all_ops); });
         logger().info("\tsmooth: {}", m_smooth_rejects.to_string());
         if (m_params.debug_output) {
             write_vtu(fmt::format("debug_{}", m_debug_print_counter++));

--- a/docs/simwild-adopted-behaviours.md
+++ b/docs/simwild-adopted-behaviours.md
@@ -278,3 +278,31 @@ surface envelope. `smoothing_containment_envelope` did move -- both applications
 `smooth_after` stays in **both** applications even though their bodies are byte-identical: the body
 is the shared `optimization::smooth_vertex_3d` template, which reaches `m_tet_attribute` and
 `smoothing_energy_envelope`, both per-application.
+
+---
+
+## Stage 3c — simwild adopts `wmtk::run_pass`
+
+The `if (NUM_THREADS > 0)` / build an `ExecutePass` / install a lock / log the time shell around
+every driver is now `wmtk::run_pass`, shared by all four meshes. **No simwild behaviour changed**:
+the shell was already identical to tetwild's and triwild's in all eleven simwild drivers, and what
+each driver does *inside* the executor is passed in as a callback, so the differences below survive
+the fold untouched rather than being silently adopted.
+
+They are listed here because folding the shell is what makes them visible, and because each one is
+now a one-line change instead of a rewrite:
+
+| | simwild | tetwild / triwild |
+|---|---|---|
+| how the pass runs | `executor(mesh, ops)` once, in 3D split, all four 3D swaps and 2D split/smooth | `run_localized_to_convergence(mesh, executor, ops)` — retries a failure only where the mesh actually changed that round |
+| 2D collapse | a hand-rolled `do { ... } while (executor.get_cnt_success() > 0)` that rebuilds the whole op list from `get_edges()` every round | the same localized retry as everything else |
+| success count | `executor.get_cnt_success()`, i.e. the last round's count | the total accumulated across rounds by the retry driver |
+
+The success-count row matters where the caller uses the return value to decide whether to keep
+going: `local_operations` stops its swap loop once a pass changes nothing, and a per-round count and
+a total disagree about when that is. simwild-2D's swap already takes the shared form (Stage 1a); the
+3D swaps do not.
+
+Adopting the localized form is a real behaviour change for simwild -- it changes which failed
+operations are re-tested and in what order -- so it wants its own commit and its own before/after,
+not a line in a refactor.

--- a/src/wmtk/utils/RunPass.cpp
+++ b/src/wmtk/utils/RunPass.cpp
@@ -1,0 +1,85 @@
+#include <wmtk/utils/RunPass.hpp>
+
+#include <wmtk/utils/Logger.hpp>
+
+#include <igl/Timer.h>
+
+namespace wmtk {
+namespace {
+
+template <class Mesh>
+std::function<bool(Mesh&, const typename Mesh::Tuple&, int)> make_locker(PassLock lock)
+{
+    using Tuple = typename Mesh::Tuple;
+    switch (lock) {
+    case PassLock::VertexOneRing:
+        return [](Mesh& m, const Tuple& e, int task_id) {
+            return m.try_set_vertex_mutex_one_ring(e, task_id);
+        };
+    case PassLock::FaceTwoRing:
+        if constexpr (std::is_base_of<TetMesh, Mesh>::value) {
+            return [](Mesh& m, const Tuple& e, int task_id) {
+                return m.try_set_face_mutex_two_ring(e, task_id);
+            };
+        } else {
+            log_and_throw_error("PassLock::FaceTwoRing is only meaningful on a tet mesh");
+        }
+    case PassLock::EdgeTwoRing: break;
+    }
+    return [](Mesh& m, const Tuple& e, int task_id) {
+        return m.try_set_edge_mutex_two_ring(e, task_id);
+    };
+}
+
+template <class Mesh>
+void run_pass_impl(
+    Mesh& m,
+    PassLock lock,
+    const std::string& label,
+    const std::function<void(ExecutePass<Mesh>&, Mesh&)>& body)
+{
+    igl::Timer timer;
+    timer.start();
+
+    const bool parallel = m.NUM_THREADS > 0;
+
+    ExecutePass<Mesh> executor(parallel ? ExecutionPolicy::kPartition : ExecutionPolicy::kSeq);
+    executor.num_threads = m.NUM_THREADS;
+    if (parallel) {
+        // Serial leaves `lock_vertices` at its default (always succeeds): there is nothing to
+        // lock against, and claiming the ring would only add work.
+        executor.lock_vertices = make_locker<Mesh>(lock);
+    }
+
+    body(executor, m);
+
+    if (!label.empty()) {
+        logger().info(
+            "{} time {}: {:.4}s",
+            label,
+            parallel ? "parallel" : "serial",
+            timer.getElapsedTimeInSec());
+    }
+}
+
+} // namespace
+
+void run_pass(
+    TriOptimizerMesh& m,
+    PassLock lock,
+    const std::string& label,
+    const std::function<void(ExecutePass<TriOptimizerMesh>&, TriOptimizerMesh&)>& body)
+{
+    run_pass_impl(m, lock, label, body);
+}
+
+void run_pass(
+    TetOptimizerMesh& m,
+    PassLock lock,
+    const std::string& label,
+    const std::function<void(ExecutePass<TetOptimizerMesh>&, TetOptimizerMesh&)>& body)
+{
+    run_pass_impl(m, lock, label, body);
+}
+
+} // namespace wmtk

--- a/src/wmtk/utils/RunPass.hpp
+++ b/src/wmtk/utils/RunPass.hpp
@@ -1,0 +1,55 @@
+#pragma once
+
+#include <wmtk/TetOptimizerMesh.h>
+#include <wmtk/TriOptimizerMesh.h>
+#include <wmtk/ExecutionScheduler.hpp>
+
+#include <functional>
+#include <string>
+
+namespace wmtk {
+
+/**
+ * @brief Which mutex an operation has to claim before it may run in parallel.
+ */
+enum class PassLock {
+    EdgeTwoRing, ///< topology-changing operations queued on edges
+    FaceTwoRing, ///< face swaps (3D only)
+    VertexOneRing, ///< smoothing, which moves a single vertex and changes no connectivity
+};
+
+/**
+ * @brief Run one optimization pass, serial or parallel according to the mesh's NUM_THREADS.
+ *
+ * Every driver in the three applications ended in the same shell: branch on `NUM_THREADS > 0`,
+ * build an `ExecutePass` with `kPartition` or `kSeq`, install the same lock function, run the
+ * driver-specific setup, and log how long it took with "parallel" or "serial" in the message.
+ * The only things that actually varied were the lock (edge two-ring for everything except
+ * smoothing), the log label, and the setup itself -- which is what @p body is.
+ *
+ * `ExecutePass` takes its policy as a *constructor argument*, so both branches build the same
+ * type and @p body can be an ordinary `std::function` rather than a template.
+ *
+ * @p body receives the executor to configure and the mesh to run it on, and is responsible for
+ * actually executing (`executor(m, ops)` or `run_localized_to_convergence(m, executor, ops)`) --
+ * drivers differ in which, and in what they do with the result.
+ *
+ * @p label is used as "<label> time parallel: ...". Pass an empty label to log nothing.
+ *
+ * @note The mesh is taken as the optimizer base, so the callbacks installed on the executor see
+ * the base type too. A lambda that needs an application-specific member must capture `this`
+ * rather than reach through the executor's mesh argument.
+ */
+void run_pass(
+    TriOptimizerMesh& m,
+    PassLock lock,
+    const std::string& label,
+    const std::function<void(ExecutePass<TriOptimizerMesh>&, TriOptimizerMesh&)>& body);
+
+void run_pass(
+    TetOptimizerMesh& m,
+    PassLock lock,
+    const std::string& label,
+    const std::function<void(ExecutePass<TetOptimizerMesh>&, TetOptimizerMesh&)>& body);
+
+} // namespace wmtk


### PR DESCRIPTION
## Stage 3c — the executor-pass shell

Fifth of the stacked de-duplication PRs. Stacked on #1007.

Every optimization driver in tetwild, triwild and simwild ended in the same block:

```cpp
if (NUM_THREADS > 0) {
    timer.start();
    auto executor = ExecutePass<TetWildMesh>(ExecutionPolicy::kPartition);
    executor.lock_vertices = [](auto& m, const auto& e, int task_id) -> bool {
        return m.try_set_edge_mutex_two_ring(e, task_id);
    };
    setup_and_execute(executor);
    time = timer.getElapsedTime();
    logger().info("edge swap operation time parallel: {:.4}s", time);
} else {
    timer.start();
    auto executor = ExecutePass<TetWildMesh>(ExecutionPolicy::kSeq);
    setup_and_execute(executor);
    time = timer.getElapsedTime();
    logger().info("edge swap operation time serial: {:.4}s", time);
}
```

**24 copies**, one per driver, and `return m.try_set_edge_mutex_two_ring(e, task_id);` appeared
verbatim 17 times. Only three things ever varied: which mutex the operation claims, the log label,
and `setup_and_execute` itself. All 24 are now

```cpp
wmtk::run_pass(*this, wmtk::PassLock::EdgeTwoRing, "edge swap operation",
               [&](auto& executor, auto& mesh) {
    executor.renew_neighbor_tuples = wmtk::renewal_edges;
    executor.priority = [&](auto& m, auto op, auto& t) { return m.get_length2(t); };
    total_success = wmtk::run_localized_to_convergence(mesh, executor, collect_all_ops);
});
```

### Why this is a plain function and not another template

Two things, both of which only became true in the earlier PRs of this stack:

- **`ExecutePass` takes its policy as a constructor argument**, not a template parameter, so the
  parallel and serial branches build the *same type*. The setup callback can therefore be an
  ordinary `std::function`.
- **The operations are virtual on the two optimizer bases** (#1007), so `ExecutePass` instantiated
  on the base runs an application's operations correctly. One instantiation serves both
  applications of a pair: **24 instantiations become 2**.

No new template is introduced, consistent with the rest of the stack.

### Behaviour

Unchanged, in all three applications.

The callbacks now see the base type rather than the application type. Where a lambda wanted an
application-specific member it captures `this` instead of reaching through the executor's mesh
argument — `swap_weight` in both 2D swap drivers is the only case. This is the one thing a
call-graph check cannot find, because the driver lambdas take `auto& m`; the compiler finds it.

Two pre-existing inconsistencies are normalised into the shared shell, neither observable:

- smoothing set `executor.num_threads` in the parallel branch only. Under `kSeq` that field only
  sizes a vector the sequential path never reads.
- triwild's collapse and swap timed the pass slightly differently from the other drivers
  (`getElapsedTimeInSec` from a timer started before the branch, vs `getElapsedTime` from one
  started inside it). Both measure the same interval; only the log text is affected, and it is
  unchanged.

`lock_vertices` still stays at its always-succeeds default in the serial branch, as before.

### simwild

The second commit deletes simwild's eleven copies. Because what happens *inside* the executor is a
callback, the three places simwild still differs from its sibling survive the fold instead of being
silently adopted — it calls the executor once where tetwild uses `run_localized_to_convergence`, its
2D collapse hand-rolls a rebuild-everything retry loop, and its 3D swaps report the last round's
success count rather than the total. All three are now recorded in
`docs/simwild-adopted-behaviours.md`; adopting them changes which failed operations get re-tested
and wants its own before/after, not a line in a refactor.

### Validation

- `ctest` 107/107.
- All 53 registered integration configs field-by-field identical (`report.json` plus an md5 of
  every emitted mesh) against the pre-refactor build — simwild's six 3D configs included, which is
  what shows the fold is behaviour-neutral there too. The two configs that run at
  `num_threads: 10` are nondeterministic by construction, so they were re-run at `num_threads: 0`
  and are byte-identical there.
- The hidden `[challenging]` set, 30 models, byte-identical.
