### PR TITLE
Let a 2D application track more than one surface

### DIFF
--- a/src/wmtk/TriOptimizerMesh.cpp
+++ b/src/wmtk/TriOptimizerMesh.cpp
@@ -127,9 +127,7 @@ std::tuple<double, double> TriOptimizerMesh::local_operations(
         logger().info("Perform sanity checks...");
         const auto edges = get_edges_by_condition([](const auto& e) { return e.m_is_surface_fs; });
         for (const auto& verts : edges) {
-            const auto& p0 = m_vertex_attribute[verts[0]].m_posf;
-            const auto& p1 = m_vertex_attribute[verts[1]].m_posf;
-            if (m_envelope->is_outside(std::array<Vector2d, 2>{{p0, p1}})) {
+            if (surface_segment_is_outside(verts[0], verts[1])) {
                 logger().error("Edge {} is outside!", verts);
             }
         }

--- a/src/wmtk/TriOptimizerMesh.h
+++ b/src/wmtk/TriOptimizerMesh.h
@@ -95,6 +95,32 @@ public:
     AttributeContainerGroup m_vertex_attr_group;
 
     /**
+     * @brief What p_edge_attrs points at, so a derived class can register more.
+     *
+     * The 2D counterpart of wmtk::TetOptimizerMesh::m_face_attr_group. An application whose
+     * edges carry data the shared operations know nothing about -- topological_offset labels
+     * each edge by which part of the construction produced it -- registers a second collection
+     * here, and it is resized, protected and rolled back with the shared one.
+     *
+     * Note what this does NOT do: the shared operations propagate edge data by copying
+     * SurfaceTagAttributes values around (the split and collapse caches, the swap cache), and
+     * they only ever see their own collection. Anything registered here survives the mesh
+     * changing shape, but its values are the registering application's to maintain.
+     */
+    AttributeContainerGroup m_edge_attr_group;
+
+    /**
+     * @brief What p_face_attrs points at, so a derived class can register more.
+     *
+     * Unlike the 3D mesh, whose cell attributes are per-application, the 2D base owns a
+     * concrete FaceAttributes -- so a derived class that needs an extra per-face field cannot
+     * add it there and registers a second collection here instead. Same caveat as the edge
+     * group: the shared operations propagate face data by copying FaceAttributes values
+     * around and never see this, so its values are the registering application's to maintain.
+     */
+    AttributeContainerGroup m_face_attr_group;
+
+    /**
      * @brief The sentinel get_quality returns for a face AMIPS2D cannot score.
      *
      * Not an energy: a positively oriented triangle whose area is too small for AMIPS, or one
@@ -134,8 +160,10 @@ public:
     {
         m_vertex_attr_group.add(&m_vertex_attribute);
         p_vertex_attrs = &m_vertex_attr_group;
-        p_edge_attrs = &m_edge_attribute;
-        p_face_attrs = &m_face_attribute;
+        m_edge_attr_group.add(&m_edge_attribute);
+        p_edge_attrs = &m_edge_attr_group;
+        m_face_attr_group.add(&m_face_attribute);
+        p_face_attrs = &m_face_attr_group;
 
         m_s_amips = 1.;
         /**
@@ -297,6 +325,34 @@ public:
         bool on_surface = m_edge_attribute.at(eid).m_is_surface_fs;
         bool on_bbox = m_edge_attribute.at(eid).m_is_bbox_fs >= 0;
         return on_surface || on_bbox;
+    }
+
+    /**
+     * @brief Envelope the tracked-surface segment `vids` must stay inside.
+     *
+     * The 2D counterpart of wmtk::TetOptimizerMesh::surface_envelope_for_face. Null means this
+     * segment carries no containment requirement, and every containment check on it is skipped.
+     * Both applications that track a single surface keep one envelope for it, so the default
+     * answers with that; an application tracking more than one (see
+     * SurfaceTagAttributes::m_surface_class) overrides this to answer per class.
+     *
+     * Keyed on the vertex ids rather than the eid because every caller is a topological
+     * operation asking about segments it is ABOUT to create or has just created.
+     */
+    virtual std::shared_ptr<SampleEnvelope> surface_envelope_for_edge(
+        const std::array<size_t, 2>& vids) const
+    {
+        return m_envelope;
+    }
+
+    /// Whether the tracked-surface segment (a,b) is outside its containment envelope. False
+    /// when it has none. Every surface containment check in the operations goes through here.
+    bool surface_segment_is_outside(const size_t a, const size_t b) const
+    {
+        const std::shared_ptr<SampleEnvelope> env = surface_envelope_for_edge({{a, b}});
+        if (!env) return false;
+        const auto& VA = m_vertex_attribute;
+        return env->is_outside(std::array<Vector2d, 2>{{VA[a].m_posf, VA[b].m_posf}});
     }
 
     std::vector<std::array<size_t, 2>> get_edges_by_condition(

--- a/src/wmtk/TriOptimizerMeshCollapse.cpp
+++ b/src/wmtk/TriOptimizerMeshCollapse.cpp
@@ -134,9 +134,7 @@ bool TriOptimizerMesh::collapse_edge_before(const Tuple& loc) // input is an edg
         // if both vertices are on the surface, the collapsing edge should be inside the envelope
         const size_t eid = loc.eid(*this);
         if (VA[v2_id].m_is_on_surface && !m_edge_attribute.at(eid).m_is_surface_fs) {
-            const Vector2d& p1 = VA[v1_id].m_posf;
-            const Vector2d& p2 = VA[v2_id].m_posf;
-            if (m_envelope->is_outside(std::array<Vector2d, 2>{{p1, p2}})) {
+            if (surface_segment_is_outside(v1_id, v2_id)) {
                 return false;
             }
         }
@@ -305,11 +303,8 @@ bool TriOptimizerMesh::collapse_edge_after(const Tuple& loc)
     // surface
     if (cache.edge_length > 0) {
         for (auto& vids : cache.surface_edges) {
-            const Vector2d a = VA.at(vids[0]).m_posf;
-            const Vector2d b = VA.at(vids[1]).m_posf;
             // surface envelope
-            bool is_out = m_envelope->is_outside(std::array<Vector2d, 2>{{a, b}});
-            if (is_out) {
+            if (surface_segment_is_outside(vids[0], vids[1])) {
                 return false;
             }
         }

--- a/src/wmtk/TriOptimizerMeshSplit.cpp
+++ b/src/wmtk/TriOptimizerMeshSplit.cpp
@@ -284,13 +284,10 @@ bool TriOptimizerMesh::split_edge_after(const Tuple& loc)
         // "inside the envelope (as expected)" --- that check samples by AREA and cannot see
         // violations that live on vanishingly small elements.
         if (cache.old_e_attrs.m_is_surface_fs) {
-            const Vector2d& pm = m_vertex_attribute[v_id].m_posf;
-            const Vector2d& p1 = m_vertex_attribute[v1_id].m_posf;
-            const Vector2d& p2 = m_vertex_attribute[v2_id].m_posf;
-            if (m_envelope->is_outside(std::array<Vector2d, 2>{{p1, pm}})) {
+            if (surface_segment_is_outside(v1_id, v_id)) {
                 return false;
             }
-            if (m_envelope->is_outside(std::array<Vector2d, 2>{{pm, p2}})) {
+            if (surface_segment_is_outside(v_id, v2_id)) {
                 return false;
             }
         }


### PR DESCRIPTION
Stacked on #1021 — **review #1020 and #1021 first**; this PR's diff includes them until they merge.

The 2D counterpart of #1020, and needed for the same reason: `topological_offset`'s 2D mesh tracks the input complex, which must stay inside the envelope and never moves, alongside the offset boundary, which is defined by which faces carry the offset label and is free to move. Both must be protected from being torn by an operation; only the first is envelope-constrained.

This is the toolkit half. The 2D port of the offset optimization itself is the next PR in the stack.

### What this adds

Less than the 3D side needed, because `TriOptimizerMesh` was already closer:

- **`SurfaceTagAttributes::m_surface_class` needs no 2D counterpart.** The 2D meshes attach that same struct to their *edges*, so #1020 already gave them the field.
- **The 2D base's `FaceAttributes` already carries a `tags` set**, which is exactly what the offset needs for its region tags — in 3D that had to be reached through `cell_quality()` because cell attributes are per-application.
- **`m_edge_attr_group` and `m_face_attr_group`** — so an application whose edges or faces carry extra data can register it and have it resized, protected and rolled back with the shared collections. The offset labels each edge *and* each face by which part of the construction produced it, and faces need a group here where they did not in 3D: the 2D base owns a concrete `FaceAttributes`, so a derived class cannot add a field to it.
- **`surface_envelope_for_edge(vids)`** — selects the envelope per segment; null means no containment requirement. The five containment checks in collapse, split and the sanity pass now go through `surface_segment_is_outside()`, which asks it. The default returns `m_envelope`, so the predicate is unchanged wherever there is only one surface.

### Validation

triwild must be byte-identical, and is. The defaults return exactly what the code returned before, so the predicates are unchanged by construction — but they are hot paths, so they were measured.

| gate | result |
|---|---|
| 53 registered configs | **all 13 triwild configs identical**; all 11 tetwild identical except `tetwild_crown` / `tetwild_octocat`, the only ones with `num_threads != 0` and therefore the only nondeterministic ones |
| `tetwild_crown` / `tetwild_octocat` at `num_threads: 0` | **identical, 0 moved** |
| 30 hidden `[challenging]` models (16 triwild20k + 14 tetwild) | **identical 30, moved 0, missing 0**, 30 OK / no failures |

Baseline is `main` at 4ae464994b. Three configs in the 53 (`topological_offset_3d`, `_3d_edge_input`, `manifold_extraction_3d`) move against that baseline because this branch carries #974's own construction changes via #1021 — nothing in this PR touches them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
