### PR TITLE
simwild: adopt tetwild's swap family, with tag propagation

### DIFF
--- a/components/simwild/wmtk/components/simwild/EdgeSwapping.cpp
+++ b/components/simwild/wmtk/components/simwild/EdgeSwapping.cpp
@@ -11,6 +11,7 @@
 #include "wmtk/utils/TupleUtils.hpp"
 
 #include <cassert>
+#include <limits>
 
 namespace wmtk::components::simwild {
 
@@ -78,22 +79,86 @@ void tracker_assign_after(
 }
 
 
+bool SimWildMesh::cache_interior_swap_tag(const std::vector<size_t>& tids)
+{
+    auto& cache = swap_cache.local();
+    assert(!tids.empty());
+    cache.tet_tags = m_tet_attribute[tids.front()].tags;
+    for (const size_t tid : tids) {
+        if (m_tet_attribute[tid].tags != cache.tet_tags) {
+            // Unreachable on a well-formed mesh: init_surfaces_and_boundaries marks a face as
+            // surface exactly when its two tets are tagged differently, and every operation
+            // maintains that, so a swap with no incident surface face sees one tag. Getting
+            // here means the invariant is already broken somewhere -- refuse rather than pick a
+            // tag and move tagged volume with no envelope check to gate it.
+            return false;
+        }
+    }
+    return true;
+}
+
+bool SimWildMesh::propagate_swap_tags(const std::vector<size_t>& tids)
+{
+    const auto& cache = swap_cache.local();
+
+    if (!cache.is_surface_flip) {
+        for (const size_t tid : tids) {
+            m_tet_attribute[tid].tags = cache.tet_tags;
+        }
+        return true;
+    }
+
+    // Surface flip: the two surface faces (a,b,c),(a,b,d) cut the ring of incident tets into
+    // two arcs, one tag each, and the flip re-cuts the same region with (a,c,d),(b,c,d). Every
+    // tet it creates contains at least one ring vertex other than c,d, and that vertex says
+    // which arc -- hence which tag -- the tet belongs to.
+    for (const size_t tid : tids) {
+        const CellTag* tag = nullptr;
+        for (const size_t v : oriented_tet_vids(tid)) {
+            const auto it = cache.ring_tags.find(v);
+            if (it == cache.ring_tags.end()) {
+                continue;
+            }
+            if (tag != nullptr && *tag != it->second) {
+                return false; // straddles both arcs: no single tag is right for it
+            }
+            tag = &it->second;
+        }
+        if (tag == nullptr) {
+            return false; // touches neither arc: cannot tell which side it ended up on
+        }
+        m_tet_attribute[tid].tags = *tag;
+    }
+    return true;
+}
+
+bool SimWildMesh::propagate_swap_tags(const std::vector<Tuple>& tets)
+{
+    std::vector<size_t> tids;
+    tids.reserve(tets.size());
+    for (const Tuple& t : tets) {
+        tids.emplace_back(t.tid(*this));
+    }
+    return propagate_swap_tags(tids);
+}
+
+
 size_t SimWildMesh::swap_all_edges_32()
 {
     igl::Timer timer;
     double time;
     timer.start();
-    auto collect_all_ops =
-        wmtk::parallel_collect_edge_ops(*this, NUM_THREADS, [](auto&, const auto& e, auto& out) {
-            out.emplace_back("edge_swap", e);
-        });
+    auto collect_all_ops = wmtk::parallel_collect_edge_ops(
+        *this,
+        NUM_THREADS,
+        [](SimWildMesh&, const Tuple& e, auto& out) { out.emplace_back("edge_swap", e); });
     time = timer.getElapsedTime();
     logger().info("edge swap prepare time: {:.4}s", time);
+    size_t total_success = 0;
     SurfaceTopoSignature sig_before;
     if (m_sim_params.check_surface_topology) {
         sig_before = surface_topology_signature();
     }
-    size_t total_success = 0;
     wmtk::run_pass(
         *this,
         wmtk::PassLock::EdgeTwoRing,
@@ -101,9 +166,6 @@ size_t SimWildMesh::swap_all_edges_32()
         [&](auto& executor, auto& mesh) {
             executor.renew_neighbor_tuples = wmtk::renewal_edges;
             executor.priority = [&](auto& m, auto op, auto& t) { return m.get_length2(t); };
-            // Retry a failed swap only where the mesh actually changed this round
-            // (dirty-epoch localized retry), and report the total across rounds rather
-            // than the last round's count -- as tetwild does.
             total_success = wmtk::run_localized_to_convergence(mesh, executor, collect_all_ops);
         });
     if (m_sim_params.check_surface_topology) {
@@ -130,146 +192,137 @@ bool SimWildMesh::swap_edge_before(const Tuple& t)
     if (is_edge_on_bbox(t)) {
         return false;
     }
-
-    const auto& TA = m_tet_attribute;
-    // cache.tet_tags = TA[incident_tets[0]].tags;
-
-    // find tag with max count
-    {
-        std::map<CellTag, size_t> tag_count;
-        for (const size_t l : incident_tets) {
-            tag_count[TA[l].tags]++;
-        }
-        if (tag_count.size() > 2) {
-            return false; // cannot swap an edge in between 3 different tags
-        }
-        size_t max_count = 0;
-        CellTag max_tag;
-        for (const auto& [tag, count] : tag_count) {
-            if (count > max_count) {
-                max_count = count;
-                max_tag = tag;
-            }
-        }
-        cache.tet_tags = max_tag;
-    }
-
-    // Surface edges are allowed only as a topology-preserving surface diagonal
-    // flip (see prepare_surface_flip_32). If disabled, keep the old behavior of
-    // rejecting all surface-edge swaps.
-    // Route on the direct incident-surface-face count so a genuine surface edge is never
-    // mistaken for interior because of a stale m_is_on_surface flag, which would tear the
-    // surface. tetwild routes all three swap paths this way.
-    if (edge_incident_surface_face_count(t) > 0) {
-        if (!m_sim_params.allow_surface_swap) {
-            return false;
-        }
-        if (!prepare_surface_flip_32(t, incident_tets)) {
-            return false;
-        }
+    // Surface edges are allowed only as a topology-preserving surface diagonal flip (see
+    // prepare_surface_flip). If disabled, keep the old behavior of rejecting all surface-edge
+    // swaps. Route on the direct incident-surface-face count so a genuine surface edge is never
+    // mistaken for interior because of stale m_is_on_surface flags (which would tear the surface).
+    const int n_surf_faces = edge_incident_surface_face_count(t);
+    if (n_surf_faces > 0) {
+        if (!m_sim_params.allow_surface_swap) return false;
+        if (!prepare_surface_flip(t, incident_tets)) return false;
+    } else if (!cache_interior_swap_tag(incident_tets)) {
+        return false;
     }
 
     double max_energy = -1.0;
     for (const size_t l : incident_tets) {
-        max_energy = std::max(TA[l].m_quality, max_energy);
+        max_energy = std::max(m_tet_attribute[l].m_quality, max_energy);
     }
     cache.max_energy = max_energy;
 
-    face_attribute_tracker(
-        *this,
-        incident_tets,
-        m_face_attribute,
-        swap_cache.local().changed_faces);
+    face_attribute_tracker(*this, incident_tets, m_face_attribute, cache.changed_faces);
 
     return true;
 }
 
-bool SimWildMesh::prepare_surface_flip_32(const Tuple& t, const std::vector<size_t>& incident_tets)
+bool SimWildMesh::prepare_surface_flip(const Tuple& t, const std::vector<size_t>& incident_tets)
 {
     auto& cache = swap_cache.local();
+    cache.is_surface_flip = false;
 
     const size_t a = t.vid(*this);
     const size_t b = t.switch_vertex(*this).vid(*this);
 
-    // The three "ring" vertices are the incident-tet vertices other than a,b.
-    std::array<size_t, 3> ring{};
-    int nr = 0;
+    // Flipping an open-boundary edge would change the surface's boundary loops.
+    if (is_open_boundary_edge(t)) {
+        return false;
+    }
+
+    // The "ring" vertices are the incident-tet vertices other than a,b (deduplicated). This works
+    // for any ring size (3->2, 4-4, 5-6); the specific retetrahedralization that realizes the flip
+    // is selected later by swap_edge_44_accept_case / swap_edge_56_accept_case.
+    std::vector<size_t> ring;
+    ring.reserve(incident_tets.size() + 1);
     for (const size_t tid : incident_tets) {
-        const auto vs = oriented_tet_vids(tid);
-        for (const size_t v : vs) {
-            if (v == a || v == b) {
-                continue;
-            }
-            bool seen = false;
-            for (int k = 0; k < nr; ++k) {
-                if (ring[k] == v) {
-                    seen = true;
-                    break;
+        for (const size_t v : oriented_tet_vids(tid)) {
+            if (v == a || v == b) continue;
+            if (std::find(ring.begin(), ring.end(), v) == ring.end()) ring.push_back(v);
+        }
+    }
+
+    // Exactly two of the ring faces (a,b,r) must be surface faces (manifold surface edge). Their
+    // apexes are the endpoints (c,d) of the new surface edge.
+    int n_surf = 0;
+    size_t c = 0, d = 0;
+    for (const size_t r : ring) {
+        auto [ftup, fid] = tuple_from_face(std::array<size_t, 3>{{a, b, r}});
+        (void)ftup;
+        if (fid == static_cast<size_t>(-1)) continue;
+        if (!m_face_attribute[fid].m_is_surface_fs) continue;
+        if (n_surf == 0) {
+            c = r;
+            cache.sf_face_attr = m_face_attribute[fid];
+        } else if (n_surf == 1) {
+            d = r;
+        } else {
+            return false; // > 2 surface faces: non-manifold edge
+        }
+        ++n_surf;
+    }
+    if (n_surf != 2) return false;
+
+    // The flip adds two surface faces (a,c,d),(b,c,d) on edge (c,d). If any surface face is
+    // already incident to edge (c,d), the result is a non-manifold surface edge (> 2 surface
+    // faces) -> reject. This counts the incident surface faces directly and does NOT rely on the
+    // m_is_on_surface vertex flags (which can be stale), unlike is_edge_on_surface().
+    //
+    // (c,d) need not exist yet: for a 3->2 flip the two apexes are adjacent, but for 4-4 / 5-6
+    // they are not, so the edge is created by the flip. Hence the validity check rather than an
+    // assert -- asserting here is a 3->2-only invariant and aborts a Debug build on 4-4.
+    {
+        const Tuple cd = tuple_from_edge(std::array<size_t, 2>{{c, d}});
+        if (cd.is_valid(*this)) {
+            const auto cd_tets = get_incident_tets_for_edge(cd);
+            for (const auto& ct : cd_tets) {
+                const auto vs = oriented_tet_vids(ct.tid(*this));
+                for (const size_t w : vs) {
+                    if (w == c || w == d) continue;
+                    auto [wf, wfid] = tuple_from_face(std::array<size_t, 3>{{c, d, w}});
+                    (void)wf;
+                    if (wfid != static_cast<size_t>(-1) && m_face_attribute[wfid].m_is_surface_fs)
+                        return false;
                 }
             }
-            if (seen) {
-                continue;
-            }
-            if (nr > 2) {
-                log_and_throw_error("prepare_surface_flip_32: more than 3 ring vertices");
-                // return false; // not a clean 3->2 ring
-            }
-            ring[nr++] = v;
         }
     }
-    if (nr != 3) {
-        log_and_throw_error("prepare_surface_flip_32: not exactly 3 ring vertices");
-        // return false;
-    }
 
-    // Of the three ring faces (a,b,ring[k]), exactly two must be surface faces
-    // (manifold surface edge). Their apexes are the new surface edge (c,d); the
-    // remaining apex is the other one (e).
-    int n_surf = 0;
-    size_t c = 0, d = 0, e = 0; // vertex ids; c/d on surface, e not
-    bool e_set = false;
-    for (int k = 0; k < 3; ++k) {
-        const auto [_, fid] = tuple_from_face(std::array<size_t, 3>{{a, b, ring[k]}});
-        (void)_; // tell compiler this variable is not needed
-        if (m_face_attribute[fid].m_is_surface_fs) {
-            if (n_surf == 0) {
-                c = ring[k];
-                cache.sf_face_attr = m_face_attribute[fid];
-            } else if (n_surf == 1) {
-                d = ring[k];
-            } else {
-                return false; // > 2 surface faces: non-manifold edge
-            }
-            ++n_surf;
-        } else {
-            if (e_set) {
-                return false; // > 1 non-surface face
-            }
-            e = ring[k];
-            e_set = true;
-        }
-    }
-    if (n_surf != 2 || !e_set) {
-        /**
-         * This statement should never be reached because the previous loop already checks for the
-         * number of surface faces and non-surface faces. If this statement is reached, it indicates
-         * a logical error in the code or an unexpected input configuration.
-         */
-        log_and_throw_error("prepare_surface_flip_32: invalid surface face configuration");
-    }
-
-    // The flip adds two surface faces (a,c,d),(b,c,d) on edge (c,d). If any
-    // surface face is already incident to edge (c,d), the result is a
-    // non-manifold surface edge (> 2 surface faces) -> reject. This counts the
-    // incident surface faces directly and does NOT rely on the m_is_on_surface
-    // vertex flags (which can be stale), unlike is_edge_on_surface().
+    // The two would-be new surface faces (a,c,d),(b,c,d) must not already be tagged surface,
+    // otherwise the flip corrupts manifoldness / boundaries.
     {
-        std::array<size_t, 2> cd{{c, d}};
-        assert(tuple_from_edge(cd).is_valid(*this));
-        const auto sf_edge = get_surface_faces_for_edge(cd);
-        if (sf_edge.size() > 0) {
-            // (c,d) already has a surface face incident
-            return false;
+        // These are the faces the flip is about to create, so on the normal path they do not
+        // exist yet. tuple_from_face treats that as a programming error -- it asserts, and only
+        // returns the -1 sentinel once asserts are compiled out -- so ask whether the three
+        // vertices share a tet before querying, rather than letting a Debug build abort on
+        // every 4-4 flip.
+        const auto face_is_surface = [&](size_t x, size_t y, size_t z) {
+            if (lowest_common_tet(x, y, z) == std::numeric_limits<size_t>::max()) {
+                return false; // no such face yet, so it cannot already be tagged surface
+            }
+            const auto [ftup, fid] = tuple_from_face(std::array<size_t, 3>{{x, y, z}});
+            (void)ftup;
+            return fid != static_cast<size_t>(-1) && m_face_attribute[fid].m_is_surface_fs;
+        };
+        if (face_is_surface(a, c, d)) return false;
+        if (face_is_surface(b, c, d)) return false;
+    }
+
+    // simwild only. The surface IS the tag interface here -- a face is tagged surface exactly
+    // when its two tets carry different tags -- so the two surface faces (a,b,c),(a,b,d) cut the
+    // ring of incident tets into two arcs, one tag each, and this flip moves the tet (a,b,c,d)
+    // worth of volume from one tag to the other. Record what each side carries, keyed by the
+    // ring vertices strictly inside it, so propagate_swap_tags can tag the new tets by which
+    // side they landed on. c and d are excluded on purpose: they sit on the interface and are
+    // shared by both sides. The two tets meeting at a non-surface face (a,b,r) must agree by
+    // the same invariant; if they do not, refuse rather than pick one.
+    cache.ring_tags.clear();
+    for (const size_t tid : incident_tets) {
+        const CellTag& tags = m_tet_attribute[tid].tags;
+        for (const size_t v : oriented_tet_vids(tid)) {
+            if (v == a || v == b || v == c || v == d) continue;
+            const auto [it, inserted] = cache.ring_tags.try_emplace(v, tags);
+            if (!inserted && it->second != tags) {
+                return false;
+            }
         }
     }
 
@@ -278,8 +331,35 @@ bool SimWildMesh::prepare_surface_flip_32(const Tuple& t, const std::vector<size
     cache.sf_b = b;
     cache.sf_c = c;
     cache.sf_d = d;
-    cache.sf_e = e;
     return true;
+}
+
+bool SimWildMesh::swap_edge_44_accept_case(const std::array<size_t, 2>& new_edge)
+{
+    const auto& cache = swap_cache.local();
+    if (!cache.is_surface_flip) return true; // interior edge: keep pure min-energy behavior
+    // Surface flip: accept only the diagonal that creates the new surface edge (c,d).
+    return (new_edge[0] == cache.sf_c && new_edge[1] == cache.sf_d) ||
+           (new_edge[0] == cache.sf_d && new_edge[1] == cache.sf_c);
+}
+
+bool SimWildMesh::swap_edge_56_accept_case(const std::array<size_t, 3>& new_face)
+{
+    const auto& cache = swap_cache.local();
+    if (!cache.is_surface_flip) return true; // interior edge: keep pure min-energy behavior
+    // Surface flip: the fan apex (new_face[0]) must be one surface apex and the other surface apex
+    // must be one of the two fan tips, so the created diagonal is exactly (c,d). Keying on the apex
+    // (not "the face contains edge (c,d)") rejects the spurious case where (c,d) is a pre-existing
+    // link edge of the fan face rather than a newly created diagonal.
+    const size_t apex = new_face[0];
+    size_t other;
+    if (apex == cache.sf_c)
+        other = cache.sf_d;
+    else if (apex == cache.sf_d)
+        other = cache.sf_c;
+    else
+        return false;
+    return new_face[1] == other || new_face[2] == other;
 }
 
 bool SimWildMesh::swap_edge_after(const Tuple& t)
@@ -288,25 +368,27 @@ bool SimWildMesh::swap_edge_after(const Tuple& t)
         return false;
     }
 
+    const auto& cache = swap_cache.local();
+
     // after swap, t points to a face with 2 neighboring tets.
     auto oppo_tet = t.switch_tetrahedron(*this);
     assert(oppo_tet.has_value() && "Should not swap boundary.");
 
-    const auto& cache = swap_cache.local();
-
-    auto twotets = std::vector<Tuple>{{t, *oppo_tet}};
-    auto max_energy = -1.0;
-    for (auto& l : twotets) {
+    std::vector<Tuple> twotets{{t, *oppo_tet}};
+    double max_energy = -1.0;
+    for (const Tuple& l : twotets) {
         if (is_inverted(l)) {
             return false;
         }
         const double q = get_quality(l);
         m_tet_attribute[l.tid(*this)].m_quality = q;
         max_energy = std::max(q, max_energy);
-
-        m_tet_attribute[l.tid(*this)].tags = cache.tet_tags;
     }
     if (max_energy >= cache.max_energy) {
+        return false;
+    }
+
+    if (!propagate_swap_tags(twotets)) {
         return false;
     }
 
@@ -344,12 +426,14 @@ bool SimWildMesh::swap_edge_after(const Tuple& t)
         // m_face_attribute[fid1].m_is_surface_fs = true;
         // m_face_attribute[fid2].m_is_surface_fs = true;
         cnt_surface_swap++;
+        cnt_surface_swap_32++;
     }
 
     cnt_swap++;
 
     return true;
 }
+
 
 size_t SimWildMesh::swap_all_faces()
 {
@@ -373,9 +457,6 @@ size_t SimWildMesh::swap_all_faces()
         [&](auto& executor, auto& mesh) {
             executor.renew_neighbor_tuples = wmtk::renewal_faces;
             executor.priority = [](auto& m, auto op, auto& t) { return m.get_length2(t); };
-            // Retry a failed swap only where the mesh actually changed this round
-            // (dirty-epoch localized retry), and report the total across rounds rather
-            // than the last round's count -- as tetwild does.
             total_success = wmtk::run_localized_to_convergence(mesh, executor, collect_all_ops);
         });
     return total_success;
@@ -389,6 +470,10 @@ bool SimWildMesh::swap_face_before(const Tuple& t)
     // if (m_params.preserve_global_topology) return false;
 
     auto& cache = swap_cache.local();
+    // A face swap never flips the surface -- the surface faces are rejected right below. The
+    // cache is thread-local and outlives the operation, so clear the flag an earlier edge swap
+    // on this thread may have left set, which propagate_swap_tags reads.
+    cache.is_surface_flip = false;
 
     const SmartTuple tt(*this, t);
 
@@ -402,9 +487,8 @@ bool SimWildMesh::swap_face_before(const Tuple& t)
     const size_t t0 = tt.tid();
     const size_t t1 = oppo_tet.value().tid();
 
-    const auto& TA = m_tet_attribute;
-
-    const double max_energy = std::max(TA[t0].m_quality, TA[t1].m_quality);
+    const double max_energy =
+        std::max(m_tet_attribute[t0].m_quality, m_tet_attribute[t1].m_quality);
 
     // pre-compute energy
     {
@@ -430,12 +514,12 @@ bool SimWildMesh::swap_face_before(const Tuple& t)
         }
     }
 
-    cache.tet_tags = TA[tt.tid()].tags;
-    // if (TA[oppo_tet.value().tid()].tags != cache.tet_tags) {
-    //    log_and_throw_error("not all tets have the same tag"); // for debugging
-    //}
-
     std::vector<size_t> twotets{t0, t1};
+
+    // The swapped face is not a surface face, so the two tets it separates carry the same tag.
+    if (!cache_interior_swap_tag(twotets)) {
+        return false;
+    }
 
     face_attribute_tracker(*this, twotets, m_face_attribute, cache.changed_faces);
     return true;
@@ -450,7 +534,10 @@ bool SimWildMesh::swap_face_after(const Tuple& t)
     for (auto& l : incident_tets) {
         auto q = get_quality(l);
         m_tet_attribute[l.tid(*this)].m_quality = q;
-        m_tet_attribute[l.tid(*this)].tags = swap_cache.local().tet_tags;
+    }
+
+    if (!propagate_swap_tags(incident_tets)) {
+        return false;
     }
 
     tracker_assign_after(*this, incident_tets, swap_cache.local().changed_faces, m_face_attribute);
@@ -472,11 +559,11 @@ size_t SimWildMesh::swap_all_edges_all()
         });
     time = timer.getElapsedTime();
     logger().info("edge swap prepare time: {:.4}s", time);
+    size_t total_success = 0;
     SurfaceTopoSignature sig_before;
     if (m_sim_params.check_surface_topology) {
         sig_before = surface_topology_signature();
     }
-    size_t total_success = 0;
     wmtk::run_pass(
         *this,
         wmtk::PassLock::EdgeTwoRing,
@@ -502,13 +589,10 @@ size_t SimWildMesh::swap_all_edges_all()
                     return op_tups;
                 };
             executor.priority = [&](auto& m, auto op, auto& t) { return m.get_length2(t); };
-            // Retry a failed swap only where the mesh actually changed this round
-            // (dirty-epoch localized retry), and report the total across rounds rather
-            // than the last round's count -- as tetwild does.
             total_success = wmtk::run_localized_to_convergence(mesh, executor, collect_all_ops);
         });
     if (m_sim_params.check_surface_topology) {
-        warn_if_surface_topology_changed(sig_before, "swap_all_edges_32");
+        warn_if_surface_topology_changed(sig_before, "swap_all_edges_all");
     }
     return total_success;
 }
@@ -526,6 +610,8 @@ size_t SimWildMesh::swap_all_edges_44()
     time = timer.getElapsedTime();
     logger().info("edge swap 44 prepare time: {:.4}s", time);
     size_t total_success = 0;
+    SurfaceTopoSignature sig_before;
+    if (m_sim_params.check_surface_topology) sig_before = surface_topology_signature();
     wmtk::run_pass(
         *this,
         wmtk::PassLock::EdgeTwoRing,
@@ -533,11 +619,10 @@ size_t SimWildMesh::swap_all_edges_44()
         [&](auto& executor, auto& mesh) {
             executor.renew_neighbor_tuples = wmtk::renewal_edges;
             executor.priority = [&](auto& m, auto op, auto& t) { return m.get_length2(t); };
-            // Retry a failed swap only where the mesh actually changed this round
-            // (dirty-epoch localized retry), and report the total across rounds rather
-            // than the last round's count -- as tetwild does.
             total_success = wmtk::run_localized_to_convergence(mesh, executor, collect_all_ops);
         });
+    if (m_sim_params.check_surface_topology)
+        warn_if_surface_topology_changed(sig_before, "swap_all_edges_44");
     return total_success;
 }
 
@@ -546,30 +631,34 @@ bool SimWildMesh::swap_edge_44_before(const Tuple& t)
     if (!TetMesh::swap_edge_44_before(t)) {
         return false;
     }
-    // if (m_params.preserve_global_topology) return false;
+
+    auto& cache = swap_cache.local();
+    cache.is_surface_flip = false;
 
     auto incident_tets = get_incident_tids_for_edge(t);
     if (incident_tets.size() != 4) {
         return false;
     }
 
-    if (edge_incident_surface_face_count(t) > 0 || is_edge_on_bbox(t)) {
+    // bbox edges are never swapped.
+    if (is_edge_on_bbox(t)) {
+        return false;
+    }
+    // Surface edges are allowed only as a topology-preserving surface diagonal flip. The base 4-4
+    // swap is steered to the case that creates the new surface edge (c,d) by
+    // swap_edge_44_accept_case; if no 4-4 diagonal yields (c,d) the swap is rejected. Route on the
+    // direct incident-surface-face count so a genuine surface edge is never mistaken for interior.
+    const int n_surf_faces = edge_incident_surface_face_count(t);
+    if (n_surf_faces > 0) {
+        if (!m_sim_params.allow_surface_swap) return false;
+        if (!prepare_surface_flip(t, incident_tets)) return false;
+    } else if (!cache_interior_swap_tag(incident_tets)) {
         return false;
     }
 
-    auto& cache = swap_cache.local();
-    const auto& TA = m_tet_attribute;
-
-    cache.tet_tags = TA[incident_tets[0]].tags;
-    double max_energy = -1.0;
-    for (const size_t l : incident_tets) {
-        max_energy = std::max(TA[l].m_quality, max_energy);
-        // if (TA[l].tags != cache.tet_tags) {
-        //     log_and_throw_error(
-        //         "not all tets have the same tags. {} != {}",
-        //         cache.tet_tags,
-        //        TA[l].tags); // for debugging
-        //}
+    auto max_energy = -1.0;
+    for (auto& l : incident_tets) {
+        max_energy = std::max(m_tet_attribute[l].m_quality, max_energy);
     }
     cache.max_energy = max_energy;
 
@@ -582,23 +671,55 @@ bool SimWildMesh::swap_edge_44_after(const Tuple& t)
 {
     if (!TetMesh::swap_edge_44_after(t)) return false;
 
-    const auto incident_tets = get_incident_tets_for_edge(t);
+    auto incident_tets = get_incident_tets_for_edge(t);
 
-    double max_energy = -1.0;
+    auto& cache = swap_cache.local();
+    auto max_energy = -1.0;
     for (auto& l : incident_tets) {
         if (is_inverted(l)) return false;
         auto q = get_quality(l);
         m_tet_attribute[l.tid(*this)].m_quality = q;
         max_energy = std::max(q, max_energy);
-
-        m_tet_attribute[l.tid(*this)].tags = swap_cache.local().tet_tags;
     }
 
-    if (max_energy >= swap_cache.local().max_energy) {
+    if (max_energy >= cache.max_energy) {
         return false;
     }
 
-    tracker_assign_after(*this, incident_tets, swap_cache.local().changed_faces, m_face_attribute);
+    if (!propagate_swap_tags(incident_tets)) {
+        return false;
+    }
+
+    if (cache.is_surface_flip) {
+        // The two new surface faces (a,c,d),(b,c,d) must stay within the Hausdorff envelope,
+        // exactly like a surface-edge collapse / the 3->2 surface flip.
+        const auto& VA = m_vertex_attribute;
+        if (m_envelope->is_outside(
+                {{VA[cache.sf_a].m_posf, VA[cache.sf_c].m_posf, VA[cache.sf_d].m_posf}}))
+            return false;
+        if (m_envelope->is_outside(
+                {{VA[cache.sf_b].m_posf, VA[cache.sf_c].m_posf, VA[cache.sf_d].m_posf}}))
+            return false;
+    }
+
+    tracker_assign_after(*this, incident_tets, cache.changed_faces, m_face_attribute);
+
+    if (cache.is_surface_flip) {
+        // Re-tag the two new surface faces (the generic tracker reset them to interior). Net
+        // surface change: -(a,b,c) -(a,b,d) +(a,c,d) +(b,c,d).
+        auto [ft1, fid1] =
+            tuple_from_face(std::array<size_t, 3>{{cache.sf_a, cache.sf_c, cache.sf_d}});
+        auto [ft2, fid2] =
+            tuple_from_face(std::array<size_t, 3>{{cache.sf_b, cache.sf_c, cache.sf_d}});
+        (void)ft1;
+        (void)ft2;
+        m_face_attribute[fid1] = cache.sf_face_attr;
+        m_face_attribute[fid2] = cache.sf_face_attr;
+        m_face_attribute[fid1].m_is_surface_fs = true;
+        m_face_attribute[fid2].m_is_surface_fs = true;
+        cnt_surface_swap++;
+        cnt_surface_swap_44++;
+    }
 
     cnt_swap++;
     return true;
@@ -616,6 +737,8 @@ size_t SimWildMesh::swap_all_edges_56()
     time = timer.getElapsedTime();
     logger().info("edge swap 56 prepare time: {:.4}s", time);
     size_t total_success = 0;
+    SurfaceTopoSignature sig_before;
+    if (m_sim_params.check_surface_topology) sig_before = surface_topology_signature();
     wmtk::run_pass(
         *this,
         wmtk::PassLock::EdgeTwoRing,
@@ -623,11 +746,10 @@ size_t SimWildMesh::swap_all_edges_56()
         [&](auto& executor, auto& mesh) {
             executor.renew_neighbor_tuples = wmtk::renewal_edges;
             executor.priority = [&](auto& m, auto op, auto& t) { return m.get_length2(t); };
-            // Retry a failed swap only where the mesh actually changed this round
-            // (dirty-epoch localized retry), and report the total across rounds rather
-            // than the last round's count -- as tetwild does.
             total_success = wmtk::run_localized_to_convergence(mesh, executor, collect_all_ops);
         });
+    if (m_sim_params.check_surface_topology)
+        warn_if_surface_topology_changed(sig_before, "swap_all_edges_56");
     return total_success;
 }
 
@@ -637,36 +759,36 @@ bool SimWildMesh::swap_edge_56_before(const Tuple& t)
         return false;
     }
 
+    auto& cache = swap_cache.local();
+    cache.is_surface_flip = false;
+
     const auto incident_tets = get_incident_tids_for_edge(t);
     if (incident_tets.size() != 5) {
         return false;
     }
-    if (edge_incident_surface_face_count(t) > 0 || is_edge_on_bbox(t)) {
+    // bbox edges are never swapped.
+    if (is_edge_on_bbox(t)) {
+        return false;
+    }
+    // Surface edges are allowed only as a topology-preserving surface diagonal flip. The base 5-6
+    // swap is steered to the fan that creates the new surface edge (c,d) by
+    // swap_edge_56_accept_case; if no fan yields (c,d) the swap is rejected. Route on the direct
+    // incident-surface-face count so a genuine surface edge is never mistaken for interior.
+    const int n_surf_faces = edge_incident_surface_face_count(t);
+    if (n_surf_faces > 0) {
+        if (!m_sim_params.allow_surface_swap) return false;
+        if (!prepare_surface_flip(t, incident_tets)) return false;
+    } else if (!cache_interior_swap_tag(incident_tets)) {
         return false;
     }
 
-    auto& cache = swap_cache.local();
-    const auto& TA = m_tet_attribute;
-
-    cache.tet_tags = TA[incident_tets[0]].tags;
     double max_energy = -1.0;
     for (const size_t l : incident_tets) {
-        max_energy = std::max(TA[l].m_quality, max_energy);
-        // if (TA[l].tags != cache.tet_tags) {
-        //     log_and_throw_error(
-        //         "not all tets have the same tags. {} != {}",
-        //         cache.tet_tags,
-        //        TA[l].tags); // for debugging
-        //}
+        max_energy = std::max(m_tet_attribute[l].m_quality, max_energy);
     }
+    cache.max_energy = max_energy;
 
-    swap_cache.local().max_energy = max_energy;
-
-    face_attribute_tracker(
-        *this,
-        incident_tets,
-        m_face_attribute,
-        swap_cache.local().changed_faces);
+    face_attribute_tracker(*this, incident_tets, m_face_attribute, cache.changed_faces);
 
     return true;
 }
@@ -686,18 +808,48 @@ bool SimWildMesh::swap_edge_56_after(const Tuple& t)
     const auto e2 = get_incident_tids_for_edge(t.switch_edge(*this));
     const auto tids = wmtk::set_union(e1, e2);
 
+    auto& cache = swap_cache.local();
     double max_energy = -1.0;
     for (const size_t tid : tids) {
         const Tuple tet = tuple_from_tet(tid);
-        if (is_inverted(tet)) return false;
         auto q = get_quality(tet);
         m_tet_attribute[tid].m_quality = q;
         max_energy = std::max(q, max_energy);
-
-        m_tet_attribute[tid].tags = swap_cache.local().tet_tags;
     }
 
-    tracker_assign_after(*this, tids, swap_cache.local().changed_faces, m_face_attribute);
+    if (!propagate_swap_tags(tids)) {
+        return false;
+    }
+
+    if (cache.is_surface_flip) {
+        // The two new surface faces (a,c,d),(b,c,d) must stay within the Hausdorff envelope.
+        const auto& VA = m_vertex_attribute;
+        if (m_envelope->is_outside(
+                {{VA[cache.sf_a].m_posf, VA[cache.sf_c].m_posf, VA[cache.sf_d].m_posf}}))
+            return false;
+        if (m_envelope->is_outside(
+                {{VA[cache.sf_b].m_posf, VA[cache.sf_c].m_posf, VA[cache.sf_d].m_posf}}))
+            return false;
+    }
+
+    tracker_assign_after(*this, tids, cache.changed_faces, m_face_attribute);
+
+    if (cache.is_surface_flip) {
+        // Re-tag the two new surface faces (the generic tracker reset them to interior). Net
+        // surface change: -(a,b,c) -(a,b,d) +(a,c,d) +(b,c,d).
+        auto [ft1, fid1] =
+            tuple_from_face(std::array<size_t, 3>{{cache.sf_a, cache.sf_c, cache.sf_d}});
+        auto [ft2, fid2] =
+            tuple_from_face(std::array<size_t, 3>{{cache.sf_b, cache.sf_c, cache.sf_d}});
+        (void)ft1;
+        (void)ft2;
+        m_face_attribute[fid1] = cache.sf_face_attr;
+        m_face_attribute[fid2] = cache.sf_face_attr;
+        m_face_attribute[fid1].m_is_surface_fs = true;
+        m_face_attribute[fid2].m_is_surface_fs = true;
+        cnt_surface_swap++;
+        cnt_surface_swap_56++;
+    }
 
     cnt_swap++;
     return true;

--- a/components/simwild/wmtk/components/simwild/SimWildMesh.cpp
+++ b/components/simwild/wmtk/components/simwild/SimWildMesh.cpp
@@ -214,7 +214,12 @@ double SimWildMesh::local_operations(const std::array<int, 4>& ops, bool collaps
                 if (m_params.debug_output) {
                     write_vtu(fmt::format("debug_{}", m_debug_print_counter++));
                 }
-                logger().info("cnt_surface_swap (cumulative) = {}", cnt_surface_swap.load());
+                logger().info(
+                    "cnt_surface_swap (cumulative) = {} [3-2: {}, 4-4: {}, 5-6: {}]",
+                    cnt_surface_swap.load(),
+                    cnt_surface_swap_32.load(),
+                    cnt_surface_swap_44.load(),
+                    cnt_surface_swap_56.load());
                 check_mesh_quality(quality_rel, true);
                 sanity_checks();
                 if (quality_rel < 1.0 && round_and_check_all_rounded()) {

--- a/components/simwild/wmtk/components/simwild/SimWildMesh.h
+++ b/components/simwild/wmtk/components/simwild/SimWildMesh.h
@@ -128,21 +128,26 @@ public:
         const std::vector<VertexAttributes>& _vertex_attribute,
         const std::vector<TetAttributes>& _tet_attribute)
     {
-        auto n_tet = _tet_attribute.size();
+        const size_t n_tet = _tet_attribute.size();
         m_vertex_attribute.resize(_vertex_attribute.size());
         m_face_attribute.resize(4 * n_tet);
         m_tet_attribute.resize(n_tet);
 
-        for (auto i = 0; i < _vertex_attribute.size(); i++) {
+        for (size_t i = 0; i < _vertex_attribute.size(); i++)
             m_vertex_attribute[i] = _vertex_attribute[i];
-        }
-        m_tet_attribute.m_attributes = std::vector<TetAttributes>(_tet_attribute.size());
-        for (auto i = 0; i < _tet_attribute.size(); i++) {
-            m_tet_attribute[i] = _tet_attribute[i];
-        }
-        for (auto i = 0; i < _tet_attribute.size(); i++) {
+
+        // Keep whatever init() reserved. AttributeCollection::resize only ever grows, so the
+        // calls above cannot shrink a collection -- but assigning m_attributes directly does,
+        // and it used to drop the tet attributes to exactly n_tet. The attributes have to stay
+        // at least as large as the connectivity: an operation that creates a new element
+        // indexes them by its id, and a 5->6 swap creates one. tetwild hit the same thing (see
+        // the note on its copy); there the overrun wrote a double past the end and libc++ let
+        // it pass, here it assigns a std::set and segfaults outright.
+        const size_t tcap = std::max(n_tet, m_tet_attribute.size());
+        m_tet_attribute.m_attributes = std::vector<TetAttributes>(tcap);
+        for (size_t i = 0; i < n_tet; i++) m_tet_attribute[i] = _tet_attribute[i];
+        for (size_t i = 0; i < n_tet; i++)
             m_tet_attribute[i].m_quality = get_quality(tuple_from_tet(i));
-        }
     }
 
     // TODO This should not be here but inside wmtk
@@ -183,27 +188,59 @@ public:
     size_t swap_all_edges_44();
     bool swap_edge_44_before(const Tuple& t) override;
     bool swap_edge_44_after(const Tuple& t) override;
+    /// Steers the 4-4 swap to the diagonal that realizes a surface flip. See
+    /// prepare_surface_flip; identical to tetwild's.
+    bool swap_edge_44_accept_case(const std::array<size_t, 2>& new_edge) override;
 
     size_t swap_all_edges_56();
     bool swap_edge_56_before(const Tuple& t) override;
     bool swap_edge_56_after(const Tuple& t) override;
+    /// Steers the 5-6 swap to the fan that realizes a surface flip. See prepare_surface_flip;
+    /// identical to tetwild's.
+    bool swap_edge_56_accept_case(const std::array<size_t, 3>& new_face) override;
 
     size_t swap_all_edges_32();
     bool swap_edge_before(const Tuple& t) override;
     bool swap_edge_after(const Tuple& t) override;
 
     /**
-     * @brief Prepare a surface 3->2 edge swap (a surface diagonal flip).
+     * @brief Prepare a surface edge swap (a surface diagonal flip).
      *
-     * Called from swap_edge_before when the swapped edge (a,b) is on the surface
-     * and has exactly 3 incident tets. Verifies the local guards that guarantee
-     * the flip preserves surface manifoldness / topology, and fills the
-     * surface-flip fields of swap_cache. Returns false (rejecting the swap) if
-     * any guard fails: open-boundary edge, non-manifold edge (!= 2 surface
-     * faces), or one of the two would-be new surface faces already tagged
-     * surface. The tets sharing (a,b) are passed in to avoid recomputation.
+     * Called from swap_edge_before / swap_edge_44_before / swap_edge_56_before when the swapped
+     * edge (a,b) is on the surface. Verifies the local guards that guarantee the flip preserves
+     * surface manifoldness / topology, and fills the surface-flip fields of swap_cache. Returns
+     * false (rejecting the swap) if any guard fails: non-manifold edge (!= 2 surface faces), a
+     * surface face already incident to the new edge (c,d), or one of the two would-be new
+     * surface faces already tagged surface. The tets sharing (a,b) are passed in to avoid
+     * recomputation.
+     *
+     * This is tetwild's, generalized to any ring size (3->2, 4-4, 5-6); the specific
+     * retetrahedralization that realizes the flip is picked by the accept_case hooks above.
+     * On top of tetwild's it records which tag each side of the interface carries -- see
+     * SwapInfoCache::ring_tags.
      */
-    bool prepare_surface_flip_32(const Tuple& t, const std::vector<size_t>& incident_tets);
+    bool prepare_surface_flip(const Tuple& t, const std::vector<size_t>& incident_tets);
+
+    /**
+     * @brief Record the one tag every tet this swap produces must carry, for an interior swap.
+     *
+     * A face is a surface face exactly when it separates differently tagged tets, so a swap
+     * with no incident surface face acts entirely inside one tagged region and there is nothing
+     * to decide. Returns false if `tids` disagree anyway -- that means the tag/surface invariant
+     * is already broken here, and re-tagging would silently move tagged volume.
+     */
+    bool cache_interior_swap_tag(const std::vector<size_t>& tids);
+
+    /**
+     * @brief Give every tet the swap just created its tag.
+     *
+     * Interior swap: the single tag cache_interior_swap_tag recorded. Surface flip: the tag of
+     * the side of the interface the tet ended up on, read off the ring vertices it contains
+     * (see SwapInfoCache::ring_tags). Returns false if any new tet cannot be assigned a tag,
+     * which rejects the swap and rolls the writes back.
+     */
+    bool propagate_swap_tags(const std::vector<size_t>& tids);
+    bool propagate_swap_tags(const std::vector<Tuple>& tets);
 
     /// A topological fingerprint of the tracked surface (m_is_surface_fs). See
     /// wmtk/utils/SurfaceTopology.hpp.
@@ -247,7 +284,10 @@ public:
     // debug use
     std::atomic<int> cnt_split = 0, cnt_collapse = 0, cnt_swap = 0;
     // Successful surface diagonal flips (subset of cnt_swap). Diagnostic.
+    // cnt_surface_swap is the grand total; the per-type counters break it down by the swap that
+    // realized the flip.
     std::atomic<int> cnt_surface_swap = 0;
+    std::atomic<int> cnt_surface_swap_32 = 0, cnt_surface_swap_44 = 0, cnt_surface_swap_56 = 0;
 
 private:
     ////// Operations
@@ -297,15 +337,26 @@ private:
     {
         double max_energy;
         std::map<std::array<size_t, 3>, FaceAttributes> changed_faces;
-        CellTag tet_tags;
 
-        // Surface 3->2 flip bookkeeping (filled by swap_edge_before when the
-        // swapped edge (a,b) lies on the surface). a,b are the removed-edge
-        // endpoints, c,d are the new surface-edge endpoints, e is the interior
-        // apex. sf_face_attr is copied onto the two new surface faces (a,c,d),
-        // (b,c,d). is_surface_flip gates the extra handling in swap_edge_after.
+        /// The tag every new tet takes, for an interior swap. See cache_interior_swap_tag.
+        CellTag tet_tags;
+        /**
+         * The tag on each side of the interface, for a surface flip, keyed by a ring vertex
+         * that identifies the side. Filled by prepare_surface_flip, read by
+         * propagate_swap_tags. c and d are deliberately absent: they sit ON the interface and
+         * so belong to both sides.
+         */
+        std::map<size_t, CellTag> ring_tags;
+
+        // Surface diagonal-flip bookkeeping (filled by prepare_surface_flip from
+        // swap_edge_before / swap_edge_44_before / swap_edge_56_before when the swapped edge
+        // (a,b) lies on the surface). a,b are the removed-edge endpoints, c,d are the new
+        // surface-edge endpoints (the apexes of the two incident surface faces). sf_face_attr
+        // is copied onto the two new surface faces (a,c,d),(b,c,d). is_surface_flip gates the
+        // accept-case case-forcing and the extra retag/envelope handling in the swap *_after
+        // callbacks.
         bool is_surface_flip = false;
-        size_t sf_a = 0, sf_b = 0, sf_c = 0, sf_d = 0, sf_e = 0;
+        size_t sf_a = 0, sf_b = 0, sf_c = 0, sf_d = 0;
         FaceAttributes sf_face_attr;
     };
     wmtk::threading::enumerable_thread_specific<SwapInfoCache> swap_cache;

--- a/components/simwild/wmtk/components/simwild/tests/CMakeLists.txt
+++ b/components/simwild/wmtk/components/simwild/tests/CMakeLists.txt
@@ -10,6 +10,7 @@ add_component_test(${COMPONENT_NAME})
 set(SRC_FILES
     test_simwild_energies.cpp
     test_expression_parser.cpp
+    test_simwild_swap_tags.cpp
     )
 
 target_sources(wmtk_test_${COMPONENT_NAME} PRIVATE ${SRC_FILES})

--- a/components/simwild/wmtk/components/simwild/tests/test_simwild_swap_tags.cpp
+++ b/components/simwild/wmtk/components/simwild/tests/test_simwild_swap_tags.cpp
@@ -1,0 +1,336 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include <wmtk/TetMesh.h>
+#include <wmtk/components/simwild/SimWildMesh.h>
+#include <wmtk/Types.hpp>
+#include <wmtk/envelope/Envelope.hpp>
+
+#include <array>
+#include <cmath>
+#include <vector>
+
+using namespace wmtk;
+using namespace wmtk::components::simwild;
+
+// ---------------------------------------------------------------------------
+// simwild's surface is the interface between differently tagged tets: a face is
+// tagged m_is_surface_fs exactly when its two tets carry different tags (see
+// SimWildMesh::init_surfaces_and_boundaries). A surface diagonal flip is therefore a
+// flip of that interface, and it moves the tet (a,b,c,d) worth of volume from one tag to
+// the other. These tests check that every tet the flip creates ends up with the tag of
+// the side it landed on -- equivalently, that the "surface iff tags differ" invariant
+// still holds afterwards.
+//
+// Fixture: an N-tet ring around edge (a=0,b=1), ring vertices 2..N+1 on a regular N-gon
+// in z=0 and a,b far apart on the z axis so (a,b) is a sliver and the flip strictly
+// lowers the AMIPS energy. Mirrors tetwild's test_surface_swap.cpp, whose swap code this
+// now shares.
+// ---------------------------------------------------------------------------
+namespace {
+
+constexpr double kPi = 3.14159265358979323846;
+
+const CellTag TAG_A{1};
+const CellTag TAG_B{2};
+
+void build_ring_n(SimWildMesh& mesh, int N, double half, double radius)
+{
+    std::vector<std::array<size_t, 4>> tets;
+    for (int i = 0; i < N; ++i) tets.push_back({{0, 1, size_t(2 + i), size_t(2 + (i + 1) % N)}});
+    mesh.init(N + 2, tets);
+
+    std::vector<VertexAttributes> va(N + 2);
+    va[0].m_posf = Vector3d(0, 0, -half);
+    va[1].m_posf = Vector3d(0, 0, half);
+    for (int i = 0; i < N; ++i) {
+        const double ang = 2.0 * kPi * i / N;
+        va[2 + i].m_posf = Vector3d(radius * std::cos(ang), radius * std::sin(ang), 0);
+    }
+    for (int i = 0; i < N + 2; ++i) {
+        va[i].m_is_rounded = true;
+        va[i].m_pos = to_rational(va[i].m_posf);
+        va[i].m_is_on_surface = false;
+        va[i].m_order = 0;
+    }
+    std::vector<TetAttributes> ta(N);
+    mesh.create_mesh_attributes(va, ta);
+}
+
+size_t fid_of(SimWildMesh& mesh, size_t x, size_t y, size_t z)
+{
+    auto [tup, fid] = mesh.tuple_from_face(std::array<size_t, 3>{{x, y, z}});
+    (void)tup;
+    return fid;
+}
+
+bool is_surface(SimWildMesh& mesh, size_t x, size_t y, size_t z)
+{
+    const size_t fid = fid_of(mesh, x, y, z);
+    if (fid == static_cast<size_t>(-1)) return false;
+    return mesh.m_face_attribute[fid].m_is_surface_fs;
+}
+
+/// Tag the ring tets: tets whose two ring vertices are both in [lo,hi] (the arc from
+/// surface apex `lo` to surface apex `hi`) get TAG_A, the rest TAG_B. Then derive the
+/// surface faces from the tags, exactly as init_surfaces_and_boundaries does.
+void tag_arcs_and_derive_surface(SimWildMesh& mesh, int N, int lo, int hi)
+{
+    for (int i = 0; i < N; ++i) {
+        const bool in_arc = (i >= lo && i < hi);
+        mesh.m_tet_attribute[i].tags = in_arc ? TAG_A : TAG_B;
+    }
+    for (int i = 0; i < N; ++i) {
+        for (int j = 0; j < 4; ++j) {
+            const auto ft = mesh.tuple_from_face(size_t(i), j);
+            const size_t fid = ft.fid(mesh);
+            const auto opp = ft.switch_tetrahedron(mesh);
+            const bool surf = opp.has_value() && mesh.m_tet_attribute[i].tags !=
+                                                     mesh.m_tet_attribute[opp->tid(mesh)].tags;
+            mesh.m_face_attribute[fid].m_is_surface_fs = surf;
+            if (!surf) continue;
+            for (const size_t v : mesh.get_face_vids(ft)) {
+                mesh.m_vertex_attribute[v].m_is_on_surface = true;
+                mesh.m_vertex_attribute[v].m_order = 1;
+            }
+        }
+    }
+}
+
+/// The invariant the whole design rests on: a face is tagged surface exactly when it
+/// separates differently tagged tets. Boundary faces (no opposite tet) are exempt --
+/// init_surfaces_and_boundaries skips them.
+void check_surface_matches_tags(SimWildMesh& mesh)
+{
+    for (size_t i = 0; i < mesh.tet_capacity(); ++i) {
+        if (!mesh.tuple_from_tet(i).is_valid(mesh)) continue;
+        for (int j = 0; j < 4; ++j) {
+            const auto ft = mesh.tuple_from_face(i, j);
+            const size_t fid = ft.fid(mesh);
+            const auto opp = ft.switch_tetrahedron(mesh);
+            if (!opp.has_value()) continue;
+            const bool differ =
+                mesh.m_tet_attribute[i].tags != mesh.m_tet_attribute[opp->tid(mesh)].tags;
+            INFO("face " << fid << " of tet " << i);
+            CHECK(mesh.m_face_attribute[fid].m_is_surface_fs == differ);
+        }
+    }
+}
+
+/// Every valid tet must carry one of the two tags -- never an empty or mixed one.
+void check_tags_are_a_or_b(SimWildMesh& mesh)
+{
+    for (size_t i = 0; i < mesh.tet_capacity(); ++i) {
+        if (!mesh.tuple_from_tet(i).is_valid(mesh)) continue;
+        const CellTag& tags = mesh.m_tet_attribute[i].tags;
+        INFO("tet " << i);
+        CHECK((tags == TAG_A || tags == TAG_B));
+    }
+}
+
+/// Tets carrying `tag`, by vids.
+std::vector<std::array<size_t, 4>> tets_with_tag(SimWildMesh& mesh, const CellTag& tag)
+{
+    std::vector<std::array<size_t, 4>> out;
+    for (size_t i = 0; i < mesh.tet_capacity(); ++i) {
+        if (!mesh.tuple_from_tet(i).is_valid(mesh)) continue;
+        if (mesh.m_tet_attribute[i].tags != tag) continue;
+        auto vids = mesh.oriented_tet_vids(i);
+        std::sort(vids.begin(), vids.end());
+        out.push_back(vids);
+    }
+    std::sort(out.begin(), out.end());
+    return out;
+}
+
+void init_env_from_surface(SampleEnvelope& env, SimWildMesh& mesh, double eps)
+{
+    std::vector<Vector3d> v(mesh.vert_capacity());
+    for (size_t i = 0; i < mesh.vert_capacity(); ++i) v[i] = mesh.m_vertex_attribute[i].m_posf;
+    std::vector<Eigen::Vector3i> f;
+    for (size_t i = 0; i < mesh.tet_capacity(); ++i) {
+        if (!mesh.tuple_from_tet(i).is_valid(mesh)) continue;
+        for (int j = 0; j < 4; ++j) {
+            const auto ft = mesh.tuple_from_face(i, j);
+            const size_t fid = ft.fid(mesh);
+            if (fid != 4 * i + j) continue; // canonical: visit each face once
+            if (!mesh.m_face_attribute[fid].m_is_surface_fs) continue;
+            const auto vs = mesh.get_face_vids(ft);
+            f.emplace_back(int(vs[0]), int(vs[1]), int(vs[2]));
+        }
+    }
+    env.init(v, f, eps);
+}
+
+int count_valid_tets(SimWildMesh& mesh)
+{
+    int n = 0;
+    for (size_t i = 0; i < mesh.tet_capacity(); ++i)
+        if (mesh.tuple_from_tet(i).is_valid(mesh)) ++n;
+    return n;
+}
+
+bool any_inverted(SimWildMesh& mesh)
+{
+    for (size_t i = 0; i < mesh.tet_capacity(); ++i) {
+        const auto tt = mesh.tuple_from_tet(i);
+        if (tt.is_valid(mesh) && mesh.is_inverted(tt)) return true;
+    }
+    return false;
+}
+
+void inflate_quality(SimWildMesh& mesh, int N)
+{
+    for (int i = 0; i < N; ++i) mesh.m_tet_attribute[i].m_quality = 1e40;
+}
+
+} // namespace
+
+TEST_CASE("simwild-swap-tags-32", "[simwild][3D][swap][tags]")
+{
+    // 3-tet ring. Surface apexes c=2, d=3 are adjacent, so the arc [2,3) holds the single
+    // tet (a,b,2,3) -- tag A -- and the other two are tag B. The flip absorbs the A tet:
+    // both resulting tets contain ring vertex 4, which is on the B side.
+    Parameters params;
+    params.init(Vector3d(-2, -2, -2000), Vector3d(2, 2, 2000));
+    SimWildMesh mesh(params, 1e-3, 1);
+    build_ring_n(mesh, 3, 1000.0, 1.0);
+    tag_arcs_and_derive_surface(mesh, 3, 0, 1);
+    REQUIRE(is_surface(mesh, 0, 1, 2));
+    REQUIRE(is_surface(mesh, 0, 1, 3));
+    REQUIRE_FALSE(is_surface(mesh, 0, 1, 4));
+    check_surface_matches_tags(mesh);
+
+    auto env = std::make_shared<SampleEnvelope>();
+    init_env_from_surface(*env, mesh, 50.0);
+    mesh.m_envelope = env;
+    inflate_quality(mesh, 3);
+
+    auto t = mesh.tuple_from_edge(std::array<size_t, 2>{{0, 1}});
+    REQUIRE(t.is_valid(mesh));
+    std::vector<TetMesh::Tuple> ret;
+    REQUIRE(mesh.swap_edge(t, ret));
+
+    CHECK(count_valid_tets(mesh) == 2);
+    CHECK(mesh.check_mesh_connectivity_validity());
+    CHECK_FALSE(any_inverted(mesh));
+    CHECK(mesh.cnt_surface_swap_32.load() == 1);
+
+    // Both new tets are on the B side of the flipped interface.
+    CHECK(tets_with_tag(mesh, TAG_A).empty());
+    CHECK(tets_with_tag(mesh, TAG_B).size() == 2);
+    check_tags_are_a_or_b(mesh);
+    check_surface_matches_tags(mesh);
+}
+
+TEST_CASE("simwild-swap-tags-44", "[simwild][3D][swap][tags]")
+{
+    // 4-tet ring with the surface apexes OPPOSITE (c=2, d=4), the only configuration a 4-4
+    // diagonal can realize. Arc [2,4) = tets 0,1 (the ones holding ring vertex 3) is tag A,
+    // tets 2,3 (holding ring vertex 5) are tag B. A 4-4 flip is volume-neutral in tet count,
+    // so both tags must survive with two tets each.
+    Parameters params;
+    params.init(Vector3d(-2, -2, -2000), Vector3d(2, 2, 2000));
+    SimWildMesh mesh(params, 1e-3, 1);
+    build_ring_n(mesh, 4, 1000.0, 1.0);
+    tag_arcs_and_derive_surface(mesh, 4, 0, 2);
+    REQUIRE(is_surface(mesh, 0, 1, 2));
+    REQUIRE(is_surface(mesh, 0, 1, 4));
+    check_surface_matches_tags(mesh);
+
+    auto env = std::make_shared<SampleEnvelope>();
+    init_env_from_surface(*env, mesh, 50.0);
+    mesh.m_envelope = env;
+    inflate_quality(mesh, 4);
+
+    auto t = mesh.tuple_from_edge(std::array<size_t, 2>{{0, 1}});
+    REQUIRE(t.is_valid(mesh));
+    std::vector<TetMesh::Tuple> ret;
+    REQUIRE(mesh.swap_edge_44(t, ret));
+
+    CHECK(count_valid_tets(mesh) == 4);
+    CHECK(mesh.check_mesh_connectivity_validity());
+    CHECK_FALSE(any_inverted(mesh));
+    CHECK(mesh.cnt_surface_swap_44.load() == 1);
+
+    // The new interface is (0,2,4),(1,2,4); the A side keeps ring vertex 3, the B side 5.
+    CHECK(is_surface(mesh, 0, 2, 4));
+    CHECK(is_surface(mesh, 1, 2, 4));
+    CHECK(
+        tets_with_tag(mesh, TAG_A) ==
+        std::vector<std::array<size_t, 4>>{{{0, 2, 3, 4}}, {{1, 2, 3, 4}}});
+    CHECK(
+        tets_with_tag(mesh, TAG_B) ==
+        std::vector<std::array<size_t, 4>>{{{0, 2, 4, 5}}, {{1, 2, 4, 5}}});
+    check_tags_are_a_or_b(mesh);
+    check_surface_matches_tags(mesh);
+}
+
+TEST_CASE("simwild-swap-tags-56", "[simwild][3D][swap][tags]")
+{
+    // 5-tet ring, surface apexes c=2, d=4. Arc [2,4) = tets 0,1 (ring vertices 2,3,4) is
+    // tag A; tets 2,3,4 (ring vertices 4,5,6,2) are tag B.
+    Parameters params;
+    params.init(Vector3d(-2, -2, -2000), Vector3d(2, 2, 2000));
+    SimWildMesh mesh(params, 1e-3, 1);
+    build_ring_n(mesh, 5, 1000.0, 1.0);
+    tag_arcs_and_derive_surface(mesh, 5, 0, 2);
+    REQUIRE(is_surface(mesh, 0, 1, 2));
+    REQUIRE(is_surface(mesh, 0, 1, 4));
+    check_surface_matches_tags(mesh);
+
+    auto env = std::make_shared<SampleEnvelope>();
+    init_env_from_surface(*env, mesh, 50.0);
+    mesh.m_envelope = env;
+    inflate_quality(mesh, 5);
+
+    auto t = mesh.tuple_from_edge(std::array<size_t, 2>{{0, 1}});
+    REQUIRE(t.is_valid(mesh));
+    std::vector<TetMesh::Tuple> ret;
+    REQUIRE(mesh.swap_edge_56(t, ret));
+
+    CHECK(count_valid_tets(mesh) == 6);
+    CHECK(mesh.check_mesh_connectivity_validity());
+    CHECK_FALSE(any_inverted(mesh));
+    CHECK(mesh.cnt_surface_swap_56.load() == 1);
+
+    CHECK(is_surface(mesh, 0, 2, 4));
+    CHECK(is_surface(mesh, 1, 2, 4));
+    // The fan is over the pentagon from apex 2 or 4; either way the A side is the pair of
+    // tets holding ring vertex 3 and the B side is the remaining four.
+    CHECK(tets_with_tag(mesh, TAG_A).size() == 2);
+    CHECK(tets_with_tag(mesh, TAG_B).size() == 4);
+    check_tags_are_a_or_b(mesh);
+    check_surface_matches_tags(mesh);
+}
+
+TEST_CASE("simwild-swap-tags-interior", "[simwild][3D][swap][tags]")
+{
+    // No surface face anywhere: every tet carries the same tag and every tet the swap
+    // creates must keep it. This is the path that used to read tags off incident_tets[0]
+    // (4-4 / 5-6) or majority-vote them (3->2).
+    Parameters params;
+    params.init(Vector3d(-2, -2, -2000), Vector3d(2, 2, 2000));
+    SimWildMesh mesh(params, 1e-3, 1);
+    build_ring_n(mesh, 4, 1000.0, 1.0);
+    tag_arcs_and_derive_surface(mesh, 4, 0, 4); // everything tag A -> no interface at all
+    for (size_t i = 0; i < mesh.tet_capacity(); ++i) {
+        if (!mesh.tuple_from_tet(i).is_valid(mesh)) continue;
+        for (int j = 0; j < 4; ++j) {
+            REQUIRE_FALSE(
+                mesh.m_face_attribute[mesh.tuple_from_face(i, j).fid(mesh)].m_is_surface_fs);
+        }
+    }
+
+    // No envelope on purpose: there is no surface here, and the envelope is only consulted
+    // on the surface-flip path. (Handing SampleEnvelope an empty face set recurses forever.)
+    inflate_quality(mesh, 4);
+
+    auto t = mesh.tuple_from_edge(std::array<size_t, 2>{{0, 1}});
+    std::vector<TetMesh::Tuple> ret;
+    REQUIRE(mesh.swap_edge_44(t, ret));
+
+    CHECK(mesh.cnt_surface_swap.load() == 0); // interior swap, not a surface flip
+    CHECK(tets_with_tag(mesh, TAG_A).size() == 4);
+    CHECK(tets_with_tag(mesh, TAG_B).empty());
+    check_surface_matches_tags(mesh);
+}

--- a/components/tetwild/wmtk/components/tetwild/TetWildMesh.h
+++ b/components/tetwild/wmtk/components/tetwild/TetWildMesh.h
@@ -408,7 +408,9 @@ public:
 
     // for open boundary
     void find_open_boundary();
-    bool is_open_boundary_edge(const Tuple& e);
+    /// tetwild's surface is the input mesh, which may be non-watertight, so the base's
+    /// "no open boundary" default does not hold here. See TetOptimizerMesh.
+    bool is_open_boundary_edge(const Tuple& e) override;
     bool is_open_boundary_edge(const std::array<size_t, 2>& e);
 
 public:

--- a/docs/simwild-adopted-behaviours.md
+++ b/docs/simwild-adopted-behaviours.md
@@ -393,10 +393,138 @@ Two configs move, both of them the 3D ones that actually run face swaps:
 Everything else in the suite is byte-identical, and the branch touches no file outside
 `components/simwild/`.
 
-**Still open in the swap family:** simwild has `cnt_surface_swap` but not tetwild's per-type
-breakdown (`cnt_surface_swap_32/44/56`), and `prepare_surface_flip` is still per-application --
-tetwild's is generalized to any ring size and drives the 4-4 and 5-6 surface flips, while simwild
-has only `prepare_surface_flip_32`, rejects surface edges in 4-4/5-6, and `log_and_throw_error`s
-where tetwild returns `false`. Both belong with the sharing commit: the tag divergence that blocks
-sharing is three lines, so the hook is a pair of no-op virtuals (`cache_swap_cell_state` /
-`restore_swap_cell_state`) that tetwild never overrides.
+Both remaining swap differences are settled below.
+
+---
+
+## Post-3c — simwild adopts tetwild's swap family, with tag propagation
+
+The last item in the de-duplication programme, and the largest single behaviour change in it.
+`components/simwild/.../EdgeSwapping.cpp` is now tetwild's file: after renaming the mesh class and
+the parameters struct, the only lines that differ are the tag handling described below and one
+`swap_all_faces` comment. Every remaining divergence has been resolved in tetwild's favour.
+
+### Why tags and the surface are the same question
+
+simwild's surface is not an input mesh — `init_surfaces_and_boundaries` tags a face
+`m_is_surface_fs` **exactly when its two tets carry different tags**. So a surface diagonal flip in
+simwild *is* a flip of the tag interface, and the volume it sweeps (the tet `(a,b,c,d)` between the
+old and new diagonal) moves from one tag to the other. That is the same thing tetwild's flip does
+across its inside/outside surface, and it is gated the same way, by the Hausdorff envelope check on
+the two new faces.
+
+Two consequences fall out and are used throughout:
+
+- An edge with **no** incident surface face has all its incident tets identically tagged, so an
+  interior swap has nothing to decide.
+- The two surface faces `(a,b,c)`, `(a,b,d)` cut the ring of incident tets into two arcs, one tag
+  each — and every tet a flip creates contains at least one ring vertex other than `c`,`d`, which
+  says which arc, hence which tag, it belongs to.
+
+### What simwild adopted
+
+| | before | after |
+|---|---|---|
+| `prepare_surface_flip` | `prepare_surface_flip_32`: exactly-3 ring only, `log_and_throw_error` on anything unexpected, `assert`s that `(c,d)` already exists | tetwild's, generalized to any ring size; rejects rather than throws; handles `(c,d)` not existing yet, which is the normal case for 4-4 and 5-6 |
+| 4-4 and 5-6 on a surface edge | rejected outright (`edge_incident_surface_face_count > 0` → `false`) | steered to the case that realizes the flip, by `swap_edge_44_accept_case` / `swap_edge_56_accept_case`, then envelope-checked and re-tagged like the 3→2 case |
+| the `(c,d)` non-manifold guard | `assert` + `get_surface_faces_for_edge` | tetwild's direct enumeration, which does not depend on the possibly-stale `m_is_on_surface` vertex flags |
+| the "would-be new faces already surface" guard | absent | tetwild's, gated on `lowest_common_tet` so a Debug build does not abort on every 4-4 flip |
+| `swap_edge_56_after` | re-checked `is_inverted` | tetwild's: `swap_edge_56_energy` returns `double::max()` for any inverted candidate and the case is only taken when strictly below the old energy, so the check could never fire |
+| `swap_all_edges_44` / `_56` | no `check_surface_topology` guard | tetwild's guard, now that these can change the surface |
+| `swap_all_edges_all` | logged its topology warning as `"swap_all_edges_32"` | its own name |
+| counters | `cnt_surface_swap` only | plus tetwild's `cnt_surface_swap_32/44/56` breakdown, and the same log line |
+| open-boundary edges | not considered | `wmtk::TetOptimizerMesh::is_open_boundary_edge`, a new virtual that defaults to `false` and that tetwild overrides — see below |
+
+`is_open_boundary_edge` defaulting to false is exact for simwild, not a stub: around an interior
+edge the tags change an even number of times going around the tet ring, so the interface can never
+terminate there; it can only end where it meets the bbox, and `is_edge_on_bbox` has already
+rejected those edges by the time the question is asked. Making it a virtual is what leaves the two
+`prepare_surface_flip` bodies byte-identical.
+
+### The tag rule
+
+Three simwild-only additions, and nothing else:
+
+- `cache_interior_swap_tag` — no incident surface face, so record the one tag the incident tets
+  share. If they *disagree* the swap is refused: that can only happen if the tag/surface invariant
+  is already broken elsewhere, and re-tagging would move tagged volume with no envelope check to
+  gate it. This replaces the old 3→2 rule (majority vote over at most two tags) and the old 4-4 /
+  5-6 rule (take `incident_tets[0]`, with a commented-out check that they all agree).
+- `prepare_surface_flip` additionally records `ring_tags`: for each ring vertex other than `c`,`d`,
+  the tag of its side.
+- `propagate_swap_tags` — interior swap: give every new tet the cached tag. Surface flip: give each
+  new tet the tag of the arc its ring vertices identify, and refuse if a tet straddles both arcs or
+  touches neither.
+
+On a well-formed mesh this leaves the 3→2 result unchanged: an interior edge has one tag, so the
+majority vote agreed with it, and on a surface edge the majority is by construction the arc holding
+two of the three tets, which is the arc both new tets land in.
+
+`SwapInfoCache::sf_e` is gone — the third apex of the 3→2 ring, which nothing read.
+
+### Measured
+
+**tetwild and triwild are byte-identical**, on all 53 registered configs — with `tetwild_crown` and
+`tetwild_octocat` re-run at `num_threads: 0`, since at their configured 10 they are nondeterministic
+by construction — and on all 30 hidden `[challenging]` models (14 tetwild Thingi10K, 16
+triwild20k), compared against two independent baselines: the run for #1011 and the run for #1009,
+which also agree with each other. The comparison is every `report.json` field except the timing
+keys, plus the md5 of every emitted mesh — `out_final.msh`, `out_simplified_input.obj`,
+`out_surface.obj` for tetwild and `out.msh`, `out.vtu`, `out_surf.vtu` for triwild.
+
+Two simwild configs move, the only two that run 3D swaps:
+
+| config | before | after |
+|---|---|---|
+| `simwild_double_sphere_3d` | 10897 tets, 2198 verts, avg 3.80078 | 10888 tets, 2197 verts, avg 3.79623 |
+| `simwild_double_sphere_notop_3d` | 21528 tets, 4257 verts, avg 3.61702, max 8.5319 | 21311 tets, 4215 verts, avg 3.59206, max 8.7158 |
+
+Both get slightly smaller at slightly better average energy, and the counters say exactly why:
+
+| config | surface flips before | surface flips after |
+|---|---|---|
+| `simwild_double_sphere_3d` | 4 | 85 = **4** (3→2) + 69 (4-4) + 12 (5-6) |
+| `simwild_double_sphere_notop_3d` | 0 | 89 = 1 (3→2) + 70 (4-4) + 18 (5-6) |
+
+The 3→2 count on the first config is *unchanged*, which is the claim above about the tag rule
+being behaviour-preserving there, measured rather than argued. All of the movement is the 4-4 and
+5-6 flips that simwild used to refuse outright — the ones that let the optimizer relieve a bad
+configuration on the interface instead of routing around it. (`notop`'s 3→2 going 0 → 1 is
+downstream: the mesh reaches configurations it never used to.)
+
+Re-running both with `check_surface_topology: true` — which takes a full topological signature of
+the tracked surface (V, E, F, Euler, components, boundary loops) before each swap pass and reports
+any change afterwards — gives **zero complaints across all 174 flips**. A diagonal flip is supposed
+to leave surface topology alone, and on real data it does.
+
+### Tested
+
+`test_simwild_swap_tags.cpp` builds an N-tet ring whose two arcs carry different tags, derives the
+surface from the tags the way `init_surfaces_and_boundaries` does, runs the flip, and checks that
+every face is surface **iff** its two tets still disagree — for the 3→2, 4-4 and 5-6 flips, plus an
+interior swap that must preserve its single tag. The 4-4 and 5-6 cases assert the resulting tets by
+vid, so a wrong side would fail rather than merely a wrong count. Release and Debug.
+
+Writing it turned up an unrelated latent defect in simwild's test-only `create_mesh_attributes`,
+fixed here: it assigned `m_tet_attribute.m_attributes` a vector sized to the *live* tet count,
+shrinking the collection below the connectivity capacity that `init()` had reserved. An
+`AttributeCollection` deliberately never grows during an operation, so a 5→6 swap indexed one past
+the end. tetwild carried the same bug and had already fixed it (ASan found it there); this is the
+same fix, and simwild's version segfaults outright rather than corrupting quietly because the field
+being written is a `std::set` and not a `double`.
+
+### 2D was already done
+
+For completeness, since "adopt all the swaps" covers both dimensions: the 2D swap family
+(`swap_all_edges`, `swap_weight`, `swap_edge_before`, `swap_edge_after`) is **already identical**
+between triwild and simwild-2D — after renaming the mesh class, the only differences are two
+comments. Stage 3a's shared `TriOptimizerMesh::FaceAttributes` carries `tags` for both, so even the
+tag lines are common code, and `SwapInfoCache::face_tags` is triwild's too. (triwild has carried an
+unused `std::set<int64_t> tags` per triangle since well before this programme — see
+`git show origin/main:.../TriWildMesh.h` — so that is pre-existing, not something the move added.)
+
+The tag propagation is correct there for a simpler reason than in 3D: the 2D swap opens with
+`if (is_edge_on_surface(t)) return false;`, and in 2D too the surface is the tag interface
+(`SimWildMeshTri::init_surfaces_and_boundaries`), so a 2D swap only ever runs on an edge whose two
+faces already agree. `cache.face_tags = FA[incident_faces[0]].tags` is then exact. There is no 2D
+counterpart to the 4-4 / 5-6 question because a 2-2 flip is the only edge swap a triangle mesh has.

--- a/src/wmtk/TetOptimizerMesh.h
+++ b/src/wmtk/TetOptimizerMesh.h
@@ -194,6 +194,18 @@ public:
     bool is_edge_on_surface(const Tuple& loc);
     bool is_edge_on_bbox(const Tuple& loc);
     /**
+     * @brief Whether edge `e` lies on the *boundary* of the tracked surface.
+     *
+     * Flipping such an edge would change the surface's boundary loops, so prepare_surface_flip
+     * refuses it. Defaults to false, which is exact for simwild: its surface is the interface
+     * between differently tagged tets, and around an interior edge the tags change an even
+     * number of times going around the tet ring, so an interface can never terminate there. It
+     * can only end where it meets the bbox -- and is_edge_on_bbox() has already rejected those
+     * edges by the time this is asked. tetwild overrides it because its surface is the input
+     * mesh, which may be non-watertight anywhere.
+     */
+    virtual bool is_open_boundary_edge(const Tuple& e) { return false; }
+    /**
      * @brief How many of the faces incident to edge `e` are on the tracked surface.
      *
      * Unlike is_edge_on_surface(), this does NOT short-circuit on the (possibly stale)


### PR DESCRIPTION
## simwild: adopt tetwild's swap family, with tag propagation

Stacked on #1014. The last item of the de-duplication programme, and the largest single behaviour
change in it.

After renaming the mesh class and the parameters struct, `components/simwild/.../EdgeSwapping.cpp`
is now **tetwild's file**: `diff` reports 128 differing lines and every one of them is either the
tag handling described below or one historical comment. The plan's original estimate for this
family (43–53% similar, "real hooks, not just a move") was right, and it resolves the way the
policy says — everything takes tetwild's.

### Why the tags made this tractable rather than harder

simwild's surface is not an input mesh. `init_surfaces_and_boundaries` marks a face
`m_is_surface_fs` **exactly when its two tets carry different tags**. The surface *is* the tag
interface — so tetwild's surface diagonal flip is, in simwild, a flip of that interface, moving the
tet `(a,b,c,d)` between the old and new diagonal from one tag to the other. That is the same thing
tetwild's flip does across its inside/outside surface, and it is gated the same way, by the
Hausdorff envelope check on the two new faces.

Two consequences carry the entire tag rule:

- an edge with **no** incident surface face has all its incident tets identically tagged, so an
  interior swap has nothing to decide;
- the two surface faces `(a,b,c)`,`(a,b,d)` cut the ring of incident tets into two arcs, one tag
  each — and every tet a flip creates contains at least one ring vertex other than `c`,`d`, which
  names its arc, hence its tag.

### What simwild adopted

| | before | after |
|---|---|---|
| `prepare_surface_flip` | `prepare_surface_flip_32`: exactly-3 ring, `log_and_throw_error` on anything unexpected, `assert`s `(c,d)` already exists | tetwild's, any ring size; rejects rather than throws; copes with `(c,d)` not existing yet, which is the **normal** case for 4-4 and 5-6 |
| 4-4 / 5-6 on a surface edge | refused outright | steered to the case that realizes the flip by `swap_edge_44_accept_case` / `swap_edge_56_accept_case`, then envelope-checked and re-tagged like 3→2 |
| the `(c,d)` non-manifold guard | `assert` + `get_surface_faces_for_edge` | tetwild's direct enumeration, which does not consult the possibly-stale `m_is_on_surface` vertex flags |
| "would-be new faces already surface" guard | absent | tetwild's, gated on `lowest_common_tet` so Debug does not abort on every 4-4 flip |
| `swap_edge_56_after` | re-checked `is_inverted` | tetwild's: `swap_edge_56_energy` returns `double::max()` for an inverted candidate and a case is only taken strictly below the old energy, so it could never fire |
| `swap_all_edges_44` / `_56` | no `check_surface_topology` guard | tetwild's, now that these can change the surface |
| `swap_all_edges_all` | logged its topology warning as `"swap_all_edges_32"` | its own name |
| counters | `cnt_surface_swap` only | plus `cnt_surface_swap_32/44/56` and tetwild's log line |

`is_open_boundary_edge` becomes a virtual on `wmtk::TetOptimizerMesh` defaulting to `false`, which
tetwild overrides. That default is **exact** for simwild, not a stub: around an interior edge the
tags change an even number of times going around the tet ring, so the interface can never terminate
there; it can only end where it meets the bbox, and `is_edge_on_bbox` rejected those edges earlier.
Making it virtual is what leaves the two `prepare_surface_flip` bodies byte-identical.

### The tag rule — three additions, nothing else

- **`cache_interior_swap_tag`** — no incident surface face, so record the one tag the incident tets
  share. If they disagree, **refuse the swap**: that can only happen when the tag/surface invariant
  is already broken elsewhere, and re-tagging would move tagged volume with no envelope check to
  gate it. Replaces the old 3→2 rule (majority vote over ≤2 tags) and the old 4-4/5-6 rule (take
  `incident_tets[0]`, with a commented-out check that they all agree).
- **`ring_tags`**, recorded by `prepare_surface_flip`: for each ring vertex other than `c`,`d`, the
  tag of its side.
- **`propagate_swap_tags`** — interior: give every new tet the cached tag. Surface flip: give each
  new tet the tag of the arc its ring vertices name, and refuse if a tet straddles both arcs or
  touches neither.

`SwapInfoCache::sf_e` is gone; nothing read it.

## Measured

**tetwild and triwild are byte-identical.** All 53 registered configs — with `tetwild_crown` and
`tetwild_octocat` re-run at `num_threads: 0`, since at their configured 10 they are nondeterministic
by construction — and all **30 hidden `[challenging]` models** (14 tetwild Thingi10K, 16 triwild20k),
against two independent baselines (#1009's run and #1011's) that also agree with each other. The
comparison is every `report.json` field bar timing, plus the md5 of every emitted mesh.

Two simwild configs move, the only two that run 3D swaps — and the counters say exactly why:

| config | tets | avg energy | surface flips |
|---|---|---|---|
| `simwild_double_sphere_3d` | 10897 → 10888 | 3.80078 → 3.79623 | 4 → 85 = **4** (3→2, *unchanged*) + 69 (4-4) + 12 (5-6) |
| `simwild_double_sphere_notop_3d` | 21528 → 21311 | 3.61702 → 3.59206 | 0 → 89 = 1 (3→2) + 70 (4-4) + 18 (5-6) |

The 3→2 count holding still on the first config is the claim that the tag rule preserves that path's
behaviour — measured, not argued. All the movement is the 4-4 and 5-6 flips simwild used to refuse
outright: the ones that let the optimizer relieve a bad configuration *on* the interface instead of
routing around it. (`notop`'s 3→2 going 0 → 1 is downstream; the mesh reaches states it never used
to.)

Re-running both with `check_surface_topology: true` — a full topological signature of the tracked
surface (V, E, F, Euler, components, boundary loops) taken before each swap pass and compared after
— gives **zero complaints across all 174 flips**. A diagonal flip is supposed to leave surface
topology alone, and on real data it does. At `num_threads: 4` both complete clean, no errors, fully
rounded; worth checking because every simwild config in the suite is serial, so the parallel swap
path has no coverage there.

## Tested

`test_simwild_swap_tags.cpp` builds an N-tet ring whose two arcs carry different tags, derives the
surface from the tags the way `init_surfaces_and_boundaries` does, runs the flip, and asserts the
invariant directly — every face is surface **iff** its two tets still disagree — for the 3→2, 4-4
and 5-6 flips plus an interior swap that must preserve its single tag. The 4-4 and 5-6 cases pin the
resulting tets **by vid**, so landing a tet on the wrong side fails rather than merely a wrong count.
Green in Release and Debug; the Debug run matters because `tuple_from_face` asserts, and the
generalized `prepare_surface_flip` is written specifically not to trip it on 4-4 / 5-6.

### A latent overrun found on the way

Writing that test turned up an unrelated defect in simwild's test-only `create_mesh_attributes`,
fixed here. It assigned `m_tet_attribute.m_attributes` a vector sized to the **live** tet count,
shrinking the collection below the connectivity capacity `init()` had reserved — and an
`AttributeCollection` deliberately never grows during an operation. So a 5→6 swap indexed one past
the end. tetwild carried the identical bug and had already fixed it (ASan found it there); this is
the same fix. simwild segfaults on it outright rather than corrupting quietly, because the field
being written there is a `std::set` and not a `double`.

## 2D needed nothing

For completeness, since this closes "the swap family" and not just the 3D one: `swap_all_edges`,
`swap_weight`, `swap_edge_before` and `swap_edge_after` are **already identical** between triwild and
simwild-2D — after renaming, the only differences are two comments. Stage 3a's shared
`TriOptimizerMesh::FaceAttributes` carries `tags` for both, so even the tag lines are common code.
The propagation is correct there for a simpler reason: the 2D swap opens with
`if (is_edge_on_surface(t)) return false;`, and in 2D the surface is likewise the tag interface, so a
2D swap only ever runs on an edge whose two faces already agree. There is no 2D counterpart to the
4-4 / 5-6 question — a 2-2 flip is the only edge swap a triangle mesh has.

`docs/simwild-adopted-behaviours.md` records all of the above.
