### PR TITLE
simwild: collect op lists with parallel_collect_edge_ops

### DIFF
--- a/components/simwild/wmtk/components/simwild/EdgeSplitting.cpp
+++ b/components/simwild/wmtk/components/simwild/EdgeSplitting.cpp
@@ -4,6 +4,7 @@
 #include <wmtk/utils/ExecutorUtils.hpp>
 #include <wmtk/utils/LocalizedRetry.hpp>
 #include <wmtk/utils/Logger.hpp>
+#include <wmtk/utils/ParallelCollect.hpp>
 #include <wmtk/utils/RunPass.hpp>
 
 namespace wmtk::components::simwild {
@@ -15,10 +16,10 @@ void SimWildMesh::split_all_edges()
     m_force_split_count = 0;
     m_exact_split_count = 0;
     timer.start();
-    std::vector<std::pair<std::string, Tuple>> collect_all_ops;
-    for (const Tuple& loc : get_edges()) {
-        collect_all_ops.emplace_back("edge_split", loc);
-    }
+    auto collect_all_ops = wmtk::parallel_collect_edge_ops(
+        *this,
+        NUM_THREADS,
+        [](SimWildMesh&, const Tuple& e, auto& out) { out.emplace_back("edge_split", e); });
     time = timer.getElapsedTime();
     wmtk::logger().info("edge split prepare time: {:.4}s", time);
     wmtk::run_pass(

--- a/components/simwild/wmtk/components/simwild/SimWildMeshTri.cpp
+++ b/components/simwild/wmtk/components/simwild/SimWildMeshTri.cpp
@@ -867,10 +867,10 @@ void SimWildMeshTri::split_all_edges()
     double time;
     m_exact_split_count = 0;
     timer.start();
-    auto collect_all_ops = std::vector<std::pair<std::string, Tuple>>();
-    for (const Tuple& loc : get_edges()) {
-        collect_all_ops.emplace_back("edge_split", loc);
-    }
+    auto collect_all_ops = wmtk::parallel_collect_edge_ops(
+        *this,
+        NUM_THREADS,
+        [](SimWildMeshTri&, const Tuple& e, auto& out) { out.emplace_back("edge_split", e); });
     time = timer.getElapsedTime();
     wmtk::logger().info("edge split prepare time: {:.4}s", time);
     wmtk::run_pass(
@@ -1160,14 +1160,16 @@ void SimWildMeshTri::collapse_all_edges(bool is_limit_length)
 {
     m_collapse_limit_length = is_limit_length;
 
-    // Built once, up front. The retry driver re-queues what the mesh actually changed, so
-    // there is nothing left for the old rebuild-from-get_edges()-every-round loop to do.
-    // Filtering of too-long edges still happens in is_weight_up_to_date.
-    std::vector<std::pair<std::string, Tuple>> all_ops;
-    for (const Tuple& loc : get_edges()) {
-        all_ops.emplace_back("edge_collapse", loc);
-        all_ops.emplace_back("edge_collapse", loc.switch_vertex(*this));
-    }
+    // Built once, up front (both edge directions). The retry driver re-queues what the mesh
+    // actually changed, so there is nothing left for the old rebuild-from-get_edges()-every-round
+    // loop to do. Filtering of too-long edges still happens in is_weight_up_to_date.
+    auto all_ops = wmtk::parallel_collect_edge_ops(
+        *this,
+        NUM_THREADS,
+        [](SimWildMeshTri& m, const Tuple& e, auto& out) {
+            out.emplace_back("edge_collapse", e);
+            out.emplace_back("edge_collapse", e.switch_vertex(m));
+        });
     logger().info("#E = {}", all_ops.size() / 2);
 
     wmtk::run_pass(

--- a/docs/simwild-adopted-behaviours.md
+++ b/docs/simwild-adopted-behaviours.md
@@ -350,3 +350,22 @@ iteration 5 where it used to reach 695 -- and the collapse pass then pulls it ba
 before, to 378. The optimizer takes a different trajectory rather than a uniformly finer or coarser
 one. Collapse itself is unchanged in aggregate: the first call's rounds used to sum to ~316
 successes and the shared driver now reports 313.
+
+---
+
+## Post-3c — simwild adopts `parallel_collect_edge_ops`
+
+The last collection-side difference. simwild built three op lists with a serial
+`for (const Tuple& e : get_edges())` -- 3D split, 2D split, 2D collapse -- where tetwild and triwild
+use the shared parallel builder. Held back from the localized-retry change because it alters the
+queue's *insertion* order, which is what breaks ties between equal-priority operations, and mixing
+the two would have made neither before/after attributable.
+
+**Measured: nothing moved.** All 53 registered configs are byte-identical, simwild's four included
+-- the same four that moved for the retry adoption. The tie-breaking concern is real in principle
+and did not materialize on any config in the suite.
+
+That leaves simwild's op collection identical to its sibling's everywhere except `swap_all_faces`,
+which is still `parallel_collect_edge_ops` where tetwild uses `parallel_collect_face_ops` -- that
+one is a defect rather than a style difference (6 edge tuples per tet instead of 4 faces) and is
+recorded above with the rest of the swap family.


### PR DESCRIPTION
## simwild: collect op lists with `parallel_collect_edge_ops`

Stacked on #1012. The last collection-side difference from tetwild and triwild.

simwild built three op lists with a serial `for (const Tuple& e : get_edges())` — 3D split, 2D
split, 2D collapse — where its sibling uses the shared parallel builder. This makes all three match.

### Why it wasn't folded into #1012

`parallel_collect_edge_ops` walks cells and emits the canonical edge of each, so the resulting
vector is in a different order from `get_edges()`. The executor sorts by priority, but **equal
priorities keep insertion order**, so the collection form can change which of two equally-long edges
is processed first — and from there the whole trajectory. Landing it with the retry change would
have made neither before/after attributable.

### Measured

**Nothing moved.** All 53 registered configs are byte-identical, including the four simwild configs
that #1012 moves. `tetwild_crown` and `tetwild_octocat` appear in the raw diff and are identical
when re-run at `num_threads: 0`; the branch touches no file outside `components/simwild/`, so they
could not have been affected. ctest 107/107.

So the tie-breaking risk is real in principle and did not materialize anywhere in the suite. That is
worth having measured rather than assumed, which is the whole reason this is its own commit.

### What's left after this

simwild's op collection now matches its sibling's everywhere except `swap_all_faces`, which still
calls `parallel_collect_edge_ops` and queues `"face_swap"` on **edge** tuples — 6 per tet — where
tetwild calls `parallel_collect_face_ops`, 4 per tet. That one is a defect rather than a style
difference and belongs with the swap family, where it is recorded in
`docs/simwild-adopted-behaviours.md`.
