### PR TITLE
Keep the 3D offset region manifold through optimization

### DIFF
--- a/components/topological_offset/wmtk/components/topological_offset/Collapse.cpp
+++ b/components/topological_offset/wmtk/components/topological_offset/Collapse.cpp
@@ -73,6 +73,18 @@ double TopoOffsetTetMesh::collapse_normal_deviation(
     return max_angle - min_angle;
 }
 
+bool TopoOffsetTetMesh::collapse_edge_before(const Tuple& t)
+{
+    if (!TetOptimizerMesh::collapse_edge_before(t)) {
+        return false;
+    }
+    // Unconditionally, where the base asks only when BOTH endpoints already sit on a tracked
+    // simplex. That rule is right for tetwild and simwild; here the offset region is a thin
+    // shell, and a collapse with one endpoint in the interior can still pinch its two sides
+    // together while every tracked surface survives intact.
+    return substructure_link_condition(t);
+}
+
 bool TopoOffsetTetMesh::collapse_before_vertex(
     const size_t v1_id,
     const size_t v2_id,

--- a/components/topological_offset/wmtk/components/topological_offset/Parameters.h
+++ b/components/topological_offset/wmtk/components/topological_offset/Parameters.h
@@ -141,6 +141,15 @@ struct Parameters : public wmtk::OptimizerParameters
         box_min = min_;
         box_max = max_;
 
+        // Not a user knob. A TOPOLOGICAL offset is defined by preserving the topology of the
+        // region it wraps, so the shared collapse must always apply the substructure link
+        // condition -- without it a collapse across a thin offset band pinches the two sides
+        // together and the region stops being manifold. The offset's own collapse applied this
+        // unconditionally before it moved onto the shared engine, where it is gated on this
+        // flag; tetwild and simwild leave the flag off, which is why it is set here and not
+        // changed in wmtk.
+        preserve_topology = true;
+
         // Fills diag_l, l/lr and splitting_l2 / collapsing_l2 -- the same 16/9 and 16/25
         // factors this used to spell out itself. It also derives eps from epsr, which the
         // offset never reads: its envelope tolerance is m_envelope_eps, set on the mesh.

--- a/components/topological_offset/wmtk/components/topological_offset/Swap.cpp
+++ b/components/topological_offset/wmtk/components/topological_offset/Swap.cpp
@@ -22,8 +22,20 @@ bool TopoOffsetTetMesh::swap_capture_tag(const std::vector<size_t>& tids)
     for (const size_t t : tids) {
         tag_count[m_tet_attribute[t].tag]++;
     }
-    if (tag_count.size() > 2) {
-        return false; // cannot swap between three different tags
+    // Refuse any swap whose ring spans more than one tag.
+    //
+    // The rule used to be "at most two tags, and the majority wins". That is what tore the
+    // offset region: a face between differently tagged tets IS the offset surface, so a ring
+    // spanning two tags has the surface running through it, and collapsing all the new cells
+    // onto the majority tag moves that surface -- merging the two regions wherever the
+    // minority lost. Measured, the swap pass alone was enough to make the region
+    // non-manifold; with this it is not.
+    //
+    // Conservative: a genuine surface flip could keep both tags by assigning each new cell the
+    // tag of the side it lands on. That is worth doing, and would recover the flips this
+    // refuses, but it needs the side-of-surface test to be exact.
+    if (tag_count.size() > 1) {
+        return false;
     }
 
     size_t max_count = 0;

--- a/components/topological_offset/wmtk/components/topological_offset/TopoOffsetTetMesh.cpp
+++ b/components/topological_offset/wmtk/components/topological_offset/TopoOffsetTetMesh.cpp
@@ -1339,7 +1339,8 @@ bool TopoOffsetTetMesh::offset_is_manifold()
     std::vector<Vector4i> offset_tets;
     for (const Tuple& t : tets) {
         size_t t_id = t.tid(*this);
-        if (m_tet_attribute[t_id].label != 0) {
+        // Region membership from the tags the operations propagate, not the derived label.
+        if (cell_in_region(t_id)) {
             auto vs = oriented_tet_vids(t_id);
             offset_tets.emplace_back(vs[0], vs[1], vs[2], vs[3]);
         }

--- a/components/topological_offset/wmtk/components/topological_offset/TopoOffsetTetMesh.h
+++ b/components/topological_offset/wmtk/components/topological_offset/TopoOffsetTetMesh.h
@@ -221,6 +221,26 @@ public:
         m_vertex_attribute[vid].m_is_rounded = true;
     }
 
+    /**
+     * @brief Whether tet `tid` belongs to the closed offset region, read from its TAGS.
+     *
+     * The 3D counterpart of TopoOffsetTriMesh::face_in_region, and it fixes the same defect.
+     * The region is the offset band plus the input complex it wraps, both named by tags -- and
+     * tags are what the shared operations propagate. The construction label says the same
+     * thing but is derived state maintained alongside them, so it goes stale the moment a
+     * split or swap creates a cell the label was never written for, putting holes in the
+     * region that offset_is_manifold() then reports as non-manifold.
+     */
+    bool cell_in_region(const size_t tid) const
+    {
+        const CellTag& tags = m_tet_attribute[tid].tag;
+        for (const int64_t t : m_offset_output_tag_ids) {
+            if (tags.count(t) != 0) return true; // in the offset band
+        }
+        const ExpressionPtr& expr = m_offset_params.offset_selection;
+        return expr && expr->eval(tags); // in the input complex it wraps
+    }
+
     /// Whether face `fid` is on the offset boundary (as opposed to the input complex).
     bool face_is_offset(const size_t fid) const
     {
@@ -339,6 +359,7 @@ public:
      * the offset surface already was, so its `after` counterpart can tell a regression from a
      * defect that was there before.
      */
+    bool collapse_edge_before(const Tuple& t) override;
     bool collapse_before_vertex(size_t v1, size_t v2, double edge_length) override;
     bool collapse_after_connectivity(
         size_t v1,


### PR DESCRIPTION
Straight off `main` (#1020, #1021 and #1022 have merged). **#1023 is stacked on top of this one.**

Keeps the 3D offset region manifold through the optimization phase. It never was — not after the migration onto the shared optimizer, and not in #974 which introduced the 3D optimization. Splitting it out here because it is a genuine defect fix, independent of the 2D port that #1023 carries.

### How it was found

Ran each operation pass alone with the others disabled:

| pass | region manifold after? |
|---|---|
| split | ✅ |
| collapse | ❌ |
| swap | ❌ |
| smoothing | ✅ |

Two independent causes, neither of them the one behind the 2D failure.

### Cause 1 — the swap's tag rule

It was *"at most two tags in the ring, and the majority wins."* But a face between differently tagged tets **is** the offset surface, so a ring spanning two tags has the surface running through it — and forcing all the new cells onto the majority tag **moves that surface**, merging the two regions wherever the minority lost. Any such swap is now refused, which made the swap pass clean on its own.

### Cause 2 — the collapse's guard condition

It asked `substructure_link_condition` only when **both** endpoints already sat on a tracked simplex. That is the right rule for tetwild and simwild. It is not enough here: the offset region is a thin shell, so a collapse with one endpoint in the interior still pinches its two sides together while every tracked surface survives intact. Asked on every collapse now.

### Also here

- **Region membership comes from the tags** every shared operation propagates, rather than from the construction label derived alongside them. The label is redundant state and goes stale the moment an operation creates a cell it was never written for.
- **`preserve_topology` is forced on.** Not a user knob — a *topological* offset is defined by preserving the topology of the region it wraps. Its default of `false` meant #1021 had silently dropped a guard the offset's own collapse applied unconditionally.

### Validation

- both `optimize: true` 3D configs keep the offset manifold, where both previously failed
- 3D construction byte-identical (`topological_offset_3d`, `_3d_edge_input`)
- `wmtk_test_topological_offset` and `wmtk_test_manifold_extraction` pass

### Not done, on purpose

The swap rule is conservative. A genuine surface flip could keep both tags by giving each new cell the tag of the side it lands on, which would recover the flips this refuses. That needs an exact side-of-surface test, so it is left as follow-up rather than guessed at.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
