### PR TITLE
tetwild: keep m_posf in step after the exact-midpoint split

### DIFF
--- a/components/tetwild/wmtk/components/tetwild/EdgeSplitting.cpp
+++ b/components/tetwild/wmtk/components/tetwild/EdgeSplitting.cpp
@@ -237,6 +237,13 @@ bool TetWildMesh::split_edge_after(const Tuple& loc)
         // does not stop until every vertex is rounded as well as the energy target being met.
         m_vertex_attribute[v_id].m_pos =
             (m_vertex_attribute[v1_id].m_pos + m_vertex_attribute[v2_id].m_pos) / 2;
+        // Keep m_posf in step with the exact position. It was left holding the double
+        // midpoint, which is a different point -- and specifically the one just found to
+        // invert an incident tet. Every un-guarded m_posf read (edge length, the envelope
+        // tests, the smoothing seed) then works from a position the vertex does not have.
+        // When an endpoint is itself un-rounded the gap is not a rounding step but the whole
+        // distance between that endpoint's exact and approximate positions.
+        m_vertex_attribute[v_id].m_posf = to_double(m_vertex_attribute[v_id].m_pos);
         // Guard against a pre-existing inverted incident tet: re-check in exact
         // arithmetic (un-rounded v_id => is_inverted uses the rational path).
         for (const Tuple& loc : locs) {


### PR DESCRIPTION
## tetwild: keep `m_posf` in step after the exact-midpoint split

Follow-up to the de-duplication stack (#1004–#1009), stacked on #1009. Independent of it — this is
the one divergence the "tetwild/triwild wins" rule could not decide, because tetwild is the odd one
out among the four meshes.

When the rounded midpoint would invert an incident tet, `split_edge_after` places the new vertex at
the **exact rational midpoint** instead. tetwild set `m_pos` and left `m_posf` holding the double
midpoint — a different point, and specifically the one just found to invert a tet. Every un-guarded
`m_posf` read (edge length, the envelope tests, the smoothing seed) then works from a position the
vertex does not have.

triwild, simwild-2D and simwild-3D all already set `m_posf = to_double(m_pos)` here, and triwild's
copy documents why. This makes tetwild agree.

### This is a latent-correctness fix with no measurable effect today

Being straight about the evidence rather than implying an improvement:

- **All 53 registered configs, `tetwild_crown` and `tetwild_octocat` at `num_threads: 0`, and all 30
  hidden `[challenging]` models are byte-identical.**
- The path *is* exercised: `challenging_tetwild_1017012` runs four rounding sweeps with up to 29
  un-rounded vertices, `challenging_tetwild_104187` one.

The two midpoints coincide whenever both endpoints are already rounded. `m_pos` is then exactly
`(p1+p2)/2` over the rationals, and `to_double` of that is the correctly-rounded average; the old
`(m_posf1 + m_posf2)/2` rounds once on the addition and then halves exactly, which is the same
value. Checked over 2,000,000 random double pairs — the only two disagreements were overflow near
1e308, which mesh coordinates never reach.

So the fix only bites when an endpoint is **itself un-rounded**. Then the double midpoint is the
average of two approximations rather than one rounding of the true midpoint, and the gap is that
endpoint's own exact-to-approximate distance, not an ulp. No model in either gate hits that
combination.

Worth landing anyway: it removes a stale field that every un-guarded reader would consume, and the
condition that makes it harmless is a property of the *inputs* seen so far, not of the code.
