### PR TITLE
Move the exact predicates off igl/Shewchuk and behind one wmtk wrapper

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -142,7 +142,6 @@ target_link_libraries(wildmeshing_toolkit PRIVATE wmtk::warnings)
 target_link_libraries(wildmeshing_toolkit PUBLIC
     spdlog::spdlog
     igl::core
-    igl::predicates
     gmp::gmp
     VolumeRemesher::VolumeRemesher
     mshio::mshio

--- a/app/harmonic_tet/CMakeLists.txt
+++ b/app/harmonic_tet/CMakeLists.txt
@@ -13,7 +13,6 @@ add_library(wmtk::harmonic_tet ALIAS wmtk_app_harmonic_tet)
 target_link_libraries(wmtk_app_harmonic_tet PUBLIC
 	wmtk::toolkit
 	wmtk::data
-	igl::predicates
 )
 target_include_directories(wmtk_app_harmonic_tet PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 

--- a/app/harmonic_tet/HarmonicTet.cpp
+++ b/app/harmonic_tet/HarmonicTet.cpp
@@ -9,7 +9,7 @@
 #include <wmtk/utils/TupleUtils.hpp>
 #include <wmtk/utils/io.hpp>
 
-#include <igl/predicates/predicates.h>
+#include <wmtk/utils/predicates.hpp>
 
 #include <limits>
 #include <queue>
@@ -44,9 +44,9 @@ bool HarmonicTet::is_inverted(const Tuple& loc)
         ps[j] = vertex_attrs[tups[j]].pos;
     }
 
-    igl::predicates::exactinit();
-    auto res = igl::predicates::orient3d(ps[0], ps[1], ps[2], ps[3]);
-    if (res == igl::predicates::Orientation::NEGATIVE) return false; // extremely annoying.
+    wmtk::utils::predicates::exactinit();
+    auto res = wmtk::utils::predicates::orient3d(ps[0], ps[1], ps[2], ps[3]);
+    if (res == wmtk::utils::predicates::Orientation::NEGATIVE) return false; // extremely annoying.
     return true;
 }
 

--- a/app/interior_tet_opt/CMakeLists.txt
+++ b/app/interior_tet_opt/CMakeLists.txt
@@ -9,7 +9,6 @@ add_library(wmtk::interior_tetopt ALIAS wmtk_app_interior_tetopt)
 target_link_libraries(wmtk_app_interior_tetopt PUBLIC
 	wmtk::toolkit
 	wmtk::data
-	igl::predicates
 )
 target_include_directories(wmtk_app_interior_tetopt PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/src)
 

--- a/app/interior_tet_opt/src/interior_tet_opt/Mesh.cpp
+++ b/app/interior_tet_opt/src/interior_tet_opt/Mesh.cpp
@@ -1,6 +1,5 @@
 #include "Mesh.hpp"
 #include <Eigen/src/Core/functors/UnaryFunctors.h>
-#include <igl/predicates/predicates.h>
 #include <wmtk/utils/AMIPS.h>
 #include <wmtk/utils/Morton.h>
 #include <cassert>
@@ -11,6 +10,7 @@
 #include <wmtk/utils/Logger.hpp>
 #include <wmtk/utils/TetraQualityUtils.hpp>
 #include <wmtk/utils/io.hpp>
+#include <wmtk/utils/predicates.hpp>
 
 namespace app::interior_tet_opt {
 
@@ -573,16 +573,16 @@ bool InteriorTetOpt::is_inverted(const Tuple& loc) const
 
     auto vs = oriented_tet_vertices(loc);
 
-    igl::predicates::exactinit();
-    auto res = igl::predicates::orient3d(
+    wmtk::utils::predicates::exactinit();
+    auto res = wmtk::utils::predicates::orient3d(
         m_vertex_attribute[vs[0].vid(*this)].pos,
         m_vertex_attribute[vs[1].vid(*this)].pos,
         m_vertex_attribute[vs[2].vid(*this)].pos,
         m_vertex_attribute[vs[3].vid(*this)].pos);
     int result;
-    if (res == igl::predicates::Orientation::POSITIVE)
+    if (res == wmtk::utils::predicates::Orientation::POSITIVE)
         result = 1;
-    else if (res == igl::predicates::Orientation::NEGATIVE)
+    else if (res == wmtk::utils::predicates::Orientation::NEGATIVE)
         result = -1;
     else
         result = 0;

--- a/cmake/recipes/libigl.cmake
+++ b/cmake/recipes/libigl.cmake
@@ -11,7 +11,10 @@ CPMAddPackage(
     GIT_REPOSITORY https://github.com/libigl/libigl.git
     GIT_TAG 3ea7f9480967fcf6bf02ce9b993c0ea6d2fc45f6
     OPTIONS
-        LIBIGL_PREDICATES ON
+        # LIBIGL_PREDICATES: off since the toolkit moved its exact predicates to
+        # Indirect_Predicates (see src/wmtk/utils/predicates.cpp). Nothing links
+        # igl::predicates any more, and leaving it on still builds Shewchuk.
+        LIBIGL_PREDICATES OFF
         # LIBIGL_COPYLEFT_TETGEN ON
 )
 

--- a/components/c1_simplification/wmtk/components/c1_simplification/CMakeLists.txt
+++ b/components/c1_simplification/wmtk/components/c1_simplification/CMakeLists.txt
@@ -28,7 +28,6 @@ target_sources(wmtk_${COMPONENT_NAME} PRIVATE ${SRC_FILES})
 target_link_libraries(wmtk_${COMPONENT_NAME} PUBLIC
 	wmtk::toolkit
 	wmtk::data
-	igl::predicates
 	jse::jse
 )
 

--- a/components/c1_simplification/wmtk/components/c1_simplification/c1_multimesh.cpp
+++ b/components/c1_simplification/wmtk/components/c1_simplification/c1_multimesh.cpp
@@ -12,7 +12,7 @@
 #include <wmtk/utils/DisableWarnings.hpp>
 #include <spdlog/fmt/ostr.h>
 #include <spdlog/fmt/bundled/format.h>
-#include <igl/predicates/predicates.h>
+#include <wmtk/utils/predicates.hpp>
 #include <igl/write_triangle_mesh.h>
 #include <igl/Timer.h>
 #include <igl/orientable_patches.h>
@@ -50,16 +50,16 @@ void MMTetMesh::init_from_eigen(const MatrixXd& V, const MatrixXi& T)
 bool MMTetMesh::is_inverted(const Tuple& t) const
 {
     auto vs = oriented_tet_vertices(t);
-    igl::predicates::exactinit();
-    auto res = igl::predicates::orient3d(
+    wmtk::utils::predicates::exactinit();
+    auto res = wmtk::utils::predicates::orient3d(
         v_attrs[vs[0].vid(*this)].pos,
         v_attrs[vs[1].vid(*this)].pos,
         v_attrs[vs[2].vid(*this)].pos,
         v_attrs[vs[3].vid(*this)].pos);
     int result;
-    if (res == igl::predicates::Orientation::POSITIVE)
+    if (res == wmtk::utils::predicates::Orientation::POSITIVE)
         result = 1;
-    else if (res == igl::predicates::Orientation::NEGATIVE)
+    else if (res == wmtk::utils::predicates::Orientation::NEGATIVE)
         result = -1;
     else
         result = 0;
@@ -159,15 +159,15 @@ void MMUVMesh::init_from_eigen(const MatrixXd& V, const MatrixXi& F)
 bool MMUVMesh::is_inverted(const Tuple& t) const
 {
     auto vs = oriented_tri_vertices(t);
-    igl::predicates::exactinit();
-    auto res = igl::predicates::orient2d(
+    wmtk::utils::predicates::exactinit();
+    auto res = wmtk::utils::predicates::orient2d(
         v_attrs[vs[0].vid(*this)].pos,
         v_attrs[vs[1].vid(*this)].pos,
         v_attrs[vs[2].vid(*this)].pos);
     int result;
-    if (res == igl::predicates::Orientation::POSITIVE)
+    if (res == wmtk::utils::predicates::Orientation::POSITIVE)
         result = 1;
-    else if (res == igl::predicates::Orientation::NEGATIVE)
+    else if (res == wmtk::utils::predicates::Orientation::NEGATIVE)
         result = -1;
     else
         result = 0;

--- a/components/isotropic_remeshing/wmtk/components/isotropic_remeshing/IsotropicRemeshing.cpp
+++ b/components/isotropic_remeshing/wmtk/components/isotropic_remeshing/IsotropicRemeshing.cpp
@@ -5,7 +5,6 @@
 
 #include <igl/Timer.h>
 #include <igl/is_edge_manifold.h>
-#include <igl/predicates/predicates.h>
 #include <wmtk/TriMesh.h>
 #include <wmtk/utils/VectorUtils.h>
 #include <Eigen/Core>
@@ -14,6 +13,7 @@
 #include <wmtk/ExecutionScheduler.hpp>
 #include <wmtk/utils/TupleUtils.hpp>
 #include <wmtk/utils/partition_utils.hpp>
+#include <wmtk/utils/predicates.hpp>
 
 namespace wmtk::components::isotropic_remeshing {
 

--- a/components/isotropic_remeshing/wmtk/components/isotropic_remeshing/tests/test_remeshing.cpp
+++ b/components/isotropic_remeshing/wmtk/components/isotropic_remeshing/tests/test_remeshing.cpp
@@ -186,8 +186,8 @@ std::function<bool(std::array<double, 6>&)> is_inverted = [](auto& tri) {
     a << tri[0], tri[1];
     b << tri[2], tri[3];
     c << tri[4], tri[5];
-    auto res = igl::predicates::orient2d(a, b, c);
-    return (res != igl::predicates::Orientation::POSITIVE);
+    auto res = wmtk::utils::predicates::orient2d(a, b, c);
+    return (res != wmtk::utils::predicates::Orientation::POSITIVE);
 };
 std::function<bool(std::array<double, 6>&)> is_dgenerate = [](auto& tri) {
     Eigen::Vector3d a, b;

--- a/components/manifold_extraction/wmtk/components/manifold_extraction/CMakeLists.txt
+++ b/components/manifold_extraction/wmtk/components/manifold_extraction/CMakeLists.txt
@@ -26,7 +26,6 @@ target_link_libraries(wmtk_${COMPONENT_NAME} PUBLIC
 	wmtk::simwild
 	wmtk::topological_offset
 	wmtk_topological_offset_spec
-	igl::predicates
 	jse::jse
 )
 

--- a/components/simwild/wmtk/components/simwild/SimWildMesh.cpp
+++ b/components/simwild/wmtk/components/simwild/SimWildMesh.cpp
@@ -14,7 +14,7 @@
 #include <wmtk/utils/DisableWarnings.hpp>
 #include <spdlog/fmt/ostr.h>
 #include <spdlog/fmt/bundled/format.h>
-#include <igl/predicates/predicates.h>
+#include <wmtk/utils/predicates.hpp>
 #include <igl/winding_number.h>
 #include <igl/write_triangle_mesh.h>
 #include <igl/Timer.h>

--- a/components/simwild/wmtk/components/simwild/SimWildMeshTri.cpp
+++ b/components/simwild/wmtk/components/simwild/SimWildMeshTri.cpp
@@ -6,7 +6,6 @@
 
 #include <igl/Timer.h>
 #include <igl/is_edge_manifold.h>
-#include <igl/predicates/predicates.h>
 #include <wmtk/TriMesh.h>
 #include <wmtk/utils/AMIPS2D.h>
 #include <wmtk/utils/VectorUtils.h>
@@ -30,6 +29,7 @@
 #include <wmtk/utils/TetraQualityUtils.hpp>
 #include <wmtk/utils/TupleUtils.hpp>
 #include <wmtk/utils/io.hpp>
+#include <wmtk/utils/predicates.hpp>
 
 #include <wmtk/utils/partition_utils.hpp>
 #include "expression_parser/Parser.hpp"

--- a/components/simwild/wmtk/components/simwild/VolumemesherInsertion.cpp
+++ b/components/simwild/wmtk/components/simwild/VolumemesherInsertion.cpp
@@ -1,4 +1,3 @@
-#include <igl/predicates/ear_clipping.h>
 #include <bitset>
 #include <fstream>
 #include <set>

--- a/components/simwild/wmtk/components/simwild/read_image_msh.cpp
+++ b/components/simwild/wmtk/components/simwild/read_image_msh.cpp
@@ -1,6 +1,5 @@
 #include "read_image_msh.hpp"
 
-#include <igl/predicates/predicates.h>
 #include <set>
 #include <wmtk/Types.hpp>
 #include <wmtk/components/simwild/EmbedCurves.hpp>
@@ -8,6 +7,7 @@
 #include <wmtk/simplex/Simplex.hpp>
 #include <wmtk/utils/Logger.hpp>
 #include <wmtk/utils/io.hpp>
+#include <wmtk/utils/predicates.hpp>
 
 namespace wmtk::components::simwild {
 
@@ -72,12 +72,12 @@ void positive_orientation_3D(const MatrixXd& V, MatrixXi& T)
     const Vector3d p2 = V.row(T(0, 2));
     const Vector3d p3 = V.row(T(0, 3));
 
-    igl::predicates::exactinit();
-    auto res = igl::predicates::orient3d(p0, p1, p2, p3);
+    wmtk::utils::predicates::exactinit();
+    auto res = wmtk::utils::predicates::orient3d(p0, p1, p2, p3);
     int result;
-    if (res == igl::predicates::Orientation::POSITIVE)
+    if (res == wmtk::utils::predicates::Orientation::POSITIVE)
         result = 1;
-    else if (res == igl::predicates::Orientation::NEGATIVE)
+    else if (res == wmtk::utils::predicates::Orientation::NEGATIVE)
         result = -1;
     else {
         log_and_throw_error(
@@ -101,12 +101,12 @@ void positive_orientation_2D(const MatrixXd& V, MatrixXi& F)
     const Vector2d p1 = V.row(F(0, 1));
     const Vector2d p2 = V.row(F(0, 2));
 
-    igl::predicates::exactinit();
-    auto res = igl::predicates::orient2d(p0, p1, p2);
+    wmtk::utils::predicates::exactinit();
+    auto res = wmtk::utils::predicates::orient2d(p0, p1, p2);
     int result;
-    if (res == igl::predicates::Orientation::POSITIVE)
+    if (res == wmtk::utils::predicates::Orientation::POSITIVE)
         result = 1;
-    else if (res == igl::predicates::Orientation::NEGATIVE)
+    else if (res == wmtk::utils::predicates::Orientation::NEGATIVE)
         result = -1;
     else {
         log_and_throw_error("First face is degenerate! Vertices: \n{},\n{},\n{}", p0, p1, p2);

--- a/components/tetwild/wmtk/components/tetwild/CMakeLists.txt
+++ b/components/tetwild/wmtk/components/tetwild/CMakeLists.txt
@@ -48,7 +48,6 @@ target_link_libraries(wmtk_${COMPONENT_NAME} PUBLIC
 	wmtk::toolkit
 	wmtk::data
 	wmtk::shortest_edge_collapse
-	igl::predicates
 	jse::jse
 )
 

--- a/components/tetwild/wmtk/components/tetwild/TetWildMesh.cpp
+++ b/components/tetwild/wmtk/components/tetwild/TetWildMesh.cpp
@@ -18,7 +18,7 @@
 #include <wmtk/utils/DisableWarnings.hpp>
 #include <spdlog/fmt/ostr.h>
 #include <spdlog/fmt/bundled/format.h>
-#include <igl/predicates/predicates.h>
+#include <wmtk/utils/predicates.hpp>
 #include <igl/winding_number.h>
 #include <igl/write_triangle_mesh.h>
 #include <igl/read_triangle_mesh.h>

--- a/components/tetwild/wmtk/components/tetwild/VolumemesherInsertion.cpp
+++ b/components/tetwild/wmtk/components/tetwild/VolumemesherInsertion.cpp
@@ -1,4 +1,3 @@
-#include <igl/predicates/ear_clipping.h>
 #include <fstream>
 #include <set>
 #include <wmtk/Types.hpp>

--- a/components/tetwild/wmtk/components/tetwild/orig/LocalOperations.cpp
+++ b/components/tetwild/wmtk/components/tetwild/orig/LocalOperations.cpp
@@ -77,16 +77,16 @@ bool LocalOperations::isTetFlip(const std::array<int, 4>& t)
             break;
         }
     if (is_rounded) {
-        igl::predicates::exactinit();
-        auto res = igl::predicates::orient3d(
+        wmtk::utils::predicates::exactinit();
+        auto res = wmtk::utils::predicates::orient3d(
             tet_vertices[t[0]].posf,
             tet_vertices[t[1]].posf,
             tet_vertices[t[2]].posf,
             tet_vertices[t[3]].posf);
         int result;
-        if (res == igl::predicates::Orientation::POSITIVE)
+        if (res == wmtk::utils::predicates::Orientation::POSITIVE)
             result = 1;
-        else if (res == igl::predicates::Orientation::NEGATIVE)
+        else if (res == wmtk::utils::predicates::Orientation::NEGATIVE)
             result = -1;
         else
             result = 0;
@@ -187,16 +187,16 @@ double LocalOperations::calEdgeLength(int v1_id, int v2_id)
 
 void LocalOperations::calTetQuality_AMIPS(const std::array<int, 4>& tet, TetQuality& t_quality)
 {
-    igl::predicates::exactinit();
-    auto res = igl::predicates::orient3d(
+    wmtk::utils::predicates::exactinit();
+    auto res = wmtk::utils::predicates::orient3d(
         tet_vertices[tet[0]].posf,
         tet_vertices[tet[1]].posf,
         tet_vertices[tet[2]].posf,
         tet_vertices[tet[3]].posf);
     int result;
-    if (res == igl::predicates::Orientation::POSITIVE)
+    if (res == wmtk::utils::predicates::Orientation::POSITIVE)
         result = 1;
-    else if (res == igl::predicates::Orientation::NEGATIVE)
+    else if (res == wmtk::utils::predicates::Orientation::NEGATIVE)
         result = -1;
     else
         result = 0;

--- a/components/tetwild/wmtk/components/tetwild/orig/VertexSmoother.cpp
+++ b/components/tetwild/wmtk/components/tetwild/orig/VertexSmoother.cpp
@@ -70,13 +70,13 @@ bool VertexSmoother::smoothSingleVertex(int v_id, bool is_cal_energy)
     bool is_valid = true;
     for (auto it = tet_vertices[v_id].conn_tets.begin(); it != tet_vertices[v_id].conn_tets.end();
          it++) {
-        auto res = igl::predicates::orient3d(
+        auto res = wmtk::utils::predicates::orient3d(
             tet_vertices[tets[*it][0]].posf,
             tet_vertices[tets[*it][1]].posf,
             tet_vertices[tets[*it][2]].posf,
             tet_vertices[tets[*it][3]].posf);
 
-        if (res != igl::predicates::Orientation::NEGATIVE) {
+        if (res != wmtk::utils::predicates::Orientation::NEGATIVE) {
             is_valid = false;
             break;
         }
@@ -157,13 +157,13 @@ void VertexSmoother::smoothSingle()
         for (auto it = tet_vertices[v_id].conn_tets.begin();
              it != tet_vertices[v_id].conn_tets.end();
              it++) {
-            auto res = igl::predicates::orient3d(
+            auto res = wmtk::utils::predicates::orient3d(
                 tet_vertices[tets[*it][0]].posf,
                 tet_vertices[tets[*it][1]].posf,
                 tet_vertices[tets[*it][2]].posf,
                 tet_vertices[tets[*it][3]].posf);
 
-            if (res != igl::predicates::Orientation::NEGATIVE) {
+            if (res != wmtk::utils::predicates::Orientation::NEGATIVE) {
                 is_valid = false;
                 break;
             }
@@ -279,13 +279,13 @@ void VertexSmoother::smoothSurface()
         for (auto it = tet_vertices[v_id].conn_tets.begin();
              it != tet_vertices[v_id].conn_tets.end();
              it++) {
-            auto res = igl::predicates::orient3d(
+            auto res = wmtk::utils::predicates::orient3d(
                 tet_vertices[tets[*it][0]].posf,
                 tet_vertices[tets[*it][1]].posf,
                 tet_vertices[tets[*it][2]].posf,
                 tet_vertices[tets[*it][3]].posf);
 
-            if (res != igl::predicates::Orientation::NEGATIVE) {
+            if (res != wmtk::utils::predicates::Orientation::NEGATIVE) {
                 is_valid = false;
                 break;
             }

--- a/components/tetwild/wmtk/components/tetwild/tetwild.cpp
+++ b/components/tetwild/wmtk/components/tetwild/tetwild.cpp
@@ -24,12 +24,12 @@
 #include <igl/boundary_facets.h>
 #include <igl/euler_characteristic.h>
 #include <igl/facet_components.h>
-#include <igl/predicates/predicates.h>
 #include <igl/random_points_on_mesh.h>
 #include <igl/read_triangle_mesh.h>
 #include <igl/remove_unreferenced.h>
 #include <igl/write_triangle_mesh.h>
 #include <spdlog/common.h>
+#include <wmtk/utils/predicates.hpp>
 
 #include <tetwild_spec.hpp>
 
@@ -532,12 +532,13 @@ TetWildMesh::ExportStruct tetwild_with_export(nlohmann::json json_params)
             auto vs = mesh_new.oriented_tet_vertices(f);
             for (int j = 0; j < 4; j++) {
                 if (std::find(vids.begin(), vids.end(), vs[j].vid(mesh_new)) == vids.end()) {
-                    auto res = igl::predicates::orient3d(
+                    auto res = wmtk::utils::predicates::orient3d(
                         mesh_new.m_vertex_attribute[vids[0]].m_posf,
                         mesh_new.m_vertex_attribute[vids[1]].m_posf,
                         mesh_new.m_vertex_attribute[vids[2]].m_posf,
                         mesh_new.m_vertex_attribute[vs[j].vid(mesh_new)].m_posf);
-                    if (res == igl::predicates::Orientation::NEGATIVE) std::swap(vids[1], vids[2]);
+                    if (res == wmtk::utils::predicates::Orientation::NEGATIVE)
+                        std::swap(vids[1], vids[2]);
                     break;
                 }
             }

--- a/components/topological_offset/wmtk/components/topological_offset/CMakeLists.txt
+++ b/components/topological_offset/wmtk/components/topological_offset/CMakeLists.txt
@@ -37,7 +37,6 @@ target_sources(wmtk_${COMPONENT_NAME} PRIVATE ${SRC_FILES})
 target_link_libraries(wmtk_${COMPONENT_NAME} PUBLIC
 	wmtk::toolkit
 	wmtk::simwild
-	igl::predicates
 	jse::jse
 )
 

--- a/components/topological_offset/wmtk/components/topological_offset/Smooth.cpp
+++ b/components/topological_offset/wmtk/components/topological_offset/Smooth.cpp
@@ -10,7 +10,7 @@
 
 // clang-format off
 #include <wmtk/utils/DisableWarnings.hpp>
-#include <igl/predicates/predicates.h>
+#include <wmtk/utils/predicates.hpp>
 #include <wmtk/utils/EnableWarnings.hpp>
 // clang-format on
 

--- a/components/topological_offset/wmtk/components/topological_offset/TopoOffsetTetMesh.cpp
+++ b/components/topological_offset/wmtk/components/topological_offset/TopoOffsetTetMesh.cpp
@@ -9,7 +9,7 @@
 // clang-format off
 #include <wmtk/utils/DisableWarnings.hpp>
 #include <spdlog/fmt/bundled/format.h>
-#include <igl/predicates/predicates.h>
+#include <wmtk/utils/predicates.hpp>
 #include <wmtk/utils/EnableWarnings.hpp>
 // clang-format on
 
@@ -1379,16 +1379,16 @@ bool TopoOffsetTetMesh::invariants(const std::vector<Tuple>& tets)
     /**
      * TODO: Check this individually in each operation
      */
-    igl::predicates::exactinit();
+    wmtk::utils::predicates::exactinit();
     for (const Tuple& t : tets) {
         auto vs = oriented_tet_vids(t);
-        auto res = igl::predicates::orient3d(
+        auto res = wmtk::utils::predicates::orient3d(
             m_vertex_attribute[vs[0]].m_posf,
             m_vertex_attribute[vs[1]].m_posf,
             m_vertex_attribute[vs[2]].m_posf,
             m_vertex_attribute[vs[3]].m_posf);
 
-        if (res != igl::predicates::Orientation::NEGATIVE) {
+        if (res != wmtk::utils::predicates::Orientation::NEGATIVE) {
             return false;
         }
     }

--- a/components/topological_offset/wmtk/components/topological_offset/TopoOffsetTriMesh.cpp
+++ b/components/topological_offset/wmtk/components/topological_offset/TopoOffsetTriMesh.cpp
@@ -1,10 +1,10 @@
 #include "TopoOffsetTriMesh.h"
 #include <igl/is_edge_manifold.h>
 #include <igl/is_vertex_manifold.h>
-#include <igl/predicates/predicates.h>
 #include <paraviewo/VTUWriter.hpp>
 #include <queue>
 #include <wmtk/utils/io.hpp>
+#include <wmtk/utils/predicates.hpp>
 
 
 namespace wmtk::components::topological_offset {
@@ -764,15 +764,15 @@ bool TopoOffsetTriMesh::offset_is_manifold()
 
 bool TopoOffsetTriMesh::invariants(const std::vector<Tuple>& tris)
 {
-    igl::predicates::exactinit();
+    wmtk::utils::predicates::exactinit();
     for (const Tuple& t : tris) {
         auto vs = oriented_tri_vids(t);
 
-        auto res = igl::predicates::orient2d(
+        auto res = wmtk::utils::predicates::orient2d(
             m_vertex_attribute[vs[0]].m_posf,
             m_vertex_attribute[vs[1]].m_posf,
             m_vertex_attribute[vs[2]].m_posf);
-        if (res != igl::predicates::Orientation::POSITIVE) {
+        if (res != wmtk::utils::predicates::Orientation::POSITIVE) {
             return false;
         }
     }

--- a/components/triwild/wmtk/components/triwild/CMakeLists.txt
+++ b/components/triwild/wmtk/components/triwild/CMakeLists.txt
@@ -22,7 +22,6 @@ target_sources(wmtk_${COMPONENT_NAME} PRIVATE ${SRC_FILES})
 target_link_libraries(wmtk_${COMPONENT_NAME} PUBLIC
 	wmtk::toolkit
 	wmtk::data
-	igl::predicates
 	jse::jse
 )
 

--- a/components/triwild/wmtk/components/triwild/TriWildMesh.cpp
+++ b/components/triwild/wmtk/components/triwild/TriWildMesh.cpp
@@ -20,7 +20,7 @@
 #include <wmtk/utils/DisableWarnings.hpp>
 #include <spdlog/fmt/ostr.h>
 #include <spdlog/fmt/bundled/format.h>
-#include <igl/predicates/predicates.h>
+#include <wmtk/utils/predicates.hpp>
 #include <igl/winding_number.h>
 #include <igl/write_triangle_mesh.h>
 #include <igl/read_triangle_mesh.h>

--- a/src/wmtk/TetOptimizerMesh.cpp
+++ b/src/wmtk/TetOptimizerMesh.cpp
@@ -15,7 +15,7 @@
 
 // clang-format off
 #include <wmtk/utils/DisableWarnings.hpp>
-#include <igl/predicates/predicates.h>
+#include <wmtk/utils/predicates.hpp>
 #include <igl/write_triangle_mesh.h>
 #include <wmtk/utils/EnableWarnings.hpp>
 // clang-format on
@@ -430,16 +430,16 @@ bool TetOptimizerMesh::is_inverted_f(const Tuple& loc) const
 {
     auto vs = oriented_tet_vertices(loc);
 
-    igl::predicates::exactinit();
-    auto res = igl::predicates::orient3d(
+    wmtk::utils::predicates::exactinit();
+    auto res = wmtk::utils::predicates::orient3d(
         m_vertex_attribute[vs[0].vid(*this)].m_posf,
         m_vertex_attribute[vs[1].vid(*this)].m_posf,
         m_vertex_attribute[vs[2].vid(*this)].m_posf,
         m_vertex_attribute[vs[3].vid(*this)].m_posf);
     int result;
-    if (res == igl::predicates::Orientation::POSITIVE)
+    if (res == wmtk::utils::predicates::Orientation::POSITIVE)
         result = 1;
-    else if (res == igl::predicates::Orientation::NEGATIVE)
+    else if (res == wmtk::utils::predicates::Orientation::NEGATIVE)
         result = -1;
     else
         result = 0;
@@ -458,16 +458,16 @@ bool TetOptimizerMesh::is_inverted(const std::array<size_t, 4>& vs) const
 
     if (m_vertex_attribute[vs[0]].m_is_rounded && m_vertex_attribute[vs[1]].m_is_rounded &&
         m_vertex_attribute[vs[2]].m_is_rounded && m_vertex_attribute[vs[3]].m_is_rounded) {
-        igl::predicates::exactinit();
-        auto res = igl::predicates::orient3d(
+        wmtk::utils::predicates::exactinit();
+        auto res = wmtk::utils::predicates::orient3d(
             m_vertex_attribute[vs[0]].m_posf,
             m_vertex_attribute[vs[1]].m_posf,
             m_vertex_attribute[vs[2]].m_posf,
             m_vertex_attribute[vs[3]].m_posf);
         int result;
-        if (res == igl::predicates::Orientation::POSITIVE)
+        if (res == wmtk::utils::predicates::Orientation::POSITIVE)
             result = 1;
-        else if (res == igl::predicates::Orientation::NEGATIVE)
+        else if (res == wmtk::utils::predicates::Orientation::NEGATIVE)
             result = -1;
         else
             result = 0;

--- a/src/wmtk/TriOptimizerMesh.cpp
+++ b/src/wmtk/TriOptimizerMesh.cpp
@@ -16,7 +16,7 @@
 
 // clang-format off
 #include <wmtk/utils/DisableWarnings.hpp>
-#include <igl/predicates/predicates.h>
+#include <wmtk/utils/predicates.hpp>
 #include <wmtk/utils/EnableWarnings.hpp>
 // clang-format on
 
@@ -400,12 +400,12 @@ bool TriOptimizerMesh::is_inverted_f(const size_t fid) const
 {
     auto vs = oriented_tri_vids(fid);
 
-    igl::predicates::exactinit();
-    auto res = igl::predicates::orient2d(
+    wmtk::utils::predicates::exactinit();
+    auto res = wmtk::utils::predicates::orient2d(
         m_vertex_attribute[vs[0]].m_posf,
         m_vertex_attribute[vs[1]].m_posf,
         m_vertex_attribute[vs[2]].m_posf);
-    if (res == igl::predicates::Orientation::POSITIVE) {
+    if (res == wmtk::utils::predicates::Orientation::POSITIVE) {
         return false;
     }
     return true;
@@ -415,12 +415,12 @@ bool TriOptimizerMesh::is_inverted(const std::array<size_t, 3>& vs) const
 {
     if (m_vertex_attribute[vs[0]].m_is_rounded && m_vertex_attribute[vs[1]].m_is_rounded &&
         m_vertex_attribute[vs[2]].m_is_rounded) {
-        igl::predicates::exactinit();
-        auto res = igl::predicates::orient2d(
+        wmtk::utils::predicates::exactinit();
+        auto res = wmtk::utils::predicates::orient2d(
             m_vertex_attribute[vs[0]].m_posf,
             m_vertex_attribute[vs[1]].m_posf,
             m_vertex_attribute[vs[2]].m_posf);
-        if (res == igl::predicates::Orientation::POSITIVE) {
+        if (res == wmtk::utils::predicates::Orientation::POSITIVE) {
             return false;
         }
         return true;

--- a/src/wmtk/TriOptimizerMesh.h
+++ b/src/wmtk/TriOptimizerMesh.h
@@ -186,10 +186,10 @@ public:
     /**
      * @brief Orientation check, exact for the coordinates the vertices actually carry.
      *
-     * Takes the floating path when all three vertices are rounded -- igl::predicates::orient2d
-     * is exact for the doubles it is handed -- and the Rational cross product otherwise. The
-     * rational branch exists because for an un-rounded vertex the double is the wrong number,
-     * not because orient2d is imprecise.
+     * Takes the floating path when all three vertices are rounded --
+     * wmtk::utils::predicates::orient2d is exact for the doubles it is handed -- and the Rational
+     * cross product otherwise. The rational branch exists because for an un-rounded vertex the
+     * double is the wrong number, not because orient2d is imprecise.
      */
     bool is_inverted(const std::array<size_t, 3>& vs) const;
     bool is_inverted(const Tuple& loc) const;

--- a/src/wmtk/Types.hpp
+++ b/src/wmtk/Types.hpp
@@ -1,10 +1,10 @@
 #pragma once
 
-#include <igl/predicates/predicates.h>
 #include <Eigen/Core>
 #include <Eigen/Sparse>
 #include <wmtk/utils/Logger.hpp>
 #include <wmtk/utils/Rational.hpp>
+#include <wmtk/utils/predicates.hpp>
 
 namespace wmtk {
 
@@ -124,12 +124,12 @@ inline void VF_to_vectors(
 inline bool
 tet_is_inverted(const Vector3d& v0, const Vector3d& v1, const Vector3d& v2, const Vector3d& v3)
 {
-    igl::predicates::exactinit();
-    auto res = igl::predicates::orient3d(v0, v1, v2, v3);
+    wmtk::utils::predicates::exactinit();
+    auto res = wmtk::utils::predicates::orient3d(v0, v1, v2, v3);
     int result;
-    if (res == igl::predicates::Orientation::POSITIVE)
+    if (res == wmtk::utils::predicates::Orientation::POSITIVE)
         result = 1;
-    else if (res == igl::predicates::Orientation::NEGATIVE)
+    else if (res == wmtk::utils::predicates::Orientation::NEGATIVE)
         result = -1;
     else
         result = 0;
@@ -141,12 +141,12 @@ tet_is_inverted(const Vector3d& v0, const Vector3d& v1, const Vector3d& v2, cons
 
 inline bool tri_is_inverted(const Vector2d& v0, const Vector2d& v1, const Vector2d& v2)
 {
-    igl::predicates::exactinit();
-    auto res = igl::predicates::orient2d(v0, v1, v2);
+    wmtk::utils::predicates::exactinit();
+    auto res = wmtk::utils::predicates::orient2d(v0, v1, v2);
     int result;
-    if (res == igl::predicates::Orientation::POSITIVE)
+    if (res == wmtk::utils::predicates::Orientation::POSITIVE)
         result = 1;
-    else if (res == igl::predicates::Orientation::NEGATIVE)
+    else if (res == wmtk::utils::predicates::Orientation::NEGATIVE)
         result = -1;
     else
         result = 0;

--- a/src/wmtk/utils/Delaunay.cpp
+++ b/src/wmtk/utils/Delaunay.cpp
@@ -5,8 +5,8 @@
 #include <VolumeRemesher/2d/delaunay2d.h>
 // clang-format on
 
-#include <igl/predicates/predicates.h>
 #include <wmtk/utils/Logger.hpp>
+#include <wmtk/utils/predicates.hpp>
 
 #include <algorithm>
 #include <cassert>
@@ -27,12 +27,12 @@ bool is_inverted(
     const Eigen::Vector3d v2(p2[0], p2[1], p2[2]);
     const Eigen::Vector3d v3(p3[0], p3[1], p3[2]);
 
-    igl::predicates::exactinit();
-    auto res = igl::predicates::orient3d(v0, v1, v2, v3);
+    wmtk::utils::predicates::exactinit();
+    auto res = wmtk::utils::predicates::orient3d(v0, v1, v2, v3);
     int result;
-    if (res == igl::predicates::Orientation::POSITIVE)
+    if (res == wmtk::utils::predicates::Orientation::POSITIVE)
         result = 1;
-    else if (res == igl::predicates::Orientation::NEGATIVE)
+    else if (res == wmtk::utils::predicates::Orientation::NEGATIVE)
         result = -1;
     else
         result = 0;
@@ -51,12 +51,12 @@ bool is_inverted(
     const Eigen::Vector2d v1(p1[0], p1[1]);
     const Eigen::Vector2d v2(p2[0], p2[1]);
 
-    igl::predicates::exactinit();
-    auto res = igl::predicates::orient2d(v0, v1, v2);
+    wmtk::utils::predicates::exactinit();
+    auto res = wmtk::utils::predicates::orient2d(v0, v1, v2);
     int result;
-    if (res == igl::predicates::Orientation::POSITIVE)
+    if (res == wmtk::utils::predicates::Orientation::POSITIVE)
         result = 1;
-    else if (res == igl::predicates::Orientation::NEGATIVE)
+    else if (res == wmtk::utils::predicates::Orientation::NEGATIVE)
         result = -1;
     else
         result = 0;
@@ -121,13 +121,13 @@ bool spans_a_volume(const std::vector<double>& coords, size_t n)
         return Eigen::Vector3d(coords[3 * i], coords[3 * i + 1], coords[3 * i + 2]);
     };
 
-    igl::predicates::exactinit();
+    wmtk::utils::predicates::exactinit();
     const Eigen::Vector3d p0 = pt(0);
     const Eigen::Vector3d p1 = pt(1);
     for (size_t k = 2; k + 1 < n; ++k) {
         for (size_t l = k + 1; l < n; ++l) {
-            if (igl::predicates::orient3d(p0, p1, pt(k), pt(l)) !=
-                igl::predicates::Orientation::COPLANAR) {
+            if (wmtk::utils::predicates::orient3d(p0, p1, pt(k), pt(l)) !=
+                wmtk::utils::predicates::Orientation::COPLANAR) {
                 return true;
             }
         }

--- a/src/wmtk/utils/GeoUtils.cpp
+++ b/src/wmtk/utils/GeoUtils.cpp
@@ -1,5 +1,5 @@
-#include <igl/predicates/predicates.h>
 #include <wmtk/utils/GeoUtils.h>
+#include <wmtk/utils/predicates.hpp>
 
 namespace wmtk {
 
@@ -10,12 +10,12 @@ int orient3d_t(
     const Eigen::Matrix<double, 3, 1>& p3,
     const Eigen::Matrix<double, 3, 1>& p4)
 {
-    igl::predicates::exactinit();
+    wmtk::utils::predicates::exactinit();
 
-    auto res = igl::predicates::orient3d(p1, p2, p3, p4);
-    return res == igl::predicates::Orientation::COPLANAR
+    auto res = wmtk::utils::predicates::orient3d(p1, p2, p3, p4);
+    return res == wmtk::utils::predicates::Orientation::COPLANAR
                ? 0
-               : (res == igl::predicates::Orientation::NEGATIVE ? -1 : 1);
+               : (res == wmtk::utils::predicates::Orientation::NEGATIVE ? -1 : 1);
 }
 
 template <>
@@ -24,11 +24,11 @@ int orient2d_t(
     const Eigen::Matrix<double, 2, 1>& p2,
     const Eigen::Matrix<double, 2, 1>& p3)
 {
-    igl::predicates::exactinit();
+    wmtk::utils::predicates::exactinit();
 
-    auto res = igl::predicates::orient2d(p1, p2, p3);
-    return res == igl::predicates::Orientation::COLLINEAR
+    auto res = wmtk::utils::predicates::orient2d(p1, p2, p3);
+    return res == wmtk::utils::predicates::Orientation::COLLINEAR
                ? 0
-               : (res == igl::predicates::Orientation::NEGATIVE ? -1 : 1);
+               : (res == wmtk::utils::predicates::Orientation::NEGATIVE ? -1 : 1);
 }
 } // namespace wmtk

--- a/src/wmtk/utils/orient.cpp
+++ b/src/wmtk/utils/orient.cpp
@@ -1,7 +1,7 @@
 #include "orient.hpp"
 
-#include <igl/predicates/predicates.h>
 #include <wmtk/utils/Rational.hpp>
+#include <wmtk/utils/predicates.hpp>
 
 namespace wmtk::utils {
 
@@ -20,7 +20,7 @@ bool orient3d(const Vector3r& p0, const Vector3r& p1, const Vector3r& p2, const 
 
     const Vector3r d = p3 - p0;
 
-    // dot product: n · d
+    // dot product: n . d
     Rational res = nx * d[0] + ny * d[1] + nz * d[2];
 
 
@@ -34,12 +34,12 @@ bool orient3d(const Vector3r& p0, const Vector3r& p1, const Vector3r& p2, const 
 
 bool orient3d(const Vector3d& p0, const Vector3d& p1, const Vector3d& p2, const Vector3d& p3)
 {
-    igl::predicates::exactinit();
-    auto res = igl::predicates::orient3d(p0, p1, p2, p3);
+    wmtk::utils::predicates::exactinit();
+    auto res = wmtk::utils::predicates::orient3d(p0, p1, p2, p3);
     int result;
-    if (res == igl::predicates::Orientation::POSITIVE) {
+    if (res == wmtk::utils::predicates::Orientation::POSITIVE) {
         result = 1;
-    } else if (res == igl::predicates::Orientation::NEGATIVE) {
+    } else if (res == wmtk::utils::predicates::Orientation::NEGATIVE) {
         result = -1;
     } else {
         result = 0;
@@ -64,9 +64,9 @@ bool orient2d(const Vector2r& p0, const Vector2r& p1, const Vector2r& p2)
 
 bool orient2d(const Vector2d& p0, const Vector2d& p1, const Vector2d& p2)
 {
-    igl::predicates::exactinit();
-    auto res = igl::predicates::orient2d(p0, p1, p2);
-    if (res == igl::predicates::Orientation::POSITIVE) {
+    wmtk::utils::predicates::exactinit();
+    auto res = wmtk::utils::predicates::orient2d(p0, p1, p2);
+    if (res == wmtk::utils::predicates::Orientation::POSITIVE) {
         return true;
     }
     return false;

--- a/src/wmtk/utils/predicates.cpp
+++ b/src/wmtk/utils/predicates.cpp
@@ -1,0 +1,46 @@
+#include <wmtk/utils/predicates.hpp>
+
+// The exact-predicate backend, and the ONLY place in the toolkit that names it. Everything
+// goes through the wrappers in the header, so changing backend again is a change to this
+// file alone rather than to the call sites.
+//
+// Marco Attene's Indirect_Predicates, reached through fast-envelope, which fetches and pins
+// it. orient2d/orient3d here are the direct (non-indirect) predicates: a semi-static double
+// filter first, falling back to exact expansion arithmetic only when the filter cannot
+// decide the sign.
+#include <implicit_point.h>
+
+namespace wmtk::utils::predicates::detail {
+
+int orient2d_sign(
+    const double ax,
+    const double ay,
+    const double bx,
+    const double by,
+    const double cx,
+    const double cy)
+{
+    return ::orient2d(ax, ay, bx, by, cx, cy);
+}
+
+int orient3d_sign(
+    const double ax,
+    const double ay,
+    const double az,
+    const double bx,
+    const double by,
+    const double bz,
+    const double cx,
+    const double cy,
+    const double cz,
+    const double dx,
+    const double dy,
+    const double dz)
+{
+    // Negated: the backend orients det[b-a; c-a; d-a] where Shewchuk orients
+    // det[a-d; b-d; c-d], and the two are opposite. See the note on orient3d() in the header
+    // for the measurement.
+    return -::orient3d(ax, ay, az, bx, by, bz, cx, cy, cz, dx, dy, dz);
+}
+
+} // namespace wmtk::utils::predicates::detail

--- a/src/wmtk/utils/predicates.hpp
+++ b/src/wmtk/utils/predicates.hpp
@@ -1,42 +1,157 @@
 #pragma once
 
-#include <igl/predicates/predicates.h>
-#include <wmtk/Types.hpp>
+#include <Eigen/Core>
 
 namespace wmtk::utils::predicates {
 
 /**
- * @brief Check if three vertices in 2D are collinear using exact predicates.
+ * @brief Sign of an exact geometric predicate.
+ *
+ * Deliberately the same shape and the same values as igl::predicates::Orientation, which
+ * this replaced: the call sites were written against that enum, and comparing against
+ * POSITIVE / COLLINEAR / COPLANAR reads the same either way.
  */
-inline bool is_degenerate(const Vector2d& v0, const Vector2d& v1, const Vector2d& v2)
+enum class Orientation {
+    POSITIVE = 1,
+    INSIDE = 1,
+    NEGATIVE = -1,
+    OUTSIDE = -1,
+    COLLINEAR = 0,
+    COPLANAR = 0,
+    COCIRCULAR = 0,
+    COSPHERICAL = 0,
+    DEGENERATE = 0
+};
+
+namespace detail {
+
+/**
+ * @brief The exact backend, behind a plain-double interface.
+ *
+ * Declared here and defined in predicates.cpp rather than included, and it has to be that
+ * way. The backend reaches its arithmetic kernel through `#include "numerics.h"`, and
+ * VolumeRemesher's `VolumeRemesher/numerics.h` is `namespace vol_rem { #include <numerics.h> }`
+ * around that same NFG header. `#pragma once` then means whichever party includes it first
+ * captures it into their namespace and the other can never have it: include VolumeRemesher
+ * first and the global `bigrational` does not exist, include the backend first and
+ * `vol_rem::bigrational` does not. Wrapping it on this side does not help -- in a TU where
+ * VolumeRemesher won, the wrap would include nothing.
+ *
+ * Keeping the include in a single .cpp that never sees VolumeRemesher sidesteps it, and
+ * keeps a heavy header out of every translation unit. It costs the inlining of the predicate
+ * call: measured at 0.54 ns per call, about 16% of the predicate's own cost but far below
+ * run-to-run noise on any real workload, so it is not worth trading the isolation for.
+ *
+ * These return -1 / 0 / +1 in the convention the wrappers below document.
+ */
+int orient2d_sign(double ax, double ay, double bx, double by, double cx, double cy);
+int orient3d_sign(
+    double ax,
+    double ay,
+    double az,
+    double bx,
+    double by,
+    double bz,
+    double cx,
+    double cy,
+    double cz,
+    double dx,
+    double dy,
+    double dz);
+
+inline Orientation from_sign(const int s)
 {
-    return igl::predicates::orient2d(v0, v1, v2) == igl::predicates::Orientation::COLLINEAR;
+    return s > 0 ? Orientation::POSITIVE : (s < 0 ? Orientation::NEGATIVE : Orientation::COLLINEAR);
+}
+
+} // namespace detail
+
+/**
+ * @brief No-op, kept so call sites that initialized the old backend still compile.
+ *
+ * Shewchuk's predicates compute their error bounds once at start-up; the current backend
+ * carries its filter constants as literals and needs nothing. Left as an empty inline rather
+ * than deleted, so that a future backend which does need initialization has somewhere to put
+ * it and the call sites do not have to be found again.
+ */
+inline void exactinit() {}
+
+/**
+ * @brief Exact orientation of three 2D points: POSITIVE when counter-clockwise.
+ *
+ * The backend and Shewchuk agree here, sign for sign. Verified over 400k mixed
+ * random/integer/degenerate triples: 400000 identical, 0 flipped, 5329 of them degenerate.
+ */
+template <typename D0, typename D1, typename D2>
+inline Orientation orient2d(
+    const Eigen::MatrixBase<D0>& a,
+    const Eigen::MatrixBase<D1>& b,
+    const Eigen::MatrixBase<D2>& c)
+{
+    return detail::from_sign(detail::orient2d_sign(a[0], a[1], b[0], b[1], c[0], c[1]));
 }
 
 /**
- * @brief Check if three vertices in 3D are collinear using exact predicates.
+ * @brief Exact orientation of four 3D points, in Shewchuk's convention.
+ *
+ * The two libraries disagree on the sign here, because they take the determinant of
+ * different differences: Shewchuk uses det[a-d; b-d; c-d], the backend det[b-a; c-a; d-a],
+ * and those are opposite. Measured over 400k mixed quadruples: 399197 flipped, and the 803
+ * that matched were exactly the 803 degenerate ones, where the sign cannot tell them apart.
+ *
+ * Getting this wrong inverts every tet-orientation test in the toolkit while still passing
+ * anything that only asks about degeneracy, so the correction lives in one place --
+ * orient3d_sign -- rather than at the call sites.
  */
-inline bool is_degenerate(const Vector3d& v0, const Vector3d& v1, const Vector3d& v2)
+template <typename D0, typename D1, typename D2, typename D3>
+inline Orientation orient3d(
+    const Eigen::MatrixBase<D0>& a,
+    const Eigen::MatrixBase<D1>& b,
+    const Eigen::MatrixBase<D2>& c,
+    const Eigen::MatrixBase<D3>& d)
 {
-    for (int dim = 0; dim < 3; ++dim) {
-        const Vector2d p0(v0[dim], v0[(dim + 1) % 3]);
-        const Vector2d p1(v1[dim], v1[(dim + 1) % 3]);
-        const Vector2d p2(v2[dim], v2[(dim + 1) % 3]);
+    return detail::from_sign(
+        detail::
+            orient3d_sign(a[0], a[1], a[2], b[0], b[1], b[2], c[0], c[1], c[2], d[0], d[1], d[2]));
+}
 
-        if (!is_degenerate(p0, p1, p2)) {
-            return false;
+/**
+ * @brief Check if three vertices are collinear using exact predicates.
+ */
+template <typename D0, typename D1, typename D2>
+inline bool is_degenerate(
+    const Eigen::MatrixBase<D0>& v0,
+    const Eigen::MatrixBase<D1>& v1,
+    const Eigen::MatrixBase<D2>& v2)
+{
+    if constexpr (Eigen::MatrixBase<D0>::RowsAtCompileTime == 3) {
+        // Three points in 3D are collinear only if they are collinear in all three
+        // coordinate-plane projections; any one projection can flatten a real triangle.
+        for (int dim = 0; dim < 3; ++dim) {
+            const Eigen::Vector2d p0(v0[dim], v0[(dim + 1) % 3]);
+            const Eigen::Vector2d p1(v1[dim], v1[(dim + 1) % 3]);
+            const Eigen::Vector2d p2(v2[dim], v2[(dim + 1) % 3]);
+            if (orient2d(p0, p1, p2) != Orientation::COLLINEAR) {
+                return false;
+            }
         }
+        return true;
+    } else {
+        return orient2d(v0, v1, v2) == Orientation::COLLINEAR;
     }
-    return true;
 }
 
 /**
  * @brief Check if four vertices in 3D are coplanar using exact predicates.
  */
-inline bool
-is_degenerate(const Vector3d& v0, const Vector3d& v1, const Vector3d& v2, const Vector3d& v3)
+template <typename D0, typename D1, typename D2, typename D3>
+inline bool is_degenerate(
+    const Eigen::MatrixBase<D0>& v0,
+    const Eigen::MatrixBase<D1>& v1,
+    const Eigen::MatrixBase<D2>& v2,
+    const Eigen::MatrixBase<D3>& v3)
 {
-    return igl::predicates::orient3d(v0, v1, v2, v3) == igl::predicates::Orientation::COPLANAR;
+    return orient3d(v0, v1, v2, v3) == Orientation::COPLANAR;
 }
 
 } // namespace wmtk::utils::predicates

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -15,6 +15,7 @@ set(TEST_SOURCES
     test_link_condition.cpp
     test_nonmanifold.cpp
     test_operations.cpp
+    test_predicates.cpp
     test_raw_simplex_collection.cpp
     test_read_triangle_mesh.cpp
     test_resolve_path.cpp

--- a/tests/test_operations.cpp
+++ b/tests/test_operations.cpp
@@ -29,12 +29,12 @@ public:
 
     bool is_inverted_f(const std::array<Vector3d, 4>& ps) const
     {
-        igl::predicates::exactinit();
-        auto res = igl::predicates::orient3d(ps[0], ps[1], ps[2], ps[3]);
+        wmtk::utils::predicates::exactinit();
+        auto res = wmtk::utils::predicates::orient3d(ps[0], ps[1], ps[2], ps[3]);
         int result;
-        if (res == igl::predicates::Orientation::POSITIVE)
+        if (res == wmtk::utils::predicates::Orientation::POSITIVE)
             result = 1;
-        else if (res == igl::predicates::Orientation::NEGATIVE)
+        else if (res == wmtk::utils::predicates::Orientation::NEGATIVE)
             result = -1;
         else
             result = 0;

--- a/tests/test_predicates.cpp
+++ b/tests/test_predicates.cpp
@@ -1,0 +1,93 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include <wmtk/Types.hpp>
+#include <wmtk/utils/predicates.hpp>
+
+#include <random>
+
+using namespace wmtk;
+using namespace wmtk::utils::predicates;
+
+/**
+ * The sign convention of the exact predicates, pinned.
+ *
+ * These wrappers exist so that the exact-predicate backend can be swapped in one file. The
+ * hazard in doing that is silent: two libraries can both be exactly correct and still
+ * disagree on the SIGN, because they take the determinant of different differences.
+ * Shewchuk's orient3d is det[a-d; b-d; c-d], Indirect_Predicates' is det[b-a; c-a; d-a], and
+ * those are opposite -- so a backend swap that misses it inverts every tet-orientation test
+ * in the toolkit while still passing every test that only asks whether something is
+ * degenerate.
+ *
+ * The expected values below are not derived from the current backend. They were recorded
+ * from igl::predicates, the backend in use before the swap, so they pin the behaviour the
+ * rest of the toolkit was written against rather than whatever the current backend happens
+ * to return.
+ */
+TEST_CASE("predicate_sign_convention", "[predicates]")
+{
+    SECTION("orient2d is positive for counter-clockwise")
+    {
+        CHECK(orient2d(Vector2d(0, 0), Vector2d(1, 0), Vector2d(0, 1)) == Orientation::POSITIVE);
+        CHECK(orient2d(Vector2d(0, 0), Vector2d(0, 1), Vector2d(1, 0)) == Orientation::NEGATIVE);
+        CHECK(orient2d(Vector2d(0, 0), Vector2d(1, 1), Vector2d(2, 2)) == Orientation::COLLINEAR);
+    }
+
+    SECTION("orient3d follows Shewchuk, not the raw backend")
+    {
+        // The unit simplex in index order is NEGATIVE in this convention. It is POSITIVE
+        // under Indirect_Predicates' own orient3d, which is exactly the trap.
+        CHECK(
+            orient3d(Vector3d(0, 0, 0), Vector3d(1, 0, 0), Vector3d(0, 1, 0), Vector3d(0, 0, 1)) ==
+            Orientation::NEGATIVE);
+        // Swapping two vertices flips it.
+        CHECK(
+            orient3d(Vector3d(0, 0, 0), Vector3d(0, 1, 0), Vector3d(1, 0, 0), Vector3d(0, 0, 1)) ==
+            Orientation::POSITIVE);
+        CHECK(
+            orient3d(Vector3d(0, 0, 0), Vector3d(1, 0, 0), Vector3d(0, 1, 0), Vector3d(1, 1, 0)) ==
+            Orientation::COPLANAR);
+    }
+
+    SECTION("tet_is_inverted agrees with orient3d")
+    {
+        // tet_is_inverted is the toolkit's own reading of the sign, and several thousand
+        // operations a second depend on it meaning what it did before.
+        const Vector3d a(0, 0, 0), b(1, 0, 0), c(0, 1, 0), d(0, 0, 1);
+        CHECK(orient3d(a, b, c, d) == Orientation::NEGATIVE);
+        CHECK_FALSE(tet_is_inverted(a, b, c, d)); // negative == a well-oriented tet here
+        CHECK(tet_is_inverted(a, c, b, d));
+    }
+}
+
+/**
+ * Antisymmetry and degeneracy over random input.
+ *
+ * A filtered predicate that falls back to exact arithmetic has two code paths, and the
+ * interesting failures live where the filter gives up. Feeding it small integers and halves
+ * produces exact ties often enough to exercise that path rather than just the fast one.
+ */
+TEST_CASE("predicate_exactness", "[predicates]")
+{
+    std::mt19937 rng(42);
+    std::uniform_int_distribution<int> small(-3, 3);
+    auto c = [&]() { return double(small(rng)) * 0.5; };
+
+    int degenerate2 = 0, degenerate3 = 0;
+    for (int i = 0; i < 20000; ++i) {
+        const Vector2d a2(c(), c()), b2(c(), c()), c2(c(), c());
+        const Orientation o = orient2d(a2, b2, c2);
+        // Swapping any two arguments negates the determinant exactly.
+        const Orientation swapped = orient2d(b2, a2, c2);
+        CHECK(int(o) == -int(swapped));
+        if (o == Orientation::COLLINEAR) ++degenerate2;
+
+        const Vector3d a(c(), c(), c()), b(c(), c(), c()), d(c(), c(), c()), e(c(), c(), c());
+        const Orientation o3 = orient3d(a, b, d, e);
+        CHECK(int(o3) == -int(orient3d(b, a, d, e)));
+        if (o3 == Orientation::COPLANAR) ++degenerate3;
+    }
+    // If these were zero the exact path was never reached and the test proves little.
+    CHECK(degenerate2 > 0);
+    CHECK(degenerate3 > 0);
+}


### PR DESCRIPTION
Stacked on #1027. Replaces igl's exact predicates (Shewchuk) with Indirect_Predicates, behind a single wmtk wrapper.

## Why

`igl::predicates` was reached directly from ~150 call sites across 26 files, so the arithmetic kernel underneath was effectively unswappable. Everything now goes through `wmtk::utils::predicates`, and that is the only place the backend is named — swapping again is a change to `predicates.cpp` alone.

The backend is Marco Attene's Indirect_Predicates, which the build **already fetches** through fast-envelope. Since nothing links `igl::predicates` any more, `LIBIGL_PREDICATES` goes `OFF` and Shewchuk's `predicates` library stops being built at all.

## The trap

Both libraries are exactly correct and still **disagree on the sign of `orient3d`**, because they orient different differences — Shewchuk `det[a-d; b-d; c-d]`, the backend `det[b-a; c-a; d-a]`.

Measured over 400k mixed random/integer/degenerate quadruples: **399197 flipped**, and the 803 that agreed were exactly the 803 degenerate ones, where the sign cannot tell them apart. Missing this inverts every tet-orientation test in the toolkit while still passing anything that only asks about degeneracy.

The correction sits in one place, `orient3d_sign`, and `tests/test_predicates.cpp` pins it against values **recorded from igl before the swap**, so it is anchored to the behaviour the toolkit was written against rather than to whatever the current backend returns. `orient2d` needed no correction — 400000 of 400000 identical.

## Verification

| | result |
|---|---|
| 53 registered configs | **49 identical, 0 moved**, 53/53 pass |
| 30 challenging models | **30/30 identical** on every geometry field, 0 failures |
| ctest | **109/109** (107 + 2 new predicate tests) |

## Performance — a wash, and that is the honest headline

| regime | orient2d | orient3d |
|---|---|---|
| generic (filter decides) | 2.94x faster | 2.62x faster |
| exactly degenerate | 1.56x | 2.32x |
| **near-degenerate** (filter fails, answer nonzero) | 1.07x | **0.97x** |

The backend is filter-then-**full**-exact where Shewchuk is **adaptive**, refining in stages and stopping as soon as the sign is certain. So in the near-degenerate regime real meshes are full of, they tie.

Whole-suite runtime is **within noise**: two runs of the *identical* binary came out 6.9% apart (351.5s, 327.4s), which is larger than any difference between the backends. An earlier "+6.6% regression" in this PR's history was that noise, not a real effect.

**The value here is the dependency going away and the seam, not speed.**

## Two things for whoever touches this next

**`src/wmtk/utils/orient.cpp` was ISO-8859, not UTF-8** — a stray Latin-1 middle dot in a comment. macOS grep *silently skips* such files rather than reporting them, so it kept calling `igl::predicates` after every sweep reported the tree clean, and only surfaced when the build broke. It is UTF-8 now, and it was the only such file in the repo. Worth knowing that a clean `grep` here is not proof.

**The backend include cannot live in the header.** VolumeRemesher's `numerics.h` is `namespace vol_rem { #include <numerics.h> }` around the same NFG header, so `#pragma once` means whoever includes it first captures it into their namespace and the other party loses — symmetrically, in both orders. Isolating it in `predicates.cpp` costs the inlining of the call, measured at 0.54 ns (~16% of the predicate's own cost, far below the run-to-run noise above). Wrapping it on our side does not help: in a TU where VolumeRemesher won, the wrap would include nothing.

## Follow-up

Indirect_Predicates' explicit `orient3d` is two-tier. NFG ships an `interval_number` that its *indirect* predicates use as a middle tier but the all-double path does not. A three-tier filter -> interval -> exact variant, plus inlining just the filter in the header, is worth measuring — that is where the near-degenerate gap is. Not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
