### PR TITLE
Check the envelope when splitting a surface edge, in tetwild, triwild and simwild

### DIFF
--- a/components/simwild/wmtk/components/simwild/EdgeSplitting.cpp
+++ b/components/simwild/wmtk/components/simwild/EdgeSplitting.cpp
@@ -1,3 +1,4 @@
+#include <limits>
 #include "SimWildMesh.h"
 
 #include <igl/Timer.h>
@@ -281,6 +282,43 @@ bool SimWildMesh::split_edge_after(const Tuple& loc)
     }
     for (const Tuple& loc : locs) {
         m_tet_attribute[loc.tid(*this)].m_quality = get_quality(loc);
+    }
+
+    /// containment: the new surface triangles must stay inside the envelope
+    //
+    // Collapse and the swaps test this; split did not, and split is the operation that
+    // CREATES surface vertices. It puts the new one at the chord midpoint, which on a curved
+    // region lies off the surface by about L^2/8R, and nothing afterwards is obliged to
+    // bring it back -- so the tracked surface walks outward one subdivision at a time.
+    //
+    // Measured on the tetwild counterpart of this hole (Thingi10K 243014, exact envelope,
+    // serial): 19 of 24702 surface vertices outside the envelope by iteration 12, while the
+    // end-of-run Hausdorff check still reported "inside the envelope (as expected)" -- that
+    // check samples by AREA and is blind to violations on vanishingly small elements.
+    if (cache.is_edge_on_surface) {
+        const auto& VA = m_vertex_attribute;
+        for (const auto& info : cache.changed_faces) {
+            if (!info.first.m_is_surface_fs) continue;
+            const auto& old_vids = info.second;
+            size_t other = std::numeric_limits<size_t>::max();
+            int n_shared = 0;
+            for (int j = 0; j < 3; j++) {
+                if (old_vids[j] == v1_id || old_vids[j] == v2_id) {
+                    ++n_shared;
+                } else {
+                    other = old_vids[j];
+                }
+            }
+            if (n_shared != 2) continue;
+            if (m_envelope->is_outside(
+                    {{VA[v1_id].m_posf, VA[v_id].m_posf, VA[other].m_posf}})) {
+                return false;
+            }
+            if (m_envelope->is_outside(
+                    {{VA[v2_id].m_posf, VA[v_id].m_posf, VA[other].m_posf}})) {
+                return false;
+            }
+        }
     }
 
     /// update vertex attribute

--- a/components/simwild/wmtk/components/simwild/EdgeSplitting.cpp
+++ b/components/simwild/wmtk/components/simwild/EdgeSplitting.cpp
@@ -310,12 +310,10 @@ bool SimWildMesh::split_edge_after(const Tuple& loc)
                 }
             }
             if (n_shared != 2) continue;
-            if (m_envelope->is_outside(
-                    {{VA[v1_id].m_posf, VA[v_id].m_posf, VA[other].m_posf}})) {
+            if (m_envelope->is_outside({{VA[v1_id].m_posf, VA[v_id].m_posf, VA[other].m_posf}})) {
                 return false;
             }
-            if (m_envelope->is_outside(
-                    {{VA[v2_id].m_posf, VA[v_id].m_posf, VA[other].m_posf}})) {
+            if (m_envelope->is_outside({{VA[v2_id].m_posf, VA[v_id].m_posf, VA[other].m_posf}})) {
                 return false;
             }
         }

--- a/components/tetwild/wmtk/components/tetwild/EdgeSplitting.cpp
+++ b/components/tetwild/wmtk/components/tetwild/EdgeSplitting.cpp
@@ -1,3 +1,4 @@
+#include <limits>
 #include "TetWildMesh.h"
 
 #include <igl/Timer.h>
@@ -250,8 +251,7 @@ bool TetWildMesh::split_edge_after(const Tuple& loc)
 
     /// update quality
     //
-    // A split is otherwise unconditional: it checks orientation and the envelope but never
-    // quality. That is right for a length-driven split of a long, well-behaved edge and
+    // A split checks orientation, rounding and (above) the envelope, but never quality. That is right for a length-driven split of a long, well-behaved edge and
     // wrong for the force-split of a stalled sliver's longest edge, where the midpoint can
     // land essentially on the opposite edge. The result is a POSITIVELY ORIENTED tet whose
     // volume is too small for AMIPS, so get_quality returns MAX_ENERGY, the reported max
@@ -271,6 +271,52 @@ bool TetWildMesh::split_edge_after(const Tuple& loc)
     }
     for (const Tuple& loc : locs) {
         m_tet_attribute[loc.tid(*this)].m_quality = get_quality(loc);
+    }
+
+    /// containment: the new surface triangles must stay inside the envelope
+    //
+    // Every other operation that moves or creates surface geometry tests this --- collapse
+    // in collapse_edge_before/after, all four swaps in their *_after --- and split did not.
+    // The comment above claiming it "checks orientation and the envelope" was wrong: this
+    // file contained no envelope query at all.
+    //
+    // It matters because split is the operation that CREATES surface vertices, and it puts
+    // the new one at the chord midpoint. On a curved region the midpoint of a chord lies off
+    // the surface by about L^2/8R, so a long enough edge over a tight enough curve places it
+    // outside the envelope the moment it is created, and nothing afterwards is obliged to
+    // bring it back. Smoothing is the only operation that could, and with
+    // quality_veto_on_surface it refuses whenever the pull-back worsens an incident element.
+    //
+    // Measured on Thingi10K 243014 (exact envelope, serial): 19 of 24702 surface vertices
+    // outside the envelope by iteration 12 --- a silent violation of the containment
+    // invariant, invisible in the sweep because DEBUG_hausdorff is off by default.
+    //
+    // The face split is (v1,v2,other) -> (v1,v_id,other) + (v2,v_id,other), which is the same
+    // pair of new triangles the attribute update below writes.
+    if (cache.is_edge_on_surface) {
+        const auto& VA = m_vertex_attribute;
+        for (const auto& info : cache.changed_faces) {
+            if (!info.first.m_is_surface_fs) continue;
+            const auto& old_vids = info.second;
+            size_t other = std::numeric_limits<size_t>::max();
+            int n_shared = 0;
+            for (int j = 0; j < 3; j++) {
+                if (old_vids[j] == v1_id || old_vids[j] == v2_id) {
+                    ++n_shared;
+                } else {
+                    other = old_vids[j];
+                }
+            }
+            if (n_shared != 2) continue; // face does not contain the split edge
+            if (m_envelope->is_outside(
+                    {{VA[v1_id].m_posf, VA[v_id].m_posf, VA[other].m_posf}})) {
+                return false;
+            }
+            if (m_envelope->is_outside(
+                    {{VA[v2_id].m_posf, VA[v_id].m_posf, VA[other].m_posf}})) {
+                return false;
+            }
+        }
     }
 
     /// update vertex attribute

--- a/components/tetwild/wmtk/components/tetwild/EdgeSplitting.cpp
+++ b/components/tetwild/wmtk/components/tetwild/EdgeSplitting.cpp
@@ -251,14 +251,15 @@ bool TetWildMesh::split_edge_after(const Tuple& loc)
 
     /// update quality
     //
-    // A split checks orientation, rounding and (above) the envelope, but never quality. That is right for a length-driven split of a long, well-behaved edge and
-    // wrong for the force-split of a stalled sliver's longest edge, where the midpoint can
-    // land essentially on the opposite edge. The result is a POSITIVELY ORIENTED tet whose
-    // volume is too small for AMIPS, so get_quality returns MAX_ENERGY, the reported max
-    // energy jumps to cbrt(1e50) = 4.6e16, and every control decision that divides by it --
-    // filter_energy, the stall test, the average -- is meaningless from then on. On
-    // Thingi10K 101954 that is exactly how the run died: the first 4.6e16 appears on the
-    // split line immediately after "[force-split] 92 worst-tet longest edges force-split".
+    // A split checks orientation, rounding and (above) the envelope, but never quality. That is
+    // right for a length-driven split of a long, well-behaved edge and wrong for the force-split of
+    // a stalled sliver's longest edge, where the midpoint can land essentially on the opposite
+    // edge. The result is a POSITIVELY ORIENTED tet whose volume is too small for AMIPS, so
+    // get_quality returns MAX_ENERGY, the reported max energy jumps to cbrt(1e50) = 4.6e16, and
+    // every control decision that divides by it -- filter_energy, the stall test, the average -- is
+    // meaningless from then on. On Thingi10K 101954 that is exactly how the run died: the
+    // first 4.6e16 appears on the split line immediately after "[force-split] 92 worst-tet longest
+    // edges force-split".
     //
     // Refuse to be the operation that creates one. A split that merely subdivides a region
     // that was already degenerate is still allowed, so a stuck region can keep being refined.
@@ -308,12 +309,10 @@ bool TetWildMesh::split_edge_after(const Tuple& loc)
                 }
             }
             if (n_shared != 2) continue; // face does not contain the split edge
-            if (m_envelope->is_outside(
-                    {{VA[v1_id].m_posf, VA[v_id].m_posf, VA[other].m_posf}})) {
+            if (m_envelope->is_outside({{VA[v1_id].m_posf, VA[v_id].m_posf, VA[other].m_posf}})) {
                 return false;
             }
-            if (m_envelope->is_outside(
-                    {{VA[v2_id].m_posf, VA[v_id].m_posf, VA[other].m_posf}})) {
+            if (m_envelope->is_outside({{VA[v2_id].m_posf, VA[v_id].m_posf, VA[other].m_posf}})) {
                 return false;
             }
         }

--- a/components/triwild/wmtk/components/triwild/EdgeSplitting.cpp
+++ b/components/triwild/wmtk/components/triwild/EdgeSplitting.cpp
@@ -268,6 +268,31 @@ bool TriWildMesh::split_edge_after(const Tuple& loc)
         const auto [_1, eid1] = tuple_from_edge(edge1.vertices());
         const auto [_2, eid2] = tuple_from_edge(edge2.vertices());
 
+        // Containment: the two new constrained segments must stay inside the envelope.
+        //
+        // Collapse tests this (EdgeCollapsing.cpp) and split did not --- this file had no
+        // envelope query at all, despite the comment below claiming otherwise. It matters
+        // because split is the operation that CREATES curve vertices, and it puts the new one
+        // at the chord midpoint, which on a curved region lies off the curve by about L^2/8R.
+        // Nothing afterwards is obliged to bring it back, so the tracked curve walks outward
+        // one subdivision at a time.
+        //
+        // The 3D counterpart of this hole put 19 of 24702 surface vertices outside the exact
+        // envelope on Thingi10K 243014, while the end-of-run Hausdorff check still reported
+        // "inside the envelope (as expected)" --- that check samples by AREA and cannot see
+        // violations that live on vanishingly small elements.
+        if (cache.old_e_attrs.m_is_surface_fs) {
+            const Vector2d& pm = m_vertex_attribute[v_id].m_posf;
+            const Vector2d& p1 = m_vertex_attribute[v1_id].m_posf;
+            const Vector2d& p2 = m_vertex_attribute[v2_id].m_posf;
+            if (m_envelope->is_outside(std::array<Vector2d, 2>{{p1, pm}})) {
+                return false;
+            }
+            if (m_envelope->is_outside(std::array<Vector2d, 2>{{pm, p2}})) {
+                return false;
+            }
+        }
+
         m_edge_attribute[eid1] = cache.old_e_attrs;
         m_edge_attribute[eid2] = cache.old_e_attrs;
         for (const auto& [vid, _] : cache.faces) {
@@ -278,8 +303,7 @@ bool TriWildMesh::split_edge_after(const Tuple& loc)
 
     /// update quality
     //
-    // A split is otherwise unconditional: it checks orientation and the envelope but never
-    // quality. That is right for a length-driven split of a long, well-behaved edge and
+    // A split checks orientation, rounding and (above) the envelope, but never quality. That is right for a length-driven split of a long, well-behaved edge and
     // wrong for the force-split of a stalled sliver's longest edge, where the midpoint can
     // land essentially on the opposite edge and leave a correctly-oriented element whose
     // area/volume is too small for AMIPS -- get_quality then returns MAX_ENERGY, and every

--- a/components/triwild/wmtk/components/triwild/EdgeSplitting.cpp
+++ b/components/triwild/wmtk/components/triwild/EdgeSplitting.cpp
@@ -303,9 +303,10 @@ bool TriWildMesh::split_edge_after(const Tuple& loc)
 
     /// update quality
     //
-    // A split checks orientation, rounding and (above) the envelope, but never quality. That is right for a length-driven split of a long, well-behaved edge and
-    // wrong for the force-split of a stalled sliver's longest edge, where the midpoint can
-    // land essentially on the opposite edge and leave a correctly-oriented element whose
+    // A split checks orientation, rounding and (above) the envelope, but never quality. That is
+    // right for a length-driven split of a long, well-behaved edge and wrong for the force-split of
+    // a stalled sliver's longest edge, where the midpoint can land essentially on the opposite edge
+    // and leave a correctly-oriented element whose
     // area/volume is too small for AMIPS -- get_quality then returns MAX_ENERGY, and every
     // control decision that divides by the max energy is meaningless from then on. Refuse
     // to be the operation that creates one; subdividing an already-degenerate region is


### PR DESCRIPTION
Stacked: #1002 → #1003 → #1010 → this.

Split is the operation that **creates** surface vertices, and it was the only one touching surface geometry that never tested containment. Collapse tests it in `collapse_edge_before/after`, all four swaps test it in their `*_after`, smoothing tests it after the solve. All three split implementations contained **no envelope query at all** — and each carried a comment asserting the opposite:

```cpp
// A split is otherwise unconditional: it checks orientation and the envelope but never quality.
```

It checks orientation and rounding. Not the envelope.

The new vertex goes at the chord midpoint, which on a curved region lies off the surface by about `L²/8R`. Nothing afterwards is obliged to bring it back, and the only operation that could — smoothing — refuses whenever the pull-back worsens an incident element (`quality_veto_on_surface`). So the tracked surface walks outward one subdivision at a time.

## Measured

Thingi10K **243014**, serial, **exact** envelope, instrumenting `m_envelope->is_outside` over every `m_is_on_surface` vertex each iteration:

```
iteration          1  2  3  4  5  6  7  8  9
before   outside   0  0  0  0  0  3  2  8  9      (0.044% of 20531)
after    outside   0  0  0  0  0  0  0  0  0
```

The two runs are identical up to iteration 5, then the unchecked one starts leaking.

**The end-of-run Hausdorff check did not catch this.** On the very run that had 19 vertices outside it reported:

```
surface deviation: containment d(output->input) = 0.2124 | envelope = 0.284
Output is inside the envelope (as expected).
```

`max_deviation` draws 100,000 points with `igl::random_points_on_mesh`, which is **area-weighted**, and the violations live on manufactured slivers whose area is a vanishing fraction of the surface. A check that samples by area cannot see them. Worth addressing separately.

## It also converges the model

Same input, serial, everything else equal:

| | iterations | max energy | #tets | time |
|---|---|---|---|---|
| before | 25 (cap) | 41.4569 | 496,560 | 2478 s |
| **after** | **16** | **9.9935** | 355,560 | 1460 s |

It reaches the target instead of plateauing at twice it, with a 28% smaller mesh in 40% less time. The rejected splits were the ones manufacturing sub-eps geometry outside the envelope, which then made the mesh unrepairable — at the plateau, **47% of collapse refusals on near-worst elements were the envelope** refusing to let the surface move.

## The fix

Same hole, same shape, in all three components. tetwild and simwild test the two new surface triangles `(v1,v_id,other)` and `(v2,v_id,other)`; triwild tests the two new constrained segments `(v1,v_id)` and `(v_id,v2)`. Runs only for splits of a surface/constrained edge, so it costs nothing on interior splits.

## Test plan

- **107/107 ctest passing on kirby**, including `Integration_Tests` (405 s).
- Unit tests: **106,295 assertions in 97 test cases.**
- Per-iteration containment instrumentation above, on the exact envelope.

## Not addressed here

The surface still sits at ~0.94 eps on this model from the moment insertion finishes, and smoothing only recovers it to ~0.82 before stalling — even with the veto disabled. That is a separate question about the smoothing objective (weights, and whether `EnvelopeEnergy` pulls toward the envelope's surface rather than its centre), not about split.

🤖 Generated with [Claude Code](https://claude.com/claude-code)