### PR TITLE
simwild: adopt the localized retry and the accumulated success count

### DIFF
--- a/components/simwild/wmtk/components/simwild/EdgeSplitting.cpp
+++ b/components/simwild/wmtk/components/simwild/EdgeSplitting.cpp
@@ -2,6 +2,7 @@
 
 #include <igl/Timer.h>
 #include <wmtk/utils/ExecutorUtils.hpp>
+#include <wmtk/utils/LocalizedRetry.hpp>
 #include <wmtk/utils/Logger.hpp>
 #include <wmtk/utils/RunPass.hpp>
 
@@ -56,7 +57,9 @@ void SimWildMesh::split_all_edges()
                 }
                 return true;
             };
-            executor(mesh, collect_all_ops);
+            // Retry a failed split only where the mesh actually changed this round
+            // (dirty-epoch localized retry), as tetwild does.
+            wmtk::run_localized_to_convergence(mesh, executor, collect_all_ops);
         });
     if (m_force_split_count > 0) {
         wmtk::logger().info(

--- a/components/simwild/wmtk/components/simwild/EdgeSwapping.cpp
+++ b/components/simwild/wmtk/components/simwild/EdgeSwapping.cpp
@@ -3,6 +3,7 @@
 #include <igl/Timer.h>
 #include <wmtk/TetMesh.h>
 #include <wmtk/utils/ExecutorUtils.hpp>
+#include <wmtk/utils/LocalizedRetry.hpp>
 #include <wmtk/utils/Logger.hpp>
 #include <wmtk/utils/ParallelCollect.hpp>
 #include <wmtk/utils/RunPass.hpp>
@@ -100,8 +101,10 @@ size_t SimWildMesh::swap_all_edges_32()
         [&](auto& executor, auto& mesh) {
             executor.renew_neighbor_tuples = wmtk::renewal_edges;
             executor.priority = [&](auto& m, auto op, auto& t) { return m.get_length2(t); };
-            executor(mesh, collect_all_ops);
-            total_success = executor.get_cnt_success();
+            // Retry a failed swap only where the mesh actually changed this round
+            // (dirty-epoch localized retry), and report the total across rounds rather
+            // than the last round's count -- as tetwild does.
+            total_success = wmtk::run_localized_to_convergence(mesh, executor, collect_all_ops);
         });
     if (m_sim_params.check_surface_topology) {
         warn_if_surface_topology_changed(sig_before, "swap_all_edges_32");
@@ -367,8 +370,10 @@ size_t SimWildMesh::swap_all_faces()
         [&](auto& executor, auto& mesh) {
             executor.renew_neighbor_tuples = wmtk::renewal_faces;
             executor.priority = [](auto& m, auto op, auto& t) { return m.get_length2(t); };
-            executor(mesh, collect_all_ops);
-            total_success = executor.get_cnt_success();
+            // Retry a failed swap only where the mesh actually changed this round
+            // (dirty-epoch localized retry), and report the total across rounds rather
+            // than the last round's count -- as tetwild does.
+            total_success = wmtk::run_localized_to_convergence(mesh, executor, collect_all_ops);
         });
     return total_success;
 }
@@ -494,8 +499,10 @@ size_t SimWildMesh::swap_all_edges_all()
                     return op_tups;
                 };
             executor.priority = [&](auto& m, auto op, auto& t) { return m.get_length2(t); };
-            executor(mesh, collect_all_ops);
-            total_success = executor.get_cnt_success();
+            // Retry a failed swap only where the mesh actually changed this round
+            // (dirty-epoch localized retry), and report the total across rounds rather
+            // than the last round's count -- as tetwild does.
+            total_success = wmtk::run_localized_to_convergence(mesh, executor, collect_all_ops);
         });
     if (m_sim_params.check_surface_topology) {
         warn_if_surface_topology_changed(sig_before, "swap_all_edges_32");
@@ -523,8 +530,10 @@ size_t SimWildMesh::swap_all_edges_44()
         [&](auto& executor, auto& mesh) {
             executor.renew_neighbor_tuples = wmtk::renewal_edges;
             executor.priority = [&](auto& m, auto op, auto& t) { return m.get_length2(t); };
-            executor(mesh, collect_all_ops);
-            total_success = executor.get_cnt_success();
+            // Retry a failed swap only where the mesh actually changed this round
+            // (dirty-epoch localized retry), and report the total across rounds rather
+            // than the last round's count -- as tetwild does.
+            total_success = wmtk::run_localized_to_convergence(mesh, executor, collect_all_ops);
         });
     return total_success;
 }
@@ -611,8 +620,10 @@ size_t SimWildMesh::swap_all_edges_56()
         [&](auto& executor, auto& mesh) {
             executor.renew_neighbor_tuples = wmtk::renewal_edges;
             executor.priority = [&](auto& m, auto op, auto& t) { return m.get_length2(t); };
-            executor(mesh, collect_all_ops);
-            total_success = executor.get_cnt_success();
+            // Retry a failed swap only where the mesh actually changed this round
+            // (dirty-epoch localized retry), and report the total across rounds rather
+            // than the last round's count -- as tetwild does.
+            total_success = wmtk::run_localized_to_convergence(mesh, executor, collect_all_ops);
         });
     return total_success;
 }

--- a/components/simwild/wmtk/components/simwild/SimWildMeshTri.cpp
+++ b/components/simwild/wmtk/components/simwild/SimWildMeshTri.cpp
@@ -908,7 +908,9 @@ void SimWildMeshTri::split_all_edges()
                 }
                 return true;
             };
-            executor(mesh, collect_all_ops);
+            // Retry a failed split only where the mesh actually changed this round
+            // (dirty-epoch localized retry), as triwild does.
+            wmtk::run_localized_to_convergence(mesh, executor, collect_all_ops);
         });
     if (m_exact_split_count > 0) {
         wmtk::logger().info(
@@ -1157,7 +1159,16 @@ bool SimWildMeshTri::split_edge_after(const Tuple& loc)
 void SimWildMeshTri::collapse_all_edges(bool is_limit_length)
 {
     m_collapse_limit_length = is_limit_length;
+
+    // Built once, up front. The retry driver re-queues what the mesh actually changed, so
+    // there is nothing left for the old rebuild-from-get_edges()-every-round loop to do.
+    // Filtering of too-long edges still happens in is_weight_up_to_date.
     std::vector<std::pair<std::string, Tuple>> all_ops;
+    for (const Tuple& loc : get_edges()) {
+        all_ops.emplace_back("edge_collapse", loc);
+        all_ops.emplace_back("edge_collapse", loc.switch_vertex(*this));
+    }
+    logger().info("#E = {}", all_ops.size() / 2);
 
     wmtk::run_pass(
         *this,
@@ -1181,22 +1192,25 @@ void SimWildMeshTri::collapse_all_edges(bool is_limit_length)
                 return true;
             };
 
-            // Execute!!
-            do {
-                all_ops.clear();
-                const auto all_edges = get_edges();
-                logger().info("#E = {}", all_edges.size());
-                for (const Tuple& loc : all_edges) {
-                    // collect all edges. Filtering too long edges happens in `is_weight_up_to_date`
-                    all_ops.emplace_back("edge_collapse", loc);
-                    all_ops.emplace_back("edge_collapse", loc.switch_vertex(*this));
-                }
-                executor(mesh, all_ops);
-                logger().info(
-                    "success: {}, failed: {}",
-                    executor.get_cnt_success(),
-                    executor.get_cnt_fail());
-            } while (executor.get_cnt_success() > 0);
+            executor.renew_neighbor_tuples =
+                [](const wmtk::TriOptimizerMesh& m, Op op, const auto& newts) {
+                    std::vector<std::pair<std::string, TriMesh::Tuple>> op_tups;
+                    op_tups.reserve(2 * newts.size());
+                    for (const Tuple& t : newts) {
+                        op_tups.emplace_back(op, t);
+                        op_tups.emplace_back(op, t.switch_vertex(m));
+                    }
+                    return op_tups;
+                };
+
+            // Retry a failed collapse only where the mesh actually changed this round
+            // (dirty-epoch localized retry), as triwild does. This replaces the loop that
+            // rebuilt the whole op list from get_edges() after every pass and re-ran the
+            // expensive geometric pre-checks on every failure, even where nothing could
+            // have changed.
+            const size_t total_success =
+                wmtk::run_localized_to_convergence(mesh, executor, all_ops);
+            logger().info("collapse success: {}", total_success);
         });
 }
 

--- a/docs/simwild-adopted-behaviours.md
+++ b/docs/simwild-adopted-behaviours.md
@@ -306,3 +306,47 @@ a total disagree about when that is. simwild-2D's swap already takes the shared 
 Adopting the localized form is a real behaviour change for simwild -- it changes which failed
 operations are re-tested and in what order -- so it wants its own commit and its own before/after,
 not a line in a refactor.
+
+---
+
+## Post-3c — simwild adopts the localized retry and the accumulated success count
+
+Closes the three differences Stage 3c recorded but deliberately left alone. Every driver now runs
+its pass the way its sibling does.
+
+| driver | was | now |
+|---|---|---|
+| 3D split, all five 3D swaps, 2D split | `executor(mesh, ops)` — **a single pass**, so an operation rejected early was dropped even when a later success next to it made it viable | `run_localized_to_convergence`, which re-runs until a pass yields nothing, re-queueing only failures adjacent to a vertex that moved that round |
+| 2D collapse | `do { all_ops.clear(); for (e : get_edges()) …; executor(…); } while (get_cnt_success() > 0)` — converged, but by re-enumerating every edge and re-running the full geometric pre-check on each one, every round | the same shared retry driver, off an op list built once |
+| the five 3D swaps' return value | `executor.get_cnt_success()`, the **last** round's count | the total accumulated across rounds |
+
+The return value is not bookkeeping: `local_operations` stops its swap loop when a pass reports
+zero, and a pass that has converged ends on a zero round by construction, so the old form made the
+loop stop after one round of swaps regardless of how much work remained.
+
+The 2D collapse needed a `renew_neighbor_tuples` — its rebuild-everything loop never had one, and
+the retry driver takes the modified region from exactly that callback. It is triwild's.
+
+**Not adopted here, still open:** simwild builds its op lists with a serial
+`for (const Tuple& e : get_edges())` where tetwild and triwild use `parallel_collect_edge_ops`. That
+changes the queue's insertion order, which breaks ties in the priority queue, so it is its own
+behaviour change and would have blurred this one's before/after.
+
+### Measured
+
+Four configs moved; every triwild and deterministic tetwild config is byte-identical, and the branch
+touches no file outside `components/simwild/`.
+
+| config | before | after |
+|---|---|---|
+| `simwild_curves_2d` | 572 tris, avg 2.385, max 8.294 | 384 tris, avg 2.499, max 8.494 |
+| `simwild_curves_two_inputs_2d` | 465 tris, avg 3.343, max 18.862 | 871 tris, avg **2.815**, max 18.844 |
+| `simwild_remeshing_2d` | 211 tris, avg 2.299, max 4.330 | 246 tris, avg 2.324, max **4.188** |
+| `simwild_double_sphere_notop_3d` | 21454 tets, avg 3.6171 | 21459 tets, avg 3.6170 |
+
+The direction is mixed, and the mechanism is visible in `simwild_curves_2d`'s log. The split pass
+now converges instead of running once, so the mesh refines far harder mid-run -- 1955 edges at
+iteration 5 where it used to reach 695 -- and the collapse pass then pulls it back further than
+before, to 378. The optimizer takes a different trajectory rather than a uniformly finer or coarser
+one. Collapse itself is unchanged in aggregate: the first call's rounds used to sum to ~316
+successes and the shared driver now reports 313.


### PR DESCRIPTION
## simwild: adopt the localized retry and the accumulated success count

Follow-up to the de-duplication stack (#1004–#1009), stacked on #1009. Closes the three differences
#1008 recorded in the ledger and deliberately left alone — folding the executor shell there kept
each driver's *execution form* intact so that PR could stay behaviour-neutral. This is that
behaviour change, on its own, with its own before/after.

| driver | was | now |
|---|---|---|
| 3D split, all five 3D swaps, 2D split | `executor(mesh, ops)` — **a single pass**. An operation rejected early was dropped even when a later success next to it made it viable. | `run_localized_to_convergence`: re-run until a pass yields nothing, re-queueing only failures adjacent to a vertex that moved that round |
| 2D collapse | `do { all_ops.clear(); for (e : get_edges()) …; executor(…); } while (get_cnt_success() > 0)` — converged, but by re-enumerating every edge and re-running the full geometric pre-check on each one, every round | the same shared driver, off an op list built once |
| the five 3D swaps' return value | `executor.get_cnt_success()`, the **last** round's count | the total accumulated across rounds |

The return value is not bookkeeping. `local_operations` stops its swap loop when a pass reports
zero, and a converged pass ends on a zero round by construction — so the old form cut the swap loop
short regardless of how much work remained.

The 2D collapse needed a `renew_neighbor_tuples`; its rebuild-everything loop never had one, and the
retry driver takes the modified region from exactly that callback. It is triwild's, verbatim.

### Measured

Four configs move. Every triwild and deterministic tetwild config is byte-identical, and the branch
touches **no file outside `components/simwild/`**.

| config | before | after |
|---|---|---|
| `simwild_curves_2d` | 572 tris, avg 2.385, max 8.294 | 384 tris, avg 2.499, max 8.494 |
| `simwild_curves_two_inputs_2d` | 465 tris, avg 3.343, max 18.862 | 871 tris, avg **2.815**, max 18.844 |
| `simwild_remeshing_2d` | 211 tris, avg 2.299, max 4.330 | 246 tris, avg 2.324, max **4.188** |
| `simwild_double_sphere_notop_3d` | 21454 tets, avg 3.6171 | 21459 tets, avg 3.6170 |

The direction is mixed, which is what a convergence change looks like — the optimizer takes a
different trajectory, not a uniformly finer or coarser one. The mechanism is visible in
`simwild_curves_2d`'s log: the split pass now converges instead of running once, so the mesh refines
far harder mid-run (1955 edges at iteration 5 where it used to reach 695) and the collapse pass then
pulls it back further than before, to 378. Collapse itself is unchanged in aggregate — the first
call's rounds used to sum to ~316 successes, and the shared driver now reports 313.

`tetwild_crown` and `tetwild_octocat` show as moved in the raw diff; they run at `num_threads: 10`
and are nondeterministic by construction. Re-run at `num_threads: 0` they are byte-identical, which
is the expected result given the branch cannot reach tetwild's code at all.

### Not adopted here

simwild still builds its op lists with a serial `for (const Tuple& e : get_edges())` where tetwild
and triwild use `parallel_collect_edge_ops`. That changes the queue's insertion order, which breaks
ties in the priority queue, so it is its own behaviour change and would have blurred this one's
before/after. It stays in `docs/simwild-adopted-behaviours.md`.
