### PR TITLE
De-dup 6/6: host the rounding sweep in wmtk::RationalPositions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,7 @@ CMakeCache.txt
 
 # Artifacts written into the working directory by the paraviewo unit tests
 /*_paraviewo_*.vtu
+
+# Viewer state written into the repo root by polyscope / imgui at runtime
+.polyscope.ini
+imgui.ini

--- a/components/simwild/wmtk/components/simwild/SimWildMesh.cpp
+++ b/components/simwild/wmtk/components/simwild/SimWildMesh.cpp
@@ -626,12 +626,6 @@ void SimWildMesh::write_msh(std::string file, const bool write_envelope)
 }
 
 
-bool SimWildMesh::round_and_check_all_rounded()
-{
-    round_all_vertices();
-    return m_all_rounded.load(std::memory_order_relaxed);
-}
-
 bool SimWildMesh::all_rounded() const
 {
     size_t cnt_round = 0;

--- a/components/simwild/wmtk/components/simwild/SimWildMesh.h
+++ b/components/simwild/wmtk/components/simwild/SimWildMesh.h
@@ -233,21 +233,6 @@ public:
 
     size_t swap_all_edges_all();
 
-    /**
-     * @brief Run the rounding sweep, then report whether the mesh is now fully rounded.
-     *
-     * The termination condition of the operation loop. Energy alone is not sufficient: a mesh
-     * that hits the quality target while some vertex still carries exact coordinates is not
-     * finished, because the output is what the caller consumes and rational coordinates in it
-     * are a defect regardless of how good the elements are.
-     *
-     * This is also what makes the exact-rational fallback in split_edge_after safe. A split is
-     * the only operation that can un-round a vertex; collapse, the swaps and smoothing never
-     * do; and the post-optimization pass is collapse-only.
-     *
-     * O(1) once m_all_rounded is set, so it is cheap enough to sit on every early-out.
-     */
-    bool round_and_check_all_rounded();
 
     /**
      * @brief Check if all vertices of the mesh are rounded.

--- a/components/simwild/wmtk/components/simwild/SimWildMeshTri.cpp
+++ b/components/simwild/wmtk/components/simwild/SimWildMeshTri.cpp
@@ -1774,12 +1774,6 @@ void SimWildMeshTri::log_total_surface_energy()
 }
 
 
-bool SimWildMeshTri::round_and_check_all_rounded()
-{
-    round_all_vertices();
-    return m_all_rounded.load(std::memory_order_relaxed);
-}
-
 double SimWildMeshTri::triangle_area(const size_t fid) const
 {
     const auto vs = oriented_tri_vids(fid);

--- a/components/simwild/wmtk/components/simwild/SimWildMeshTri.hpp
+++ b/components/simwild/wmtk/components/simwild/SimWildMeshTri.hpp
@@ -188,14 +188,6 @@ public:
      */
     void log_total_surface_energy();
 
-    /**
-     * @brief Run the rounding sweep, then report whether the mesh is now fully rounded.
-     *
-     * The termination condition of the operation loop, and what makes the exact-rational
-     * fallback in split_edge_after safe: a split is the only operation that can un-round a
-     * vertex, so the loop only has to outlast the sweep. See SimWildMesh's counterpart.
-     */
-    bool round_and_check_all_rounded();
 
     /**
      * @brief Splits in the last pass that fell back to the exact rational midpoint.

--- a/src/wmtk/RationalPositions.cpp
+++ b/src/wmtk/RationalPositions.cpp
@@ -1,0 +1,43 @@
+#include <wmtk/RationalPositions.h>
+
+#include <wmtk/utils/Logger.hpp>
+
+namespace wmtk {
+
+size_t RationalPositions::round_all_vertices()
+{
+    if (m_all_rounded.load(std::memory_order_relaxed)) {
+        return 0;
+    }
+
+    size_t reclaimed = 0, still_unrounded = 0;
+    for (const size_t vid : all_vertex_ids()) {
+        if (vertex_is_rounded(vid)) {
+            continue;
+        }
+        if (round_vertex(vid)) {
+            ++reclaimed;
+        } else {
+            ++still_unrounded;
+        }
+    }
+
+    if (still_unrounded == 0) {
+        m_all_rounded.store(true, std::memory_order_relaxed);
+    }
+    if (reclaimed > 0 || still_unrounded > 0) {
+        logger().info(
+            "rounding sweep: reclaimed {}, still unrounded {}",
+            reclaimed,
+            still_unrounded);
+    }
+    return reclaimed;
+}
+
+bool RationalPositions::round_and_check_all_rounded()
+{
+    round_all_vertices();
+    return m_all_rounded.load(std::memory_order_relaxed);
+}
+
+} // namespace wmtk

--- a/src/wmtk/RationalPositions.h
+++ b/src/wmtk/RationalPositions.h
@@ -1,0 +1,76 @@
+#pragma once
+
+#include <atomic>
+#include <cstddef>
+#include <vector>
+
+namespace wmtk {
+
+/**
+ * @brief The rounded/exact bookkeeping shared by every mesh that keeps both coordinates.
+ *
+ * All four application meshes store a vertex position twice -- exactly, as rationals, and
+ * rounded, as doubles -- and carry the same invariant about which of the two the rest of the
+ * code may read. This holds that invariant, and the sweep that restores it, in one place.
+ *
+ * Dimension-free by construction: nothing here mentions a Tuple or a position type, so the
+ * three hooks below are all a mesh has to supply. Unlike the improvement loop -- which the two
+ * optimizer bases still duplicate, because 2D and 3D genuinely disagree about the stop
+ * condition and the cbrt convention -- this really is the same code twice.
+ */
+class RationalPositions
+{
+public:
+    virtual ~RationalPositions() = default;
+
+    /**
+     * @brief Try to round every un-rounded vertex; returns the number reclaimed.
+     *
+     * Operations round opportunistically, at the vertex they touch (the new vertex of a split,
+     * the merged vertex of a collapse), and none of them reaches a vertex that only becomes
+     * roundable later -- smoothing skips "good" regions by default. Without a sweep such a
+     * vertex keeps exact coordinates all the way into the output for no geometric reason, and
+     * split_edge_after introduces them unconditionally whenever the rounded midpoint would
+     * invert, so the sweep is what keeps that from reaching the caller.
+     *
+     * Skipped outright when m_all_rounded says there is nothing to do.
+     */
+    size_t round_all_vertices();
+
+    /**
+     * @brief Run the sweep, then report whether the mesh is now fully rounded.
+     *
+     * The termination condition of the operation loop. A mesh that hits the quality target
+     * while some vertex still carries exact coordinates is not finished, because the output is
+     * what the caller consumes and rational coordinates in it are a defect regardless of how
+     * good the elements are.
+     *
+     * This is also what makes the exact-rational fallback in split_edge_after safe: a split is
+     * the only operation that can un-round a vertex -- collapse, the swaps and smoothing never
+     * do, and the post-optimization pass is collapse-only -- so the loop only has to outlast
+     * the sweep.
+     *
+     * O(1) once m_all_rounded is set, so it is cheap enough to sit on every early-out.
+     */
+    bool round_and_check_all_rounded();
+
+protected:
+    /// Every live vertex, in the mesh's own iteration order.
+    virtual std::vector<size_t> all_vertex_ids() const = 0;
+    /// Whether this vertex's double position is currently trusted.
+    virtual bool vertex_is_rounded(const size_t vid) const = 0;
+    /// Try to replace this vertex's exact position with its rounded one; false if that would
+    /// invert an incident cell, in which case nothing is changed.
+    virtual bool round_vertex(const size_t vid) = 0;
+
+    /**
+     * @brief True when every vertex is known to be rounded.
+     *
+     * Only trusted when true, and only round_all_vertices() sets it that way. Any code that
+     * leaves a vertex un-rounded must clear it, or the sweep will skip the vertex forever.
+     * Atomic because operations that clear it run in parallel.
+     */
+    std::atomic<bool> m_all_rounded = false;
+};
+
+} // namespace wmtk

--- a/src/wmtk/TetOptimizerMesh.cpp
+++ b/src/wmtk/TetOptimizerMesh.cpp
@@ -107,34 +107,15 @@ std::shared_ptr<SampleEnvelope> TetOptimizerMesh::smoothing_containment_envelope
     return m_envelope;
 }
 
-size_t TetOptimizerMesh::round_all_vertices()
+std::vector<size_t> TetOptimizerMesh::all_vertex_ids() const
 {
-    if (m_all_rounded.load(std::memory_order_relaxed)) {
-        return 0;
+    const std::vector<Tuple> vs = get_vertices();
+    std::vector<size_t> ids;
+    ids.reserve(vs.size());
+    for (const Tuple& v : vs) {
+        ids.push_back(v.vid(*this));
     }
-
-    size_t reclaimed = 0, still_unrounded = 0;
-    for (const Tuple& v : get_vertices()) {
-        if (m_vertex_attribute[v.vid(*this)].m_is_rounded) {
-            continue;
-        }
-        if (round(v)) {
-            ++reclaimed;
-        } else {
-            ++still_unrounded;
-        }
-    }
-
-    if (still_unrounded == 0) {
-        m_all_rounded.store(true, std::memory_order_relaxed);
-    }
-    if (reclaimed > 0 || still_unrounded > 0) {
-        logger().info(
-            "rounding sweep: reclaimed {}, still unrounded {}",
-            reclaimed,
-            still_unrounded);
-    }
-    return reclaimed;
+    return ids;
 }
 
 void TetOptimizerMesh::gradation_smooth_sizing(double grade, const std::vector<size_t>& seeds)

--- a/src/wmtk/TetOptimizerMesh.h
+++ b/src/wmtk/TetOptimizerMesh.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <wmtk/OptimizerParameters.h>
+#include <wmtk/RationalPositions.h>
 #include <wmtk/SurfaceTagAttributes.h>
 #include <wmtk/TetMesh.h>
 #include <wmtk/Types.hpp>
@@ -38,7 +39,7 @@ namespace wmtk {
  * that touch a cell attribute at all, and both are once-per-pass sweeps rather than
  * per-operation code.
  */
-class TetOptimizerMesh : public wmtk::TetMesh
+class TetOptimizerMesh : public wmtk::TetMesh, public wmtk::RationalPositions
 {
 public:
     struct VertexAttributes
@@ -120,15 +121,6 @@ public:
     /// Why smoothing attempts were refused, reported once per pass.
     optimization::SmoothRejectCounters m_smooth_rejects;
 
-    /**
-     * @brief True when every vertex is known to be rounded.
-     *
-     * Only trusted when true, and only round_all_vertices() sets it that way. Any code that
-     * leaves a vertex un-rounded must clear it, or the sweep will skip the vertex forever.
-     * Atomic because operations that clear it run in parallel.
-     */
-    std::atomic<bool> m_all_rounded = false;
-
     /// Whether the current collapse pass applies the target-length limit; read by
     /// collapse_edge_before, which is where that limit is enforced.
     bool m_collapse_limit_length = true;
@@ -184,13 +176,21 @@ public:
      * @return True if successful or already rounded, false otherwise.
      */
     bool round(const Tuple& v);
-    /**
-     * @brief Try to round every un-rounded vertex; returns the number reclaimed.
-     *
-     * Skipped outright when m_all_rounded says there is nothing to do.
-     */
-    size_t round_all_vertices();
 
+protected:
+    // RationalPositions supplies round_all_vertices() and round_and_check_all_rounded() on
+    // top of these three.
+    std::vector<size_t> all_vertex_ids() const override;
+    bool vertex_is_rounded(const size_t vid) const override
+    {
+        return m_vertex_attribute.at(vid).m_is_rounded;
+    }
+    // Equivalent to round() on the tuple get_vertices() would have yielded: round() reads only
+    // the vid and the one-ring, and the one-ring query is answered from
+    // m_vertex_connectivity[vid] regardless of which cell the tuple names.
+    bool round_vertex(const size_t vid) override { return round(tuple_from_vertex(vid)); }
+
+public:
     bool is_edge_on_surface(const Tuple& loc);
     bool is_edge_on_bbox(const Tuple& loc);
     /**

--- a/src/wmtk/TriOptimizerMesh.cpp
+++ b/src/wmtk/TriOptimizerMesh.cpp
@@ -151,34 +151,15 @@ bool TriOptimizerMesh::is_inverted(const size_t fid) const
     return is_inverted(vs);
 }
 
-size_t TriOptimizerMesh::round_all_vertices()
+std::vector<size_t> TriOptimizerMesh::all_vertex_ids() const
 {
-    if (m_all_rounded.load(std::memory_order_relaxed)) {
-        return 0;
+    const std::vector<Tuple> vs = get_vertices();
+    std::vector<size_t> ids;
+    ids.reserve(vs.size());
+    for (const Tuple& v : vs) {
+        ids.push_back(v.vid(*this));
     }
-
-    size_t reclaimed = 0, still_unrounded = 0;
-    for (const Tuple& v : get_vertices()) {
-        if (m_vertex_attribute[v.vid(*this)].m_is_rounded) {
-            continue;
-        }
-        if (round(v)) {
-            ++reclaimed;
-        } else {
-            ++still_unrounded;
-        }
-    }
-
-    if (still_unrounded == 0) {
-        m_all_rounded.store(true, std::memory_order_relaxed);
-    }
-    if (reclaimed > 0 || still_unrounded > 0) {
-        logger().info(
-            "rounding sweep: reclaimed {}, still unrounded {}",
-            reclaimed,
-            still_unrounded);
-    }
-    return reclaimed;
+    return ids;
 }
 
 bool TriOptimizerMesh::round(const Tuple& v)

--- a/src/wmtk/TriOptimizerMesh.h
+++ b/src/wmtk/TriOptimizerMesh.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <wmtk/OptimizerParameters.h>
+#include <wmtk/RationalPositions.h>
 #include <wmtk/SurfaceTagAttributes.h>
 #include <wmtk/TriMesh.h>
 #include <wmtk/Types.hpp>
@@ -33,7 +34,7 @@ namespace wmtk {
  * the stop condition (absolute energy vs per-cell relative quality) abstracted first. Two
  * readable copies beat one over-parameterized one.
  */
-class TriOptimizerMesh : public wmtk::TriMesh
+class TriOptimizerMesh : public wmtk::TriMesh, public wmtk::RationalPositions
 {
 public:
     struct VertexAttributes
@@ -121,15 +122,6 @@ public:
     /// Why smoothing attempts were refused, reported once per pass.
     optimization::SmoothRejectCounters m_smooth_rejects;
 
-    /**
-     * @brief True when every vertex is known to be rounded.
-     *
-     * Only trusted when true, and only round_all_vertices() sets it that way. Any code that
-     * leaves a vertex un-rounded must clear it, or the sweep will skip the vertex forever.
-     * Atomic because operations that clear it run in parallel.
-     */
-    std::atomic<bool> m_all_rounded = false;
-
     bool m_collapse_limit_length = true;
     int m_debug_print_counter = 0;
 
@@ -189,20 +181,21 @@ public:
      * @return True if successful or already rounded, false otherwise.
      */
     bool round(const Tuple& v);
-    /**
-     * @brief Try to round every un-rounded vertex; returns the number reclaimed.
-     *
-     * round() is otherwise only attempted as a side effect of another operation (smoothing
-     * the vertex, or the merged vertex of a collapse), and neither reaches a vertex that only
-     * becomes roundable later: smoothing skips "good" regions by default. Without a sweep such
-     * a vertex keeps exact coordinates into the output for no geometric reason -- and
-     * split_edge_after introduces them unconditionally whenever the rounded midpoint would
-     * invert, so the sweep is what keeps that from reaching the output.
-     *
-     * Skipped outright when m_all_rounded says there is nothing to do.
-     */
-    size_t round_all_vertices();
 
+protected:
+    // RationalPositions supplies round_all_vertices() and round_and_check_all_rounded() on
+    // top of these three.
+    std::vector<size_t> all_vertex_ids() const override;
+    bool vertex_is_rounded(const size_t vid) const override
+    {
+        return m_vertex_attribute.at(vid).m_is_rounded;
+    }
+    // Equivalent to round() on the tuple get_vertices() would have yielded: round() reads only
+    // the vid and the one-ring, and the one-ring query is answered from
+    // m_vertex_connectivity[vid] regardless of which cell the tuple names.
+    bool round_vertex(const size_t vid) override { return round(tuple_from_vertex(vid)); }
+
+public:
     bool is_edge_on_surface(const Tuple& loc) const;
     bool is_edge_on_surface(const std::array<size_t, 2>& vids) const;
     bool is_edge_on_bbox(const Tuple& loc) const;


### PR DESCRIPTION
## Stage 4 — the rounding sweep

Sixth and last of the stacked de-duplication PRs. Stacked on #1008.

All four meshes keep every vertex position twice — exactly, as rationals, and rounded, as doubles —
and carry the same invariant about which of the two the rest of the code may read:

> `m_all_rounded` is trusted only when true, only the sweep sets it that way, and anything that
> leaves a vertex un-rounded must clear it or the sweep will skip that vertex forever.

Stage 3 already took the sweep from four copies to two, one per optimizer base. This takes it to
one, in a small mixin the two bases inherit alongside `wmtk::TetMesh` / `wmtk::TriMesh`.

```
wmtk::TetMesh   wmtk::RationalPositions        wmtk::TriMesh   wmtk::RationalPositions
        \        /                                     \        /
    wmtk::TetOptimizerMesh                        wmtk::TriOptimizerMesh
```

The mixin owns `m_all_rounded`, `round_all_vertices()` and `round_and_check_all_rounded()`. The
bases supply three hooks: `all_vertex_ids()`, `vertex_is_rounded(vid)`, `round_vertex(vid)`.

### Why this one and not the improvement loop

The plan deliberately leaves `MAX_ENERGY`, `get_max_avg_energy` and the improvement loop duplicated
between the two bases, because unifying them needs the stop condition abstracted (tetwild/triwild
use an absolute `max_energy < stop_energy`; simwild a per-cell relative check) plus the cbrt
convention, and two readable copies beat one over-parameterized one.

The sweep is the opposite case. **Nothing in it mentions a Tuple or a position type** — it is
genuinely the same code twice, and unifying it needs no parameter, only the three hooks.

### The one non-textual change

`round_vertex(vid)` is `round(tuple_from_vertex(vid))`, where the old loop called `round(v)` on the
tuple `get_vertices()` yielded. These are the same call: `round()` reads only the vid and the
one-ring, and both `get_one_ring_tets_for_vertex` and its 2D counterpart answer from
`m_vertex_connectivity[vid]` regardless of which cell the tuple names — in `m_conn_tets` order
either way. The vertex order of the sweep itself is unchanged, since `all_vertex_ids()` is built
from `get_vertices()`.

### Size

Honest accounting: `RationalPositions.{h,cpp}` is 119 lines, about half of it the merged
documentation of the invariant, against 126 removed. **This is not a line-count win** — Stage 3 had
already collected most of it. What it buys is that the invariant, the sweep and the loop-termination
condition that depends on them are stated once instead of four times across two libraries and two
applications.

### Validation

- `ctest` 107/107.
- All 53 registered integration configs field-by-field identical against #1008; the two that run at
  `num_threads: 10` are nondeterministic by construction and are identical when re-run at
  `num_threads: 0`.
- The hidden `[challenging]` set, 30 models, byte-identical.
