### PR TITLE
Key the operation queue by an interned index instead of the operation name

### DIFF
--- a/src/wmtk/ExecutionScheduler.hpp
+++ b/src/wmtk/ExecutionScheduler.hpp
@@ -264,8 +264,39 @@ public:
      */
     bool operator()(AppMesh& m, const std::vector<std::pair<Op, Tuple>>& operation_tuples)
     {
-        using Elem = std::tuple<double, Op, Tuple, size_t>; // priority, operation, tuple, #retries
+        // The queue holds an operation's INDEX rather than its name. edit_operation_maps is a
+        // std::map, so iterating it yields the names in lexicographic order and an index is
+        // exactly a name's rank among them -- comparing indices is therefore identical to
+        // comparing the strings, which is what keeps the queue order, and so the output,
+        // bit-for-bit unchanged. What it buys is that a queue element is now trivially
+        // copyable: a heap sift moves 8 bytes instead of a std::string, and a tie on the
+        // priority is an integer compare instead of a string compare. It also turns the
+        // per-operation dispatch from a string-keyed std::map lookup into an index.
+        using OpId = uint32_t;
+        using Elem = std::tuple<double, OpId, Tuple, size_t>; // priority, op index, tuple, #retries
         using Queue = wmtk::threading::concurrent_priority_queue<Elem>;
+
+        std::vector<const Op*> op_name;
+        std::vector<std::function<std::optional<std::vector<Tuple>>(AppMesh&, const Tuple&)>*>
+            op_fn;
+        std::map<Op, OpId> op_id;
+        op_name.reserve(edit_operation_maps.size());
+        op_fn.reserve(edit_operation_maps.size());
+        for (auto& kv : edit_operation_maps) {
+            op_id.emplace(kv.first, OpId(op_name.size()));
+            op_name.push_back(&kv.first);
+            op_fn.push_back(&kv.second);
+        }
+        // An operation with no entry here was previously default-constructed into the map by
+        // operator[] and then called, which throws bad_function_call -- so it cannot occur in
+        // any working configuration. Say so plainly rather than ordering it arbitrarily.
+        const auto id_of = [&op_id](const Op& name) {
+            const auto it = op_id.find(name);
+            if (it == op_id.end()) {
+                log_and_throw_error("No operation registered under the name '{}'.", name);
+            }
+            return it->second;
+        };
 
         std::atomic<bool> stop(false);
         cnt_success = 0;
@@ -300,26 +331,27 @@ public:
                         continue;
                     }
                     if (tup.is_valid(m)) {
+                        const Op& op_str = *op_name[op];
                         if (!is_weight_up_to_date(
                                 m,
-                                std::tuple<double, Op, Tuple>(weight, op, tup))) {
+                                std::tuple<double, Op, Tuple>(weight, op_str, tup))) {
                             operation_cleanup(m);
                             continue;
                         } // this can encode, in qslim, recompute(energy) == weight.
-                        auto newtup = edit_operation_maps[op](m, tup);
+                        auto newtup = (*op_fn[op])(m, tup);
                         std::vector<std::pair<Op, Tuple>> renewed_tuples;
                         if (newtup) {
-                            renewed_tuples = renew_neighbor_tuples(m, op, newtup.value());
+                            renewed_tuples = renew_neighbor_tuples(m, op_str, newtup.value());
                             cnt_success++;
                             cnt_update++;
                         } else {
-                            on_fail(m, op, tup);
+                            on_fail(m, op_str, tup);
                             cnt_fail++;
                         }
                         for (const auto& [o, e] : renewed_tuples) {
                             auto val = priority(m, o, e);
                             if (should_renew(val)) {
-                                renewed_elements.emplace_back(val, o, e, 0);
+                                renewed_elements.emplace_back(val, id_of(o), e, 0);
                             }
                         }
                     }
@@ -347,7 +379,7 @@ public:
                 if (!e.is_valid(m)) {
                     continue;
                 }
-                final_queue.emplace(priority(m, op, e), op, e, 0);
+                final_queue.emplace(priority(m, op, e), id_of(op), e, 0);
             }
             run_single_queue(final_queue, 0);
         } else {
@@ -355,7 +387,7 @@ public:
                 if (!e.is_valid(m)) {
                     continue;
                 }
-                queues[get_partition_id(m, e)].emplace(priority(m, op, e), op, e, 0);
+                queues[get_partition_id(m, e)].emplace(priority(m, op, e), id_of(op), e, 0);
             }
             // Comment out parallel: work on serial first.
             wmtk::threading::task_group tg;


### PR DESCRIPTION
Profiling tetwild found one genuinely free win. This is it.

## What the profile said

macOS `sample` on `tetwild_thingi_229953` (Release, -O3), by self time:

| | share |
|---|---|
| allocator + memmove/memset | 11.4% |
| AMIPS energy/jacobian/hessian | 11.3% |
| VolumeRemesher `bignatural` | 7.8% |
| `pow` | 7.1% |
| SimpleBVH distance queries | ~7% |
| **`__pop_heap` + tuple compare** | **6.3%** |
| `orient3d` | 4.6% |

Everything except the queue is inherent work. `pow` in particular is *not* low-hanging fruit: the `pow(x, 2)` squarings are already folded to multiplies by the compiler (`AMIPS.cpp.o` contains no `pow` call for them), and the real calls use exponent `-0.333333333333333`, which is not `-1/3` and therefore not `cbrt` — swapping it changes results.

## The change

The queue element was `std::tuple<double, std::string, Tuple, size_t>` — it carried the operation's **name**. So every heap sift moved a `std::string`, every tie on the priority double compared one, and each operation dispatched through `edit_operation_maps[op]`, a string-keyed `std::map` lookup, per operation.

It now carries the name's **index**.

**Why the order is unchanged:** `edit_operation_maps` is a `std::map`, so iterating it yields names in lexicographic order, and an index is exactly a name's rank among them. Comparing indices is therefore identical to comparing the strings — the heap order, the sequence of operations, and the output are all unchanged.

The public API is untouched: `Op` is still `std::string` in every callback signature, so no application code changes.

## Verification

**Byte-identical** on the 53 registered configs at `num_threads: 0` — **49 of 49 reports and every mesh hash, 0 moved**, 53/53 passing. Both arms built from the same tree with only this file swapped. `ctest` 107/107.

## Performance

Measured on the 53 registered configs at `num_threads: 0`, both arms built from the same tree with only this file swapped:

| | total wall |
|---|---|
| baseline | 382.7s |
| interned | **375.6s** |
| | **-1.8%** |

`#t` and `#iterations` are identical on 49 of 49 configs, so this is a like-for-like comparison: the same operations in the same order, just cheaper per operation.

**A note on how this was measured, because the first attempt was wrong.** I originally ran this A/B on one large model at 16 threads and reported 1.19-1.25x. That measurement was invalid: the parallel executor is non-deterministic at any thread count > 0, so the two arms built *different meshes* and did *different amounts of work* — 19 iterations and 262k tets against 18 and 238k. Two runs of the *identical* baseline binary came out 237.4s and 181.1s, a 31% spread. Wall-clock at >0 threads cannot compare two builds here at all. The `num_threads: 0` figure above is the honest one, and it is much smaller.

So the case for this change is not headline speed. It is:

- **-1.8% suite-wide, for free** — no behaviour change at all, byte-identical output.
- Removing a string-keyed `std::map` lookup from the per-operation hot path.
- Closing the data race below.

## Incidental fix

`edit_operation_maps[op]` used `operator[]`, which **inserts** on a missing key — so an unregistered operation name would mutate a `std::map` shared across worker threads. It then died on `bad_function_call`, so it was unreachable in any working configuration, but it was a data race waiting for a typo. It is now an explicit error instead of a write to shared state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
