### PR TITLE
tetwild: force-split only elements that are too large, not merely bad

### DIFF
--- a/components/tetwild/wmtk/components/tetwild/TetWildMesh.cpp
+++ b/components/tetwild/wmtk/components/tetwild/TetWildMesh.cpp
@@ -626,13 +626,36 @@ size_t TetWildMesh::refine_sizing_around_worst(double max_energy)
     // force-splits exactly those edges (bypasses the length gate), so a stuck sliver's
     // long edge is split immediately -- WITHOUT changing the sizing field.
     m_force_split_edges.clear();
+    size_t already_at_size = 0;
     if (m_params.stuck_refine_force_split) {
         for (const auto& [q, tid] : worst) {
-            m_force_split_edges.insert(
-                utils::longest_edge(oriented_tet_vids(tid), [this](size_t vid) -> const Vector3d& {
-                    return m_vertex_attribute[vid].m_posf;
-                }));
+            const auto e = utils::longest_edge(
+                oriented_tet_vids(tid),
+                [this](size_t vid) -> const Vector3d& { return m_vertex_attribute[vid].m_posf; });
+            if (m_params.stuck_refine_force_split_oversized_only) {
+                // Refinement can only help a cell that is too big for its target length. See
+                // OptimizerParameters::stuck_refine_force_split_oversized_only for why
+                // splitting a badly shaped one is a ratchet rather than an escape.
+                const auto& ev = e.vertices();
+                const double sizing = (m_vertex_attribute[ev[0]].m_sizing_scalar +
+                                       m_vertex_attribute[ev[1]].m_sizing_scalar) /
+                                      2;
+                const double len2 =
+                    (m_vertex_attribute[ev[0]].m_posf - m_vertex_attribute[ev[1]].m_posf)
+                        .squaredNorm();
+                if (len2 <= m_params.splitting_l2 * sizing * sizing) {
+                    ++already_at_size;
+                    continue;
+                }
+            }
+            m_force_split_edges.insert(e);
         }
+    }
+    if (already_at_size > 0) {
+        logger().info(
+            "[force-split] {} worst tets are already at target size; refinement cannot "
+            "improve their shape",
+            already_at_size);
     }
 
     // Seed the region with the worst tets' vertices, then BFS n_rings hops.

--- a/components/tetwild/wmtk/components/tetwild/tetwild.cpp
+++ b/components/tetwild/wmtk/components/tetwild/tetwild.cpp
@@ -131,6 +131,8 @@ TetWildMesh::ExportStruct tetwild_with_export(nlohmann::json json_params)
     params.stuck_refine_rings = json_params["stuck_refine_rings"];
     params.stuck_refine_factor = json_params["stuck_refine_factor"];
     params.stuck_refine_force_split = json_params["stuck_refine_force_split"];
+    params.stuck_refine_force_split_oversized_only =
+        json_params["stuck_refine_force_split_oversized_only"];
     params.stuck_refine_min_scalar = json_params["stuck_refine_min_scalar"];
     params.stuck_refine_gradation = json_params["stuck_refine_gradation"];
 

--- a/components/tetwild/wmtk/components/tetwild/tetwild_spec.json
+++ b/components/tetwild/wmtk/components/tetwild/tetwild_spec.json
@@ -49,6 +49,7 @@
       "stuck_refine_min_scalar",
       "stuck_refine_gradation",
       "stuck_refine_force_split",
+      "stuck_refine_force_split_oversized_only",
       "skip_good_regions",
       "skip_good_regions_margin",
       "skip_winding_number"
@@ -350,6 +351,12 @@
     "type": "bool",
     "default": true,
     "doc": "When the max energy stalls, split each worst tet's longest edge once, bypassing the split length gate, to unstick a sliver without changing the sizing field. Adds at most one split per worst tet per stall."
+  },
+  {
+    "pointer": "/stuck_refine_force_split_oversized_only",
+    "type": "bool",
+    "default": true,
+    "doc": "Force-split only a cell whose longest edge exceeds its target length. Force-split exists to unstick a sliver but cannot: AMIPS is scale invariant, so subdividing a badly shaped cell yields two badly shaped cells of the same energy, the cell stays the worst one, and its longest edge halves on every stall -- a ratchet with no exit. On Thingi10K 243014 that drove a legitimate 0.155 surface edge, the finest the simplified input has, down to 1.0e-4 in about eleven firings. Measured serially on 243014 over 25 iterations: off gives final max energy 41.46 with a 1.02e-04 minimum edge and 0.373% of edges below 1e-3, on gives 20.87, 8.15e-04 and 0.019% -- and without it the mesh reaches 20.87 then degrades to 41.46, while with it 20.87 holds."
   },
   {
     "pointer": "/skip_good_regions",

--- a/src/wmtk/OptimizerParameters.h
+++ b/src/wmtk/OptimizerParameters.h
@@ -79,6 +79,23 @@ struct OptimizerParameters
     // stall, so it does not bloat the element count.
     bool stuck_refine_force_split = true;
 
+    /**
+     * Force-split only a cell that is too LARGE for its sizing field.
+     *
+     * Force-split exists to unstick a sliver, but it cannot: AMIPS is scale invariant, so
+     * subdividing a badly SHAPED cell yields two badly shaped cells of the same energy. The
+     * cell stays the worst one, is force-split again on the next stall, and its longest edge
+     * halves every time -- a ratchet with no exit. On Thingi10K 243014 that drove a legitimate
+     * 0.155 surface edge, the finest the simplified input has, down to 1.0e-4 in about eleven
+     * firings, ~1500x below anything in the input.
+     *
+     * Refinement only helps a cell that is too big for its target length, so require that.
+     * Measured serially on 243014 over 25 iterations: off gives final max energy 41.46 with a
+     * 1.02e-04 minimum edge and 0.373% of edges below 1e-3; on gives 20.87, 8.15e-04 and
+     * 0.019%. Without it the mesh reaches 20.87 then degrades to 41.46; with it 20.87 holds.
+     */
+    bool stuck_refine_force_split_oversized_only = true;
+
     // ---- Skip good regions ----------------------------------------------
     // Only smooth vertices incident to a cell whose energy is >=
     // skip_good_regions_margin * stop_energy. Smoothing a vertex surrounded by


### PR DESCRIPTION
Stacked on #1003 (AMIPS translation) which is stacked on #1002 (delaunay orphan points).

Force-split splits the worst tet's longest edge on every stall, bypassing the length gate, to "unstick a sliver". **It cannot do that.** AMIPS is scale-invariant, so subdividing a badly *shaped* element yields two badly shaped elements of the same energy — the element stays the worst one, gets force-split again next stall, and its longest edge halves every time. A ratchet with no exit.

On Thingi10K **243014** that drove a legitimate **0.155** surface edge — the finest edge the *simplified* input has — down to **1.0e-4** in about eleven firings, ~1500× below anything in the input. The four worst elements are congruent copies of the same manufactured sliver, collinear along one feature, energies identical to the last digit.

## Measured, serial (`num_threads: 1`), 25 iterations

| | final max energy | mesh min edge | edges < 1e-3 | #tets |
|---|---|---|---|---|
| off | 41.4569 | 1.02e-04 | 0.373% | 496,560 |
| **on** | **20.8691** | **8.15e-04** | **0.019%** | 549,975 |

Both reach 20.8691; **without the gate the mesh then degrades to 41.46, with it 20.8691 holds.** Sub-1e-3 edges drop 20×.

## What this does not fix

243014 still does not converge. What remains at 20.87 is an element that is the right *size* but the wrong *shape*, and the collapse that would remove it is refused for reasons that are largely legitimate. Instrumenting collapse refusals for edges on near-worst elements, at the plateau:

```
offered 207  accepted 17 (8.2%)
  surface-envelope   89   47%
  inverted           59   31%
  quality>ring-max   42   22%
```

78% of the blocking is real geometry — the collapse would push the tracked surface outside the envelope, or invert a neighbour. That is a question about what the envelope permits, not about refinement, and it is not addressed here.

## Test plan

- Serial A/B above, one variable, same binary except the flag.
- Unit tests: **106,295 assertions in 97 test cases, all passing.**
- Behind `stuck_refine_force_split_oversized_only`, default true; set false for the old behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)