### PR TITLE
Let a 3D application track more than one surface

### DIFF
--- a/components/simwild/wmtk/components/simwild/EdgeCollapsing.cpp
+++ b/components/simwild/wmtk/components/simwild/EdgeCollapsing.cpp
@@ -5,7 +5,7 @@
 
 namespace wmtk::components::simwild {
 
-bool SimWildMesh::collapse_before_vertex(size_t v1, size_t v2, double edge_length) const
+bool SimWildMesh::collapse_before_vertex(size_t v1, size_t v2, double edge_length)
 {
     if (edge_length <= 0 || m_vertex_attribute[v1].m_order != 2) return true;
     return m_vertex_attribute[v2].m_order >= 2;

--- a/components/simwild/wmtk/components/simwild/SimWildMesh.h
+++ b/components/simwild/wmtk/components/simwild/SimWildMesh.h
@@ -188,7 +188,7 @@ protected:
     bool optimization_stop_at_float() const override { return m_sim_params.stop_at_float; }
     void write_optimization_debug_output(const std::string& path) override { write_vtu(path); }
 
-    bool collapse_before_vertex(size_t v1, size_t v2, double edge_length) const override;
+    bool collapse_before_vertex(size_t v1, size_t v2, double edge_length) override;
     bool collapse_quality_allowed(size_t v1, double quality, double ring_max) const override;
     bool collapse_is_order_2_edge(const std::array<size_t, 2>& e) override;
     bool collapse_after_connectivity(

--- a/components/tetwild/wmtk/components/tetwild/TetWildMesh.h
+++ b/components/tetwild/wmtk/components/tetwild/TetWildMesh.h
@@ -92,7 +92,7 @@ public:
     {
         m_vertex_extra[vid].m_is_on_open_boundary = is_open_boundary;
     }
-    bool collapse_before_vertex(size_t v1, size_t v2, double edge_length) const override
+    bool collapse_before_vertex(size_t v1, size_t v2, double edge_length) override
     {
         if (edge_length <= 0 || !m_vertex_extra[v1].m_is_on_open_boundary) return true;
         return m_vertex_extra[v2].m_is_on_open_boundary ||

--- a/src/wmtk/SurfaceTagAttributes.h
+++ b/src/wmtk/SurfaceTagAttributes.h
@@ -19,16 +19,35 @@ public:
     /// Which bbox side this simplex is on; -1 for none.
     int m_is_bbox_fs = -1;
 
+    /**
+     * @brief Which tracked surface this simplex belongs to, for applications that track more
+     * than one.
+     *
+     * 0 is the application's primary surface, and is all tetwild and simwild ever use.
+     * topological_offset tracks two -- the input complex it must stay in the envelope of, and
+     * the offset boundary it is free to move -- and uses 1 for the latter. Meaningless, and
+     * left at 0, when m_is_surface_fs is false.
+     *
+     * The class lives here, on the attribute struct, rather than in a container of its own
+     * because the shared operations copy face attributes WHOLESALE -- assignment in the split
+     * and collapse caches, merge() in collapse_edge_before, reset() in the swap tracker. A
+     * field here is carried by all of that for free; a parallel container would be silently
+     * dropped by every one of those operations.
+     */
+    int m_surface_class = 0;
+
     void reset()
     {
         m_is_surface_fs = false;
         m_is_bbox_fs = -1;
+        m_surface_class = 0;
     }
 
     void merge(const SurfaceTagAttributes& attr)
     {
         m_is_surface_fs = m_is_surface_fs || attr.m_is_surface_fs;
         if (attr.m_is_bbox_fs >= 0) m_is_bbox_fs = attr.m_is_bbox_fs;
+        if (attr.m_surface_class != 0) m_surface_class = attr.m_surface_class;
     }
 };
 

--- a/src/wmtk/TetOptimizerMesh.cpp
+++ b/src/wmtk/TetOptimizerMesh.cpp
@@ -130,10 +130,7 @@ std::tuple<double, double> TetOptimizerMesh::local_operations(
         logger().info("Perform sanity checks...");
         const auto faces = get_faces_by_condition([](const auto& f) { return f.m_is_surface_fs; });
         for (const auto& verts : faces) {
-            const auto p0 = m_vertex_attribute[verts[0]].m_posf;
-            const auto p1 = m_vertex_attribute[verts[1]].m_posf;
-            const auto p2 = m_vertex_attribute[verts[2]].m_posf;
-            if (m_envelope->is_outside({{p0, p1, p2}})) {
+            if (surface_triangle_is_outside(verts[0], verts[1], verts[2])) {
                 logger().error("Face {} is outside!", verts);
             }
         }

--- a/src/wmtk/TetOptimizerMesh.h
+++ b/src/wmtk/TetOptimizerMesh.h
@@ -91,6 +91,21 @@ public:
     AttributeContainerGroup m_vertex_attr_group;
 
     /**
+     * @brief What p_face_attrs points at, so a derived class can register more.
+     *
+     * The counterpart of m_vertex_attr_group for faces. An application whose faces carry data
+     * the shared operations know nothing about -- topological_offset labels each face by which
+     * part of the construction produced it -- registers a second collection here, and it is
+     * resized, protected and rolled back with the shared one.
+     *
+     * Note what this does NOT do: the shared operations propagate face data by copying
+     * SurfaceTagAttributes values around (the split and collapse caches, the swap tracker), and
+     * they only ever see their own collection. Anything registered here survives the mesh
+     * changing shape, but its values are the registering application's to maintain.
+     */
+    AttributeContainerGroup m_face_attr_group;
+
+    /**
      * @brief The sentinel get_quality returns for an element AMIPS cannot score.
      *
      * Not an energy: a positively oriented tet whose volume is too small for AMIPS, or one that
@@ -149,7 +164,8 @@ public:
     {
         m_vertex_attr_group.add(&m_vertex_attribute);
         p_vertex_attrs = &m_vertex_attr_group;
-        p_face_attrs = &m_face_attribute;
+        m_face_attr_group.add(&m_face_attribute);
+        p_face_attrs = &m_face_attr_group;
     }
     ~TetOptimizerMesh() override = default;
 
@@ -233,6 +249,35 @@ public:
      * per-vertex flag -- it counts the incident tets' face attributes directly.
      */
     int edge_incident_surface_face_count(const Tuple& e);
+
+    /**
+     * @brief Envelope the tracked-surface triangle `vids` must stay inside.
+     *
+     * Null means this triangle carries no containment requirement, and every containment check
+     * on it is skipped. Both applications that track a single surface keep one envelope for it,
+     * so the default answers with that; an application tracking more than one surface (see
+     * SurfaceTagAttributes::m_surface_class) overrides this to answer per class -- the offset
+     * boundary, for instance, is free to move and is checked against nothing.
+     *
+     * Keyed on the vertex ids rather than the fid because every caller is a topological
+     * operation asking about the triangles it is ABOUT to create or has just created, where
+     * only the vids are known for certain.
+     */
+    virtual std::shared_ptr<SampleEnvelope> surface_envelope_for_face(
+        const std::array<size_t, 3>& vids) const
+    {
+        return m_envelope;
+    }
+
+    /// Whether the tracked-surface triangle (a,b,c) is outside its containment envelope. False
+    /// when it has none. Every surface containment check in the operations goes through here.
+    bool surface_triangle_is_outside(const size_t a, const size_t b, const size_t c) const
+    {
+        const std::shared_ptr<SampleEnvelope> env = surface_envelope_for_face({{a, b, c}});
+        if (!env) return false;
+        const auto& VA = m_vertex_attribute;
+        return env->is_outside({{VA[a].m_posf, VA[b].m_posf, VA[c].m_posf}});
+    }
 
     bool vertex_is_on_surface(const size_t vid) const override;
     bool face_is_on_surface(const size_t fid) const override;
@@ -346,7 +391,9 @@ protected:
     virtual void optimization_sanity_checks_extra() {}
     virtual bool optimization_stop_at_float() const { return false; }
 
-    virtual bool collapse_before_vertex(size_t, size_t, double) const { return true; }
+    /// Non-const: an override may cache what it measured before the collapse so its `after`
+    /// counterpart can tell a regression from a defect that was already there.
+    virtual bool collapse_before_vertex(size_t, size_t, double) { return true; }
     virtual bool collapse_quality_allowed(size_t v1, double quality, double ring_max) const
     {
         return !m_vertex_attribute.at(v1).m_is_rounded || quality <= ring_max;

--- a/src/wmtk/TetOptimizerMeshCollapse.cpp
+++ b/src/wmtk/TetOptimizerMeshCollapse.cpp
@@ -100,7 +100,12 @@ bool TetOptimizerMesh::collapse_edge_before(const Tuple& loc) // input is an edg
 
     // surface
     if (cache.edge_length > 0 && VA[v1_id].m_is_on_surface) {
-        if (!VA[v2_id].m_is_on_surface && m_envelope->is_outside(VA[v2_id].m_posf)) {
+        // Moving a surface vertex onto a non-surface one is only safe if the destination is
+        // inside the envelope. With no envelope to ask, that cannot be certified, so refuse --
+        // which is also what keeps this from dereferencing a null envelope. Both applications
+        // that reach here always have one, so the guard never fires for them.
+        if (!VA[v2_id].m_is_on_surface &&
+            (!m_envelope || m_envelope->is_outside(VA[v2_id].m_posf))) {
             return false;
         }
     }
@@ -331,9 +336,7 @@ bool TetOptimizerMesh::collapse_edge_after(const Tuple& loc)
     if (cache.edge_length > 0) {
         for (auto& vids : cache.surface_faces) {
             // surface envelope
-            bool is_out = m_envelope->is_outside(
-                {{VA.at(vids[0]).m_posf, VA.at(vids[1]).m_posf, VA.at(vids[2]).m_posf}});
-            if (is_out) {
+            if (surface_triangle_is_outside(vids[0], vids[1], vids[2])) {
                 return false;
             }
 

--- a/src/wmtk/TetOptimizerMeshSplit.cpp
+++ b/src/wmtk/TetOptimizerMeshSplit.cpp
@@ -304,7 +304,6 @@ bool TetOptimizerMesh::split_edge_after(const Tuple& loc)
     // The face split is (v1,v2,other) -> (v1,v_id,other) + (v2,v_id,other), which is the same
     // pair of new triangles the attribute update below writes.
     if (cache.is_edge_on_surface) {
-        const auto& VA = m_vertex_attribute;
         for (const auto& info : cache.changed_faces) {
             if (!info.first.m_is_surface_fs) continue;
             const auto& old_vids = info.second;
@@ -318,10 +317,10 @@ bool TetOptimizerMesh::split_edge_after(const Tuple& loc)
                 }
             }
             if (n_shared != 2) continue; // face does not contain the split edge
-            if (m_envelope->is_outside({{VA[v1_id].m_posf, VA[v_id].m_posf, VA[other].m_posf}})) {
+            if (surface_triangle_is_outside(v1_id, v_id, other)) {
                 return false;
             }
-            if (m_envelope->is_outside({{VA[v2_id].m_posf, VA[v_id].m_posf, VA[other].m_posf}})) {
+            if (surface_triangle_is_outside(v2_id, v_id, other)) {
                 return false;
             }
         }

--- a/src/wmtk/TetOptimizerMeshSwaps.cpp
+++ b/src/wmtk/TetOptimizerMeshSwaps.cpp
@@ -322,13 +322,8 @@ bool TetOptimizerMesh::swap_edge_after(const Tuple& t)
     if (cache.is_surface_flip) {
         // The two new surface faces (a,c,d),(b,c,d) must stay within the
         // Hausdorff envelope, exactly like a surface-edge collapse.
-        const auto& VA = m_vertex_attribute;
-        if (m_envelope->is_outside(
-                {{VA[cache.sf_a].m_posf, VA[cache.sf_c].m_posf, VA[cache.sf_d].m_posf}}))
-            return false;
-        if (m_envelope->is_outside(
-                {{VA[cache.sf_b].m_posf, VA[cache.sf_c].m_posf, VA[cache.sf_d].m_posf}}))
-            return false;
+        if (surface_triangle_is_outside(cache.sf_a, cache.sf_c, cache.sf_d)) return false;
+        if (surface_triangle_is_outside(cache.sf_b, cache.sf_c, cache.sf_d)) return false;
     }
 
     tracker_assign_after(*this, twotets, cache.changed_faces, m_face_attribute);
@@ -613,13 +608,8 @@ bool TetOptimizerMesh::swap_edge_44_after(const Tuple& t)
     if (cache.is_surface_flip) {
         // The two new surface faces (a,c,d),(b,c,d) must stay within the Hausdorff envelope,
         // exactly like a surface-edge collapse / the 3->2 surface flip.
-        const auto& VA = m_vertex_attribute;
-        if (m_envelope->is_outside(
-                {{VA[cache.sf_a].m_posf, VA[cache.sf_c].m_posf, VA[cache.sf_d].m_posf}}))
-            return false;
-        if (m_envelope->is_outside(
-                {{VA[cache.sf_b].m_posf, VA[cache.sf_c].m_posf, VA[cache.sf_d].m_posf}}))
-            return false;
+        if (surface_triangle_is_outside(cache.sf_a, cache.sf_c, cache.sf_d)) return false;
+        if (surface_triangle_is_outside(cache.sf_b, cache.sf_c, cache.sf_d)) return false;
     }
 
     tracker_assign_after(*this, incident_tets, cache.changed_faces, m_face_attribute);
@@ -740,13 +730,8 @@ bool TetOptimizerMesh::swap_edge_56_after(const Tuple& t)
 
     if (cache.is_surface_flip) {
         // The two new surface faces (a,c,d),(b,c,d) must stay within the Hausdorff envelope.
-        const auto& VA = m_vertex_attribute;
-        if (m_envelope->is_outside(
-                {{VA[cache.sf_a].m_posf, VA[cache.sf_c].m_posf, VA[cache.sf_d].m_posf}}))
-            return false;
-        if (m_envelope->is_outside(
-                {{VA[cache.sf_b].m_posf, VA[cache.sf_c].m_posf, VA[cache.sf_d].m_posf}}))
-            return false;
+        if (surface_triangle_is_outside(cache.sf_a, cache.sf_c, cache.sf_d)) return false;
+        if (surface_triangle_is_outside(cache.sf_b, cache.sf_c, cache.sf_d)) return false;
     }
 
     tracker_assign_after(*this, tids, cache.changed_faces, m_face_attribute);


### PR DESCRIPTION
Lets a 3D application track **more than one tracked surface**, which is what `topological_offset` needs to run its optimization on `wmtk::TetOptimizerMesh` (PR B, stacked on this one).

`TetOptimizerMesh` assumes one surface with one envelope. The offset has two: the input complex, which must stay inside the envelope and never moves, and the offset boundary, which is defined by which tets carry the offset label and is free to move. Both must be protected from being torn by an operation, but only the first is envelope-constrained.

### What this adds

- **`SurfaceTagAttributes::m_surface_class`** — which surface a simplex belongs to, `0` being the primary one. It lives on the attribute struct rather than in a container of its own because the shared operations copy face attributes *wholesale* — assignment in the split and collapse caches, `merge()` in `collapse_edge_before`, `reset()` in the swap tracker — so a field here is carried by all of that for free, where a parallel container would be silently dropped by every one of those operations.
- **`surface_envelope_for_face(vids)`** — selects the envelope per triangle; null means the triangle carries no containment requirement. The nine containment checks in collapse, split and the three surface flips now go through `surface_triangle_is_outside()`, which asks it. The default returns `m_envelope`, so the predicate is unchanged wherever there is only one surface.
- **`m_face_attr_group`** — the counterpart of `m_vertex_attr_group` for faces, so an application whose faces carry extra data can register it and have it resized, protected and rolled back with the shared collection.
- **`collapse_before_vertex` is no longer `const`**, so an override can cache what it measured before the collapse and let its `after` counterpart tell a regression from a defect that was already there.

Also makes the surface-vertex collapse guard null-safe: it dereferenced `m_envelope` unconditionally, and with no envelope to ask, whether the destination is inside it cannot be certified, so the collapse is refused rather than crashing.

### Validation

tetwild and triwild must be byte-identical, and are. Every default returns exactly what the code returned before, so the predicates are unchanged by construction — but they are hot paths, so they were measured anyway.

| gate | result |
|---|---|
| 53 registered integration configs | **47 identical, 0 moved**, 53 OK / no failures. The other 2 are `tetwild_crown` and `tetwild_octocat`, the only registered configs with `num_threads != 0` and therefore the only nondeterministic ones — re-checked below |
| `tetwild_crown` / `tetwild_octocat` at `num_threads: 0` | **identical, 0 moved** |
| 30 hidden `[challenging]` models | **identical 30, moved 0, missing 0**, 30 OK / no failures |

Baseline is `main` at 4ae464994b.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
