### PR TITLE
Pull surface vertices with a fixed-target spring, in 2D and 3D, on by default

### DIFF
--- a/components/simwild/wmtk/components/simwild/Parameters.h
+++ b/components/simwild/wmtk/components/simwild/Parameters.h
@@ -87,7 +87,7 @@ struct Parameters : public wmtk::OptimizerParameters
         eps_simplify = json_params["eps_simplify"];
 
         w_amips = json_params["w_amips"];
-        spring_pull = json_params["spring_pull"];
+        pull_mode = json_params["pull_mode"];
         smooth_quality_gate = json_params["smooth_quality_gate"];
         two_stage = json_params["two_stage"];
         num_smoothing_passes = json_params["num_smoothing_passes"];

--- a/components/simwild/wmtk/components/simwild/Parameters.h
+++ b/components/simwild/wmtk/components/simwild/Parameters.h
@@ -87,6 +87,7 @@ struct Parameters : public wmtk::OptimizerParameters
         eps_simplify = json_params["eps_simplify"];
 
         w_amips = json_params["w_amips"];
+        spring_pull = json_params["spring_pull"];
         num_smoothing_passes = json_params["num_smoothing_passes"];
         interleaved_smoothing = json_params["interleaved_smoothing"];
         interleaved_smoothing_passes = json_params["interleaved_smoothing_passes"];

--- a/components/simwild/wmtk/components/simwild/Parameters.h
+++ b/components/simwild/wmtk/components/simwild/Parameters.h
@@ -89,6 +89,7 @@ struct Parameters : public wmtk::OptimizerParameters
         w_amips = json_params["w_amips"];
         spring_pull = json_params["spring_pull"];
         smooth_quality_gate = json_params["smooth_quality_gate"];
+        two_stage = json_params["two_stage"];
         num_smoothing_passes = json_params["num_smoothing_passes"];
         interleaved_smoothing = json_params["interleaved_smoothing"];
         interleaved_smoothing_passes = json_params["interleaved_smoothing_passes"];

--- a/components/simwild/wmtk/components/simwild/Parameters.h
+++ b/components/simwild/wmtk/components/simwild/Parameters.h
@@ -88,6 +88,7 @@ struct Parameters : public wmtk::OptimizerParameters
 
         w_amips = json_params["w_amips"];
         spring_pull = json_params["spring_pull"];
+        smooth_quality_gate = json_params["smooth_quality_gate"];
         num_smoothing_passes = json_params["num_smoothing_passes"];
         interleaved_smoothing = json_params["interleaved_smoothing"];
         interleaved_smoothing_passes = json_params["interleaved_smoothing_passes"];

--- a/components/simwild/wmtk/components/simwild/SimWildMesh.h
+++ b/components/simwild/wmtk/components/simwild/SimWildMesh.h
@@ -99,7 +99,7 @@ public:
 
         optimization::deactivate_opt_logger();
 
-        m_s_envelope = 1. / (m_params.diag_l * m_params.eps * m_params.eps);
+        m_s_envelope = 1. / (m_params.eps * m_params.eps);
 
         double& wa = m_params.w_amips;
         double& we = m_params.w_envelope;

--- a/components/simwild/wmtk/components/simwild/simwild_spec.json
+++ b/components/simwild/wmtk/components/simwild/simwild_spec.json
@@ -33,6 +33,7 @@
       "w_amips",
       "spring_pull",
       "smooth_quality_gate",
+      "two_stage",
       "num_smoothing_passes",
       "interleaved_smoothing",
       "interleaved_smoothing_passes",
@@ -315,8 +316,14 @@
     "type": "bool",
     "default": true,
     "doc": "Apply the quality gate after a smoothing move -- the check that refuses a move making the worst incident element worse. Turning it off lets every non-inverting smoothing move through."
-},
-{
+  },
+  {
+    "pointer": "/two_stage",
+    "type": "bool",
+    "default": true,
+    "doc": "Run the balanced warm-up solve (AMIPS and the pull at equal footing) before the weighted smoothing solve for surface vertices. The balanced objective contains no small weight, so the warm-up accepts tangential slides at any configured w_amips; measured on triwild20k_202090 this produces a weight-independent surface deviation floor (~4e-5) that disappears with the warm-up off, at unchanged max energy."
+  },
+  {
     "pointer": "/spring_pull",
     "type": "bool",
     "default": true,

--- a/components/simwild/wmtk/components/simwild/simwild_spec.json
+++ b/components/simwild/wmtk/components/simwild/simwild_spec.json
@@ -31,7 +31,7 @@
       "stop_at_float",
       "preserve_topology",
       "w_amips",
-      "spring_pull",
+      "pull_mode",
       "smooth_quality_gate",
       "two_stage",
       "num_smoothing_passes",
@@ -324,11 +324,12 @@
     "doc": "Run the balanced warm-up solve (AMIPS and the pull at equal footing) before the weighted smoothing solve for surface vertices. The balanced objective contains no small weight, so the warm-up accepts tangential slides at any configured w_amips; measured on triwild20k_202090 this produces a weight-independent surface deviation floor (~4e-5) that disappears with the warm-up off, at unchanged max energy."
   },
   {
-    "pointer": "/spring_pull",
-    "type": "bool",
-    "default": true,
-    "doc": "Pull a surface vertex toward a fixed target point (the nearest point on the input, captured once before each solve) instead of toward the input as a set. The default squared-distance term lets a vertex slide along the input at no cost, which leaves a floor on the surface deviation that no weight removes; the spring forbids sliding and its pull does not weaken as the vertex approaches, because the target does not move to meet it."
-  },
+    "pointer": "/pull_mode",
+    "type": "string",
+    "default": "spring",
+    "options": ["envelope", "spring", "spring_refresh"],
+    "doc": "How smoothing pulls a surface vertex toward the input. 'envelope': squared distance to the input as a set; the nearest point is re-queried per evaluation, so the vertex slides along the input for free. 'spring': fixed-target spring to the nearest point captured once per solve; no sliding, surface deviation scales as w_amips with no floor. 'spring_refresh': the spring with its target re-captured at every accepted iterate; restores slow sliding while keeping each iterate an exact quadratic. On the 53 registered configs, envelope and spring_refresh terminate 53/53; the frozen spring stalls one config and costs ~20% more iterations."
+},
   {
     "pointer": "/w_amips",
     "type": "float",

--- a/components/simwild/wmtk/components/simwild/simwild_spec.json
+++ b/components/simwild/wmtk/components/simwild/simwild_spec.json
@@ -31,6 +31,7 @@
       "stop_at_float",
       "preserve_topology",
       "w_amips",
+      "spring_pull",
       "num_smoothing_passes",
       "interleaved_smoothing",
       "interleaved_smoothing_passes",
@@ -307,6 +308,12 @@
     "type": "bool",
     "default": true,
     "doc": "Preserve topology of input."
+  },
+  {
+    "pointer": "/spring_pull",
+    "type": "bool",
+    "default": true,
+    "doc": "Pull a surface vertex toward a fixed target point (the nearest point on the input, captured once before each solve) instead of toward the input as a set. The default squared-distance term lets a vertex slide along the input at no cost, which leaves a floor on the surface deviation that no weight removes; the spring forbids sliding and its pull does not weaken as the vertex approaches, because the target does not move to meet it."
   },
   {
     "pointer": "/w_amips",

--- a/components/simwild/wmtk/components/simwild/simwild_spec.json
+++ b/components/simwild/wmtk/components/simwild/simwild_spec.json
@@ -32,6 +32,7 @@
       "preserve_topology",
       "w_amips",
       "spring_pull",
+      "smooth_quality_gate",
       "num_smoothing_passes",
       "interleaved_smoothing",
       "interleaved_smoothing_passes",
@@ -310,6 +311,12 @@
     "doc": "Preserve topology of input."
   },
   {
+    "pointer": "/smooth_quality_gate",
+    "type": "bool",
+    "default": true,
+    "doc": "Apply the quality gate after a smoothing move -- the check that refuses a move making the worst incident element worse. Turning it off lets every non-inverting smoothing move through."
+},
+{
     "pointer": "/spring_pull",
     "type": "bool",
     "default": true,

--- a/components/simwild/wmtk/components/simwild/simwild_spec.json
+++ b/components/simwild/wmtk/components/simwild/simwild_spec.json
@@ -327,7 +327,7 @@
     "pointer": "/pull_mode",
     "type": "string",
     "default": "spring",
-    "options": ["envelope", "spring", "spring_refresh"],
+    "options": ["envelope", "spring", "spring_refresh", "exact"],
     "doc": "How smoothing pulls a surface vertex toward the input. 'envelope': squared distance to the input as a set; the nearest point is re-queried per evaluation, so the vertex slides along the input for free. 'spring': fixed-target spring to the nearest point captured once per solve; no sliding, surface deviation scales as w_amips with no floor. 'spring_refresh': the spring with its target re-captured at every accepted iterate; restores slow sliding while keeping each iterate an exact quadratic. On the 53 registered configs, envelope and spring_refresh terminate 53/53; the frozen spring stalls one config and costs ~20% more iterations."
 },
   {

--- a/components/tetwild/wmtk/components/tetwild/TetWildMesh.h
+++ b/components/tetwild/wmtk/components/tetwild/TetWildMesh.h
@@ -134,7 +134,7 @@ public:
         m_collapse_check_manifold = false;
 
         optimization::deactivate_opt_logger();
-        m_s_envelope = 1. / (m_params.diag_l * m_params.eps * m_params.eps);
+        m_s_envelope = 1. / (m_params.eps * m_params.eps);
         m_params.w_envelope = 1. - m_params.w_amips;
     }
 

--- a/components/tetwild/wmtk/components/tetwild/tetwild.cpp
+++ b/components/tetwild/wmtk/components/tetwild/tetwild.cpp
@@ -115,7 +115,7 @@ TetWildMesh::ExportStruct tetwild_with_export(nlohmann::json json_params)
     params.interleaved_smoothing = json_params["interleaved_smoothing"];
     params.interleaved_smoothing_passes = json_params["interleaved_smoothing_passes"];
     params.w_amips = json_params["w_amips"];
-    params.spring_pull = json_params["spring_pull"];
+    params.pull_mode = json_params["pull_mode"];
     params.smooth_quality_gate = json_params["smooth_quality_gate"];
     params.two_stage = json_params["two_stage"];
 

--- a/components/tetwild/wmtk/components/tetwild/tetwild.cpp
+++ b/components/tetwild/wmtk/components/tetwild/tetwild.cpp
@@ -115,6 +115,7 @@ TetWildMesh::ExportStruct tetwild_with_export(nlohmann::json json_params)
     params.interleaved_smoothing = json_params["interleaved_smoothing"];
     params.interleaved_smoothing_passes = json_params["interleaved_smoothing_passes"];
     params.w_amips = json_params["w_amips"];
+    params.spring_pull = json_params["spring_pull"];
 
     params.preserve_topology = json_params["preserve_topology"];
 

--- a/components/tetwild/wmtk/components/tetwild/tetwild.cpp
+++ b/components/tetwild/wmtk/components/tetwild/tetwild.cpp
@@ -116,6 +116,7 @@ TetWildMesh::ExportStruct tetwild_with_export(nlohmann::json json_params)
     params.interleaved_smoothing_passes = json_params["interleaved_smoothing_passes"];
     params.w_amips = json_params["w_amips"];
     params.spring_pull = json_params["spring_pull"];
+    params.smooth_quality_gate = json_params["smooth_quality_gate"];
 
     params.preserve_topology = json_params["preserve_topology"];
 

--- a/components/tetwild/wmtk/components/tetwild/tetwild.cpp
+++ b/components/tetwild/wmtk/components/tetwild/tetwild.cpp
@@ -117,6 +117,7 @@ TetWildMesh::ExportStruct tetwild_with_export(nlohmann::json json_params)
     params.w_amips = json_params["w_amips"];
     params.spring_pull = json_params["spring_pull"];
     params.smooth_quality_gate = json_params["smooth_quality_gate"];
+    params.two_stage = json_params["two_stage"];
 
     params.preserve_topology = json_params["preserve_topology"];
 

--- a/components/tetwild/wmtk/components/tetwild/tetwild_spec.json
+++ b/components/tetwild/wmtk/components/tetwild/tetwild_spec.json
@@ -28,6 +28,7 @@
       "w_amips",
       "spring_pull",
       "smooth_quality_gate",
+      "two_stage",
       "num_smoothing_passes",
       "interleaved_smoothing",
       "interleaved_smoothing_passes",
@@ -206,6 +207,12 @@
     "type": "bool",
     "default": true,
     "doc": "Apply the quality gate after a smoothing move -- the check that refuses a move making the worst incident element worse. Turning it off lets every non-inverting smoothing move through."
+},
+{
+    "pointer": "/two_stage",
+    "type": "bool",
+    "default": true,
+    "doc": "Run the balanced warm-up solve (AMIPS and the pull at equal footing) before the weighted smoothing solve for surface vertices. The balanced objective contains no small weight, so the warm-up accepts tangential slides at any configured w_amips; measured on triwild20k_202090 this produces a weight-independent surface deviation floor (~4e-5) that disappears with the warm-up off, at unchanged max energy."
 },
 {
     "pointer": "/spring_pull",

--- a/components/tetwild/wmtk/components/tetwild/tetwild_spec.json
+++ b/components/tetwild/wmtk/components/tetwild/tetwild_spec.json
@@ -27,6 +27,7 @@
       "split_high_valence_threshold",
       "w_amips",
       "spring_pull",
+      "smooth_quality_gate",
       "num_smoothing_passes",
       "interleaved_smoothing",
       "interleaved_smoothing_passes",
@@ -201,6 +202,12 @@
     "doc": "Incident-tet count above which a vertex accepts only one valence-increasing split per split pass, or 0 to disable. A well-shaped tet mesh has valence around 20-30; a split cascade can drive one vertex into the thousands, at which point every operation touching it is O(valence) and the pass stalls. Splitting an edge leaves its endpoints' counts unchanged and adds one to each vertex in the edge's link, so the gate applies to the link."
   },
   {
+    "pointer": "/smooth_quality_gate",
+    "type": "bool",
+    "default": true,
+    "doc": "Apply the quality gate after a smoothing move -- the check that refuses a move making the worst incident element worse. Turning it off lets every non-inverting smoothing move through."
+},
+{
     "pointer": "/spring_pull",
     "type": "bool",
     "default": true,

--- a/components/tetwild/wmtk/components/tetwild/tetwild_spec.json
+++ b/components/tetwild/wmtk/components/tetwild/tetwild_spec.json
@@ -26,7 +26,7 @@
       "stop_energy",
       "split_high_valence_threshold",
       "w_amips",
-      "spring_pull",
+      "pull_mode",
       "smooth_quality_gate",
       "two_stage",
       "num_smoothing_passes",
@@ -215,11 +215,12 @@
     "doc": "Run the balanced warm-up solve (AMIPS and the pull at equal footing) before the weighted smoothing solve for surface vertices. The balanced objective contains no small weight, so the warm-up accepts tangential slides at any configured w_amips; measured on triwild20k_202090 this produces a weight-independent surface deviation floor (~4e-5) that disappears with the warm-up off, at unchanged max energy."
 },
 {
-    "pointer": "/spring_pull",
-    "type": "bool",
-    "default": true,
-    "doc": "Pull a surface vertex toward a fixed target point (the nearest point on the input, captured once before each solve) instead of toward the input as a set. The default squared-distance term lets a vertex slide along the input at no cost, which leaves a floor on the surface deviation that no weight removes; the spring forbids sliding and its pull does not weaken as the vertex approaches, because the target does not move to meet it."
-  },
+    "pointer": "/pull_mode",
+    "type": "string",
+    "default": "spring",
+    "options": ["envelope", "spring", "spring_refresh"],
+    "doc": "How smoothing pulls a surface vertex toward the input. 'envelope': squared distance to the input as a set; the nearest point is re-queried per evaluation, so the vertex slides along the input for free. 'spring': fixed-target spring to the nearest point captured once per solve; no sliding, surface deviation scales as w_amips with no floor. 'spring_refresh': the spring with its target re-captured at every accepted iterate; restores slow sliding while keeping each iterate an exact quadratic. On the 53 registered configs, envelope and spring_refresh terminate 53/53; the frozen spring stalls one config and costs ~20% more iterations."
+},
   {
     "pointer": "/w_amips",
     "type": "float",

--- a/components/tetwild/wmtk/components/tetwild/tetwild_spec.json
+++ b/components/tetwild/wmtk/components/tetwild/tetwild_spec.json
@@ -26,6 +26,7 @@
       "stop_energy",
       "split_high_valence_threshold",
       "w_amips",
+      "spring_pull",
       "num_smoothing_passes",
       "interleaved_smoothing",
       "interleaved_smoothing_passes",
@@ -198,6 +199,12 @@
     "type": "int",
     "default": 200,
     "doc": "Incident-tet count above which a vertex accepts only one valence-increasing split per split pass, or 0 to disable. A well-shaped tet mesh has valence around 20-30; a split cascade can drive one vertex into the thousands, at which point every operation touching it is O(valence) and the pass stalls. Splitting an edge leaves its endpoints' counts unchanged and adds one to each vertex in the edge's link, so the gate applies to the link."
+  },
+  {
+    "pointer": "/spring_pull",
+    "type": "bool",
+    "default": true,
+    "doc": "Pull a surface vertex toward a fixed target point (the nearest point on the input, captured once before each solve) instead of toward the input as a set. The default squared-distance term lets a vertex slide along the input at no cost, which leaves a floor on the surface deviation that no weight removes; the spring forbids sliding and its pull does not weaken as the vertex approaches, because the target does not move to meet it."
   },
   {
     "pointer": "/w_amips",

--- a/components/tetwild/wmtk/components/tetwild/tetwild_spec.json
+++ b/components/tetwild/wmtk/components/tetwild/tetwild_spec.json
@@ -218,7 +218,7 @@
     "pointer": "/pull_mode",
     "type": "string",
     "default": "spring",
-    "options": ["envelope", "spring", "spring_refresh"],
+    "options": ["envelope", "spring", "spring_refresh", "exact"],
     "doc": "How smoothing pulls a surface vertex toward the input. 'envelope': squared distance to the input as a set; the nearest point is re-queried per evaluation, so the vertex slides along the input for free. 'spring': fixed-target spring to the nearest point captured once per solve; no sliding, surface deviation scales as w_amips with no floor. 'spring_refresh': the spring with its target re-captured at every accepted iterate; restores slow sliding while keeping each iterate an exact quadratic. On the 53 registered configs, envelope and spring_refresh terminate 53/53; the frozen spring stalls one config and costs ~20% more iterations."
 },
   {

--- a/components/topological_offset/wmtk/components/topological_offset/Parameters.h
+++ b/components/topological_offset/wmtk/components/topological_offset/Parameters.h
@@ -132,6 +132,7 @@ struct Parameters : public wmtk::OptimizerParameters
         split_high_valence_threshold = json_params["split_high_valence_threshold"];
         skip_good_regions = json_params["skip_good_regions"];
         w_amips = json_params["w_amips"];
+        spring_pull = json_params["spring_pull"];
         w_envelope = 1. - w_amips;
         perform_sanity_checks = json_params["perform_sanity_checks"];
     }

--- a/components/topological_offset/wmtk/components/topological_offset/Parameters.h
+++ b/components/topological_offset/wmtk/components/topological_offset/Parameters.h
@@ -133,6 +133,7 @@ struct Parameters : public wmtk::OptimizerParameters
         skip_good_regions = json_params["skip_good_regions"];
         w_amips = json_params["w_amips"];
         spring_pull = json_params["spring_pull"];
+        smooth_quality_gate = json_params["smooth_quality_gate"];
         w_envelope = 1. - w_amips;
         perform_sanity_checks = json_params["perform_sanity_checks"];
     }

--- a/components/topological_offset/wmtk/components/topological_offset/Parameters.h
+++ b/components/topological_offset/wmtk/components/topological_offset/Parameters.h
@@ -132,7 +132,7 @@ struct Parameters : public wmtk::OptimizerParameters
         split_high_valence_threshold = json_params["split_high_valence_threshold"];
         skip_good_regions = json_params["skip_good_regions"];
         w_amips = json_params["w_amips"];
-        spring_pull = json_params["spring_pull"];
+        pull_mode = json_params["pull_mode"];
         smooth_quality_gate = json_params["smooth_quality_gate"];
         two_stage = json_params["two_stage"];
         w_envelope = 1. - w_amips;

--- a/components/topological_offset/wmtk/components/topological_offset/Parameters.h
+++ b/components/topological_offset/wmtk/components/topological_offset/Parameters.h
@@ -134,6 +134,7 @@ struct Parameters : public wmtk::OptimizerParameters
         w_amips = json_params["w_amips"];
         spring_pull = json_params["spring_pull"];
         smooth_quality_gate = json_params["smooth_quality_gate"];
+        two_stage = json_params["two_stage"];
         w_envelope = 1. - w_amips;
         perform_sanity_checks = json_params["perform_sanity_checks"];
     }

--- a/components/topological_offset/wmtk/components/topological_offset/topological_offset_spec.json
+++ b/components/topological_offset/wmtk/components/topological_offset/topological_offset_spec.json
@@ -45,6 +45,7 @@
             "skip_good_regions",
             "w_amips",
             "spring_pull",
+            "smooth_quality_gate",
             "perform_sanity_checks"
         ]
     },
@@ -282,6 +283,12 @@
         "type": "bool",
         "default": false,
         "doc": "Only smooth vertices incident to a tet whose energy is still far from stop_energy. Smoothing a vertex surrounded by good tets does nothing, so skipping it is free (only used if optimize is true)."
+    },
+    {
+        "pointer": "/smooth_quality_gate",
+        "type": "bool",
+        "default": true,
+        "doc": "Apply the quality gate after a smoothing move -- the check that refuses a move making the worst incident element worse. Turning it off lets every non-inverting smoothing move through."
     },
     {
         "pointer": "/spring_pull",

--- a/components/topological_offset/wmtk/components/topological_offset/topological_offset_spec.json
+++ b/components/topological_offset/wmtk/components/topological_offset/topological_offset_spec.json
@@ -44,6 +44,7 @@
             "split_high_valence_threshold",
             "skip_good_regions",
             "w_amips",
+            "spring_pull",
             "perform_sanity_checks"
         ]
     },
@@ -281,6 +282,12 @@
         "type": "bool",
         "default": false,
         "doc": "Only smooth vertices incident to a tet whose energy is still far from stop_energy. Smoothing a vertex surrounded by good tets does nothing, so skipping it is free (only used if optimize is true)."
+    },
+    {
+        "pointer": "/spring_pull",
+        "type": "bool",
+        "default": true,
+        "doc": "Pull a surface vertex toward a fixed target point (the nearest point on the input, captured once before each solve) instead of toward the input as a set. The default squared-distance term lets a vertex slide along the input at no cost, which leaves a floor on the surface deviation that no weight removes; the spring forbids sliding and its pull does not weaken as the vertex approaches, because the target does not move to meet it."
     },
     {
         "pointer": "/w_amips",

--- a/components/topological_offset/wmtk/components/topological_offset/topological_offset_spec.json
+++ b/components/topological_offset/wmtk/components/topological_offset/topological_offset_spec.json
@@ -46,6 +46,7 @@
             "w_amips",
             "spring_pull",
             "smooth_quality_gate",
+      "two_stage",
             "perform_sanity_checks"
         ]
     },
@@ -290,6 +291,12 @@
         "default": true,
         "doc": "Apply the quality gate after a smoothing move -- the check that refuses a move making the worst incident element worse. Turning it off lets every non-inverting smoothing move through."
     },
+{
+    "pointer": "/two_stage",
+    "type": "bool",
+    "default": true,
+    "doc": "Run the balanced warm-up solve (AMIPS and the pull at equal footing) before the weighted smoothing solve for surface vertices. The balanced objective contains no small weight, so the warm-up accepts tangential slides at any configured w_amips; measured on triwild20k_202090 this produces a weight-independent surface deviation floor (~4e-5) that disappears with the warm-up off, at unchanged max energy."
+},
     {
         "pointer": "/spring_pull",
         "type": "bool",

--- a/components/topological_offset/wmtk/components/topological_offset/topological_offset_spec.json
+++ b/components/topological_offset/wmtk/components/topological_offset/topological_offset_spec.json
@@ -44,7 +44,7 @@
             "split_high_valence_threshold",
             "skip_good_regions",
             "w_amips",
-            "spring_pull",
+            "pull_mode",
             "smooth_quality_gate",
       "two_stage",
             "perform_sanity_checks"
@@ -298,11 +298,12 @@
     "doc": "Run the balanced warm-up solve (AMIPS and the pull at equal footing) before the weighted smoothing solve for surface vertices. The balanced objective contains no small weight, so the warm-up accepts tangential slides at any configured w_amips; measured on triwild20k_202090 this produces a weight-independent surface deviation floor (~4e-5) that disappears with the warm-up off, at unchanged max energy."
 },
     {
-        "pointer": "/spring_pull",
-        "type": "bool",
-        "default": true,
-        "doc": "Pull a surface vertex toward a fixed target point (the nearest point on the input, captured once before each solve) instead of toward the input as a set. The default squared-distance term lets a vertex slide along the input at no cost, which leaves a floor on the surface deviation that no weight removes; the spring forbids sliding and its pull does not weaken as the vertex approaches, because the target does not move to meet it."
-    },
+    "pointer": "/pull_mode",
+    "type": "string",
+    "default": "spring",
+    "options": ["envelope", "spring", "spring_refresh"],
+    "doc": "How smoothing pulls a surface vertex toward the input. 'envelope': squared distance to the input as a set; the nearest point is re-queried per evaluation, so the vertex slides along the input for free. 'spring': fixed-target spring to the nearest point captured once per solve; no sliding, surface deviation scales as w_amips with no floor. 'spring_refresh': the spring with its target re-captured at every accepted iterate; restores slow sliding while keeping each iterate an exact quadratic. On the 53 registered configs, envelope and spring_refresh terminate 53/53; the frozen spring stalls one config and costs ~20% more iterations."
+},
     {
         "pointer": "/w_amips",
         "type": "float",

--- a/components/topological_offset/wmtk/components/topological_offset/topological_offset_spec.json
+++ b/components/topological_offset/wmtk/components/topological_offset/topological_offset_spec.json
@@ -301,7 +301,7 @@
     "pointer": "/pull_mode",
     "type": "string",
     "default": "spring",
-    "options": ["envelope", "spring", "spring_refresh"],
+    "options": ["envelope", "spring", "spring_refresh", "exact"],
     "doc": "How smoothing pulls a surface vertex toward the input. 'envelope': squared distance to the input as a set; the nearest point is re-queried per evaluation, so the vertex slides along the input for free. 'spring': fixed-target spring to the nearest point captured once per solve; no sliding, surface deviation scales as w_amips with no floor. 'spring_refresh': the spring with its target re-captured at every accepted iterate; restores slow sliding while keeping each iterate an exact quadratic. On the 53 registered configs, envelope and spring_refresh terminate 53/53; the frozen spring stalls one config and costs ~20% more iterations."
 },
     {

--- a/components/triwild/wmtk/components/triwild/Parameters.h
+++ b/components/triwild/wmtk/components/triwild/Parameters.h
@@ -94,6 +94,7 @@ struct Parameters : public wmtk::OptimizerParameters
         split_high_valence_threshold = json_params["split_high_valence_threshold"];
         w_amips = json_params["w_amips"];
         spring_pull = json_params["spring_pull"];
+        smooth_quality_gate = json_params["smooth_quality_gate"];
         num_smoothing_passes = json_params["num_smoothing_passes"];
         interleaved_smoothing = json_params["interleaved_smoothing"];
         interleaved_smoothing_passes = json_params["interleaved_smoothing_passes"];

--- a/components/triwild/wmtk/components/triwild/Parameters.h
+++ b/components/triwild/wmtk/components/triwild/Parameters.h
@@ -93,7 +93,7 @@ struct Parameters : public wmtk::OptimizerParameters
 
         split_high_valence_threshold = json_params["split_high_valence_threshold"];
         w_amips = json_params["w_amips"];
-        spring_pull = json_params["spring_pull"];
+        pull_mode = json_params["pull_mode"];
         smooth_quality_gate = json_params["smooth_quality_gate"];
         two_stage = json_params["two_stage"];
         num_smoothing_passes = json_params["num_smoothing_passes"];

--- a/components/triwild/wmtk/components/triwild/Parameters.h
+++ b/components/triwild/wmtk/components/triwild/Parameters.h
@@ -95,6 +95,7 @@ struct Parameters : public wmtk::OptimizerParameters
         w_amips = json_params["w_amips"];
         spring_pull = json_params["spring_pull"];
         smooth_quality_gate = json_params["smooth_quality_gate"];
+        two_stage = json_params["two_stage"];
         num_smoothing_passes = json_params["num_smoothing_passes"];
         interleaved_smoothing = json_params["interleaved_smoothing"];
         interleaved_smoothing_passes = json_params["interleaved_smoothing_passes"];

--- a/components/triwild/wmtk/components/triwild/Parameters.h
+++ b/components/triwild/wmtk/components/triwild/Parameters.h
@@ -93,6 +93,7 @@ struct Parameters : public wmtk::OptimizerParameters
 
         split_high_valence_threshold = json_params["split_high_valence_threshold"];
         w_amips = json_params["w_amips"];
+        spring_pull = json_params["spring_pull"];
         num_smoothing_passes = json_params["num_smoothing_passes"];
         interleaved_smoothing = json_params["interleaved_smoothing"];
         interleaved_smoothing_passes = json_params["interleaved_smoothing_passes"];

--- a/components/triwild/wmtk/components/triwild/triwild.cpp
+++ b/components/triwild/wmtk/components/triwild/triwild.cpp
@@ -99,18 +99,31 @@ std::vector<int> compute_euler_characteristics(const MatrixXi& E)
  * its own from 10k to 100k after finding a 21x under-estimate). This is opt-in diagnostic
  * code; a stable answer is worth the samples.
  */
-double
-max_deviation(const MatrixXd& V, const MatrixXi& E, const SampleEnvelope& target, int n_samples)
+struct Deviation
+{
+    double max = -1;
+    /// Mean over the same samples. Because the budget is already spread by length, this is
+    /// the mean along the curve rather than the mean over segments, so a dense patch of short
+    /// segments does not outvote a long one. The max alone hides what a change did to the
+    /// bulk of the curve: it is a single worst sample, and one stubborn corner pins it while
+    /// everything else moves.
+    double mean = -1;
+};
+
+Deviation
+deviation_stats(const MatrixXd& V, const MatrixXi& E, const SampleEnvelope& target, int n_samples)
 {
     double total_length = 0;
     for (int i = 0; i < E.rows(); ++i) {
         total_length += (V.row(E(i, 1)) - V.row(E(i, 0))).norm();
     }
     if (E.rows() == 0 || total_length <= 0) {
-        return -1;
+        return {};
     }
 
     double sq_max = -1;
+    double sum = 0;
+    long long count = 0;
     Vector2d projection;
     for (int i = 0; i < E.rows(); ++i) {
         const Vector2d a = V.row(E(i, 0));
@@ -119,10 +132,56 @@ max_deviation(const MatrixXd& V, const MatrixXi& E, const SampleEnvelope& target
         const int n = std::max(1, int(n_samples * len / total_length));
         for (int s = 0; s <= n; ++s) {
             const Vector2d p = a + (b - a) * (double(s) / double(n));
-            sq_max = std::max(sq_max, target.nearest_point(p, projection));
+            // nearest_point returns the SQUARED distance.
+            const double sq = target.nearest_point(p, projection);
+            sq_max = std::max(sq_max, sq);
+            sum += std::sqrt(sq);
+            ++count;
         }
     }
-    return sq_max < 0 ? -1 : std::sqrt(sq_max);
+    if (sq_max < 0 || count == 0) {
+        return {};
+    }
+    return {std::sqrt(sq_max), sum / double(count)};
+}
+
+/**
+ * @brief Deviation of the tracked VERTICES alone, ignoring the chords between them.
+ *
+ * Separates the two things the edge-sampled figure mixes together. Smoothing places
+ * vertices, so a vertex's distance to the input is what the envelope penalty actually
+ * controls. The interior of a tracked edge is a chord across whatever the input does between
+ * its endpoints, so it carries the discretization error that collapse left behind -- no
+ * weight on the penalty can pull a chord onto a curve whose intermediate vertex was removed.
+ *
+ * Reported alongside the edge figure so a saturating edge deviation can be attributed to one
+ * or the other rather than guessed at.
+ */
+Deviation vertex_deviation(const MatrixXd& V, const MatrixXi& E, const SampleEnvelope& target)
+{
+    std::vector<bool> used(V.rows(), false);
+    for (int i = 0; i < E.rows(); ++i) {
+        used[E(i, 0)] = true;
+        used[E(i, 1)] = true;
+    }
+
+    double sq_max = -1;
+    double sum = 0;
+    long long count = 0;
+    Vector2d projection;
+    for (int i = 0; i < V.rows(); ++i) {
+        if (!used[i]) {
+            continue;
+        }
+        const double sq = target.nearest_point(Vector2d(V.row(i)), projection);
+        sq_max = std::max(sq_max, sq);
+        sum += std::sqrt(sq);
+        ++count;
+    }
+    if (count == 0 || sq_max < 0) {
+        return {};
+    }
+    return {std::sqrt(sq_max), sum / double(count)};
 }
 
 /**
@@ -425,8 +484,9 @@ void triwild(nlohmann::json json_params)
     // "larger than the envelope" -- exactly the mistake #967 fixed in 3D, where a legitimate
     // result read 50x eps on containment that was actually 0.34x. On the 2D sweep it made ~60%
     // of successful models look like envelope violations.
-    double containment_distance = -1;
-    double coverage_distance = -1;
+    Deviation containment;
+    Deviation coverage;
+    Deviation containment_v;
     if (json_params["DEBUG_hausdorff"]) {
         const int n_samples = 100000;
         MatrixXd V_track;
@@ -437,14 +497,23 @@ void triwild(nlohmann::json json_params)
         } else {
             const auto env_in = envelope_over(V_in, E_in);
             const auto env_out = envelope_over(V_track, E_track);
-            containment_distance = max_deviation(V_track, E_track, *env_in, n_samples);
-            coverage_distance = max_deviation(V_in, E_in, *env_out, n_samples);
+            containment = deviation_stats(V_track, E_track, *env_in, n_samples);
+            coverage = deviation_stats(V_in, E_in, *env_out, n_samples);
+            containment_v = vertex_deviation(V_track, E_track, *env_in);
 
             logger().info(
-                "curve deviation: containment d(output->input) = {:.4} | envelope = {:.4}",
-                containment_distance,
+                "curve deviation: containment over tracked VERTICES only max = {:.4}, mean = "
+                "{:.4}",
+                containment_v.max,
+                containment_v.mean);
+
+            logger().info(
+                "curve deviation: containment d(output->input) max = {:.4}, mean = {:.4} | "
+                "envelope = {:.4}",
+                containment.max,
+                containment.mean,
                 params.eps);
-            if (containment_distance > params.eps) {
+            if (containment.max > params.eps) {
                 logger().warn(
                     "Output is outside the envelope; the containment invariant was "
                     "violated.");
@@ -453,9 +522,10 @@ void triwild(nlohmann::json json_params)
             }
             // No comparison against eps: the pipeline does not promise this direction.
             logger().info(
-                "curve deviation: coverage d(input->output) = {:.4} (diagnostic; large means "
-                "the output no longer covers part of the input)",
-                coverage_distance);
+                "curve deviation: coverage d(input->output) max = {:.4}, mean = {:.4} "
+                "(diagnostic; large means the output no longer covers part of the input)",
+                coverage.max,
+                coverage.mean);
         }
     }
 
@@ -533,8 +603,12 @@ void triwild(nlohmann::json json_params)
         // report["time"] = time;
         // "hausdorff" keeps its name and now holds containment, the invariant; "coverage" is
         // the other direction. Same convention as the tetwild report.
-        report["hausdorff"] = containment_distance;
-        report["coverage"] = coverage_distance;
+        report["hausdorff"] = containment.max;
+        report["hausdorff_mean"] = containment.mean;
+        report["hausdorff_vertex"] = containment_v.max;
+        report["hausdorff_vertex_mean"] = containment_v.mean;
+        report["coverage"] = coverage.max;
+        report["coverage_mean"] = coverage.mean;
         if (json_params["DEBUG_feature_retention"]) {
             report["features_retained"] = feat_kept;
             report["features_total"] = feat_total;

--- a/components/triwild/wmtk/components/triwild/triwild_spec.json
+++ b/components/triwild/wmtk/components/triwild/triwild_spec.json
@@ -228,8 +228,8 @@
     "pointer": "/pull_mode",
     "type": "string",
     "default": "spring",
-    "options": ["envelope", "spring", "spring_refresh"],
-    "doc": "How smoothing pulls a surface vertex toward the input. 'envelope': squared distance to the input as a set; the nearest point is re-queried per evaluation, so the vertex slides along the input for free. 'spring': fixed-target spring to the nearest point captured once per solve; no sliding, surface deviation scales as w_amips with no floor. 'spring_refresh': the spring with its target re-captured at every accepted iterate; restores slow sliding while keeping each iterate an exact quadratic. On the 53 registered configs, envelope and spring_refresh terminate 53/53; the frozen spring stalls one config and costs ~20% more iterations."
+    "options": ["envelope", "spring", "spring_refresh", "exact"],
+    "doc": "How smoothing pulls a surface vertex toward the input. 'envelope': squared distance to the input as a set; the nearest point is re-queried per evaluation, so the vertex slides along the input for free. 'spring': fixed-target spring to the nearest point captured once per solve; no sliding, surface deviation scales as w_amips with no floor. 'spring_refresh': the spring with its target re-captured at every accepted iterate; restores slow sliding while keeping each iterate an exact quadratic. 'exact' (2D only): the true distance with its true region-wise Hessian; free sliding on segment interiors, isotropic hold at corners. On the 53 registered configs, envelope and spring_refresh terminate 53/53; the frozen spring stalls one config and costs ~20% more iterations."
 },
   {
     "pointer": "/w_amips",

--- a/components/triwild/wmtk/components/triwild/triwild_spec.json
+++ b/components/triwild/wmtk/components/triwild/triwild_spec.json
@@ -24,6 +24,7 @@
       "split_high_valence_threshold",
       "w_amips",
       "spring_pull",
+      "smooth_quality_gate",
       "num_smoothing_passes",
       "interleaved_smoothing",
       "interleaved_smoothing_passes",
@@ -211,6 +212,12 @@
     "doc": "Incident-triangle count above which a vertex accepts only one valence-increasing split per split pass, or 0 to disable. A well-shaped triangle mesh has vertex valence around 6; a split cascade can drive one vertex much higher, at which point every operation touching it is O(valence) and the pass stalls. Splitting an edge leaves its endpoints' counts unchanged and adds one to each vertex opposite the edge, so the gate applies to those. Expect this to fire far less often than in 3D, where the edge's link is a whole ring rather than one or two vertices."
   },
   {
+    "pointer": "/smooth_quality_gate",
+    "type": "bool",
+    "default": true,
+    "doc": "Apply the quality gate after a smoothing move -- the check that refuses a move making the worst incident element worse. Turning it off lets every non-inverting smoothing move through."
+},
+{
     "pointer": "/spring_pull",
     "type": "bool",
     "default": false,

--- a/components/triwild/wmtk/components/triwild/triwild_spec.json
+++ b/components/triwild/wmtk/components/triwild/triwild_spec.json
@@ -229,7 +229,7 @@
     "type": "string",
     "default": "spring",
     "options": ["envelope", "spring", "spring_refresh", "exact"],
-    "doc": "How smoothing pulls a surface vertex toward the input. 'envelope': squared distance to the input as a set; the nearest point is re-queried per evaluation, so the vertex slides along the input for free. 'spring': fixed-target spring to the nearest point captured once per solve; no sliding, surface deviation scales as w_amips with no floor. 'spring_refresh': the spring with its target re-captured at every accepted iterate; restores slow sliding while keeping each iterate an exact quadratic. 'exact' (2D only): the true distance with its true region-wise Hessian; free sliding on segment interiors, isotropic hold at corners. On the 53 registered configs, envelope and spring_refresh terminate 53/53; the frozen spring stalls one config and costs ~20% more iterations."
+    "doc": "How smoothing pulls a surface vertex toward the input. 'envelope': squared distance to the input as a set; the nearest point is re-queried per evaluation, so the vertex slides along the input for free. 'spring': fixed-target spring to the nearest point captured once per solve; no sliding, surface deviation scales as w_amips with no floor. 'spring_refresh': the spring with its target re-captured at every accepted iterate; restores slow sliding while keeping each iterate an exact quadratic. 'exact': the true distance with its true region-wise Hessian; sliding is free exactly where the input is flat, held at corners/vertices, partially constrained on 3D edges. On the 53 registered configs, envelope and spring_refresh terminate 53/53; the frozen spring stalls one config and costs ~20% more iterations."
 },
   {
     "pointer": "/w_amips",

--- a/components/triwild/wmtk/components/triwild/triwild_spec.json
+++ b/components/triwild/wmtk/components/triwild/triwild_spec.json
@@ -23,6 +23,7 @@
       "stop_energy",
       "split_high_valence_threshold",
       "w_amips",
+      "spring_pull",
       "num_smoothing_passes",
       "interleaved_smoothing",
       "interleaved_smoothing_passes",
@@ -208,6 +209,12 @@
     "type": "int",
     "default": 200,
     "doc": "Incident-triangle count above which a vertex accepts only one valence-increasing split per split pass, or 0 to disable. A well-shaped triangle mesh has vertex valence around 6; a split cascade can drive one vertex much higher, at which point every operation touching it is O(valence) and the pass stalls. Splitting an edge leaves its endpoints' counts unchanged and adds one to each vertex opposite the edge, so the gate applies to those. Expect this to fire far less often than in 3D, where the edge's link is a whole ring rather than one or two vertices."
+  },
+  {
+    "pointer": "/spring_pull",
+    "type": "bool",
+    "default": false,
+    "doc": "Pull a surface vertex toward a fixed target point (the nearest point on the input, captured once before each solve) instead of toward the input as a set. The default squared-distance term lets a vertex slide along the input at no cost, which is what frees it to relax along a curve it sits on; the spring forbids sliding but its pull does not weaken as the vertex approaches, because the target does not move to meet it. 2D only."
   },
   {
     "pointer": "/w_amips",

--- a/components/triwild/wmtk/components/triwild/triwild_spec.json
+++ b/components/triwild/wmtk/components/triwild/triwild_spec.json
@@ -25,6 +25,7 @@
       "w_amips",
       "spring_pull",
       "smooth_quality_gate",
+      "two_stage",
       "num_smoothing_passes",
       "interleaved_smoothing",
       "interleaved_smoothing_passes",
@@ -216,6 +217,12 @@
     "type": "bool",
     "default": true,
     "doc": "Apply the quality gate after a smoothing move -- the check that refuses a move making the worst incident element worse. Turning it off lets every non-inverting smoothing move through."
+},
+{
+    "pointer": "/two_stage",
+    "type": "bool",
+    "default": true,
+    "doc": "Run the balanced warm-up solve (AMIPS and the pull at equal footing) before the weighted smoothing solve for surface vertices. The balanced objective contains no small weight, so the warm-up accepts tangential slides at any configured w_amips; measured on triwild20k_202090 this produces a weight-independent surface deviation floor (~4e-5) that disappears with the warm-up off, at unchanged max energy."
 },
 {
     "pointer": "/spring_pull",

--- a/components/triwild/wmtk/components/triwild/triwild_spec.json
+++ b/components/triwild/wmtk/components/triwild/triwild_spec.json
@@ -23,7 +23,7 @@
       "stop_energy",
       "split_high_valence_threshold",
       "w_amips",
-      "spring_pull",
+      "pull_mode",
       "smooth_quality_gate",
       "two_stage",
       "num_smoothing_passes",
@@ -225,11 +225,12 @@
     "doc": "Run the balanced warm-up solve (AMIPS and the pull at equal footing) before the weighted smoothing solve for surface vertices. The balanced objective contains no small weight, so the warm-up accepts tangential slides at any configured w_amips; measured on triwild20k_202090 this produces a weight-independent surface deviation floor (~4e-5) that disappears with the warm-up off, at unchanged max energy."
 },
 {
-    "pointer": "/spring_pull",
-    "type": "bool",
-    "default": false,
-    "doc": "Pull a surface vertex toward a fixed target point (the nearest point on the input, captured once before each solve) instead of toward the input as a set. The default squared-distance term lets a vertex slide along the input at no cost, which is what frees it to relax along a curve it sits on; the spring forbids sliding but its pull does not weaken as the vertex approaches, because the target does not move to meet it. 2D only."
-  },
+    "pointer": "/pull_mode",
+    "type": "string",
+    "default": "spring",
+    "options": ["envelope", "spring", "spring_refresh"],
+    "doc": "How smoothing pulls a surface vertex toward the input. 'envelope': squared distance to the input as a set; the nearest point is re-queried per evaluation, so the vertex slides along the input for free. 'spring': fixed-target spring to the nearest point captured once per solve; no sliding, surface deviation scales as w_amips with no floor. 'spring_refresh': the spring with its target re-captured at every accepted iterate; restores slow sliding while keeping each iterate an exact quadratic. On the 53 registered configs, envelope and spring_refresh terminate 53/53; the frozen spring stalls one config and costs ~20% more iterations."
+},
   {
     "pointer": "/w_amips",
     "type": "float",

--- a/src/wmtk/OptimizerParameters.h
+++ b/src/wmtk/OptimizerParameters.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <limits>
+#include <string>
 
 namespace wmtk {
 
@@ -138,7 +139,8 @@ struct OptimizerParameters
      * removes -- a vertex slides tangentially at no cost until the geometry rather than the
      * force balance stops it -- while the spring is a clean 1/w over six decades.
      */
-    bool spring_pull = true;
+    /// See SmoothVertexOptions::PullMode; parsed from the string parameter pull_mode.
+    std::string pull_mode = "spring";
     /// Apply the quality gate after a smoothing move. See SmoothVertexOptions.
     bool smooth_quality_gate = true;
 

--- a/src/wmtk/OptimizerParameters.h
+++ b/src/wmtk/OptimizerParameters.h
@@ -129,6 +129,16 @@ struct OptimizerParameters
      * light quality preference.
      */
     double w_amips = 1e-4;
+    /**
+     * Pull surface vertices with a fixed-target spring instead of the squared distance to the
+     * input. See SpringEnergy2D: the difference is whether a vertex may slide along the input
+     * for free.
+     *
+     * Defaults ON. The sliding form leaves a floor on the surface deviation that no weight
+     * removes -- a vertex slides tangentially at no cost until the geometry rather than the
+     * force balance stops it -- while the spring is a clean 1/w over six decades.
+     */
+    bool spring_pull = true;
     double w_envelope = 1. - 1e-4; // derived; not read from json
 
     /// Number and placement of smoothing passes in the shared Wild optimization driver.

--- a/src/wmtk/OptimizerParameters.h
+++ b/src/wmtk/OptimizerParameters.h
@@ -139,6 +139,8 @@ struct OptimizerParameters
      * force balance stops it -- while the spring is a clean 1/w over six decades.
      */
     bool spring_pull = true;
+    /// Apply the quality gate after a smoothing move. See SmoothVertexOptions.
+    bool smooth_quality_gate = true;
     double w_envelope = 1. - 1e-4; // derived; not read from json
 
     /// Number and placement of smoothing passes in the shared Wild optimization driver.

--- a/src/wmtk/OptimizerParameters.h
+++ b/src/wmtk/OptimizerParameters.h
@@ -141,6 +141,16 @@ struct OptimizerParameters
     bool spring_pull = true;
     /// Apply the quality gate after a smoothing move. See SmoothVertexOptions.
     bool smooth_quality_gate = true;
+
+    /**
+     * Run the balanced warm-up solve (AMIPS and the pull at equal footing) before the
+     * weighted smoothing solve, for surface vertices. The balanced objective contains no
+     * small weight, so the warm-up's line search accepts tangential slides at any configured
+     * w_amips -- measured on triwild20k_202090 this produces a weight-independent surface
+     * deviation floor (~4e-5) that disappears with the warm-up off, at unchanged max energy.
+     * Default on until the full-corpus A/B says otherwise.
+     */
+    bool two_stage = true;
     double w_envelope = 1. - 1e-4; // derived; not read from json
 
     /// Number and placement of smoothing passes in the shared Wild optimization driver.

--- a/src/wmtk/TetOptimizerMesh.cpp
+++ b/src/wmtk/TetOptimizerMesh.cpp
@@ -290,7 +290,7 @@ bool TetOptimizerMesh::smooth_after(const Tuple& t)
     opts.w_envelope = m_params.w_envelope;
     opts.s_amips = m_s_amips;
     opts.s_envelope = m_s_envelope;
-    opts.two_stage = true;
+    opts.two_stage = m_params.two_stage;
     opts.spring_pull = m_params.spring_pull;
     opts.smooth_quality_gate = m_params.smooth_quality_gate;
 

--- a/src/wmtk/TetOptimizerMesh.cpp
+++ b/src/wmtk/TetOptimizerMesh.cpp
@@ -291,7 +291,9 @@ bool TetOptimizerMesh::smooth_after(const Tuple& t)
     opts.s_amips = m_s_amips;
     opts.s_envelope = m_s_envelope;
     opts.two_stage = m_params.two_stage;
-    if (m_params.pull_mode == "envelope") {
+    if (m_params.pull_mode == "exact") {
+        opts.pull_mode = optimization::SmoothVertexOptions::PullMode::Exact;
+    } else if (m_params.pull_mode == "envelope") {
         opts.pull_mode = optimization::SmoothVertexOptions::PullMode::Envelope;
     } else if (m_params.pull_mode == "spring_refresh") {
         opts.pull_mode = optimization::SmoothVertexOptions::PullMode::SpringRefresh;

--- a/src/wmtk/TetOptimizerMesh.cpp
+++ b/src/wmtk/TetOptimizerMesh.cpp
@@ -292,6 +292,7 @@ bool TetOptimizerMesh::smooth_after(const Tuple& t)
     opts.s_envelope = m_s_envelope;
     opts.two_stage = true;
     opts.spring_pull = m_params.spring_pull;
+    opts.smooth_quality_gate = m_params.smooth_quality_gate;
 
     return optimization::smooth_vertex_3d(*this, t, opts, m_solver.local(), &m_smooth_rejects);
 }

--- a/src/wmtk/TetOptimizerMesh.cpp
+++ b/src/wmtk/TetOptimizerMesh.cpp
@@ -291,6 +291,7 @@ bool TetOptimizerMesh::smooth_after(const Tuple& t)
     opts.s_amips = m_s_amips;
     opts.s_envelope = m_s_envelope;
     opts.two_stage = true;
+    opts.spring_pull = m_params.spring_pull;
 
     return optimization::smooth_vertex_3d(*this, t, opts, m_solver.local(), &m_smooth_rejects);
 }

--- a/src/wmtk/TetOptimizerMesh.cpp
+++ b/src/wmtk/TetOptimizerMesh.cpp
@@ -291,7 +291,13 @@ bool TetOptimizerMesh::smooth_after(const Tuple& t)
     opts.s_amips = m_s_amips;
     opts.s_envelope = m_s_envelope;
     opts.two_stage = m_params.two_stage;
-    opts.spring_pull = m_params.spring_pull;
+    if (m_params.pull_mode == "envelope") {
+        opts.pull_mode = optimization::SmoothVertexOptions::PullMode::Envelope;
+    } else if (m_params.pull_mode == "spring_refresh") {
+        opts.pull_mode = optimization::SmoothVertexOptions::PullMode::SpringRefresh;
+    } else {
+        opts.pull_mode = optimization::SmoothVertexOptions::PullMode::Spring;
+    }
     opts.smooth_quality_gate = m_params.smooth_quality_gate;
 
     return optimization::smooth_vertex_3d(*this, t, opts, m_solver.local(), &m_smooth_rejects);

--- a/src/wmtk/TriOptimizerMeshSmooth.cpp
+++ b/src/wmtk/TriOptimizerMeshSmooth.cpp
@@ -30,7 +30,13 @@ bool TriOptimizerMesh::smooth_after(const Tuple& t)
     opts.s_amips = m_s_amips;
     opts.s_envelope = m_s_envelope;
     opts.two_stage = m_params.two_stage;
-    opts.spring_pull = m_params.spring_pull;
+    if (m_params.pull_mode == "envelope") {
+        opts.pull_mode = optimization::SmoothVertexOptions::PullMode::Envelope;
+    } else if (m_params.pull_mode == "spring_refresh") {
+        opts.pull_mode = optimization::SmoothVertexOptions::PullMode::SpringRefresh;
+    } else {
+        opts.pull_mode = optimization::SmoothVertexOptions::PullMode::Spring;
+    }
     opts.smooth_quality_gate = m_params.smooth_quality_gate;
 
     // Deliberately retain TriWild's default quality_veto_on_surface=true. A homogeneous

--- a/src/wmtk/TriOptimizerMeshSmooth.cpp
+++ b/src/wmtk/TriOptimizerMeshSmooth.cpp
@@ -29,7 +29,7 @@ bool TriOptimizerMesh::smooth_after(const Tuple& t)
     opts.w_envelope = m_params.w_envelope;
     opts.s_amips = m_s_amips;
     opts.s_envelope = m_s_envelope;
-    opts.two_stage = true;
+    opts.two_stage = m_params.two_stage;
     opts.spring_pull = m_params.spring_pull;
     opts.smooth_quality_gate = m_params.smooth_quality_gate;
 

--- a/src/wmtk/TriOptimizerMeshSmooth.cpp
+++ b/src/wmtk/TriOptimizerMeshSmooth.cpp
@@ -30,6 +30,7 @@ bool TriOptimizerMesh::smooth_after(const Tuple& t)
     opts.s_amips = m_s_amips;
     opts.s_envelope = m_s_envelope;
     opts.two_stage = true;
+    opts.spring_pull = m_params.spring_pull;
 
     // Deliberately retain TriWild's default quality_veto_on_surface=true. A homogeneous
     // SimWild mesh must accept and reject the same candidate positions as TriWild.

--- a/src/wmtk/TriOptimizerMeshSmooth.cpp
+++ b/src/wmtk/TriOptimizerMeshSmooth.cpp
@@ -31,6 +31,7 @@ bool TriOptimizerMesh::smooth_after(const Tuple& t)
     opts.s_envelope = m_s_envelope;
     opts.two_stage = true;
     opts.spring_pull = m_params.spring_pull;
+    opts.smooth_quality_gate = m_params.smooth_quality_gate;
 
     // Deliberately retain TriWild's default quality_veto_on_surface=true. A homogeneous
     // SimWild mesh must accept and reject the same candidate positions as TriWild.

--- a/src/wmtk/TriOptimizerMeshSmooth.cpp
+++ b/src/wmtk/TriOptimizerMeshSmooth.cpp
@@ -30,7 +30,9 @@ bool TriOptimizerMesh::smooth_after(const Tuple& t)
     opts.s_amips = m_s_amips;
     opts.s_envelope = m_s_envelope;
     opts.two_stage = m_params.two_stage;
-    if (m_params.pull_mode == "envelope") {
+    if (m_params.pull_mode == "exact") {
+        opts.pull_mode = optimization::SmoothVertexOptions::PullMode::Exact;
+    } else if (m_params.pull_mode == "envelope") {
         opts.pull_mode = optimization::SmoothVertexOptions::PullMode::Envelope;
     } else if (m_params.pull_mode == "spring_refresh") {
         opts.pull_mode = optimization::SmoothVertexOptions::PullMode::SpringRefresh;

--- a/src/wmtk/envelope/Envelope.cpp
+++ b/src/wmtk/envelope/Envelope.cpp
@@ -227,6 +227,9 @@ void SampleEnvelope::init(
     // ends, so its corners sit at exactly eps.
     init_exact_edges(V, F, _eps);
 
+    m_v2 = V;
+    m_e2 = F;
+
     sampling_dist = _eps;
     // eps2 keeps the lattice constant for point queries; eps2_edge carries the one derived
     // for a sampled segment. See the header.
@@ -444,6 +447,41 @@ double SampleEnvelope::nearest_point(const Eigen::Vector2d& pts, Eigen::Vector2d
     double dist;
     m_bvh->nearest_facet(pts, result, dist);
     return dist;
+}
+
+double SampleEnvelope::nearest_point_feature(
+    const Eigen::Vector2d& p,
+    Eigen::Vector2d& result,
+    bool& on_corner,
+    Eigen::Vector2d& seg_normal,
+    int& feature_id) const
+{
+    assert(!m_v2.empty() && !m_e2.empty());
+    Eigen::Vector2d nearest;
+    double sq_dist;
+    const int fid = m_bvh->nearest_facet(p, nearest, sq_dist);
+    const Eigen::Vector2d a = m_v2[m_e2[fid][0]];
+    const Eigen::Vector2d b = m_v2[m_e2[fid][1]];
+    const Eigen::Vector2d ab = b - a;
+    const double len2 = ab.squaredNorm();
+    // Recompute the foot on the reported segment so the classification and the returned
+    // point come from the same arithmetic (the BVH's own foot can differ in the last ulp).
+    const double t = len2 > 0 ? (p - a).dot(ab) / len2 : 0.0;
+    if (len2 <= 0 || t <= 0) {
+        result = a;
+        on_corner = true;
+        feature_id = m_e2[fid][0]; // polyline vertex index: canonical across both segments
+    } else if (t >= 1) {
+        result = b;
+        on_corner = true;
+        feature_id = m_e2[fid][1];
+    } else {
+        result = a + t * ab;
+        on_corner = false;
+        seg_normal = Eigen::Vector2d(-ab[1], ab[0]) / std::sqrt(len2);
+        feature_id = fid;
+    }
+    return (p - result).squaredNorm();
 }
 
 double SampleEnvelope::squared_distance(const Eigen::Vector3d& p) const

--- a/src/wmtk/envelope/Envelope.cpp
+++ b/src/wmtk/envelope/Envelope.cpp
@@ -1,5 +1,7 @@
 #include "Envelope.hpp"
 
+#include <limits>
+
 #include <wmtk/Types.hpp>
 #include <wmtk/utils/Logger.hpp>
 
@@ -139,6 +141,8 @@ void SampleEnvelope::init(
         logger().info("Using sample envelope.");
     }
     m_kind = Kind::Triangles3d;
+    m_v3 = V;
+    m_f3 = F;
     exact_envelope.init(V, F, _eps);
 
     // sampleTriangle lays samples on a triangular lattice of spacing `sampling_dist`, whose
@@ -457,31 +461,171 @@ double SampleEnvelope::nearest_point_feature(
     int& feature_id) const
 {
     assert(!m_v2.empty() && !m_e2.empty());
+    // nearest_facet returns SimpleBVH's INTERNAL primitive index (only intersect_box maps
+    // back to input ids), so the facet id cannot be used to look up the segment. Take the
+    // foot point, box-query it (intersect_box does map ids), and classify against the
+    // candidate segments, keeping the closest.
     Eigen::Vector2d nearest;
     double sq_dist;
-    const int fid = m_bvh->nearest_facet(p, nearest, sq_dist);
-    const Eigen::Vector2d a = m_v2[m_e2[fid][0]];
-    const Eigen::Vector2d b = m_v2[m_e2[fid][1]];
-    const Eigen::Vector2d ab = b - a;
-    const double len2 = ab.squaredNorm();
-    // Recompute the foot on the reported segment so the classification and the returned
-    // point come from the same arithmetic (the BVH's own foot can differ in the last ulp).
-    const double t = len2 > 0 ? (p - a).dot(ab) / len2 : 0.0;
-    if (len2 <= 0 || t <= 0) {
-        result = a;
-        on_corner = true;
-        feature_id = m_e2[fid][0]; // polyline vertex index: canonical across both segments
-    } else if (t >= 1) {
-        result = b;
-        on_corner = true;
-        feature_id = m_e2[fid][1];
-    } else {
-        result = a + t * ab;
-        on_corner = false;
-        seg_normal = Eigen::Vector2d(-ab[1], ab[0]) / std::sqrt(len2);
-        feature_id = fid;
+    m_bvh->nearest_facet(p, nearest, sq_dist);
+
+    std::vector<unsigned int> candidates;
+    const double pad = 1e-9 + 1e-9 * std::sqrt(sq_dist);
+    // The BVH stores 2D data lifted to z = 0; query with a 3D box spanning it.
+    const Eigen::Vector3d lo(nearest[0] - pad, nearest[1] - pad, -pad);
+    const Eigen::Vector3d hi(nearest[0] + pad, nearest[1] + pad, pad);
+    m_bvh->intersect_box(lo, hi, candidates);
+    assert(!candidates.empty());
+
+    double best = std::numeric_limits<double>::max();
+    for (const unsigned int fid : candidates) {
+        const Eigen::Vector2d a = m_v2[m_e2[fid][0]];
+        const Eigen::Vector2d b = m_v2[m_e2[fid][1]];
+        const Eigen::Vector2d ab = b - a;
+        const double len2 = ab.squaredNorm();
+        const double t = len2 > 0 ? (p - a).dot(ab) / len2 : 0.0;
+        Eigen::Vector2d foot;
+        bool corner;
+        int id;
+        if (len2 <= 0 || t <= 0) {
+            foot = a;
+            corner = true;
+            id = m_e2[fid][0];
+        } else if (t >= 1) {
+            foot = b;
+            corner = true;
+            id = m_e2[fid][1];
+        } else {
+            foot = a + t * ab;
+            corner = false;
+            id = int(fid);
+        }
+        const double d2 = (p - foot).squaredNorm();
+        if (d2 < best) {
+            best = d2;
+            result = foot;
+            on_corner = corner;
+            feature_id = id;
+            if (!corner) {
+                seg_normal = Eigen::Vector2d(-ab[1], ab[0]) / std::sqrt(len2);
+            }
+        }
     }
-    return (p - result).squaredNorm();
+    return best;
+}
+
+double SampleEnvelope::nearest_point_feature(
+    const Eigen::Vector3d& p,
+    Eigen::Vector3d& result,
+    int& feature_dim,
+    Eigen::Vector3d& dir,
+    long long& feature_id) const
+{
+    assert(!m_v3.empty() && !m_f3.empty());
+    // See the 2D overload: nearest_facet's id is internal, so recover candidates by
+    // box-querying the foot point and classify against each.
+    Eigen::Vector3d nearest;
+    double sq_dist;
+    m_bvh->nearest_facet(p, nearest, sq_dist);
+
+    std::vector<unsigned int> candidates;
+    const double pad = 1e-9 + 1e-9 * std::sqrt(sq_dist);
+    const Eigen::Vector3d lo = nearest.array() - pad;
+    const Eigen::Vector3d hi = nearest.array() + pad;
+    m_bvh->intersect_box(lo, hi, candidates);
+    assert(!candidates.empty());
+
+    const long long nv = (long long)m_v3.size();
+    double best = std::numeric_limits<double>::max();
+    for (const unsigned int fid : candidates) {
+        if (fid >= m_f3.size()) {
+            log_and_throw_error(
+                "nearest_point_feature: candidate id {} out of range ({} faces)",
+                fid,
+                m_f3.size());
+        }
+        const Eigen::Vector3i& tri = m_f3[fid];
+        if (tri[0] >= (int)m_v3.size() || tri[1] >= (int)m_v3.size() ||
+            tri[2] >= (int)m_v3.size()) {
+            log_and_throw_error(
+                "nearest_point_feature: face {} references vertices ({},{},{}) beyond {}",
+                fid,
+                tri[0],
+                tri[1],
+                tri[2],
+                m_v3.size());
+        }
+        const Eigen::Vector3d a = m_v3[tri[0]];
+        const Eigen::Vector3d b = m_v3[tri[1]];
+        const Eigen::Vector3d c = m_v3[tri[2]];
+
+        Eigen::Vector3d foot, fdir(0, 0, 0);
+        int fdim = 0;
+        long long id = tri[0];
+
+        // Ericson, "Real-Time Collision Detection": closest point on triangle, by region.
+        const Eigen::Vector3d ab = b - a, ac = c - a, ap = p - a;
+        const double d1 = ab.dot(ap), d2 = ac.dot(ap);
+        const Eigen::Vector3d bp = p - b;
+        const double d3 = ab.dot(bp), d4 = ac.dot(bp);
+        const Eigen::Vector3d cp = p - c;
+        const double d5 = ab.dot(cp), d6 = ac.dot(cp);
+        const double vc = d1 * d4 - d3 * d2;
+        const double vb = d5 * d2 - d1 * d6;
+        const double va = d3 * d6 - d5 * d4;
+
+        auto vertex_case = [&](int local) {
+            foot = m_v3[tri[local]];
+            fdim = 0;
+            id = tri[local];
+        };
+        auto edge_case = [&](int l0, int l1, double t) {
+            const Eigen::Vector3d e0 = m_v3[tri[l0]];
+            const Eigen::Vector3d e1 = m_v3[tri[l1]];
+            foot = e0 + t * (e1 - e0);
+            fdim = 1;
+            fdir = (e1 - e0).normalized();
+            const long long l = std::min(tri[l0], tri[l1]);
+            const long long h = std::max(tri[l0], tri[l1]);
+            id = l * nv + h;
+        };
+
+        if (d1 <= 0 && d2 <= 0) {
+            vertex_case(0);
+        } else if (d3 >= 0 && d4 <= d3) {
+            vertex_case(1);
+        } else if (vc <= 0 && d1 >= 0 && d3 <= 0) {
+            edge_case(0, 1, d1 / (d1 - d3));
+        } else if (d6 >= 0 && d5 <= d6) {
+            vertex_case(2);
+        } else if (vb <= 0 && d2 >= 0 && d6 <= 0) {
+            edge_case(0, 2, d2 / (d2 - d6));
+        } else if (va <= 0 && d4 - d3 >= 0 && d5 - d6 >= 0) {
+            edge_case(1, 2, (d4 - d3) / ((d4 - d3) + (d5 - d6)));
+        } else {
+            const double denom = 1.0 / (va + vb + vc);
+            const Eigen::Vector3d n = ab.cross(ac);
+            const double nn = n.norm();
+            if (nn <= 0) {
+                vertex_case(0); // degenerate triangle: no face region exists
+            } else {
+                foot = a + ab * (vb * denom) + ac * (vc * denom);
+                fdim = 2;
+                fdir = n / nn;
+                id = fid;
+            }
+        }
+
+        const double d2foot = (p - foot).squaredNorm();
+        if (d2foot < best) {
+            best = d2foot;
+            result = foot;
+            feature_dim = fdim;
+            dir = fdir;
+            feature_id = fdim == 2 ? (long long)fid : id;
+        }
+    }
+    return best;
 }
 
 double SampleEnvelope::squared_distance(const Eigen::Vector3d& p) const

--- a/src/wmtk/envelope/Envelope.hpp
+++ b/src/wmtk/envelope/Envelope.hpp
@@ -142,6 +142,24 @@ public:
     bool is_outside(const Eigen::Vector2d& pts) const;
     double nearest_point(const Eigen::Vector3d& pts, Eigen::Vector3d& result) const;
     double nearest_point(const Eigen::Vector2d& pts, Eigen::Vector2d& result) const;
+
+    /**
+     * 2D only: nearest point plus which feature of the input carries it. Returns the SQUARED
+     * distance. on_corner reports whether the foot point is a polyline vertex; seg_normal is
+     * the unit normal of the closest segment, valid only when !on_corner (sign arbitrary);
+     * feature_id is the polyline vertex index when on_corner, else the segment index --
+     * canonical, so two queries can be compared for "did the closest feature change".
+     *
+     * The distance to a piecewise-linear input is exactly quadratic within each closest-
+     * feature region and kinks where the feature changes; anything that wants the true
+     * second-order behavior (ExactDistanceEnergy2D) needs this classification.
+     */
+    double nearest_point_feature(
+        const Eigen::Vector2d& p,
+        Eigen::Vector2d& result,
+        bool& on_corner,
+        Eigen::Vector2d& seg_normal,
+        int& feature_id) const;
     bool initialized() { return m_bvh != nullptr; };
 
     Kind kind() const { return m_kind; }
@@ -160,6 +178,9 @@ private:
 
     std::vector<int> geo_vertex_ind;
     std::vector<int> geo_face_ind;
+    /// 2D input copy backing nearest_point_feature (filled by the 2D init only).
+    std::vector<Eigen::Vector2d> m_v2;
+    std::vector<Eigen::Vector2i> m_e2;
     std::shared_ptr<SimpleBVH::BVH> m_bvh;
 
 private:

--- a/src/wmtk/envelope/Envelope.hpp
+++ b/src/wmtk/envelope/Envelope.hpp
@@ -160,6 +160,20 @@ public:
         bool& on_corner,
         Eigen::Vector2d& seg_normal,
         int& feature_id) const;
+
+    /**
+     * 3D triangle-mesh counterpart. feature_dim reports where the foot point lies: 2 = face
+     * interior, 1 = edge interior, 0 = mesh vertex. dir is the face normal (dim 2) or the
+     * edge direction (dim 1), unit length, sign arbitrary; unused for dim 0. feature_id is
+     * canonical across adjacent triangles: the face index (dim 2), the sorted vertex pair
+     * packed as min * n_vertices + max (dim 1), or the vertex index (dim 0).
+     */
+    double nearest_point_feature(
+        const Eigen::Vector3d& p,
+        Eigen::Vector3d& result,
+        int& feature_dim,
+        Eigen::Vector3d& dir,
+        long long& feature_id) const;
     bool initialized() { return m_bvh != nullptr; };
 
     Kind kind() const { return m_kind; }
@@ -181,6 +195,9 @@ private:
     /// 2D input copy backing nearest_point_feature (filled by the 2D init only).
     std::vector<Eigen::Vector2d> m_v2;
     std::vector<Eigen::Vector2i> m_e2;
+    /// 3D input copy backing nearest_point_feature (filled by the triangle init only).
+    std::vector<Eigen::Vector3d> m_v3;
+    std::vector<Eigen::Vector3i> m_f3;
     std::shared_ptr<SimpleBVH::BVH> m_bvh;
 
 private:

--- a/src/wmtk/optimization/EnergySum.cpp
+++ b/src/wmtk/optimization/EnergySum.cpp
@@ -1,5 +1,7 @@
 #include "EnergySum.hpp"
 
+#include <algorithm>
+
 #include <wmtk/utils/orient.hpp>
 
 namespace wmtk::optimization {
@@ -43,7 +45,32 @@ void EnergySum::hessian(const TVector& x, MatrixXd& hessian)
     }
 }
 
-void EnergySum::solution_changed(const TVector& new_x) {}
+void EnergySum::solution_changed(const TVector& new_x)
+{
+    for (const auto& e : m_energies) {
+        e->solution_changed(new_x);
+    }
+}
+
+bool EnergySum::after_line_search_custom_operation(const TVector& x0, const TVector& x1)
+{
+    // polysolve calls solution_changed on an accepted iterate only when this returns true,
+    // so forward and report whether any child wants it.
+    bool any = false;
+    for (const auto& e : m_energies) {
+        any = e->after_line_search_custom_operation(x0, x1) || any;
+    }
+    return any;
+}
+
+double EnergySum::max_step_size(const TVector& x0, const TVector& x1)
+{
+    double a = 1.0;
+    for (const auto& e : m_energies) {
+        a = std::min(a, e->max_step_size(x0, x1));
+    }
+    return a;
+}
 
 bool EnergySum::is_step_valid(const TVector& x0, const TVector& x1)
 {

--- a/src/wmtk/optimization/EnergySum.hpp
+++ b/src/wmtk/optimization/EnergySum.hpp
@@ -34,6 +34,10 @@ public:
 
     void solution_changed(const TVector& new_x) override;
 
+    bool after_line_search_custom_operation(const TVector& x0, const TVector& x1) override;
+
+    double max_step_size(const TVector& x0, const TVector& x1) override;
+
     bool is_step_valid(const TVector& x0, const TVector& x1) override;
 
 private:

--- a/src/wmtk/optimization/EnvelopeEnergy.cpp
+++ b/src/wmtk/optimization/EnvelopeEnergy.cpp
@@ -75,9 +75,13 @@ void EnvelopeEnergy2D::hessian(const TVector& x, MatrixXd& hessian)
 void EnvelopeEnergy2D::solution_changed(const TVector& new_x) {}
 
 
-SpringEnergy2D::SpringEnergy2D(const Vector2d& target, const double weight)
+SpringEnergy2D::SpringEnergy2D(
+    const Vector2d& target,
+    const double weight,
+    const std::shared_ptr<SampleEnvelope>& refresh_envelope)
     : m_target(target)
     , m_weight(weight)
+    , m_refresh_envelope(refresh_envelope)
 {}
 
 double SpringEnergy2D::value(const TVector& x)
@@ -97,6 +101,13 @@ void SpringEnergy2D::hessian(const TVector& x, MatrixXd& hessian)
     // Exact, not Gauss-Newton: with the target fixed the energy is a plain quadratic. The
     // isotropy is the whole difference from EnvelopeEnergy2D -- it is what forbids sliding.
     hessian = 2 * m_weight * Matrix2d::Identity();
+}
+
+void SpringEnergy2D::solution_changed(const TVector& new_x)
+{
+    if (m_refresh_envelope) {
+        m_refresh_envelope->nearest_point(Vector2d(new_x), m_target);
+    }
 }
 
 
@@ -138,9 +149,13 @@ void EnvelopeEnergy3D::hessian(const TVector& x, MatrixXd& hessian)
 
 void EnvelopeEnergy3D::solution_changed(const TVector& new_x) {}
 
-SpringEnergy3D::SpringEnergy3D(const Vector3d& target, const double weight)
+SpringEnergy3D::SpringEnergy3D(
+    const Vector3d& target,
+    const double weight,
+    const std::shared_ptr<SampleEnvelope>& refresh_envelope)
     : m_target(target)
     , m_weight(weight)
+    , m_refresh_envelope(refresh_envelope)
 {}
 
 double SpringEnergy3D::value(const TVector& x)
@@ -159,6 +174,13 @@ void SpringEnergy3D::hessian(const TVector& x, MatrixXd& hessian)
 {
     // Exact, not Gauss-Newton: with the target fixed the energy is a plain quadratic.
     hessian = 2 * m_weight * Matrix3d::Identity();
+}
+
+void SpringEnergy3D::solution_changed(const TVector& new_x)
+{
+    if (m_refresh_envelope) {
+        m_refresh_envelope->nearest_point(Vector3d(new_x), m_target);
+    }
 }
 
 } // namespace wmtk::optimization

--- a/src/wmtk/optimization/EnvelopeEnergy.cpp
+++ b/src/wmtk/optimization/EnvelopeEnergy.cpp
@@ -38,11 +38,9 @@ Mat gauss_newton_hessian(const Vec& r, const Vec& nearest, const double weight)
 
 EnvelopeEnergy2D::EnvelopeEnergy2D(
     const std::shared_ptr<SampleEnvelope>& envelope,
-    const double weight,
-    bool check_step_validity)
+    const double weight)
     : m_envelope(envelope)
     , m_weight(weight)
-    , m_check_step_validity(check_step_validity)
 {
     assert(m_envelope);
 }
@@ -76,30 +74,10 @@ void EnvelopeEnergy2D::hessian(const TVector& x, MatrixXd& hessian)
 
 void EnvelopeEnergy2D::solution_changed(const TVector& new_x) {}
 
-bool EnvelopeEnergy2D::is_step_valid(const TVector& x0, const TVector& x1)
-{
-    if (!m_check_step_validity) {
-        return true;
-    }
 
-    Vector2d r(x1);
-    if (m_envelope->is_outside(r)) {
-        return false;
-    }
-
-    return true;
-}
-
-
-SpringEnergy2D::SpringEnergy2D(
-    const Vector2d& target,
-    const double weight,
-    const std::shared_ptr<SampleEnvelope>& envelope,
-    bool check_step_validity)
+SpringEnergy2D::SpringEnergy2D(const Vector2d& target, const double weight)
     : m_target(target)
     , m_weight(weight)
-    , m_envelope(envelope)
-    , m_check_step_validity(check_step_validity)
 {}
 
 double SpringEnergy2D::value(const TVector& x)
@@ -121,22 +99,12 @@ void SpringEnergy2D::hessian(const TVector& x, MatrixXd& hessian)
     hessian = 2 * m_weight * Matrix2d::Identity();
 }
 
-bool SpringEnergy2D::is_step_valid(const TVector& x0, const TVector& x1)
-{
-    if (!m_check_step_validity || !m_envelope) {
-        return true;
-    }
-    return !m_envelope->is_outside(Vector2d(x1));
-}
-
 
 EnvelopeEnergy3D::EnvelopeEnergy3D(
     const std::shared_ptr<SampleEnvelope>& envelope,
-    const double weight,
-    bool check_step_validity)
+    const double weight)
     : m_envelope(envelope)
     , m_weight(weight)
-    , m_check_step_validity(check_step_validity)
 {
     assert(m_envelope);
 }
@@ -170,29 +138,9 @@ void EnvelopeEnergy3D::hessian(const TVector& x, MatrixXd& hessian)
 
 void EnvelopeEnergy3D::solution_changed(const TVector& new_x) {}
 
-bool EnvelopeEnergy3D::is_step_valid(const TVector& x0, const TVector& x1)
-{
-    if (!m_check_step_validity) {
-        return true;
-    }
-
-    Vector3d r(x1);
-    if (m_envelope->is_outside(r)) {
-        return false;
-    }
-
-    return true;
-}
-
-SpringEnergy3D::SpringEnergy3D(
-    const Vector3d& target,
-    const double weight,
-    const std::shared_ptr<SampleEnvelope>& envelope,
-    bool check_step_validity)
+SpringEnergy3D::SpringEnergy3D(const Vector3d& target, const double weight)
     : m_target(target)
     , m_weight(weight)
-    , m_envelope(envelope)
-    , m_check_step_validity(check_step_validity)
 {}
 
 double SpringEnergy3D::value(const TVector& x)
@@ -211,14 +159,6 @@ void SpringEnergy3D::hessian(const TVector& x, MatrixXd& hessian)
 {
     // Exact, not Gauss-Newton: with the target fixed the energy is a plain quadratic.
     hessian = 2 * m_weight * Matrix3d::Identity();
-}
-
-bool SpringEnergy3D::is_step_valid(const TVector& x0, const TVector& x1)
-{
-    if (!m_check_step_validity || !m_envelope) {
-        return true;
-    }
-    return !m_envelope->is_outside(Vector3d(x1));
 }
 
 } // namespace wmtk::optimization

--- a/src/wmtk/optimization/EnvelopeEnergy.cpp
+++ b/src/wmtk/optimization/EnvelopeEnergy.cpp
@@ -91,6 +91,45 @@ bool EnvelopeEnergy2D::is_step_valid(const TVector& x0, const TVector& x1)
 }
 
 
+SpringEnergy2D::SpringEnergy2D(
+    const Vector2d& target,
+    const double weight,
+    const std::shared_ptr<SampleEnvelope>& envelope,
+    bool check_step_validity)
+    : m_target(target)
+    , m_weight(weight)
+    , m_envelope(envelope)
+    , m_check_step_validity(check_step_validity)
+{}
+
+double SpringEnergy2D::value(const TVector& x)
+{
+    assert(x.size() == 2);
+    return m_weight * (Vector2d(x) - m_target).squaredNorm();
+}
+
+void SpringEnergy2D::gradient(const TVector& x, TVector& gradv)
+{
+    assert(x.size() == 2);
+    gradv = 2 * m_weight * (Vector2d(x) - m_target);
+}
+
+void SpringEnergy2D::hessian(const TVector& x, MatrixXd& hessian)
+{
+    // Exact, not Gauss-Newton: with the target fixed the energy is a plain quadratic. The
+    // isotropy is the whole difference from EnvelopeEnergy2D -- it is what forbids sliding.
+    hessian = 2 * m_weight * Matrix2d::Identity();
+}
+
+bool SpringEnergy2D::is_step_valid(const TVector& x0, const TVector& x1)
+{
+    if (!m_check_step_validity || !m_envelope) {
+        return true;
+    }
+    return !m_envelope->is_outside(Vector2d(x1));
+}
+
+
 EnvelopeEnergy3D::EnvelopeEnergy3D(
     const std::shared_ptr<SampleEnvelope>& envelope,
     const double weight,
@@ -143,6 +182,43 @@ bool EnvelopeEnergy3D::is_step_valid(const TVector& x0, const TVector& x1)
     }
 
     return true;
+}
+
+SpringEnergy3D::SpringEnergy3D(
+    const Vector3d& target,
+    const double weight,
+    const std::shared_ptr<SampleEnvelope>& envelope,
+    bool check_step_validity)
+    : m_target(target)
+    , m_weight(weight)
+    , m_envelope(envelope)
+    , m_check_step_validity(check_step_validity)
+{}
+
+double SpringEnergy3D::value(const TVector& x)
+{
+    assert(x.size() == 3);
+    return m_weight * (Vector3d(x) - m_target).squaredNorm();
+}
+
+void SpringEnergy3D::gradient(const TVector& x, TVector& gradv)
+{
+    assert(x.size() == 3);
+    gradv = 2 * m_weight * (Vector3d(x) - m_target);
+}
+
+void SpringEnergy3D::hessian(const TVector& x, MatrixXd& hessian)
+{
+    // Exact, not Gauss-Newton: with the target fixed the energy is a plain quadratic.
+    hessian = 2 * m_weight * Matrix3d::Identity();
+}
+
+bool SpringEnergy3D::is_step_valid(const TVector& x0, const TVector& x1)
+{
+    if (!m_check_step_validity || !m_envelope) {
+        return true;
+    }
+    return !m_envelope->is_outside(Vector3d(x1));
 }
 
 } // namespace wmtk::optimization

--- a/src/wmtk/optimization/EnvelopeEnergy.cpp
+++ b/src/wmtk/optimization/EnvelopeEnergy.cpp
@@ -176,6 +176,71 @@ double ExactDistanceEnergy2D::max_step_size(const TVector& x0, const TVector& x1
     return hi;
 }
 
+
+ExactDistanceEnergy3D::ExactDistanceEnergy3D(
+    const std::shared_ptr<SampleEnvelope>& envelope,
+    const double weight)
+    : m_envelope(envelope)
+    , m_weight(weight)
+{
+    assert(m_envelope);
+}
+
+double ExactDistanceEnergy3D::value(const TVector& x)
+{
+    assert(x.size() == 3);
+    return m_weight * m_envelope->squared_distance(Vector3d(x));
+}
+
+void ExactDistanceEnergy3D::gradient(const TVector& x, TVector& gradv)
+{
+    assert(x.size() == 3);
+    Vector3d r(x);
+    Vector3d n;
+    m_envelope->nearest_point(r, n);
+    gradv = 2 * m_weight * (r - n);
+}
+
+void ExactDistanceEnergy3D::hessian(const TVector& x, MatrixXd& hessian)
+{
+    Vector3d n, dir;
+    int dim = -1;
+    long long feature_id = -1;
+    m_envelope->nearest_point_feature(Vector3d(x), n, dim, dir, feature_id);
+    if (dim == 2) {
+        // Face interior: stiff along the face normal only.
+        hessian = 2.0 * m_weight * (dir * dir.transpose());
+    } else if (dim == 1) {
+        // Edge interior: free along the edge, stiff in both perpendicular directions.
+        hessian = 2.0 * m_weight * (Matrix3d::Identity() - dir * dir.transpose());
+    } else {
+        // Mesh vertex: distance to a point, isotropic.
+        hessian = 2.0 * m_weight * Matrix3d::Identity();
+    }
+}
+
+double ExactDistanceEnergy3D::max_step_size(const TVector& x0, const TVector& x1)
+{
+    const Vector3d p0(x0), p1(x1);
+    Vector3d n, dir;
+    int dim0 = -1, dim1 = -1;
+    long long id0 = -1, id1 = -1;
+    m_envelope->nearest_point_feature(p0, n, dim0, dir, id0);
+    m_envelope->nearest_point_feature(p1, n, dim1, dir, id1);
+    if (dim0 == dim1 && id0 == id1) {
+        return 1.0;
+    }
+    double lo = 0.0, hi = 1.0;
+    for (int it = 0; it < 40 && hi - lo > 1e-6; ++it) {
+        const double mid = 0.5 * (lo + hi);
+        int dm = -1;
+        long long idm = -1;
+        m_envelope->nearest_point_feature(p0 + mid * (p1 - p0), n, dm, dir, idm);
+        ((dm == dim0 && idm == id0) ? lo : hi) = mid;
+    }
+    return hi;
+}
+
 EnvelopeEnergy3D::EnvelopeEnergy3D(
     const std::shared_ptr<SampleEnvelope>& envelope,
     const double weight)

--- a/src/wmtk/optimization/EnvelopeEnergy.cpp
+++ b/src/wmtk/optimization/EnvelopeEnergy.cpp
@@ -151,6 +151,31 @@ void ExactDistanceEnergy2D::hessian(const TVector& x, MatrixXd& hessian)
     }
 }
 
+double ExactDistanceEnergy2D::max_step_size(const TVector& x0, const TVector& x1)
+{
+    const Vector2d p0(x0), p1(x1);
+    Vector2d n, u;
+    bool c = false;
+    int id0 = -1, id1 = -1;
+    m_envelope->nearest_point_feature(p0, n, c, u, id0);
+    const bool corner0 = c;
+    m_envelope->nearest_point_feature(p1, n, c, u, id1);
+    if (corner0 == c && id0 == id1) {
+        return 1.0;
+    }
+    // The step crosses a feature boundary -- the kink of d^2. Bisect for the crossing on
+    // the classification (each probe is one BVH point query) and land just past it, so the
+    // next iterate is classified into, and modeled by, the other region.
+    double lo = 0.0, hi = 1.0;
+    for (int it = 0; it < 40 && hi - lo > 1e-6; ++it) {
+        const double mid = 0.5 * (lo + hi);
+        int idm = -1;
+        m_envelope->nearest_point_feature(p0 + mid * (p1 - p0), n, c, u, idm);
+        ((c == corner0 && idm == id0) ? lo : hi) = mid;
+    }
+    return hi;
+}
+
 EnvelopeEnergy3D::EnvelopeEnergy3D(
     const std::shared_ptr<SampleEnvelope>& envelope,
     const double weight)

--- a/src/wmtk/optimization/EnvelopeEnergy.cpp
+++ b/src/wmtk/optimization/EnvelopeEnergy.cpp
@@ -111,6 +111,46 @@ void SpringEnergy2D::solution_changed(const TVector& new_x)
 }
 
 
+ExactDistanceEnergy2D::ExactDistanceEnergy2D(
+    const std::shared_ptr<SampleEnvelope>& envelope,
+    const double weight)
+    : m_envelope(envelope)
+    , m_weight(weight)
+{
+    assert(m_envelope);
+}
+
+double ExactDistanceEnergy2D::value(const TVector& x)
+{
+    assert(x.size() == 2);
+    return m_weight * m_envelope->squared_distance(Vector2d(x));
+}
+
+void ExactDistanceEnergy2D::gradient(const TVector& x, TVector& gradv)
+{
+    assert(x.size() == 2);
+    Vector2d r(x);
+    Vector2d n;
+    m_envelope->nearest_point(r, n);
+    gradv = 2 * m_weight * (r - n);
+}
+
+void ExactDistanceEnergy2D::hessian(const TVector& x, MatrixXd& hessian)
+{
+    Vector2d n, seg_normal;
+    bool on_corner = false;
+    int feature_id = -1;
+    m_envelope->nearest_point_feature(Vector2d(x), n, on_corner, seg_normal, feature_id);
+    if (on_corner) {
+        // Distance to a point: the true Hessian of d^2 is isotropic.
+        hessian = 2.0 * m_weight * Matrix2d::Identity();
+    } else {
+        // Distance to a segment interior: rank-one along the segment normal. Well-defined
+        // even at d == 0, where the residual direction is unavailable.
+        hessian = 2.0 * m_weight * (seg_normal * seg_normal.transpose());
+    }
+}
+
 EnvelopeEnergy3D::EnvelopeEnergy3D(
     const std::shared_ptr<SampleEnvelope>& envelope,
     const double weight)

--- a/src/wmtk/optimization/EnvelopeEnergy.hpp
+++ b/src/wmtk/optimization/EnvelopeEnergy.hpp
@@ -17,10 +17,7 @@ public:
      * @brief The energy is the squared distance to an envelope.
      *
      */
-    EnvelopeEnergy2D(
-        const std::shared_ptr<SampleEnvelope>& envelope,
-        const double weight = 1,
-        bool check_step_validity = true);
+    EnvelopeEnergy2D(const std::shared_ptr<SampleEnvelope>& envelope, const double weight = 1);
 
     double value(const TVector& x) override;
     void gradient(const TVector& x, TVector& gradv) override;
@@ -32,12 +29,9 @@ public:
 
     void solution_changed(const TVector& new_x) override;
 
-    bool is_step_valid(const TVector& x0, const TVector& x1) override;
-
 private:
     std::shared_ptr<SampleEnvelope> m_envelope;
     double m_weight;
-    bool m_check_step_validity;
 };
 
 /**
@@ -60,9 +54,6 @@ private:
  * vertex to that single point. The energy is then an exact quadratic, the hessian is the full
  * 2w*I, and tangential motion is resisted exactly as strongly as normal motion. No sliding,
  * but also no floor -- the same sweep gives a clean 1/w over six decades.
- *
- * `envelope` is optional and used only by is_step_valid, so that a run with the spring
- * refuses the same steps as a run with the envelope energy and the two are comparable.
  */
 class SpringEnergy2D : public polysolve::nonlinear::Problem
 {
@@ -71,11 +62,7 @@ public:
     using typename polysolve::nonlinear::Problem::THessian;
     using typename polysolve::nonlinear::Problem::TVector;
 
-    SpringEnergy2D(
-        const Vector2d& target,
-        const double weight = 1,
-        const std::shared_ptr<SampleEnvelope>& envelope = nullptr,
-        bool check_step_validity = true);
+    SpringEnergy2D(const Vector2d& target, const double weight = 1);
 
     double value(const TVector& x) override;
     void gradient(const TVector& x, TVector& gradv) override;
@@ -87,13 +74,9 @@ public:
 
     void solution_changed(const TVector& new_x) override {}
 
-    bool is_step_valid(const TVector& x0, const TVector& x1) override;
-
 private:
     Vector2d m_target;
     double m_weight;
-    std::shared_ptr<SampleEnvelope> m_envelope;
-    bool m_check_step_validity;
 };
 
 class EnvelopeEnergy3D : public polysolve::nonlinear::Problem
@@ -107,10 +90,7 @@ public:
      * @brief The energy is the squared distance to an envelope.
      *
      */
-    EnvelopeEnergy3D(
-        const std::shared_ptr<SampleEnvelope>& envelope,
-        const double weight = 1,
-        bool check_step_validity = true);
+    EnvelopeEnergy3D(const std::shared_ptr<SampleEnvelope>& envelope, const double weight = 1);
 
     double value(const TVector& x) override;
     void gradient(const TVector& x, TVector& gradv) override;
@@ -122,12 +102,9 @@ public:
 
     void solution_changed(const TVector& new_x) override;
 
-    bool is_step_valid(const TVector& x0, const TVector& x1) override;
-
 private:
     std::shared_ptr<SampleEnvelope> m_envelope;
     double m_weight;
-    bool m_check_step_validity;
 };
 
 /// 3D counterpart of SpringEnergy2D; see there for what the fixed target buys and costs.
@@ -138,11 +115,7 @@ public:
     using typename polysolve::nonlinear::Problem::THessian;
     using typename polysolve::nonlinear::Problem::TVector;
 
-    SpringEnergy3D(
-        const Vector3d& target,
-        const double weight = 1,
-        const std::shared_ptr<SampleEnvelope>& envelope = nullptr,
-        bool check_step_validity = true);
+    SpringEnergy3D(const Vector3d& target, const double weight = 1);
 
     double value(const TVector& x) override;
     void gradient(const TVector& x, TVector& gradv) override;
@@ -154,13 +127,9 @@ public:
 
     void solution_changed(const TVector& new_x) override {}
 
-    bool is_step_valid(const TVector& x0, const TVector& x1) override;
-
 private:
     Vector3d m_target;
     double m_weight;
-    std::shared_ptr<SampleEnvelope> m_envelope;
-    bool m_check_step_validity;
 };
 
 } // namespace wmtk::optimization

--- a/src/wmtk/optimization/EnvelopeEnergy.hpp
+++ b/src/wmtk/optimization/EnvelopeEnergy.hpp
@@ -139,6 +139,38 @@ private:
     double m_weight;
 };
 
+
+/// 3D counterpart of ExactDistanceEnergy2D. The true Hessian of w*d^2 to a triangle mesh is
+/// 2w * n n^T over a face interior (n the face normal), 2w * (I - t t^T) over an edge
+/// interior (t the edge direction), and 2w * I at a mesh vertex -- each region exactly
+/// quadratic, all PSD, all the actual second derivative.
+class ExactDistanceEnergy3D : public polysolve::nonlinear::Problem
+{
+public:
+    using typename polysolve::nonlinear::Problem::Scalar;
+    using typename polysolve::nonlinear::Problem::THessian;
+    using typename polysolve::nonlinear::Problem::TVector;
+
+    ExactDistanceEnergy3D(const std::shared_ptr<SampleEnvelope>& envelope, const double weight = 1);
+
+    double value(const TVector& x) override;
+    void gradient(const TVector& x, TVector& gradv) override;
+    void hessian(const TVector& x, THessian& hessian) override
+    {
+        log_and_throw_error("Sparse functions do not exist, use dense solver");
+    }
+    void hessian(const TVector& x, MatrixXd& hessian) override;
+
+    void solution_changed(const TVector& new_x) override {}
+
+    /// See ExactDistanceEnergy2D::max_step_size; identical contract, 3D features.
+    double max_step_size(const TVector& x0, const TVector& x1) override;
+
+private:
+    std::shared_ptr<SampleEnvelope> m_envelope;
+    double m_weight;
+};
+
 class EnvelopeEnergy3D : public polysolve::nonlinear::Problem
 {
 public:

--- a/src/wmtk/optimization/EnvelopeEnergy.hpp
+++ b/src/wmtk/optimization/EnvelopeEnergy.hpp
@@ -125,6 +125,15 @@ public:
 
     void solution_changed(const TVector& new_x) override {}
 
+    /**
+     * Clamp a proposed step at the closest-feature region boundary, so Newton lands on the
+     * kink of d^2 instead of overshooting across it and rediscovering it by backtracking.
+     * Returns 1 when the classification is unchanged over the step. Helps when the
+     * iteration budget can absorb the extra, shorter steps; see the commit message for the
+     * measured trade.
+     */
+    double max_step_size(const TVector& x0, const TVector& x1) override;
+
 private:
     std::shared_ptr<SampleEnvelope> m_envelope;
     double m_weight;

--- a/src/wmtk/optimization/EnvelopeEnergy.hpp
+++ b/src/wmtk/optimization/EnvelopeEnergy.hpp
@@ -62,7 +62,15 @@ public:
     using typename polysolve::nonlinear::Problem::THessian;
     using typename polysolve::nonlinear::Problem::TVector;
 
-    SpringEnergy2D(const Vector2d& target, const double weight = 1);
+    /**
+     * @param refresh_envelope when non-null, the target is re-captured as this envelope's
+     * nearest point at every accepted iterate (via solution_changed); when null the target
+     * stays fixed for the whole solve.
+     */
+    SpringEnergy2D(
+        const Vector2d& target,
+        const double weight = 1,
+        const std::shared_ptr<SampleEnvelope>& refresh_envelope = nullptr);
 
     double value(const TVector& x) override;
     void gradient(const TVector& x, TVector& gradv) override;
@@ -72,11 +80,16 @@ public:
     }
     void hessian(const TVector& x, MatrixXd& hessian) override;
 
-    void solution_changed(const TVector& new_x) override {}
+    void solution_changed(const TVector& new_x) override;
+    bool after_line_search_custom_operation(const TVector& x0, const TVector& x1) override
+    {
+        return m_refresh_envelope != nullptr;
+    }
 
 private:
     Vector2d m_target;
     double m_weight;
+    std::shared_ptr<SampleEnvelope> m_refresh_envelope;
 };
 
 class EnvelopeEnergy3D : public polysolve::nonlinear::Problem
@@ -115,7 +128,15 @@ public:
     using typename polysolve::nonlinear::Problem::THessian;
     using typename polysolve::nonlinear::Problem::TVector;
 
-    SpringEnergy3D(const Vector3d& target, const double weight = 1);
+    /**
+     * @param refresh_envelope when non-null, the target is re-captured as this envelope's
+     * nearest point at every accepted iterate (via solution_changed); when null the target
+     * stays fixed for the whole solve.
+     */
+    SpringEnergy3D(
+        const Vector3d& target,
+        const double weight = 1,
+        const std::shared_ptr<SampleEnvelope>& refresh_envelope = nullptr);
 
     double value(const TVector& x) override;
     void gradient(const TVector& x, TVector& gradv) override;
@@ -125,11 +146,16 @@ public:
     }
     void hessian(const TVector& x, MatrixXd& hessian) override;
 
-    void solution_changed(const TVector& new_x) override {}
+    void solution_changed(const TVector& new_x) override;
+    bool after_line_search_custom_operation(const TVector& x0, const TVector& x1) override
+    {
+        return m_refresh_envelope != nullptr;
+    }
 
 private:
     Vector3d m_target;
     double m_weight;
+    std::shared_ptr<SampleEnvelope> m_refresh_envelope;
 };
 
 } // namespace wmtk::optimization

--- a/src/wmtk/optimization/EnvelopeEnergy.hpp
+++ b/src/wmtk/optimization/EnvelopeEnergy.hpp
@@ -92,6 +92,44 @@ private:
     std::shared_ptr<SampleEnvelope> m_refresh_envelope;
 };
 
+
+/**
+ * @brief The true w * d^2 to the exact piecewise-linear input with its TRUE Hessian.
+ *
+ * For a PL input the distance is exactly quadratic within each closest-feature region: the
+ * Hessian of w*d^2 is 2w * n n^T (n the segment normal) when the foot point lies in a
+ * segment interior, and 2w * I when it is a polyline corner -- distance to a point is
+ * isotropic. Both are the actual second derivative, so unlike EnvelopeEnergy2D (whose
+ * hessian is the Gauss-Newton model) all three callbacks agree under finite differences,
+ * everywhere except exactly on a region boundary.
+ *
+ * Behaviorally: free sliding along segment interiors, isotropic hold at corners -- the
+ * geometry decides where tangential motion is free, not a policy.
+ */
+class ExactDistanceEnergy2D : public polysolve::nonlinear::Problem
+{
+public:
+    using typename polysolve::nonlinear::Problem::Scalar;
+    using typename polysolve::nonlinear::Problem::THessian;
+    using typename polysolve::nonlinear::Problem::TVector;
+
+    ExactDistanceEnergy2D(const std::shared_ptr<SampleEnvelope>& envelope, const double weight = 1);
+
+    double value(const TVector& x) override;
+    void gradient(const TVector& x, TVector& gradv) override;
+    void hessian(const TVector& x, THessian& hessian) override
+    {
+        log_and_throw_error("Sparse functions do not exist, use dense solver");
+    }
+    void hessian(const TVector& x, MatrixXd& hessian) override;
+
+    void solution_changed(const TVector& new_x) override {}
+
+private:
+    std::shared_ptr<SampleEnvelope> m_envelope;
+    double m_weight;
+};
+
 class EnvelopeEnergy3D : public polysolve::nonlinear::Problem
 {
 public:

--- a/src/wmtk/optimization/EnvelopeEnergy.hpp
+++ b/src/wmtk/optimization/EnvelopeEnergy.hpp
@@ -40,6 +40,62 @@ private:
     bool m_check_step_validity;
 };
 
+/**
+ * @brief w * |x - t|^2 with t a FIXED target point, the no-sliding alternative to
+ * EnvelopeEnergy2D.
+ *
+ * EnvelopeEnergy penalises the distance to the input as a SET: it recomputes the nearest
+ * point at every evaluation, so its gradient 2w*(x - n(x)) is always normal to the input and
+ * a vertex can slide along it at no cost. That is what the rank-one Gauss-Newton hessian
+ * encodes, and it is deliberate -- sliding is what lets a surface vertex relax along the
+ * curve it sits on.
+ *
+ * It also has a consequence. Under a competing term the vertex is pushed tangentially with
+ * no restoring force at all, so it slides until the geometry rather than the force balance
+ * stops it, and the leftover distance no longer depends on the weight. Measured on
+ * triwild20k_202090 that floor is ~4e-5 and raising the weight by four further decades does
+ * not move it.
+ *
+ * This is the other choice: capture the nearest point once, before the solve, and spring the
+ * vertex to that single point. The energy is then an exact quadratic, the hessian is the full
+ * 2w*I, and tangential motion is resisted exactly as strongly as normal motion. No sliding,
+ * but also no floor -- the same sweep gives a clean 1/w over six decades.
+ *
+ * `envelope` is optional and used only by is_step_valid, so that a run with the spring
+ * refuses the same steps as a run with the envelope energy and the two are comparable.
+ */
+class SpringEnergy2D : public polysolve::nonlinear::Problem
+{
+public:
+    using typename polysolve::nonlinear::Problem::Scalar;
+    using typename polysolve::nonlinear::Problem::THessian;
+    using typename polysolve::nonlinear::Problem::TVector;
+
+    SpringEnergy2D(
+        const Vector2d& target,
+        const double weight = 1,
+        const std::shared_ptr<SampleEnvelope>& envelope = nullptr,
+        bool check_step_validity = true);
+
+    double value(const TVector& x) override;
+    void gradient(const TVector& x, TVector& gradv) override;
+    void hessian(const TVector& x, THessian& hessian) override
+    {
+        log_and_throw_error("Sparse functions do not exist, use dense solver");
+    }
+    void hessian(const TVector& x, MatrixXd& hessian) override;
+
+    void solution_changed(const TVector& new_x) override {}
+
+    bool is_step_valid(const TVector& x0, const TVector& x1) override;
+
+private:
+    Vector2d m_target;
+    double m_weight;
+    std::shared_ptr<SampleEnvelope> m_envelope;
+    bool m_check_step_validity;
+};
+
 class EnvelopeEnergy3D : public polysolve::nonlinear::Problem
 {
 public:
@@ -71,6 +127,39 @@ public:
 private:
     std::shared_ptr<SampleEnvelope> m_envelope;
     double m_weight;
+    bool m_check_step_validity;
+};
+
+/// 3D counterpart of SpringEnergy2D; see there for what the fixed target buys and costs.
+class SpringEnergy3D : public polysolve::nonlinear::Problem
+{
+public:
+    using typename polysolve::nonlinear::Problem::Scalar;
+    using typename polysolve::nonlinear::Problem::THessian;
+    using typename polysolve::nonlinear::Problem::TVector;
+
+    SpringEnergy3D(
+        const Vector3d& target,
+        const double weight = 1,
+        const std::shared_ptr<SampleEnvelope>& envelope = nullptr,
+        bool check_step_validity = true);
+
+    double value(const TVector& x) override;
+    void gradient(const TVector& x, TVector& gradv) override;
+    void hessian(const TVector& x, THessian& hessian) override
+    {
+        log_and_throw_error("Sparse functions do not exist, use dense solver");
+    }
+    void hessian(const TVector& x, MatrixXd& hessian) override;
+
+    void solution_changed(const TVector& new_x) override {}
+
+    bool is_step_valid(const TVector& x0, const TVector& x1) override;
+
+private:
+    Vector3d m_target;
+    double m_weight;
+    std::shared_ptr<SampleEnvelope> m_envelope;
     bool m_check_step_validity;
 };
 

--- a/src/wmtk/optimization/SmoothVertex.hpp
+++ b/src/wmtk/optimization/SmoothVertex.hpp
@@ -126,9 +126,10 @@ struct SmoothVertexOptions
      * once when the solve begins; tangential motion is resisted like normal motion.
      * SpringRefresh: the same spring, but the target is re-captured at every accepted
      * iterate, which restores slow tangential motion (one force-balance displacement per
-     * iterate) while keeping each iterate's model an exact quadratic. Exact (2D only): the
-     * true distance with its true region-wise Hessian -- free sliding on segment interiors,
-     * isotropic hold at corners; see ExactDistanceEnergy2D.
+     * iterate) while keeping each iterate's model an exact quadratic. Exact: the true distance
+     * with its true region-wise Hessian -- sliding is free exactly where the input is flat
+     * (segment/face interiors), partially constrained on 3D edges, held at corners and
+     * vertices; see ExactDistanceEnergy2D/3D.
      */
     enum class PullMode { Envelope, Spring, SpringRefresh, Exact };
     PullMode pull_mode = PullMode::Spring;
@@ -220,9 +221,15 @@ bool smooth_vertex_3d(
     if (pull_env) {
         const double pull_w = opts.s_envelope * opts.w_envelope;
         std::shared_ptr<polysolve::nonlinear::Problem> envelope_energy;
-        if (opts.pull_mode == SmoothVertexOptions::PullMode::Exact) {
-            log_and_throw_error("pull_mode 'exact' is only implemented in 2D");
-        } else if (opts.pull_mode == SmoothVertexOptions::PullMode::Envelope) {
+        if (opts.pull_mode == SmoothVertexOptions::PullMode::Exact &&
+            pull_env->kind() == SampleEnvelope::Kind::Triangles3d) {
+            envelope_energy = std::make_shared<ExactDistanceEnergy3D>(pull_env, pull_w);
+        } else if (
+            opts.pull_mode == SmoothVertexOptions::PullMode::Envelope ||
+            opts.pull_mode == SmoothVertexOptions::PullMode::Exact) {
+            // Exact classification is implemented for triangle envelopes; a vertex pulled
+            // toward an order-2 CURVE envelope falls back to the Gauss-Newton pull, whose
+            // rank-one model is the correct segment-interior behavior there anyway.
             envelope_energy = std::make_shared<EnvelopeEnergy3D>(pull_env, pull_w);
         } else {
             Vector3d target;

--- a/src/wmtk/optimization/SmoothVertex.hpp
+++ b/src/wmtk/optimization/SmoothVertex.hpp
@@ -118,14 +118,18 @@ struct SmoothVertexOptions
     bool smooth_quality_gate = true;
 
     /**
-     * Pull a surface vertex with a fixed-target spring (SpringEnergy2D/3D) instead of the
-     * squared distance to the input (EnvelopeEnergy2D/3D).
+     * How a surface vertex is pulled toward the input.
      *
-     * The two differ in whether the vertex may slide along the input for free; see
-     * SpringEnergy2D. The target is the nearest point on the input to where the vertex stands
-     * when the solve begins, captured once.
+     * Envelope: squared distance to the input as a set (EnvelopeEnergy2D/3D); the nearest
+     * point is re-queried at every evaluation, so the vertex may slide along the input for
+     * free. Spring: a fixed-target spring (SpringEnergy2D/3D) to the nearest point captured
+     * once when the solve begins; tangential motion is resisted like normal motion.
+     * SpringRefresh: the same spring, but the target is re-captured at every accepted
+     * iterate, which restores slow tangential motion (one force-balance displacement per
+     * iterate) while keeping each iterate's model an exact quadratic.
      */
-    bool spring_pull = true;
+    enum class PullMode { Envelope, Spring, SpringRefresh };
+    PullMode pull_mode = PullMode::Spring;
 };
 
 /**
@@ -214,12 +218,14 @@ bool smooth_vertex_3d(
     if (pull_env) {
         const double pull_w = opts.s_envelope * opts.w_envelope;
         std::shared_ptr<polysolve::nonlinear::Problem> envelope_energy;
-        if (opts.spring_pull) {
+        if (opts.pull_mode == SmoothVertexOptions::PullMode::Envelope) {
+            envelope_energy = std::make_shared<EnvelopeEnergy3D>(pull_env, pull_w);
+        } else {
             Vector3d target;
             pull_env->nearest_point(Vector3d(VA[vid].m_posf), target);
-            envelope_energy = std::make_shared<SpringEnergy3D>(target, pull_w);
-        } else {
-            envelope_energy = std::make_shared<EnvelopeEnergy3D>(pull_env, pull_w);
+            const bool refresh = opts.pull_mode == SmoothVertexOptions::PullMode::SpringRefresh;
+            envelope_energy =
+                std::make_shared<SpringEnergy3D>(target, pull_w, refresh ? pull_env : nullptr);
         }
 
         if (opts.two_stage) {
@@ -392,12 +398,14 @@ bool smooth_vertex_2d(
     if (envelope) {
         const double pull_w = opts.s_envelope * opts.w_envelope;
         std::shared_ptr<polysolve::nonlinear::Problem> envelope_energy;
-        if (opts.spring_pull) {
+        if (opts.pull_mode == SmoothVertexOptions::PullMode::Envelope) {
+            envelope_energy = std::make_shared<EnvelopeEnergy2D>(envelope, pull_w);
+        } else {
             Vector2d target;
             envelope->nearest_point(m.smoothing_position(vid), target);
-            envelope_energy = std::make_shared<SpringEnergy2D>(target, pull_w);
-        } else {
-            envelope_energy = std::make_shared<EnvelopeEnergy2D>(envelope, pull_w);
+            const bool refresh = opts.pull_mode == SmoothVertexOptions::PullMode::SpringRefresh;
+            envelope_energy =
+                std::make_shared<SpringEnergy2D>(target, pull_w, refresh ? envelope : nullptr);
         }
 
         if (opts.two_stage) {

--- a/src/wmtk/optimization/SmoothVertex.hpp
+++ b/src/wmtk/optimization/SmoothVertex.hpp
@@ -61,8 +61,9 @@ struct SmoothRejectCounters
  * The weights follow simwild's convention: `w_envelope = 1 - w_amips`, with w_amips small
  * (1e-4), so the envelope term dominates and the AMIPS term acts as a light quality
  * preference. The scale factors put the two on a comparable footing --- AMIPS is
- * dimensionless while the envelope energy is a squared distance, so s_envelope is normally
- * 1 / (diag * eps^2).
+ * dimensionless while the envelope energy is a squared distance, so s_envelope is
+ * 1 / eps^2 and the term reads (d/eps)^2: distance in envelope widths, dimensionless
+ * like AMIPS in both 2D and 3D.
  */
 struct SmoothVertexOptions
 {

--- a/src/wmtk/optimization/SmoothVertex.hpp
+++ b/src/wmtk/optimization/SmoothVertex.hpp
@@ -103,6 +103,16 @@ struct SmoothVertexOptions
      * veto).
      */
     bool quality_veto_on_surface = true;
+
+    /**
+     * Pull a surface vertex with a fixed-target spring (SpringEnergy2D/3D) instead of the
+     * squared distance to the input (EnvelopeEnergy2D/3D).
+     *
+     * The two differ in whether the vertex may slide along the input for free; see
+     * SpringEnergy2D. The target is the nearest point on the input to where the vertex stands
+     * when the solve begins, captured once.
+     */
+    bool spring_pull = true;
 };
 
 /**
@@ -186,8 +196,15 @@ bool smooth_vertex_3d(
         VA[vid].m_is_on_surface ? m.smoothing_energy_envelope(vid) : nullptr;
 
     if (pull_env) {
-        auto envelope_energy =
-            std::make_shared<EnvelopeEnergy3D>(pull_env, opts.s_envelope * opts.w_envelope);
+        const double pull_w = opts.s_envelope * opts.w_envelope;
+        std::shared_ptr<polysolve::nonlinear::Problem> envelope_energy;
+        if (opts.spring_pull) {
+            Vector3d target;
+            pull_env->nearest_point(Vector3d(VA[vid].m_posf), target);
+            envelope_energy = std::make_shared<SpringEnergy3D>(target, pull_w, pull_env);
+        } else {
+            envelope_energy = std::make_shared<EnvelopeEnergy3D>(pull_env, pull_w);
+        }
 
         if (opts.two_stage) {
             auto warmup = std::make_shared<EnergySum>();
@@ -357,8 +374,15 @@ bool smooth_vertex_2d(
         VA[vid].m_is_on_surface ? m.m_envelope : nullptr;
 
     if (envelope) {
-        auto envelope_energy =
-            std::make_shared<EnvelopeEnergy2D>(envelope, opts.s_envelope * opts.w_envelope);
+        const double pull_w = opts.s_envelope * opts.w_envelope;
+        std::shared_ptr<polysolve::nonlinear::Problem> envelope_energy;
+        if (opts.spring_pull) {
+            Vector2d target;
+            envelope->nearest_point(m.smoothing_position(vid), target);
+            envelope_energy = std::make_shared<SpringEnergy2D>(target, pull_w, envelope);
+        } else {
+            envelope_energy = std::make_shared<EnvelopeEnergy2D>(envelope, pull_w);
+        }
 
         if (opts.two_stage) {
             auto warmup = std::make_shared<EnergySum>();

--- a/src/wmtk/optimization/SmoothVertex.hpp
+++ b/src/wmtk/optimization/SmoothVertex.hpp
@@ -132,11 +132,14 @@ struct SmoothVertexOptions
  * @brief One Newton smoothing step for a single vertex, shared by the 3D applications.
  *
  * The envelope enters the objective as a squared-distance penalty rather than as a
- * projection applied afterwards, so a vertex is drawn back toward the surface gradually and
- * the line search refuses any step that leaves the envelope
- * (EnvelopeEnergy3D::is_step_valid). That is the difference from a hard `nearest_point`
- * snap, which moves the vertex the whole way in one jump and is therefore rejected exactly
- * when the vertex most needs moving.
+ * projection applied afterwards, so a vertex is drawn back toward the surface gradually.
+ * That is the difference from a hard `nearest_point` snap, which moves the vertex the whole
+ * way in one jump and is therefore rejected exactly when the vertex most needs moving.
+ *
+ * The line search never consults the envelope: the pull energies answer is_step_valid with
+ * the base-class "true", AMIPS keeps its pole guard against stepping over an inversion, and
+ * eps-containment is owned by the accept checks after the solve, which test whole incident
+ * faces rather than the vertex point anyway.
  *
  * `Mesh` must provide, on top of what wmtk::TetMesh already gives:
  *   - m_vertex_attribute[vid].{m_pos, m_posf, m_is_on_surface}
@@ -214,7 +217,7 @@ bool smooth_vertex_3d(
         if (opts.spring_pull) {
             Vector3d target;
             pull_env->nearest_point(Vector3d(VA[vid].m_posf), target);
-            envelope_energy = std::make_shared<SpringEnergy3D>(target, pull_w, pull_env);
+            envelope_energy = std::make_shared<SpringEnergy3D>(target, pull_w);
         } else {
             envelope_energy = std::make_shared<EnvelopeEnergy3D>(pull_env, pull_w);
         }
@@ -269,8 +272,7 @@ bool smooth_vertex_3d(
         max_after_quality = std::max(max_after_quality, quality);
     }
 
-    if (opts.smooth_quality_gate &&
-        (!VA[vid].m_is_on_surface || opts.quality_veto_on_surface)) {
+    if (opts.smooth_quality_gate && (!VA[vid].m_is_on_surface || opts.quality_veto_on_surface)) {
         if (max_after_quality > max_quality) {
             if (counters) ++counters->quality;
             return false;
@@ -393,7 +395,7 @@ bool smooth_vertex_2d(
         if (opts.spring_pull) {
             Vector2d target;
             envelope->nearest_point(m.smoothing_position(vid), target);
-            envelope_energy = std::make_shared<SpringEnergy2D>(target, pull_w, envelope);
+            envelope_energy = std::make_shared<SpringEnergy2D>(target, pull_w);
         } else {
             envelope_energy = std::make_shared<EnvelopeEnergy2D>(envelope, pull_w);
         }
@@ -447,8 +449,7 @@ bool smooth_vertex_2d(
         max_after_quality = std::max(max_after_quality, q);
     }
 
-    if (opts.smooth_quality_gate &&
-        (!VA[vid].m_is_on_surface || opts.quality_veto_on_surface)) {
+    if (opts.smooth_quality_gate && (!VA[vid].m_is_on_surface || opts.quality_veto_on_surface)) {
         if (max_after_quality > max_quality) {
             if (counters) ++counters->quality;
             return false;

--- a/src/wmtk/optimization/SmoothVertex.hpp
+++ b/src/wmtk/optimization/SmoothVertex.hpp
@@ -126,9 +126,11 @@ struct SmoothVertexOptions
      * once when the solve begins; tangential motion is resisted like normal motion.
      * SpringRefresh: the same spring, but the target is re-captured at every accepted
      * iterate, which restores slow tangential motion (one force-balance displacement per
-     * iterate) while keeping each iterate's model an exact quadratic.
+     * iterate) while keeping each iterate's model an exact quadratic. Exact (2D only): the
+     * true distance with its true region-wise Hessian -- free sliding on segment interiors,
+     * isotropic hold at corners; see ExactDistanceEnergy2D.
      */
-    enum class PullMode { Envelope, Spring, SpringRefresh };
+    enum class PullMode { Envelope, Spring, SpringRefresh, Exact };
     PullMode pull_mode = PullMode::Spring;
 };
 
@@ -218,7 +220,9 @@ bool smooth_vertex_3d(
     if (pull_env) {
         const double pull_w = opts.s_envelope * opts.w_envelope;
         std::shared_ptr<polysolve::nonlinear::Problem> envelope_energy;
-        if (opts.pull_mode == SmoothVertexOptions::PullMode::Envelope) {
+        if (opts.pull_mode == SmoothVertexOptions::PullMode::Exact) {
+            log_and_throw_error("pull_mode 'exact' is only implemented in 2D");
+        } else if (opts.pull_mode == SmoothVertexOptions::PullMode::Envelope) {
             envelope_energy = std::make_shared<EnvelopeEnergy3D>(pull_env, pull_w);
         } else {
             Vector3d target;
@@ -398,7 +402,9 @@ bool smooth_vertex_2d(
     if (envelope) {
         const double pull_w = opts.s_envelope * opts.w_envelope;
         std::shared_ptr<polysolve::nonlinear::Problem> envelope_energy;
-        if (opts.pull_mode == SmoothVertexOptions::PullMode::Envelope) {
+        if (opts.pull_mode == SmoothVertexOptions::PullMode::Exact) {
+            envelope_energy = std::make_shared<ExactDistanceEnergy2D>(envelope, pull_w);
+        } else if (opts.pull_mode == SmoothVertexOptions::PullMode::Envelope) {
             envelope_energy = std::make_shared<EnvelopeEnergy2D>(envelope, pull_w);
         } else {
             Vector2d target;

--- a/src/wmtk/optimization/SmoothVertex.hpp
+++ b/src/wmtk/optimization/SmoothVertex.hpp
@@ -105,6 +105,18 @@ struct SmoothVertexOptions
     bool quality_veto_on_surface = true;
 
     /**
+     * Apply the "do not make the worst incident element worse" gate at all. False drops it
+     * for every vertex, surface or not, and quality_veto_on_surface stops meaning anything.
+     *
+     * On by default, and the note above records what it is worth: without it smoothing raised
+     * the max energy in 38% of passes and a mesh would oscillate for tens of iterations until
+     * a reading happened to fall below target. Exposed because that measurement was taken with
+     * the sliding pull, and a pull that holds a vertex in place may not need the same
+     * protection.
+     */
+    bool smooth_quality_gate = true;
+
+    /**
      * Pull a surface vertex with a fixed-target spring (SpringEnergy2D/3D) instead of the
      * squared distance to the input (EnvelopeEnergy2D/3D).
      *
@@ -256,7 +268,8 @@ bool smooth_vertex_3d(
         max_after_quality = std::max(max_after_quality, quality);
     }
 
-    if (!VA[vid].m_is_on_surface || opts.quality_veto_on_surface) {
+    if (opts.smooth_quality_gate &&
+        (!VA[vid].m_is_on_surface || opts.quality_veto_on_surface)) {
         if (max_after_quality > max_quality) {
             if (counters) ++counters->quality;
             return false;
@@ -433,7 +446,8 @@ bool smooth_vertex_2d(
         max_after_quality = std::max(max_after_quality, q);
     }
 
-    if (!VA[vid].m_is_on_surface || opts.quality_veto_on_surface) {
+    if (opts.smooth_quality_gate &&
+        (!VA[vid].m_is_on_surface || opts.quality_veto_on_surface)) {
         if (max_after_quality > max_quality) {
             if (counters) ++counters->quality;
             return false;

--- a/tests/test_optimization.cpp
+++ b/tests/test_optimization.cpp
@@ -388,6 +388,99 @@ TEST_CASE("biharmonic_energy_bunny_3d", "[energies][.]")
         // igl::writeOFF(fmt::format("debug_{}.off", i), V, F);
     }
 }
+TEST_CASE("exact_distance_energy_3d", "[energies]")
+{
+    // A 90-degree roof: two triangles sharing the ridge (0,0,0)-(4,0,0), one lying in the
+    // z=0 plane (y<0), one in the y=0 plane (z<0). Probes in the (+y,+z) quadrant see the
+    // ridge as a convex crease. The three closest-feature kinds get one probe each; within
+    // each region the energy is exactly quadratic, so full FD checks must pass, and the
+    // hessian's rank reports the feature.
+    auto env = std::make_shared<SampleEnvelope>(false);
+    const std::vector<Eigen::Vector3d> V = {
+        Eigen::Vector3d(0, 0, 0),
+        Eigen::Vector3d(4, 0, 0),
+        Eigen::Vector3d(2, -3, 0),
+        Eigen::Vector3d(2, 0, -3)};
+    const std::vector<Eigen::Vector3i> F = {Eigen::Vector3i(0, 1, 2), Eigen::Vector3i(0, 1, 3)};
+    env->init(V, F, 0.1);
+
+    const double w = 3.0;
+    optimization::ExactDistanceEnergy3D energy(env, w);
+
+    const double h = 1e-6;
+    auto fd_check = [&](const Vector3d& p) {
+        VectorXd g;
+        energy.gradient(p, g);
+        MatrixXd H;
+        energy.hessian(p, H);
+        for (int i = 0; i < 3; ++i) {
+            Vector3d a = p, b = p;
+            a[i] -= h;
+            b[i] += h;
+            const double fd = (energy.value(b) - energy.value(a)) / (2 * h);
+            CHECK(std::abs(g[i] - fd) <= 1e-5 * std::max(1.0, std::abs(fd)));
+            VectorXd ga, gb;
+            energy.gradient(a, ga);
+            energy.gradient(b, gb);
+            for (int j = 0; j < 3; ++j) {
+                const double fdh = (gb[j] - ga[j]) / (2 * h);
+                CHECK(std::abs(H(j, i) - fdh) <= 1e-4 * std::max(1.0, std::abs(fdh)));
+            }
+        }
+    };
+
+    SECTION("face interior: rank one along the face normal")
+    {
+        const Vector3d p(2.0, -1.0, 0.5); // above the z=0 triangle
+        fd_check(p);
+        MatrixXd H;
+        energy.hessian(p, H);
+        CHECK((H * Vector3d(1, 0, 0)).norm() <= 1e-9);
+        CHECK((H * Vector3d(0, 1, 0)).norm() <= 1e-9);
+        CHECK(
+            std::abs((Vector3d(0, 0, 1).transpose() * H * Vector3d(0, 0, 1)).value() - 2 * w) <=
+            1e-9);
+    }
+
+    SECTION("edge interior: free along the ridge, stiff across")
+    {
+        const Vector3d p(2.0, 1.0, 1.0); // over the ridge, outside both faces
+        fd_check(p);
+        MatrixXd H;
+        energy.hessian(p, H);
+        CHECK((H * Vector3d(1, 0, 0)).norm() <= 1e-9);
+        CHECK(
+            std::abs((Vector3d(0, 1, 0).transpose() * H * Vector3d(0, 1, 0)).value() - 2 * w) <=
+            1e-9);
+        CHECK(
+            std::abs((Vector3d(0, 0, 1).transpose() * H * Vector3d(0, 0, 1)).value() - 2 * w) <=
+            1e-9);
+    }
+
+    SECTION("mesh vertex: isotropic")
+    {
+        const Vector3d p(5.0, 1.0, 1.0); // beyond the ridge end at (4,0,0)
+        fd_check(p);
+        MatrixXd H;
+        energy.hessian(p, H);
+        CHECK((H - 2 * w * MatrixXd::Identity(3, 3)).norm() <= 1e-9);
+    }
+
+    SECTION("max_step_size clamps at the face-to-ridge boundary")
+    {
+        CHECK(energy.max_step_size(Vector3d(1.0, -1.0, 0.5), Vector3d(2.0, -1.0, 0.5)) == 1.0);
+        // From over the z=0 face into the region where the ridge is closest: the boundary
+        // is the y=0 plane (foot leaves the face interior at y=0).
+        const Vector3d a(2.0, -1.0, 0.5);
+        const Vector3d b(2.0, 2.0, 0.5);
+        const double alpha = energy.max_step_size(a, b);
+        CHECK(alpha < 1.0);
+        const double y_land = a[1] + alpha * (b[1] - a[1]);
+        CHECK(y_land >= 0.0);
+        CHECK(y_land <= 0.0 + 1e-4 * (b[1] - a[1]));
+    }
+}
+
 TEST_CASE("exact_distance_energy_2d", "[energies]")
 {
     // An L-shaped polyline: one horizontal and one vertical segment meeting at a convex

--- a/tests/test_optimization.cpp
+++ b/tests/test_optimization.cpp
@@ -388,6 +388,59 @@ TEST_CASE("biharmonic_energy_bunny_3d", "[energies][.]")
         // igl::writeOFF(fmt::format("debug_{}.off", i), V, F);
     }
 }
+TEST_CASE("spring_energy_2d_fd_consistency", "[energies]")
+{
+    // The spring is an exact quadratic to a fixed target, so unlike the envelope energy --
+    // whose hessian is deliberately the Gauss-Newton model, not the derivative of the
+    // gradient -- ALL THREE callbacks must pass a finite-difference check against each
+    // other, to rounding.
+    const Vector2d target(1.5, -0.5);
+    const double w = 3.0;
+    optimization::SpringEnergy2D energy(target, w);
+
+    const std::vector<Vector2d> probes = {
+        Vector2d(1.0, 0.30),
+        Vector2d(2.0, -0.45),
+        Vector2d(-0.7, 1.10),
+    };
+    const double h = 1e-6;
+
+    SECTION("gradient is the derivative of the value")
+    {
+        for (const Vector2d& p : probes) {
+            VectorXd g;
+            energy.gradient(p, g);
+            for (int i = 0; i < 2; ++i) {
+                Vector2d a = p, b = p;
+                a[i] -= h;
+                b[i] += h;
+                const double fd = (energy.value(b) - energy.value(a)) / (2 * h);
+                CHECK(std::abs(g[i] - fd) <= 1e-5 * std::max(1.0, std::abs(fd)));
+            }
+        }
+    }
+
+    SECTION("hessian is the derivative of the gradient")
+    {
+        for (const Vector2d& p : probes) {
+            MatrixXd H;
+            energy.hessian(p, H);
+            for (int i = 0; i < 2; ++i) {
+                Vector2d a = p, b = p;
+                a[i] -= h;
+                b[i] += h;
+                VectorXd ga, gb;
+                energy.gradient(a, ga);
+                energy.gradient(b, gb);
+                for (int j = 0; j < 2; ++j) {
+                    const double fd = (gb[j] - ga[j]) / (2 * h);
+                    CHECK(std::abs(H(j, i) - fd) <= 1e-5 * std::max(1.0, std::abs(fd)));
+                }
+            }
+        }
+    }
+}
+
 TEST_CASE("envelope_energy_2d_derivatives", "[energies]")
 {
     // value(), gradient() and hessian() have to describe the SAME function. Nothing checked

--- a/tests/test_optimization.cpp
+++ b/tests/test_optimization.cpp
@@ -437,6 +437,24 @@ TEST_CASE("exact_distance_energy_2d", "[energies]")
         CHECK(std::abs((Vector2d(0, 1).transpose() * H * Vector2d(0, 1)).value() - 2 * w) <= 1e-9);
     }
 
+    SECTION("max_step_size clamps at the feature boundary")
+    {
+        // A step staying over one segment interior is not clamped.
+        CHECK(energy.max_step_size(Vector2d(1.0, 0.4), Vector2d(2.0, 0.4)) == 1.0);
+
+        // A step from over the horizontal segment toward the vertical one crosses the
+        // inner bisector at x = 3.6, where both segments are 0.4 away and the closest
+        // feature switches (the C0 kink of the distance on the concave side). The clamp
+        // must land just past that boundary, not sail to the far end.
+        const Vector2d a(3.0, 0.4);
+        const Vector2d b(6.0, 0.4);
+        const double alpha = energy.max_step_size(a, b);
+        CHECK(alpha < 1.0);
+        const double x_land = a[0] + alpha * (b[0] - a[0]);
+        CHECK(x_land >= 3.6);
+        CHECK(x_land <= 3.6 + 1e-4 * (b[0] - a[0]));
+    }
+
     SECTION("corner region: full FD consistency and isotropic hessian")
     {
         const Vector2d p(4.5, -0.5); // beyond the corner at (4,0), outside both segments

--- a/tests/test_optimization.cpp
+++ b/tests/test_optimization.cpp
@@ -388,6 +388,65 @@ TEST_CASE("biharmonic_energy_bunny_3d", "[energies][.]")
         // igl::writeOFF(fmt::format("debug_{}.off", i), V, F);
     }
 }
+TEST_CASE("exact_distance_energy_2d", "[energies]")
+{
+    // An L-shaped polyline: one horizontal and one vertical segment meeting at a convex
+    // corner. Within each closest-feature region the distance is exactly quadratic, so the
+    // energy must pass full FD checks there, with the rank of the hessian reporting the
+    // feature: rank one (segment normal) over an interior, isotropic at the corner.
+    auto env = std::make_shared<SampleEnvelope>(false);
+    const std::vector<Eigen::Vector2d> V = {
+        Eigen::Vector2d(0, 0),
+        Eigen::Vector2d(4, 0),
+        Eigen::Vector2d(4, 4)};
+    const std::vector<Eigen::Vector2i> E = {Eigen::Vector2i(0, 1), Eigen::Vector2i(1, 2)};
+    env->init(V, E, 0.1);
+
+    const double w = 3.0;
+    optimization::ExactDistanceEnergy2D energy(env, w);
+
+    const double h = 1e-6;
+    auto fd_check = [&](const Vector2d& p) {
+        VectorXd g;
+        energy.gradient(p, g);
+        MatrixXd H;
+        energy.hessian(p, H);
+        for (int i = 0; i < 2; ++i) {
+            Vector2d a = p, b = p;
+            a[i] -= h;
+            b[i] += h;
+            const double fd = (energy.value(b) - energy.value(a)) / (2 * h);
+            CHECK(std::abs(g[i] - fd) <= 1e-5 * std::max(1.0, std::abs(fd)));
+            VectorXd ga, gb;
+            energy.gradient(a, ga);
+            energy.gradient(b, gb);
+            for (int j = 0; j < 2; ++j) {
+                const double fdh = (gb[j] - ga[j]) / (2 * h);
+                CHECK(std::abs(H(j, i) - fdh) <= 1e-4 * std::max(1.0, std::abs(fdh)));
+            }
+        }
+    };
+
+    SECTION("interior region: full FD consistency and rank-one hessian")
+    {
+        const Vector2d p(2.0, 0.4); // above the horizontal segment, foot in its interior
+        fd_check(p);
+        MatrixXd H;
+        energy.hessian(p, H);
+        CHECK((H * Vector2d(1, 0)).norm() <= 1e-9); // free along the segment
+        CHECK(std::abs((Vector2d(0, 1).transpose() * H * Vector2d(0, 1)).value() - 2 * w) <= 1e-9);
+    }
+
+    SECTION("corner region: full FD consistency and isotropic hessian")
+    {
+        const Vector2d p(4.5, -0.5); // beyond the corner at (4,0), outside both segments
+        fd_check(p);
+        MatrixXd H;
+        energy.hessian(p, H);
+        CHECK((H - 2 * w * MatrixXd::Identity(2, 2)).norm() <= 1e-9);
+    }
+}
+
 TEST_CASE("spring_energy_2d_fd_consistency", "[energies]")
 {
     // The spring is an exact quadratic to a fixed target, so unlike the envelope energy --

--- a/tools/compare_pull_energy.py
+++ b/tools/compare_pull_energy.py
@@ -6,11 +6,14 @@ so lowering w_amips raises the pull's weight relative to the quality term. This 
 model at a range of w_amips under both pulls and reports how far the output surface ends up
 from the input.
 
-    envelope (spring_pull=false)  penalises the distance to the input as a SET, recomputing
-                                  the nearest point every evaluation. Its gradient is always
-                                  normal to the input, so a vertex slides along it for free.
-    spring   (spring_pull=true)   captures the nearest point once per solve and springs the
-                                  vertex to that fixed point. No sliding.
+    envelope        penalises the distance to the input as a SET, recomputing the nearest
+                    point every evaluation; a vertex slides along the input for free.
+    spring          captures the nearest point once per solve and springs the vertex to that
+                    fixed point. No sliding.
+    spring_refresh  the spring with its target re-captured at every accepted iterate.
+    exact           (triwild only) the true distance with its true region-wise Hessian.
+
+Select with --modes; each run sets the pull_mode config parameter.
 
 The point of the sweep is the SHAPE of each curve, not any single number. A well-behaved
 quadratic penalty gives one decade of deviation per decade of weight; a curve that flattens
@@ -54,18 +57,18 @@ import sys
 import tempfile
 
 DEFAULT_WEIGHTS = ["1e-1", "1e-2", "1e-3", "1e-4", "1e-5", "1e-6", "1e-7"]
-MODES = [("envelope", False), ("spring", True)]
+DEFAULT_MODES = ["envelope", "spring", "spring_refresh"]
 
 
-def run_one(app_bin, outdir, app, model, w_amips, spring, extra):
-    d = outdir / f"{'spring' if spring else 'envelope'}_{w_amips}"
+def run_one(app_bin, outdir, app, model, w_amips, mode, extra):
+    d = outdir / f"{mode}_{w_amips}"
     d.mkdir(parents=True, exist_ok=True)
     cfg = {
         "application": app,
         "input": [str(pathlib.Path(model).resolve())],
         "num_threads": 0,
         "w_amips": float(w_amips),
-        "spring_pull": spring,
+        "pull_mode": mode,
         "DEBUG_hausdorff": True,
         "output": str(d / "out"),
         "report": str(d / "report.json"),
@@ -78,14 +81,14 @@ def run_one(app_bin, outdir, app, model, w_amips, spring, extra):
         [str(app_bin), "-j", str(d / "config.json")], capture_output=True, text=True
     )
     if proc.returncode != 0:
-        print(f"  FAILED ({'spring' if spring else 'envelope'}, w_amips={w_amips});"
+        print(f"  FAILED ({mode}, w_amips={w_amips});"
               f" see {d / 'log.txt'}", file=sys.stderr)
         return None
     return json.loads((d / "report.json").read_text())
 
 
-def table(results, weights, has_vertex):
-    for mode, _ in MODES:
+def table(results, weights, modes, has_vertex):
+    for mode in modes:
         print(f"\n===== {mode.upper()} =====")
         if has_vertex:
             head = (f"{'w_amips':>8} | {'vtx max':>11} {'vtx mean':>11} "
@@ -108,7 +111,7 @@ def table(results, weights, has_vertex):
     key = "hausdorff_vertex_mean" if has_vertex else "hausdorff"
     print(f"\n===== shape of each curve ({key}) =====")
     print("A quadratic penalty gives ~10x per decade of weight; ~1x means a floor.")
-    for mode, _ in MODES:
+    for mode in modes:
         vals = [results[(mode, w)] for w in weights]
         if any(v is None for v in vals):
             continue
@@ -117,10 +120,10 @@ def table(results, weights, has_vertex):
         print(f"  {mode:>9}: {pretty}   (total {vals[0][key] / vals[-1][key]:.3g}x)")
 
 
-def write_svg(path, results, weights, key, ylabel):
+def write_svg(path, results, weights, modes, key, ylabel):
     W, H, L, R, T, B = 860, 520, 92, 220, 56, 64
     PW, PH = W - L - R, H - T - B
-    pts_all = [results[(m, w)][key] for m, _ in MODES for w in weights
+    pts_all = [results[(m, w)][key] for m in modes for w in weights
                if results[(m, w)] is not None]
     if not pts_all:
         return
@@ -153,7 +156,8 @@ def write_svg(path, results, weights, key, ylabel):
     o.append(f'<text transform="translate(24,{T+PH/2:.0f}) rotate(-90)" font-size="12.5" '
              f'fill="#3a3f4a" text-anchor="middle">{ylabel}</text>')
 
-    for (mode, _), color in zip(MODES, ["#1f6fb4", "#c4452f"]):
+    palette = ["#1f6fb4", "#c4452f", "#3a8f5d", "#8455a5"]
+    for mode, color in zip(modes, palette):
         xs, ys = [], []
         for w in weights:
             r = results[(mode, w)]
@@ -183,6 +187,11 @@ def main():
     ap.add_argument("--app", choices=["triwild", "tetwild"], default="triwild")
     ap.add_argument("--input", required=True)
     ap.add_argument("--weights", nargs="+", default=DEFAULT_WEIGHTS)
+    ap.add_argument(
+        "--modes",
+        nargs="+",
+        default=DEFAULT_MODES,
+        help="pull_mode values to sweep; 'exact' is triwild-only")
     ap.add_argument("--outdir", default=None)
     ap.add_argument("--wmtk-app", default="build/app/wmtk_app")
     ap.add_argument("--extra", default="{}")
@@ -198,19 +207,19 @@ def main():
     print(f"{a.app}  {a.input}\noutput -> {outdir}\n")
 
     results = {}
-    for mode, spring in MODES:
+    for mode in a.modes:
         for w in a.weights:
             print(f"  running {mode:>9}  w_amips={w} ...", flush=True)
-            results[(mode, w)] = run_one(app_bin, outdir, a.app, a.input, w, spring, extra)
+            results[(mode, w)] = run_one(app_bin, outdir, a.app, a.input, w, mode, extra)
 
     ok = [r for r in results.values() if r is not None]
     if not ok:
         sys.exit("every run failed")
     has_vertex = "hausdorff_vertex" in ok[0]
-    table(results, a.weights, has_vertex)
+    table(results, a.weights, a.modes, has_vertex)
     if a.svg:
         key = "hausdorff_vertex_mean" if has_vertex else "hausdorff"
-        write_svg(a.svg, results, a.weights, key,
+        write_svg(a.svg, results, a.weights, a.modes, key,
                   "mean vertex distance to input" if has_vertex else "hausdorff")
 
 

--- a/tools/compare_pull_energy.py
+++ b/tools/compare_pull_energy.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+"""Compare the two surface-pull energies by sweeping their weight.
+
+Smoothing minimises `w_amips * AMIPS + w_envelope * pull`, with `w_envelope = 1 - w_amips`,
+so lowering w_amips raises the pull's weight relative to the quality term. This runs the same
+model at a range of w_amips under both pulls and reports how far the output surface ends up
+from the input.
+
+    envelope (spring_pull=false)  penalises the distance to the input as a SET, recomputing
+                                  the nearest point every evaluation. Its gradient is always
+                                  normal to the input, so a vertex slides along it for free.
+    spring   (spring_pull=true)   captures the nearest point once per solve and springs the
+                                  vertex to that fixed point. No sliding.
+
+The point of the sweep is the SHAPE of each curve, not any single number. A well-behaved
+quadratic penalty gives one decade of deviation per decade of weight; a curve that flattens
+is one where something other than the force balance is setting the deviation.
+
+Usage
+-----
+    # 2D, the model the PR quotes (~1s per run, 14 runs)
+    python3 tools/compare_pull_energy.py --app triwild --input data/models/triwild20k_202090.obj
+
+    # 3D
+    python3 tools/compare_pull_energy.py --app tetwild --input data/models/sphere.obj
+
+    # wider or narrower sweep, and a plot
+    python3 tools/compare_pull_energy.py --app triwild --input <model.obj> \
+        --weights 1e-2 1e-4 1e-6 --svg /tmp/sweep.svg
+
+Options:
+    --app        triwild (2D) or tetwild (3D)
+    --input      input model
+    --weights    w_amips values to sweep (default 1e-1 ... 1e-7)
+    --outdir     where configs/reports go (default a temp dir)
+    --wmtk-app   path to wmtk_app (default build/app/wmtk_app)
+    --extra      extra JSON config keys, e.g. --extra '{"stop_energy": 20}'
+    --svg        also write a log-log plot there
+
+Only triwild reports the vertex-level figures; tetwild reports `hausdorff` alone, and the
+table adapts. Columns:
+
+    vtx max/mean    distance from the output's tracked VERTICES to the input. This is what
+                    the pull term actually controls -- smoothing places vertices.
+    edge max/mean   the same sampled along the tracked EDGES, so it also carries the
+                    discretization error of chords across a curve.
+"""
+import argparse
+import json
+import math
+import pathlib
+import subprocess
+import sys
+import tempfile
+
+DEFAULT_WEIGHTS = ["1e-1", "1e-2", "1e-3", "1e-4", "1e-5", "1e-6", "1e-7"]
+MODES = [("envelope", False), ("spring", True)]
+
+
+def run_one(app_bin, outdir, app, model, w_amips, spring, extra):
+    d = outdir / f"{'spring' if spring else 'envelope'}_{w_amips}"
+    d.mkdir(parents=True, exist_ok=True)
+    cfg = {
+        "application": app,
+        "input": [str(pathlib.Path(model).resolve())],
+        "num_threads": 0,
+        "w_amips": float(w_amips),
+        "spring_pull": spring,
+        "DEBUG_hausdorff": True,
+        "output": str(d / "out"),
+        "report": str(d / "report.json"),
+        "log_file": str(d / "log.txt"),
+    }
+    cfg.update(extra)
+    (d / "config.json").write_text(json.dumps(cfg, indent=2))
+
+    proc = subprocess.run(
+        [str(app_bin), "-j", str(d / "config.json")], capture_output=True, text=True
+    )
+    if proc.returncode != 0:
+        print(f"  FAILED ({'spring' if spring else 'envelope'}, w_amips={w_amips});"
+              f" see {d / 'log.txt'}", file=sys.stderr)
+        return None
+    return json.loads((d / "report.json").read_text())
+
+
+def table(results, weights, has_vertex):
+    for mode, _ in MODES:
+        print(f"\n===== {mode.upper()} =====")
+        if has_vertex:
+            head = (f"{'w_amips':>8} | {'vtx max':>11} {'vtx mean':>11} "
+                    f"| {'edge max':>11} {'edge mean':>11} | {'max_E':>7}")
+        else:
+            head = f"{'w_amips':>8} | {'hausdorff':>11} | {'max_E':>7}"
+        print(head)
+        for w in weights:
+            r = results[(mode, w)]
+            if r is None:
+                print(f"{w:>8} |  (failed)")
+                continue
+            if has_vertex:
+                print(f"{w:>8} | {r['hausdorff_vertex']:>11.4e} "
+                      f"{r['hausdorff_vertex_mean']:>11.4e} | {r['hausdorff']:>11.4e} "
+                      f"{r['hausdorff_mean']:>11.4e} | {r['max_energy']:>7.2f}")
+            else:
+                print(f"{w:>8} | {r['hausdorff']:>11.4e} | {r['max_energy']:>7.2f}")
+
+    key = "hausdorff_vertex_mean" if has_vertex else "hausdorff"
+    print(f"\n===== shape of each curve ({key}) =====")
+    print("A quadratic penalty gives ~10x per decade of weight; ~1x means a floor.")
+    for mode, _ in MODES:
+        vals = [results[(mode, w)] for w in weights]
+        if any(v is None for v in vals):
+            continue
+        ratios = [vals[i - 1][key] / vals[i][key] for i in range(1, len(vals))]
+        pretty = "  ".join(f"{r:5.2f}x" for r in ratios)
+        print(f"  {mode:>9}: {pretty}   (total {vals[0][key] / vals[-1][key]:.3g}x)")
+
+
+def write_svg(path, results, weights, key, ylabel):
+    W, H, L, R, T, B = 860, 520, 92, 220, 56, 64
+    PW, PH = W - L - R, H - T - B
+    pts_all = [results[(m, w)][key] for m, _ in MODES for w in weights
+               if results[(m, w)] is not None]
+    if not pts_all:
+        return
+    y0 = math.floor(math.log10(min(pts_all))) - 0.3
+    y1 = math.ceil(math.log10(max(pts_all))) + 0.3
+    x0 = math.log10(1 / float(weights[0])) - 0.3
+    x1 = math.log10(1 / float(weights[-1])) + 0.3
+    px = lambda x: L + (math.log10(x) - x0) / (x1 - x0) * PW
+    py = lambda y: T + (y1 - math.log10(y)) / (y1 - y0) * PH
+
+    o = [f'<svg xmlns="http://www.w3.org/2000/svg" width="{W}" height="{H}" '
+         f'viewBox="0 0 {W} {H}" font-family="Helvetica,Arial,sans-serif">',
+         f'<rect width="{W}" height="{H}" fill="#ffffff"/>',
+         f'<text x="{L}" y="30" font-size="17" font-weight="600" fill="#16181d">'
+         f'Surface pull: envelope vs fixed-target spring</text>']
+    for e in range(int(math.ceil(x0)), int(x1) + 1):
+        x = px(10.0 ** e)
+        o.append(f'<line x1="{x:.1f}" y1="{T}" x2="{x:.1f}" y2="{T+PH}" stroke="#e8eaee"/>')
+        o.append(f'<text x="{x:.1f}" y="{T+PH+20}" font-size="11.5" fill="#5b6270" '
+                 f'text-anchor="middle">10^{e}</text>')
+    for e in range(int(math.ceil(y0)), int(y1) + 1):
+        y = py(10.0 ** e)
+        o.append(f'<line x1="{L}" y1="{y:.1f}" x2="{L+PW}" y2="{y:.1f}" stroke="#e8eaee"/>')
+        o.append(f'<text x="{L-10}" y="{y+4:.1f}" font-size="11.5" fill="#5b6270" '
+                 f'text-anchor="end">1e{e}</text>')
+    o.append(f'<line x1="{L}" y1="{T+PH}" x2="{L+PW}" y2="{T+PH}" stroke="#9aa1ad"/>')
+    o.append(f'<line x1="{L}" y1="{T}" x2="{L}" y2="{T+PH}" stroke="#9aa1ad"/>')
+    o.append(f'<text x="{L+PW/2:.0f}" y="{H-18}" font-size="12.5" fill="#3a3f4a" '
+             f'text-anchor="middle">pull weight / AMIPS weight</text>')
+    o.append(f'<text transform="translate(24,{T+PH/2:.0f}) rotate(-90)" font-size="12.5" '
+             f'fill="#3a3f4a" text-anchor="middle">{ylabel}</text>')
+
+    for (mode, _), color in zip(MODES, ["#1f6fb4", "#c4452f"]):
+        xs, ys = [], []
+        for w in weights:
+            r = results[(mode, w)]
+            if r is not None:
+                xs.append(1 / float(w))
+                ys.append(r[key])
+        if not xs:
+            continue
+        o.append('<polyline points="' + " ".join(f"{px(x):.1f},{py(y):.1f}"
+                 for x, y in zip(xs, ys)) + f'" fill="none" stroke="{color}" '
+                 'stroke-width="2.2" stroke-linejoin="round"/>')
+        for x, y in zip(xs, ys):
+            o.append(f'<circle cx="{px(x):.1f}" cy="{py(y):.1f}" r="3.4" fill="#fff" '
+                     f'stroke="{color}" stroke-width="2"/>')
+        o.append(f'<text x="{px(xs[-1])+12:.1f}" y="{py(ys[-1])+4:.1f}" font-size="12" '
+                 f'font-weight="600" fill="{color}">{mode}</text>')
+        o.append(f'<text x="{px(xs[-1])+12:.1f}" y="{py(ys[-1])+19:.1f}" font-size="11" '
+                 f'fill="#6b717c">{ys[-1]:.2e}</text>')
+    o.append("</svg>")
+    pathlib.Path(path).write_text("\n".join(o))
+    print(f"\nwrote {path}")
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--app", choices=["triwild", "tetwild"], default="triwild")
+    ap.add_argument("--input", required=True)
+    ap.add_argument("--weights", nargs="+", default=DEFAULT_WEIGHTS)
+    ap.add_argument("--outdir", default=None)
+    ap.add_argument("--wmtk-app", default="build/app/wmtk_app")
+    ap.add_argument("--extra", default="{}")
+    ap.add_argument("--svg", default=None)
+    a = ap.parse_args()
+
+    app_bin = pathlib.Path(a.wmtk_app).resolve()
+    if not app_bin.exists():
+        sys.exit(f"wmtk_app not found at {app_bin}; build it or pass --wmtk-app")
+    outdir = pathlib.Path(a.outdir).resolve() if a.outdir else \
+        pathlib.Path(tempfile.mkdtemp(prefix="pull_sweep_"))
+    extra = json.loads(a.extra)
+    print(f"{a.app}  {a.input}\noutput -> {outdir}\n")
+
+    results = {}
+    for mode, spring in MODES:
+        for w in a.weights:
+            print(f"  running {mode:>9}  w_amips={w} ...", flush=True)
+            results[(mode, w)] = run_one(app_bin, outdir, a.app, a.input, w, spring, extra)
+
+    ok = [r for r in results.values() if r is not None]
+    if not ok:
+        sys.exit("every run failed")
+    has_vertex = "hausdorff_vertex" in ok[0]
+    table(results, a.weights, has_vertex)
+    if a.svg:
+        key = "hausdorff_vertex_mean" if has_vertex else "hausdorff"
+        write_svg(a.svg, results, a.weights, key,
+                  "mean vertex distance to input" if has_vertex else "hausdorff")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds a fixed-target spring as an alternative to the envelope pull during smoothing, in 2D and 3D, plus a switch for the smoothing quality gate.

> **⚠️ This PR currently defaults `spring_pull` to `true`, and in that configuration it FAILS 2 of the 53 integration configs.** The full measurements are below and they do not support that default. Recommendation is to ship it `false` (opt-in); it is left `true` pending the author's decision.

## What it does

`EnvelopeEnergy` penalises the distance to the input **as a set** — it recomputes the nearest point at every evaluation, so its gradient `2w(x − n(x))` is always normal to the input and a vertex slides along it at no cost. That is deliberate, and it is what the rank-one Gauss-Newton Hessian encodes.

`SpringEnergy2D/3D` captures the nearest point once, before the solve, and springs the vertex to that single point. The energy is then an exact quadratic — value, gradient (`2w(x − t)`) and Hessian (`2w·I`) all exact, no Gauss-Newton approximation — and tangential motion is resisted as strongly as normal motion.

## The one thing the spring is better at

The envelope pull leaves a floor on surface deviation that no weight removes: pushed tangentially with no restoring force, a vertex slides until geometry rather than the force balance stops it. Sweeping the weight over six decades on `triwild20k_202090`, mean tracked-vertex deviation:

| `w_amips` | envelope | spring |
|---|---|---|
| 1e-1 | 2.872e-04 | 8.560e-04 |
| 1e-3 | 4.211e-05 | 8.419e-06 |
| 1e-5 | 3.981e-05 | 8.419e-08 |
| 1e-7 | **3.978e-05** (floor) | **8.419e-10** |

The envelope flattens at ~4e-5; the spring is a clean one decade per decade, no floor. Reproduce with `tools/compare_pull_energy.py` (see below).

Worth keeping in proportion: that floor is ~4e-5 against an envelope of 2.2e-2, i.e. 0.2% of eps.

## What it costs — 53 integration configs, `THREADS=0`, sequential

| `w_amips` | pull | gate | terminates | wall time | iterations |
|---|---|---|---|---|---|
| 1e-4 | envelope | on | **53/53** | 376.0s | 83 |
| 1e-4 | envelope | off | **53/53** | 377.6s (+0.4%) | 83 (+0.0%) |
| 1e-4 | **spring** | on | **51/53** | 476.7s (+26.8%) | 122 (+47%) |
| 1e-4 | spring | off | 53/53 | 461.5s (+22.7%) | 112 (+35%) |
| 1e-9 | envelope | on | 53/53 | 380.1s (+1.1%) | 85 (+2.4%) |
| 1e-9 | envelope | off | 53/53 | 373.7s (−0.6%) | 86 (+3.6%) |
| 1e-9 | spring | on | 52/53 | 531.7s (+41.4%) | 125 (+51%) |
| 1e-9 | spring | off | 51/53 | **5822.9s (+1448%)** | 155 (+87%) |

The failures are tetwild stall configs blowing their iteration assertions — `tetwild_thingi_111388_stall` (max 20) traces the whole story across the matrix: **11 → 25 → 20 → 11 → 8 → 27 → 40 (cap) → 9**.

Readings:

- **The envelope pull is insensitive to both knobs** — all four cells 53/53 within ±1.1% time.
- **Every spring cell costs 23–41%**, except `1e-9 + no gate`, which took 97 minutes against 6.3 and failed twice.
- **Removing the quality gate helps the spring at 1e-4** (fixes both failures) **and catastrophically hurts it at 1e-9**. The gate is what contains the damage once the quality term is too weak to drive convergence.
- The best spring cell still terminates on a knife edge: `111388` at exactly its limit of 20.

## Quality

Not the bar for this PR, but recorded because the regressions are large and 3D-specific:

| | max_energy worse | better | ~same |
|---|---|---|---|
| 2D | 4 | 2 | 16 |
| 3D | **7** | 1 | 9 |

`tetwild_sphere` 5.41 → 98.71, `tetwild_thingi_100827` 18.68 → 38.69, `tetwild_crown` 44.32 → 86.13, `tetwild_octocat` 52.98 → 79.89. This is the failure mode the `gauss_newton_hessian` comment predicted — surface vertices that cannot slide cannot relax a sliver — so that comment's rationale is **confirmed**, not superseded.

An earlier revision of this description claimed the spring "reaches a lower max energy, 14.33 against 16.25". That was true of the single model swept, which turned out to be one of only 2 improvements out of 22 2D configs against 4 regressions. The claim was over-read from one model and is withdrawn.

## Reproducing

```bash
# deviation sweep (the first table)
python3 tools/compare_pull_energy.py \
    --app triwild --input data/models/triwild20k_202090.obj --extra '{"stop_energy": 20}'
python3 tools/compare_pull_energy.py --app tetwild --input data/models/sphere.obj
```

It prints the deviation table and then the line carrying the claim:

```
===== shape of each curve (hausdorff_vertex_mean) =====
A quadratic penalty gives ~10x per decade of weight; ~1x means a floor.
   envelope:  4.82x   1.41x   1.05x   1.00x   1.00x   1.00x   (total 7.22x)
     spring: 10.16x  10.00x  10.00x  10.00x  10.00x  10.00x   (total 1.02e+06x)
```

Flags: `--weights`, `--outdir`, `--wmtk-app`, `--extra`, `--svg`. Only triwild reports the vertex-level figures; tetwild falls back to `hausdorff`.

The cost matrix was produced by running the 53 integration configs under each combination of `spring_pull` and `smooth_quality_gate` at `num_threads: 0`, sequentially.

## Changes

- `SpringEnergy2D` / `SpringEnergy3D`, and `SmoothVertexOptions::spring_pull`, used by `smooth_vertex_2d` and `smooth_vertex_3d`.
- `SmoothVertexOptions::smooth_quality_gate` — drops the "don't make the worst incident element worse" check for every vertex. Default `true` (unchanged behaviour).
- Both exposed as JSON in the tetwild, triwild, simwild and topological_offset specs.
- `tools/compare_pull_energy.py`.
- triwild now also reports `hausdorff_mean`, `hausdorff_vertex` and `hausdorff_vertex_mean` — the max alone hides what a change did to the bulk of the curve.

## Still not done

- The hidden `[challenging]` set has not been run.
- 3D deviation has not been swept; the 3D spring is implemented symmetrically and runs, but the accuracy claim above is 2D-only evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
