### PR TITLE
Take the tracked surface from the arrangement's provenance

### DIFF
--- a/cmake/recipes/volumeremesher.cmake
+++ b/cmake/recipes/volumeremesher.cmake
@@ -22,16 +22,16 @@ message(STATUS "Third-party: creating target 'VolumeRemesher::VolumeRemesher'")
 # is exact: the built-in bigrational::get_str() emits the fraction in base 2, the base
 # init_from_bin parses.
 #
-# Pinned at main. The previous pin (dcf40546) was two commits behind it; the only
-# functional change between them is PR #17, which reuses a cell's local data structure
-# across non-splitting constraints in BSP.cpp -- a performance change in the
-# arrangement core, so it is the kind of bump that wants the full test suite run
-# against it rather than a smoke test.
+# Pinned at main. The previous pin (ba8a7329) is this one's first parent; the only change
+# between them is VolumeRemesher PR #24, which adds an output to embed_tri_in_poly_mesh --
+# out_triangle_group, mapping each input triangle to its coplanar group, i.e. to its index
+# into out_triangle_provenance. Nothing existing changes behaviour, but the signature grows,
+# so every caller of that function must be updated in the same commit.
 include(CPM)
 CPMAddPackage(
     NAME VolumeRemesher
     GITHUB_REPOSITORY wildmeshing/VolumeRemesher
-    GIT_TAG ba8a7329cf1225356dcc8e7bcee0883e0cc51e85
+    GIT_TAG 64c52aa54d39a5ed821c6cd3b120a55fad2790f7
     OPTIONS
     "VOLUMEREMESHER_BUILD_TESTS OFF"
 )

--- a/components/simwild/wmtk/components/simwild/EmbedCurves.cpp
+++ b/components/simwild/wmtk/components/simwild/EmbedCurves.cpp
@@ -6,7 +6,11 @@
 #include <wmtk/utils/SimplifySegments.hpp>
 #include <wmtk/utils/WindingNumber.hpp>
 
+#include <algorithm>
 #include <fstream>
+#include <map>
+#include <queue>
+#include <set>
 
 namespace wmtk::components::simwild {
 
@@ -60,6 +64,18 @@ EmbedCurves::EmbedCurves(
         }
     }
 
+    // Which input each row of the concatenated network came from. read_input_curves
+    // concatenates in order, and the transform rebuild above preserves that, so the blocks
+    // are contiguous. Carried across simplify_curves so the arrangement's provenance can be
+    // read back in input terms.
+    m_E_input.clear();
+    for (size_t i = 0; i < m_Es.size(); ++i) {
+        m_E_input.resize(m_E_input.size() + size_t(m_Es[i].rows()), i);
+    }
+    if (m_E_input.size() != size_t(m_E_curves.rows())) {
+        m_E_input.clear(); // the concatenation is not the plain per-input one; do not guess
+    }
+
     if (m_V_curves.rows() == 0 || m_E_curves.rows() == 0) {
         log_and_throw_error(
             "No curves read. A 2D input must be an OBJ with 'l' polyline records; a file with "
@@ -91,8 +107,20 @@ void EmbedCurves::simplify_curves(
     // Link condition on: simplification here may not change the topology of the curve
     // network, because the winding-number tags are evaluated against the untouched per-input
     // copies and merging two curves would make them disagree.
-    const size_t removed =
-        utils::simplify_segments(m_V_curves, m_E_curves, envelope, /*use_link_condition=*/true);
+    std::vector<int> surviving_edges;
+    const size_t removed = utils::simplify_segments(
+        m_V_curves,
+        m_E_curves,
+        envelope,
+        /*use_link_condition=*/true,
+        m_E_input.empty() ? nullptr : &surviving_edges);
+    if (!m_E_input.empty()) {
+        std::vector<size_t> E_input(surviving_edges.size());
+        for (size_t k = 0; k < surviving_edges.size(); ++k) {
+            E_input[k] = m_E_input[size_t(surviving_edges[k])];
+        }
+        m_E_input = std::move(E_input);
+    }
     logger().info(
         "input simplification: #V {} -> {}, #E {} -> {} ({} vertices removed), envelope {} "
         "(eps {:.4})",
@@ -105,10 +133,38 @@ void EmbedCurves::simplify_curves(
         eps);
 }
 
-bool EmbedCurves::embed_curves()
+bool EmbedCurves::embed_curves(const bool tag_from_winding_number)
 {
     std::vector<Vector2r> V_rational;
-    utils::embed_segments(m_V_curves, m_E_curves, m_V_emb, V_rational, m_F_emb, m_E_constrained);
+    std::vector<std::vector<int>> E_sources;
+    utils::embed_segments(
+        m_V_curves,
+        m_E_curves,
+        m_V_emb,
+        V_rational,
+        m_F_emb,
+        m_E_constrained,
+        tag_from_winding_number ? nullptr : &E_sources);
+
+    if (!tag_from_winding_number) {
+        if (m_E_input.empty()) {
+            log_and_throw_error(
+                "Provenance tagging asked for, but the input segments could not be traced "
+                "back to their curve networks.");
+        }
+        // Input segment -> input curve, for every constrained output edge.
+        m_E_constrained_inputs.assign(E_sources.size(), {});
+        for (size_t e = 0; e < E_sources.size(); ++e) {
+            auto& inputs = m_E_constrained_inputs[e];
+            for (const int s : E_sources[e]) {
+                const size_t in = m_E_input[size_t(s)];
+                if (std::find(inputs.begin(), inputs.end(), in) == inputs.end()) {
+                    inputs.push_back(in);
+                }
+            }
+            std::sort(inputs.begin(), inputs.end());
+        }
+    }
 
     m_V_emb_r.resize(V_rational.size(), 2);
     for (size_t i = 0; i < V_rational.size(); ++i) {
@@ -128,7 +184,11 @@ bool EmbedCurves::embed_curves()
         }
     }
 
-    tag_from_winding_number();
+    if (tag_from_winding_number) {
+        this->tag_from_winding_number();
+    } else {
+        tag_from_provenance();
+    }
 
     logger().info(
         "2D embedding: #V = {}, #F = {}, all rounded = {}",
@@ -137,6 +197,141 @@ bool EmbedCurves::embed_curves()
         all_rounded);
 
     return all_rounded;
+}
+
+void EmbedCurves::tag_from_provenance()
+{
+    if (m_E_constrained_inputs.size() != size_t(m_E_constrained.rows())) {
+        log_and_throw_error(
+            "tag_from_provenance: segment provenance was not collected ({} entries for {} "
+            "constrained edges)",
+            m_E_constrained_inputs.size(),
+            m_E_constrained.rows());
+    }
+
+    // The constrained edges, keyed by vertex pair, with the inputs they belong to.
+    std::map<std::pair<int, int>, const std::vector<size_t>*> constrained;
+    for (size_t i = 0; i < m_E_constrained_inputs.size(); ++i) {
+        int a = m_E_constrained(i, 0), b = m_E_constrained(i, 1);
+        if (a > b) {
+            std::swap(a, b);
+        }
+        constrained[{a, b}] = &m_E_constrained_inputs[i];
+    }
+
+    // Triangle adjacency across the arrangement: for each face, the neighbour opposite each
+    // of its three vertices, i.e. across edge (j+1, j+2).
+    std::map<std::pair<int, int>, std::array<int, 2>> edge_faces;
+    for (int f = 0; f < m_F_emb.rows(); ++f) {
+        for (int j = 0; j < 3; ++j) {
+            int a = m_F_emb(f, (j + 1) % 3), b = m_F_emb(f, (j + 2) % 3);
+            if (a > b) {
+                std::swap(a, b);
+            }
+            auto [it, inserted] =
+                edge_faces.try_emplace(std::pair{a, b}, std::array<int, 2>{-1, -1});
+            if (inserted) {
+                it->second[0] = f;
+            } else if (it->second[1] < 0) {
+                it->second[1] = f;
+            } else {
+                log_and_throw_error(
+                    "tag_from_provenance: edge ({}, {}) is shared by more than two faces",
+                    a,
+                    b);
+            }
+        }
+    }
+
+    // Seed: a face touching the lexicographically smallest vertex. The arrangement
+    // triangulates the bounding box of the input plus a padding grid, so that corner is
+    // outside every input curve and its face carries no tags.
+    int seed = 0;
+    {
+        int seed_v = 0;
+        for (int i = 1; i < m_V_emb.rows(); ++i) {
+            if (std::make_pair(m_V_emb(i, 0), m_V_emb(i, 1)) <
+                std::make_pair(m_V_emb(seed_v, 0), m_V_emb(seed_v, 1))) {
+                seed_v = i;
+            }
+        }
+        for (int f = 0; f < m_F_emb.rows(); ++f) {
+            if (m_F_emb(f, 0) == seed_v || m_F_emb(f, 1) == seed_v || m_F_emb(f, 2) == seed_v) {
+                seed = f;
+                break;
+            }
+        }
+    }
+
+    std::vector<std::set<size_t>> tags(m_F_emb.rows());
+    std::vector<bool> visited(m_F_emb.rows(), false);
+    std::queue<int> q;
+    q.push(seed);
+    visited[seed] = true;
+
+    size_t n_inconsistent = 0;
+    while (!q.empty()) {
+        const int f = q.front();
+        q.pop();
+        for (int j = 0; j < 3; ++j) {
+            int a = m_F_emb(f, (j + 1) % 3), b = m_F_emb(f, (j + 2) % 3);
+            if (a > b) {
+                std::swap(a, b);
+            }
+            const auto& pair = edge_faces.at({a, b});
+            const int nb = pair[0] == f ? pair[1] : pair[0];
+            if (nb < 0) {
+                continue; // the outer boundary of the arrangement
+            }
+
+            std::set<size_t> t = tags[f];
+            const auto it = constrained.find({a, b});
+            if (it != constrained.end()) {
+                for (const size_t in : *it->second) {
+                    if (!t.insert(in).second) {
+                        t.erase(in);
+                    }
+                }
+            }
+
+            if (!visited[nb]) {
+                visited[nb] = true;
+                tags[nb] = std::move(t);
+                q.push(nb);
+            } else if (tags[nb] != t) {
+                ++n_inconsistent;
+            }
+        }
+    }
+
+    if (n_inconsistent > 0) {
+        log_and_throw_error(
+            "tag_from_provenance: {} edge crossings disagree with the tags already assigned. "
+            "That means an input curve is not closed, so inside/outside is not decided by the "
+            "curve alone -- use the winding-number tagging for this input.",
+            n_inconsistent);
+    }
+    for (size_t i = 0; i < visited.size(); ++i) {
+        if (!visited[i]) {
+            log_and_throw_error("tag_from_provenance: face {} was not reached", i);
+        }
+    }
+
+    m_F_tags.resize(m_F_emb.rows(), m_Vs.size());
+    size_t n_tagged = 0;
+    for (size_t i = 0; i < tags.size(); ++i) {
+        for (const size_t t : tags[i]) {
+            m_F_tags.coeffRef(int(i), int(t)) = 1;
+        }
+        if (!tags[i].empty()) {
+            ++n_tagged;
+        }
+    }
+    m_F_tags.makeCompressed();
+    logger().info(
+        "Tagged {} of {} faces from the arrangement's segment provenance.",
+        n_tagged,
+        tags.size());
 }
 
 void EmbedCurves::tag_from_winding_number()

--- a/components/simwild/wmtk/components/simwild/EmbedCurves.hpp
+++ b/components/simwild/wmtk/components/simwild/EmbedCurves.hpp
@@ -57,9 +57,12 @@ public:
     /**
      * @brief Compute the exact arrangement of the (simplified) curve union.
      *
+     * @param tag_from_winding_number Decide each face's tags by evaluating the winding
+     * number of every input at its barycenter (the default), rather than by propagating them
+     * across the arrangement's own segment provenance. See tag_from_provenance.
      * @return true when every arrangement vertex has an exact double representation.
      */
-    bool embed_curves();
+    bool embed_curves(const bool tag_from_winding_number = true);
 
     /**
      * @brief Remove vertices not referenced by any output face.
@@ -92,6 +95,23 @@ private:
      */
     void tag_from_winding_number();
 
+    /**
+     * @brief Decide the face tags from the arrangement's segment provenance.
+     *
+     * The exact alternative to tag_from_winding_number, and the 2D twin of
+     * EmbedSurface::tag_from_provenance. Each constrained output edge knows which input
+     * segments it tiles, hence which input curves; tags then propagate combinatorially,
+     * starting from a face on the outside of the bounding box and flipping membership of an
+     * input whenever an edge belonging to it is crossed. Every input curve must be closed --
+     * an open polyline encloses nothing -- and a traversal that disagrees with itself says
+     * so rather than returning a tagging that depends on the order it walked in.
+     *
+     * It also removes the mismatch the winding-number route documents: those tags are
+     * evaluated against the ORIGINAL per-input curves while the arrangement is of the
+     * SIMPLIFIED union, so the two can disagree near a curve the simplification moved.
+     */
+    void tag_from_provenance();
+
 private:
     /// Per input, as read: kept separate because the winding number is per input.
     std::vector<MatrixXd> m_Vs;
@@ -100,6 +120,11 @@ private:
     /// The union, which is what gets simplified and arranged.
     MatrixXd m_V_curves;
     MatrixXi m_E_curves;
+    /// Per row of m_E_curves: which input it came from. Kept alongside m_E_curves across the
+    /// simplification, so the arrangement's provenance can be read back in input terms.
+    std::vector<size_t> m_E_input;
+    /// Per row of m_E_constrained: which inputs tile it. Only filled for tag_from_provenance.
+    std::vector<std::vector<size_t>> m_E_constrained_inputs;
 
     MatrixXd m_V_emb;
     MatrixXr m_V_emb_r;

--- a/components/simwild/wmtk/components/simwild/EmbedSurface.cpp
+++ b/components/simwild/wmtk/components/simwild/EmbedSurface.cpp
@@ -15,7 +15,10 @@
 #include <wmtk/utils/VectorUtils.h>
 #include <bitset>
 #include <filesystem>
+#include <limits>
+#include <map>
 #include <paraviewo/VTUWriter.hpp>
+#include <queue>
 #include <wmtk/io/read_triangle_mesh.hpp>
 #include <wmtk/utils/InsertTriangleUtils.hpp>
 #include <wmtk/utils/Logger.hpp>
@@ -67,7 +70,9 @@ void embed_surface(
     MatrixXr& V_emb,
     MatrixXi& T_emb,
     MatrixXi& F_on_surface,
-    const bool perform_sanity_checks)
+    const bool perform_sanity_checks,
+    const std::vector<size_t>& F_input,
+    std::vector<std::vector<size_t>>* F_on_surface_inputs)
 {
     // old output
     std::vector<std::array<size_t, 3>> facets_after;
@@ -118,6 +123,8 @@ void embed_surface(
     std::vector<bool> polygon_faces_on_input;
     wmtk::utils::EmbedTrianglesOptions opts;
     opts.check_orientation = perform_sanity_checks;
+    opts.check_surface_provenance = perform_sanity_checks;
+    wmtk::utils::EmbedTrianglesProvenance prov;
     wmtk::utils::embed_triangles_in_tets(
         tri_vrt_coord,
         triangle_indices,
@@ -129,7 +136,8 @@ void embed_surface(
         is_v_on_input,
         tets_after,
         tet_face_on_input_surface,
-        opts);
+        opts,
+        F_on_surface_inputs == nullptr ? nullptr : &prov);
 
     T_emb.resize(tets_after.size(), 4);
     for (int i = 0; i < tets_after.size(); ++i) {
@@ -156,6 +164,68 @@ void embed_surface(
         }
         const auto& f = polygon_faces[i];
         F_on_surface.row(n_face_on_input++) = Vector3i(f[0], f[1], f[2]);
+    }
+
+    if (F_on_surface_inputs == nullptr) {
+        return;
+    }
+
+    // Which input surface each output surface face came from.
+    //
+    // The arrangement answers per coplanar group, so first collapse the per-triangle
+    // labels into per-group ones. A group normally holds triangles of a single input;
+    // it holds several only where two inputs are exactly coplanar and edge-adjacent,
+    // and then the face genuinely belongs to both -- which is the case the geometric
+    // look-up this replaces could not distinguish.
+    std::vector<std::vector<size_t>> group_inputs(
+        prov.face_groups.empty() ? 0
+                                 : 1 + std::max_element(
+                                           prov.face_groups.begin(),
+                                           prov.face_groups.end(),
+                                           [](const auto& a, const auto& b) { return a[1] < b[1]; })
+                                           ->at(1));
+    for (size_t t = 0; t < prov.triangle_group.size(); ++t) {
+        const uint32_t g = prov.triangle_group[t];
+        if (g == std::numeric_limits<uint32_t>::max() || g >= group_inputs.size()) {
+            continue; // degenerate triangle, or a group no output face lies on
+        }
+        const size_t in = t < F_input.size() ? F_input[t] : std::numeric_limits<size_t>::max();
+        if (in == std::numeric_limits<size_t>::max()) {
+            continue;
+        }
+        auto& v = group_inputs[g];
+        if (std::find(v.begin(), v.end(), in) == v.end()) {
+            v.push_back(in);
+        }
+    }
+    for (auto& v : group_inputs) {
+        std::sort(v.begin(), v.end());
+    }
+
+    // prov.face_groups is sorted by facet, and F_on_surface keeps the facets in that same
+    // order, so one walk fills both.
+    F_on_surface_inputs->assign(n_face_on_input, {});
+    {
+        size_t row = 0;
+        size_t p = 0;
+        for (size_t i = 0; i < polygon_faces.size(); ++i) {
+            if (!polygon_faces_on_input[i]) {
+                continue;
+            }
+            auto& inputs = (*F_on_surface_inputs)[row++];
+            while (p < prov.face_groups.size() && prov.face_groups[p][0] < i) {
+                ++p;
+            }
+            for (; p < prov.face_groups.size() && prov.face_groups[p][0] == i; ++p) {
+                for (const size_t in : group_inputs[prov.face_groups[p][1]]) {
+                    if (std::find(inputs.begin(), inputs.end(), in) == inputs.end()) {
+                        inputs.push_back(in);
+                    }
+                }
+            }
+            std::sort(inputs.begin(), inputs.end());
+        }
+        assert(row == n_face_on_input);
     }
 }
 
@@ -201,6 +271,12 @@ EmbedSurface::EmbedSurface(
         F_single.array() += nV_old;
         m_F_surface.conservativeResize(m_F_surface.rows() + F_single.rows(), 3);
         m_F_surface.block(nF_old, 0, Fs[i].rows(), 3) = F_single;
+
+        // Which input each row of the concatenated soup came from. Kept alongside
+        // m_F_surface from here on -- remove_unreferenced only touches vertices, and
+        // simplify_surface permutes both together -- so it still answers the question
+        // after the surface has been coarsened, which is where the arrangement sees it.
+        m_F_input.resize(m_F_surface.rows(), i);
     }
 
 
@@ -239,6 +315,19 @@ void EmbedSurface::simplify_surface(const double eps, const int num_threads)
     assert(surf_mesh.check_mesh_connectivity_validity());
 
     surf_mesh.collapse_shortest(0);
+
+    // Which original row of m_F_surface each surviving triangle is. A collapse removes
+    // triangles and rewires the rest, so a survivor keeps its fid, and consolidate_mesh
+    // then compacts the fids in ascending order (TriMesh.cpp, map_t_ids) -- so the k-th
+    // surviving fid, sorted, becomes triangle k. This is what carries the input labels
+    // across the simplification without the arrangement having to guess them back.
+    std::vector<size_t> surviving_fids;
+    surviving_fids.reserve(surf_mesh.tri_capacity());
+    for (const auto& t : surf_mesh.get_faces()) {
+        surviving_fids.push_back(t.fid(surf_mesh));
+    }
+    std::sort(surviving_fids.begin(), surviving_fids.end());
+
     surf_mesh.consolidate_mesh();
     // surf_mesh.write_triangle_mesh("triangle_soup_coarse.off");
 
@@ -262,6 +351,15 @@ void EmbedSurface::simplify_surface(const double eps, const int num_threads)
 
     V_surf_from_vector(v_simplified);
     F_surf_from_vector(f_simplified);
+
+    if (!m_F_input.empty()) {
+        std::vector<size_t> F_input(f_simplified.size(), std::numeric_limits<size_t>::max());
+        const size_t n = std::min(F_input.size(), surviving_fids.size());
+        for (size_t k = 0; k < n; ++k) {
+            F_input[k] = m_F_input[surviving_fids[k]];
+        }
+        m_F_input = std::move(F_input);
+    }
 }
 
 void EmbedSurface::remove_duplicates(const double eps)
@@ -269,13 +367,18 @@ void EmbedSurface::remove_duplicates(const double eps)
     auto v = V_surf_to_vector();
     auto f = F_surf_to_vector();
 
+    // No caller today. If one appears, m_F_input has to be permuted the same way
+    // wmtk::remove_duplicates permutes the triangles, or the input labels stop lining up
+    // with m_F_surface -- see simplify_surface.
+    m_F_input.clear();
+
     wmtk::remove_duplicates(v, f, eps);
 
     V_surf_from_vector(v);
     F_surf_from_vector(f);
 }
 
-bool EmbedSurface::embed_surface(const bool flood_fill)
+bool EmbedSurface::embed_surface(const bool flood_fill, const bool tag_from_winding_number)
 {
     logger().info("Embed with VolumeInsertion");
 
@@ -328,7 +431,9 @@ bool EmbedSurface::embed_surface(const bool flood_fill)
         m_V_emb_r,
         m_T_emb,
         m_F_on_surface,
-        m_perform_sanity_checks);
+        m_perform_sanity_checks,
+        m_F_input,
+        tag_from_winding_number ? nullptr : &m_F_tags_surface);
 
     if (m_perform_sanity_checks) {
         // check that all tets contain valid vertex indices and no duplicates
@@ -497,7 +602,14 @@ bool EmbedSurface::embed_surface(const bool flood_fill)
     if (Fs.empty()) {
         log_and_throw_error("No input surface to embed");
     }
-    tag_from_winding_number();
+    if (tag_from_winding_number) {
+        this->tag_from_winding_number();
+    } else {
+        tag_from_provenance();
+    }
+    if (m_perform_sanity_checks) {
+        check_tag_surface_invariant(tag_from_winding_number ? "winding number" : "provenance");
+    }
 
     /**
      * Cluster tags by flood-filling regions that are bounded by the surface. All tags within one
@@ -745,6 +857,185 @@ void EmbedSurface::F_surf_from_vector(const std::vector<std::array<size_t, 3>>& 
         m_F_surface(i, 1) = tris[i][1];
         m_F_surface(i, 2) = tris[i][2];
     }
+}
+
+void EmbedSurface::check_tag_surface_invariant(const std::string& how) const
+{
+    // Everything downstream of here reads the surface off the tags: SimWildMesh marks a face
+    // m_is_surface_fs exactly when its two tets disagree (init_surfaces_and_boundaries), and
+    // the whole swap family rests on that. So the tagging is only right if it reproduces the
+    // surface the arrangement actually computed.
+    std::set<std::array<int, 3>> surface;
+    for (size_t i = 0; i < m_F_on_surface.rows(); ++i) {
+        std::array<int, 3> f{{m_F_on_surface(i, 0), m_F_on_surface(i, 1), m_F_on_surface(i, 2)}};
+        std::sort(f.begin(), f.end());
+        surface.insert(f);
+    }
+
+    MatrixXi TT;
+    igl::tet_tet_adjacency(m_T_emb, TT);
+
+    size_t differ_not_surface = 0, surface_not_differ = 0, n_internal = 0;
+    for (size_t i = 0; i < m_T_emb.rows(); ++i) {
+        const auto& tet = m_T_emb.row(i);
+        const std::array<std::array<int, 3>, 4> fv{
+            {{{tet[0], tet[1], tet[2]}},
+             {{tet[0], tet[1], tet[3]}},
+             {{tet[1], tet[2], tet[3]}},
+             {{tet[2], tet[0], tet[3]}}}};
+        for (int j = 0; j < 4; ++j) {
+            const int nb = TT(i, j);
+            if (nb < 0 || size_t(nb) < i) {
+                continue; // outside, or already seen from the other side
+            }
+            ++n_internal;
+            std::array<int, 3> key = fv[j];
+            std::sort(key.begin(), key.end());
+            const bool on_surface = surface.count(key) > 0;
+            const bool tags_differ = m_tags[i] != m_tags[size_t(nb)];
+            if (tags_differ && !on_surface) {
+                ++differ_not_surface;
+            } else if (on_surface && !tags_differ) {
+                ++surface_not_differ;
+            }
+        }
+    }
+
+    logger().info(
+        "tag/surface invariant ({}): {} internal faces, {} have differing tags but are not on "
+        "the surface, {} are on the surface but have equal tags",
+        how,
+        n_internal,
+        differ_not_surface,
+        surface_not_differ);
+}
+
+void EmbedSurface::tag_from_provenance()
+{
+    if (m_F_tags_surface.size() != size_t(m_F_on_surface.rows())) {
+        log_and_throw_error(
+            "tag_from_provenance: surface provenance was not collected ({} entries for {} "
+            "surface faces)",
+            m_F_tags_surface.size(),
+            m_F_on_surface.rows());
+    }
+
+    // The surface, keyed by vertex triple, with the inputs it belongs to. A face separates
+    // two cells whose tags differ exactly in those inputs.
+    std::map<std::array<int, 3>, const std::vector<size_t>*> surface;
+    for (size_t i = 0; i < m_F_tags_surface.size(); ++i) {
+        std::array<int, 3> f{{m_F_on_surface(i, 0), m_F_on_surface(i, 1), m_F_on_surface(i, 2)}};
+        std::sort(f.begin(), f.end());
+        surface[f] = &m_F_tags_surface[i];
+    }
+
+    MatrixXi TT;
+    igl::tet_tet_adjacency(m_T_emb, TT);
+
+    // Seed: the tet holding the lexicographically smallest vertex. That vertex is a corner
+    // of the padded Delaunay box (delaunay_box_mesh pads past the input bounding box), so
+    // it lies outside every input and its cell carries no tags.
+    size_t seed = 0;
+    {
+        int seed_v = -1;
+        for (size_t i = 0; i < m_V_emb.rows(); ++i) {
+            const Vector3d p = m_V_emb.row(i);
+            if (seed_v < 0 ||
+                std::make_tuple(p[0], p[1], p[2]) <
+                    std::make_tuple(m_V_emb(seed_v, 0), m_V_emb(seed_v, 1), m_V_emb(seed_v, 2))) {
+                seed_v = int(i);
+            }
+        }
+        for (size_t i = 0; i < m_T_emb.rows(); ++i) {
+            if (m_T_emb(i, 0) == seed_v || m_T_emb(i, 1) == seed_v || m_T_emb(i, 2) == seed_v ||
+                m_T_emb(i, 3) == seed_v) {
+                seed = i;
+                break;
+            }
+        }
+    }
+
+    m_tags.assign(m_T_emb.rows(), {});
+    std::vector<bool> visited(m_T_emb.rows(), false);
+    std::queue<size_t> q;
+    q.push(seed);
+    visited[seed] = true;
+
+    size_t n_inconsistent = 0;
+    while (!q.empty()) {
+        const size_t tid = q.front();
+        q.pop();
+        const auto& tet = m_T_emb.row(tid);
+        // Face-vertex ids in igl::tet_tet_adjacency's order: face j is opposite vertex j.
+        const std::array<std::array<int, 3>, 4> fv{
+            {{{tet[0], tet[1], tet[2]}},
+             {{tet[0], tet[1], tet[3]}},
+             {{tet[1], tet[2], tet[3]}},
+             {{tet[2], tet[0], tet[3]}}}};
+
+        for (int j = 0; j < 4; ++j) {
+            const int nb = TT(tid, j);
+            if (nb < 0) {
+                continue; // outside the domain
+            }
+            std::array<int, 3> key = fv[j];
+            std::sort(key.begin(), key.end());
+
+            std::set<int64_t> tags = m_tags[tid];
+            const auto it = surface.find(key);
+            if (it != surface.end()) {
+                for (const size_t in : *it->second) {
+                    // Crossing input in's surface flips whether we are inside it.
+                    if (!tags.insert(int64_t(in)).second) {
+                        tags.erase(int64_t(in));
+                    }
+                }
+            }
+
+            if (!visited[nb]) {
+                visited[nb] = true;
+                m_tags[nb] = std::move(tags);
+                q.push(size_t(nb));
+            } else if (m_tags[nb] != tags) {
+                ++n_inconsistent;
+            }
+        }
+    }
+
+    if (n_inconsistent > 0) {
+        log_and_throw_error(
+            "tag_from_provenance: {} face crossings disagree with the tags already assigned. "
+            "That means an input surface is not closed, so inside/outside is not decided by "
+            "the surface alone -- use the winding-number tagging for this input.",
+            n_inconsistent);
+    }
+    // Every cell must be reached: the domain is connected across non-surface faces and the
+    // surface never disconnects it, since crossing a surface face is still a step.
+    for (size_t i = 0; i < visited.size(); ++i) {
+        if (!visited[i]) {
+            log_and_throw_error("tag_from_provenance: tet {} was not reached", i);
+        }
+    }
+
+    m_T_tags.resize(m_T_emb.rows(), Fs.size());
+    m_T_tags.setZero();
+    for (size_t i = 0; i < m_tags.size(); ++i) {
+        for (const int64_t t : m_tags[i]) {
+            m_T_tags.coeffRef(i, t) = 1;
+        }
+    }
+    m_T_tags.makeCompressed();
+
+    size_t n_tagged = 0;
+    for (const auto& t : m_tags) {
+        if (!t.empty()) {
+            ++n_tagged;
+        }
+    }
+    logger().info(
+        "Tagged {} of {} cells from the arrangement's surface provenance.",
+        n_tagged,
+        m_tags.size());
 }
 
 void EmbedSurface::tag_from_winding_number()

--- a/components/simwild/wmtk/components/simwild/EmbedSurface.hpp
+++ b/components/simwild/wmtk/components/simwild/EmbedSurface.hpp
@@ -40,6 +40,12 @@ void delaunay_box_mesh(
  * @param[out] V_emb Vertices after embedding.
  * @param[out] T_emb Tets after embedding.
  * @param[out] F_on_surface Faces that are on the surface.
+ * @param F_input Which input surface each row of F_surface came from, or SIZE_MAX for a row
+ * that belongs to none. Pass empty to skip the provenance below.
+ * @param[out] F_on_surface_inputs Parallel to F_on_surface: the input surfaces tiling each
+ * output surface face, from the arrangement's own triangle provenance. Usually one; more
+ * where two inputs meet coplanarly, which is exactly the case a geometric look-up cannot
+ * tell apart.
  */
 void embed_surface(
     const MatrixXd& V_surface,
@@ -49,7 +55,9 @@ void embed_surface(
     MatrixXr& V_emb,
     MatrixXi& T_emb,
     MatrixXi& F_on_surface,
-    const bool perform_sanity_checks = false);
+    const bool perform_sanity_checks = false,
+    const std::vector<size_t>& F_input = {},
+    std::vector<std::vector<size_t>>* F_on_surface_inputs = nullptr);
 
 /**
  * A class for reading an image and converting it into a tet mesh.
@@ -78,7 +86,15 @@ public:
      */
     void remove_duplicates(const double eps);
 
-    bool embed_surface(const bool flood_fill = false);
+    /**
+     * @brief Run the arrangement and tag the resulting cells.
+     *
+     * @param flood_fill Unify the tags of each region bounded by the surface.
+     * @param tag_from_winding_number Decide each cell's tags by evaluating the winding
+     * number of every input at its centroid (the default), rather than by propagating them
+     * across the arrangement's own surface provenance. See tag_from_provenance.
+     */
+    bool embed_surface(const bool flood_fill = false, const bool tag_from_winding_number = true);
 
     /**
      * @brief Remove unreferenced vertices.
@@ -123,6 +139,28 @@ private:
 
     void tag_from_winding_number();
 
+    /**
+     * @brief Decide the cell tags from the arrangement's surface provenance.
+     *
+     * The exact alternative to tag_from_winding_number. m_F_tags_surface says which inputs
+     * each surface face belongs to, so tags propagate combinatorially: start from a cell of
+     * the padded box, which is outside everything, and walk the tet adjacency graph toggling
+     * membership of input i whenever a face belonging to input i is crossed. Every input
+     * surface is closed, so the parity along any two paths to the same cell agrees; if it
+     * does not, the input was not closed and this throws rather than returning a tagging
+     * that depends on the traversal order.
+     */
+    void tag_from_provenance();
+
+    /**
+     * @brief Count where the tagging and the arrangement's surface disagree.
+     *
+     * Everything downstream reads the surface off the tags -- SimWildMesh marks a face as
+     * surface exactly when its two tets' tags differ -- so a tagging is only right if it
+     * reproduces the surface the arrangement computed. Diagnostic, under DEBUG_sanity_checks.
+     */
+    void check_tag_surface_invariant(const std::string& how) const;
+
 private:
     std::vector<std::string> m_img_filenames;
     std::vector<ImageData> m_img_datas;
@@ -131,7 +169,12 @@ private:
     MatrixXd m_V_surface;
     MatrixXi m_F_surface;
 
-    std::vector<std::vector<std::pair<size_t, size_t>>> m_F_tags_surface;
+    // per row of m_F_surface: which input it came from, or SIZE_MAX for none
+    std::vector<size_t> m_F_input;
+
+    // per row of m_F_on_surface: which inputs tile it, from the arrangement's provenance.
+    // Only filled when the provenance tagging is asked for.
+    std::vector<std::vector<size_t>> m_F_tags_surface;
 
     std::vector<size_t> modified_nonmanifold_v;
 

--- a/components/simwild/wmtk/components/simwild/read_image_msh.cpp
+++ b/components/simwild/wmtk/components/simwild/read_image_msh.cpp
@@ -423,6 +423,7 @@ InputData read_mesh(
     const bool perform_sanity_checks = json_params["DEBUG_sanity_checks"];
     const bool preserve_topology = json_params["preserve_topology"];
     const bool skip_simplify = json_params["skip_simplify"];
+    const bool tag_from_winding_number = json_params["tag_from_winding_number"];
     const double epsr_simplify = json_params["eps_simplify_rel"];
     double eps_simplify = json_params["eps_simplify"];
     const std::vector<std::string> input_names = json_params["input_names"];
@@ -466,7 +467,7 @@ InputData read_mesh(
     input_data.V_envelope = image_mesh.V_surface();
     input_data.F_envelope = image_mesh.F_surface();
 
-    const bool all_rounded = image_mesh.embed_surface(preserve_topology);
+    const bool all_rounded = image_mesh.embed_surface(preserve_topology, tag_from_winding_number);
     image_mesh.consolidate();
 
     if (debug_output) {
@@ -549,7 +550,7 @@ InputData read_curves(
     input_data.V_envelope = curves.V_curves();
     input_data.F_envelope = curves.E_curves();
 
-    const bool all_rounded = curves.embed_curves();
+    const bool all_rounded = curves.embed_curves(json_params["tag_from_winding_number"]);
     curves.consolidate();
 
     input_data.V_input = curves.V_emb();

--- a/components/simwild/wmtk/components/simwild/simwild_spec.json
+++ b/components/simwild/wmtk/components/simwild/simwild_spec.json
@@ -14,6 +14,7 @@
       "input_transform",
       "input_dir",
       "skip_simplify",
+      "tag_from_winding_number",
       "use_sample_envelope",
       "num_threads",
       "max_iterations",
@@ -161,6 +162,12 @@
     "type": "bool",
     "default": false,
     "doc": "If true, input simplification will be skipped. Only surface input may be simplified. If the input is already a tet mesh (.msh), it will never be simplified."
+  },
+  {
+    "pointer": "/tag_from_winding_number",
+    "type": "bool",
+    "default": true,
+    "doc": "How the cells of the arrangement are tagged. True evaluates the winding number of every input at each cell's centroid. False propagates the tags across the arrangement's own surface provenance instead: combinatorial and exact, starting from a cell of the padded box (which is outside everything) and flipping membership of an input whenever a face belonging to that input is crossed. The provenance route needs every input surface to be closed, and says which crossings disagree rather than returning a tagging that depends on the traversal order. 3D surface input only -- a .msh input arrives already tagged."
   },
   {
     "pointer": "/use_sample_envelope",

--- a/components/tetwild/wmtk/components/tetwild/VolumemesherInsertion.cpp
+++ b/components/tetwild/wmtk/components/tetwild/VolumemesherInsertion.cpp
@@ -118,6 +118,7 @@ void TetWildMesh::insertion_by_volumeremesher(
     utils::EmbedTrianglesOptions opts;
     opts.check_collinear_input = m_params.perform_sanity_checks;
     opts.check_orientation = m_params.perform_sanity_checks;
+    opts.check_surface_provenance = m_params.perform_sanity_checks;
     utils::embed_triangles_in_tets(
         tri_vrt_coord,
         triangle_indices,

--- a/src/wmtk/utils/EmbedSegments.cpp
+++ b/src/wmtk/utils/EmbedSegments.cpp
@@ -11,6 +11,7 @@
 #include <array>
 #include <bitset>
 #include <cstdint>
+#include <map>
 #include <set>
 
 namespace wmtk::utils {
@@ -113,7 +114,8 @@ void embed_segments(
     MatrixXd& V_out,
     std::vector<Vector2r>& V_rational,
     MatrixXi& F_out,
-    MatrixXi& E_out)
+    MatrixXi& E_out,
+    std::vector<std::vector<int>>* E_out_sources)
 {
     assert(V.cols() == 2);
     assert(E.cols() == 2);
@@ -190,26 +192,37 @@ void embed_segments(
 
     // The constrained edges of the output are the union of the per-segment edge
     // lists. Overlapping input segments share output edges, so deduplicate; a
-    // std::set keyed on the sorted vertex pair also fixes the row order, which
-    // keeps the result reproducible.
-    std::set<std::pair<int, int>> constrained_edges;
-    for (const auto& seg : segment_provenance) {
-        for (const auto& e : seg) {
+    // std::map keyed on the sorted vertex pair also fixes the row order, which
+    // keeps the result reproducible. The value is which input segments produced
+    // the edge -- the provenance the caller would otherwise have to guess back
+    // geometrically, and cannot where two inputs overlap.
+    std::map<std::pair<int, int>, std::vector<int>> constrained_edges;
+    for (size_t s = 0; s < segment_provenance.size(); ++s) {
+        for (const auto& e : segment_provenance[s]) {
             int a = int(e[1]);
             int b = int(e[2]);
             if (a > b) {
                 std::swap(a, b);
             }
-            constrained_edges.insert({a, b});
+            auto& src = constrained_edges[{a, b}];
+            if (src.empty() || src.back() != int(s)) {
+                src.push_back(int(s)); // s ascends, so this keeps it sorted and unique
+            }
         }
     }
 
     E_out.resize(constrained_edges.size(), 2);
+    if (E_out_sources != nullptr) {
+        E_out_sources->assign(constrained_edges.size(), {});
+    }
     {
         int idx = 0;
-        for (const auto& edge : constrained_edges) {
+        for (const auto& [edge, src] : constrained_edges) {
             E_out(idx, 0) = edge.first;
             E_out(idx, 1) = edge.second;
+            if (E_out_sources != nullptr) {
+                (*E_out_sources)[idx] = src;
+            }
             ++idx;
         }
     }

--- a/src/wmtk/utils/EmbedSegments.hpp
+++ b/src/wmtk/utils/EmbedSegments.hpp
@@ -28,6 +28,9 @@ namespace wmtk::utils {
  * @param V_rational output vertices, exact (size K)
  * @param F_out output faces (Lx3)
  * @param E_out output edges (Px2) - the output edges tiling the input edges
+ * @param[out] E_out_sources optional: for each row of E_out, the input edges (rows of E) it
+ *             tiles, ascending. Usually one; more where input edges overlap, which is
+ *             exactly the case a geometric look-up on E_out alone cannot tell apart.
  */
 void embed_segments(
     const MatrixXd& V,
@@ -35,7 +38,8 @@ void embed_segments(
     MatrixXd& V_out,
     std::vector<Vector2r>& V_rational,
     MatrixXi& F_out,
-    MatrixXi& E_out);
+    MatrixXi& E_out,
+    std::vector<std::vector<int>>* E_out_sources = nullptr);
 
 /**
  * @brief Read every input edge mesh and concatenate them into one segment network.

--- a/src/wmtk/utils/EmbedTriangles.cpp
+++ b/src/wmtk/utils/EmbedTriangles.cpp
@@ -13,6 +13,7 @@
 #include <wmtk/utils/EnableWarnings.hpp>
 // clang-format on
 
+#include <algorithm>
 #include <set>
 
 namespace wmtk::utils {
@@ -28,7 +29,8 @@ void embed_triangles_in_tets(
     std::vector<bool>& is_v_on_input,
     std::vector<std::array<size_t, 4>>& tets_after,
     std::vector<bool>& tet_face_on_input_surface,
-    const EmbedTrianglesOptions& opts)
+    const EmbedTrianglesOptions& opts,
+    EmbedTrianglesProvenance* provenance)
 {
     // Remesher outputs. The tet-based ones are what this consumes: out_tets (the
     // remesher's tetrahedra), final_tets_parent (parent polyhedral cell of each
@@ -80,6 +82,7 @@ void embed_triangles_in_tets(
     std::vector<double> vr_edge_coords, vr_point_coords;
     std::vector<uint32_t> vr_edge_indexes;
     std::vector<std::vector<std::array<uint32_t, 4>>> vr_tri_provenance;
+    std::vector<uint32_t> vr_tri_group;
     std::vector<std::vector<std::array<uint32_t, 3>>> vr_edge_provenance;
     std::vector<std::array<uint32_t, 2>> vr_point_provenance;
     vol_rem::embed_tri_in_poly_mesh(
@@ -99,6 +102,7 @@ void embed_triangles_in_tets(
         vr_edge_indexes,
         vr_point_coords,
         vr_tri_provenance,
+        vr_tri_group,
         vr_edge_provenance,
         vr_point_provenance,
         true);
@@ -164,13 +168,89 @@ void embed_triangles_in_tets(
     }
     logger().info("done");
 
-    // Per-face on-input-surface flags.
+    // Per-face on-input-surface flags, from the remesher's triangle provenance.
+    //
+    // vr_tri_provenance[g] lists, for coplanar group g of the input, the output faces tiling
+    // it as {tet, v0, v1, v2}; vr_tri_group maps each input triangle to its g. A face is on
+    // the input surface iff some group names it. The faces are named by vertex triple rather
+    // than by facet index, so index them the same way -- sorted triples in a sorted vector,
+    // which is both cheaper to build than a hash set and deterministic.
+    //
+    // What this replaces is the remesher's `facets_on_input`, which is every face coloured
+    // BLACK_A ("fully contained in one constraint"). The two agree on every model in the
+    // suite (measured, see the commit message), but provenance is the stronger statement:
+    // it is contained in a *genuine input* constraint, positive-area-overlapping it, whereas
+    // the colour also fires on the virtual constraints the arrangement adds for itself.
     logger().info("Tags loop...");
+    using FaceKey = std::pair<std::array<uint32_t, 3>, uint32_t>; // sorted triple -> group
+    std::vector<FaceKey> on_input_faces;
+    {
+        size_t n = 0;
+        for (const auto& group : vr_tri_provenance) {
+            n += group.size();
+        }
+        on_input_faces.reserve(n);
+        for (size_t g = 0; g < vr_tri_provenance.size(); ++g) {
+            for (const auto& e : vr_tri_provenance[g]) {
+                std::array<uint32_t, 3> key{{e[1], e[2], e[3]}};
+                std::sort(key.begin(), key.end());
+                on_input_faces.emplace_back(key, uint32_t(g));
+            }
+        }
+        // A face where two exactly-coplanar groups meet is listed under both, so the keys
+        // are unique as pairs but the triples are not.
+        std::sort(on_input_faces.begin(), on_input_faces.end());
+    }
+    // All the entries naming one output face, as a range in the sorted vector above.
+    const auto groups_of = [&on_input_faces](const std::array<size_t, 3>& f) {
+        std::array<uint32_t, 3> key{{uint32_t(f[0]), uint32_t(f[1]), uint32_t(f[2])}};
+        std::sort(key.begin(), key.end());
+        return std::equal_range(
+            on_input_faces.begin(),
+            on_input_faces.end(),
+            FaceKey{key, 0},
+            [](const FaceKey& a, const FaceKey& b) { return a.first < b.first; });
+    };
+
     polygon_faces_on_input.assign(polygon_faces.size(), false);
-    for (size_t i = 0; i < embedded_facets_on_input.size(); ++i) {
-        polygon_faces_on_input[embedded_facets_on_input[i]] = true;
+    if (provenance != nullptr) {
+        provenance->triangle_group = vr_tri_group;
+        provenance->face_groups.reserve(on_input_faces.size());
+    }
+    for (size_t i = 0; i < polygon_faces.size(); ++i) {
+        const auto [lo, hi] = groups_of(polygon_faces[i]);
+        polygon_faces_on_input[i] = lo != hi;
+        if (provenance != nullptr) {
+            for (auto it = lo; it != hi; ++it) {
+                provenance->face_groups.push_back({uint32_t(i), it->second});
+            }
+        }
     }
     logger().info("done");
+
+    // The old colour-based answer, kept only to be diffed against the one above. Off by
+    // default: it is what the check exists to retire, and holding both costs a second pass.
+    if (opts.check_surface_provenance) {
+        std::vector<bool> by_colour(polygon_faces.size(), false);
+        for (size_t i = 0; i < embedded_facets_on_input.size(); ++i) {
+            by_colour[embedded_facets_on_input[i]] = true;
+        }
+        size_t only_colour = 0, only_provenance = 0;
+        for (size_t i = 0; i < polygon_faces.size(); ++i) {
+            if (by_colour[i] && !polygon_faces_on_input[i]) {
+                ++only_colour;
+            } else if (!by_colour[i] && polygon_faces_on_input[i]) {
+                ++only_provenance;
+            }
+        }
+        logger().info(
+            "surface provenance check: {} faces on input by provenance, {} by colour, "
+            "{} only-colour, {} only-provenance",
+            std::count(polygon_faces_on_input.begin(), polygon_faces_on_input.end(), true),
+            std::count(by_colour.begin(), by_colour.end(), true),
+            only_colour,
+            only_provenance);
+    }
 
     // Step 4c: surface tracking, from the remesher-provided metadata. For each
     // output tet it looks at its parent cell (final_tets_parent) and the parent
@@ -180,12 +260,21 @@ void embed_triangles_in_tets(
     assert(final_tets_parent_faces.size() == out_tets.size());
     for (size_t i = 0; i < out_tets.size(); ++i) {
         const auto& tetra = out_tets[i];
-        const uint32_t tetra_parent = final_tets_parent[i];
 
-        // Fast path: if the parent cell has no faces on the input surface, none
-        // of this tet's faces can either -- push four false flags and move on.
-        if (!cells_with_faces_on_input[tetra_parent]) {
-            for (int i = 0; i < 4; ++i) {
+        // Fast path: if none of the parent faces bounding this tet is on the input surface,
+        // neither is any of its own faces -- push four false flags and skip the sorting
+        // below. This is the exact test rather than the remesher's per-cell
+        // cells_with_faces_on_input, which answers the same question one level coarser and
+        // in terms of the face colour this no longer reads.
+        bool any_on_input = false;
+        for (const auto& f : final_tets_parent_faces[i]) {
+            if (polygon_faces_on_input[f]) {
+                any_on_input = true;
+                break;
+            }
+        }
+        if (!any_on_input) {
+            for (int k = 0; k < 4; ++k) {
                 tet_face_on_input_surface.push_back(false);
             }
             continue;

--- a/src/wmtk/utils/EmbedTriangles.hpp
+++ b/src/wmtk/utils/EmbedTriangles.hpp
@@ -18,6 +18,34 @@ struct EmbedTrianglesOptions
     /// Check every output tet's orientation in exact arithmetic, after embedding and again
     /// after the vertex compaction.
     bool check_orientation = false;
+    /// Report how the provenance-derived "face is on the input surface" answer differs from
+    /// the remesher's older colour-derived `facets_on_input`. Diagnostic only -- the surface
+    /// always comes from provenance; this just counts the disagreement.
+    bool check_surface_provenance = false;
+};
+
+/**
+ * @brief Which input triangles each output surface face came from.
+ *
+ * The arrangement answers this per *coplanar group* rather than per input triangle: the
+ * remesher first partitions the input into maximal sets of triangles that are transitively
+ * edge-adjacent and exactly coplanar, then tracks which output faces tile each set. A flat
+ * region tiled by many input triangles is therefore one group, and -- the case to design
+ * around -- a group can span triangles from several input surfaces where they meet
+ * coplanarly along a shared edge.
+ *
+ * Optional: pass nullptr (the default) if the boolean `polygon_faces_on_input` is enough,
+ * as it is for tetwild, and neither vector is built.
+ */
+struct EmbedTrianglesProvenance
+{
+    /// (facet, coplanar group) pairs, sorted, indexing `polygon_faces`. Only facets on the
+    /// input surface appear, and a facet where two exactly-coplanar groups meet appears once
+    /// per group.
+    std::vector<std::array<uint32_t, 2>> face_groups;
+    /// Per input triangle (same indexing as `triangle_indices`): its coplanar group, or
+    /// UINT32_MAX if it was degenerate and dropped before the arrangement.
+    std::vector<uint32_t> triangle_group;
 };
 
 /**
@@ -29,10 +57,10 @@ struct EmbedTrianglesOptions
  *   1. run the arrangement;
  *   2. convert the remesher's bigrational coordinates to Vector3r;
  *   3. decode embedded_facets into triangles (fixed stride of 4: one size prefix + 3 vertex
- *      ids) and recover which are on the input surface;
- *   4. track the surface onto the output tets, using the remesher's own metadata --
- *      final_tets_parent (which polyhedral cell each tet came from), final_tets_parent_faces
- *      (which polygon faces bound it) and cells_with_faces_on_input;
+ *      ids) and recover which are on the input surface, from the remesher's triangle
+ *      provenance -- the output faces each coplanar group of input triangles is tiled by;
+ *   4. track the surface onto the output tets, using final_tets_parent_faces (which polygon
+ *      faces bound each tet);
  *   5. compact away vertices left unreferenced by out_tets and remap every index;
  *   6. reorder the per-tet face flags into WMTK's local face order.
  *
@@ -53,6 +81,7 @@ struct EmbedTrianglesOptions
  * @param[out] is_v_on_input per vertex: is it a corner of an on-input facet
  * @param[out] tets_after    output tets
  * @param[out] tet_face_on_input_surface  4 flags per tet, in WMTK local face order
+ * @param[out] provenance    optional: which input triangles each surface face came from
  */
 void embed_triangles_in_tets(
     const std::vector<double>& tri_vrt_coord,
@@ -65,6 +94,7 @@ void embed_triangles_in_tets(
     std::vector<bool>& is_v_on_input,
     std::vector<std::array<size_t, 4>>& tets_after,
     std::vector<bool>& tet_face_on_input_surface,
-    const EmbedTrianglesOptions& opts = {});
+    const EmbedTrianglesOptions& opts = {},
+    EmbedTrianglesProvenance* provenance = nullptr);
 
 } // namespace wmtk::utils

--- a/src/wmtk/utils/SimplifySegments.cpp
+++ b/src/wmtk/utils/SimplifySegments.cpp
@@ -23,11 +23,18 @@ Key key_of(int a, int b)
 
 } // namespace
 
-size_t
-simplify_segments(MatrixXd& V, MatrixXi& E, const SampleEnvelope& envelope, bool use_link_condition)
+size_t simplify_segments(
+    MatrixXd& V,
+    MatrixXi& E,
+    const SampleEnvelope& envelope,
+    bool use_link_condition,
+    std::vector<int>* surviving_edges)
 {
     const int nv = static_cast<int>(V.rows());
     const int ne = static_cast<int>(E.rows());
+    if (surviving_edges != nullptr) {
+        surviving_edges->clear();
+    }
     if (ne == 0 || nv == 0) {
         return 0;
     }
@@ -262,6 +269,9 @@ simplify_segments(MatrixXd& V, MatrixXi& E, const SampleEnvelope& envelope, bool
         ne_new += edge_alive[e] ? 1 : 0;
     }
     MatrixXi E_new(ne_new, 2);
+    if (surviving_edges != nullptr) {
+        surviving_edges->reserve(ne_new);
+    }
     int idx = 0;
     for (int e = 0; e < ne; ++e) {
         if (!edge_alive[e]) {
@@ -271,6 +281,9 @@ simplify_segments(MatrixXd& V, MatrixXi& E, const SampleEnvelope& envelope, bool
         assert(seg[e][0] != seg[e][1]);
         E_new(idx, 0) = remap[seg[e][0]];
         E_new(idx, 1) = remap[seg[e][1]];
+        if (surviving_edges != nullptr) {
+            surviving_edges->push_back(e);
+        }
         ++idx;
     }
 

--- a/src/wmtk/utils/SimplifySegments.hpp
+++ b/src/wmtk/utils/SimplifySegments.hpp
@@ -50,12 +50,18 @@ namespace wmtk::utils {
  *                   simplification cannot change the topology of the curve network. When
  *                   false the network simplifies much further on dirty inputs, at the cost
  *                   of merging junctions and separate curves that pass within the envelope.
+ * @param[out] surviving_edges  optional: for each row of the compacted E, its row index in
+ *                   the E that was passed in. A collapse rewires segments but never creates
+ *                   one, so this is exactly the surviving rows in ascending order -- which
+ *                   is what lets a caller carry per-segment labels (which input curve a
+ *                   segment came from) across the simplification.
  * @return the number of vertices removed
  */
 size_t simplify_segments(
     MatrixXd& V,
     MatrixXi& E,
     const SampleEnvelope& envelope,
-    bool use_link_condition = true);
+    bool use_link_condition = true,
+    std::vector<int>* surviving_edges = nullptr);
 
 } // namespace wmtk::utils


### PR DESCRIPTION
Stacked on #1018 — base is `simwild-cleanup`, so review only the two commits here.

## Why

The four meshes split two ways on where the tracked surface comes from. tetwild 3D and triwild 2D take it **from the arrangement**. simwild 3D and 2D did **not**: they ran the arrangement, discarded the surface it computed, evaluated the winding number of every input at each cell's centroid, and then re-derived the surface as *"the two incident cells' tags differ"*. That derived invariant is what the whole simwild swap family rests on, so it mattered that it was **voted on** rather than **known**.

`EmbedTriangles.cpp` had already asked the remesher for all three provenance vectors and never read one of them. `EmbedSurface.hpp` declares `m_F_tags_surface` and has never written it, next to a comment saying so:

> We should not rely on geometric look-up at all, but use the information stored in `m_F_tags_surface`. This is more work so I took a shortcut here.

## What

**`Take the 3D surface from the arrangement's triangle provenance`** — a face is on the input surface iff some coplanar group of the input tiles it, rather than iff the remesher coloured it `BLACK_A`. The colour also fires on the virtual constraints the arrangement adds for itself; provenance is the stronger statement. Needs VolumeRemesher [#24](https://github.com/wildmeshing/VolumeRemesher/pull/24) (merged), which returns the input-triangle → coplanar-group map that was computed and never exposed; the pin moves with it.

Also adds `EmbedTrianglesProvenance`, an optional output carrying the `(facet, group)` pairs and the triangle → group map. tetwild passes `nullptr` and neither vector is built.

**`simwild: tag cells from the arrangement, behind tag_from_winding_number`** — the other tagging route, in both dimensions, off by default:

```json
"tag_from_winding_number": false
```

Tags then propagate combinatorially: from a cell of the padded box, which is outside everything, flip membership of input *i* whenever a face belonging to *i* is crossed. Crossings that disagree with the tags already assigned are counted, and a nonzero count throws — that means an input is not closed, so inside/outside is not a property of the surface alone.

## Is it right, or just different?

The invariant everything downstream depends on is *a face is surface iff its two cells' tags differ* — `init_surfaces_and_boundaries` builds `m_is_surface_fs` from exactly that. `check_tag_surface_invariant`, under `DEBUG_sanity_checks`, counts where a tagging breaks it:

| model | provenance | winding number |
|---|---|---|
| `simwild_double_sphere_3d` | **0** | 120 (81 differ off-surface, 39 equal on-surface) |
| `simwild_double_sphere_notop_3d` | **0** | 4671 |

0 with *and* without input simplification, which is also what checks the label mapping below. Where `preserve_topology` is set, the flood fill that follows repairs the winding-number noise and the two routes then produce **byte-identical output** — which is why nobody had noticed. Without it (`notop`) the noise reaches the mesh. In 2D, two overlapping closed circles give byte-identical output under both routes; the two 2D configs that arrange curves have **open** polylines as input, and the provenance route says so instead of guessing.

## The part that needed care

Both dimensions coarsen the input *before* arranging it, so the arrangement answers in terms of the coarsened primitives and the input labels have to survive that. Neither simplification ever creates a primitive, and both compact survivors in ascending id order (`TriMesh::consolidate_mesh`'s `map_t_ids`, `simplify_segments`' final loop) — so the sorted surviving ids **are** the map. `simplify_segments` now returns them; the 3D side reads the fids off the mesh before consolidating.

## Validation

Per the standing policy — tetwild and triwild byte-identical, simwild may move and every move is measured. All against the parent commit (#1018 head):

- **53 registered configs**, every `report.json` field + md5 of every emitted mesh: **47 identical, 0 moved**, 0 failures.
- **`tetwild_crown` / `tetwild_octocat` at `num_threads: 0`** (they are multithread-nondeterministic and move on any run, so they are compared at 0 on both sides): **identical, 0 moved**.
- **The 30 hidden `[challenging]` models** (14 tetwild Thingi10K, 16 triwild20k): **identical 30, moved 0, missing 0**, 30 OK / no failures.

Nothing moved anywhere with the option at its default.

## Not done, on purpose

The plan's step 4 was *"triwild feature points from point provenance"*. `out_point_provenance` answers "which output vertex is input point *k*" — a different question from triwild's rule, which is the **valence of the constrained-edge network in the output**. Arrangement crossings are genuine junctions and must be features; an input-point rule would miss every one of them. triwild's `E` already comes from `segment_provenance`, so its features are provenance-derived transitively. Doing step 4 literally would make triwild worse.