### PR TITLE
Stop paying for a lock and two counters the hot path does not need

### DIFF
--- a/components/tetwild/wmtk/components/tetwild/DelaunayBoxMesh.cpp
+++ b/components/tetwild/wmtk/components/tetwild/DelaunayBoxMesh.cpp
@@ -10,7 +10,6 @@
 #include "wmtk/utils/InsertTriangleUtils.hpp"
 #include "wmtk/utils/Logger.hpp"
 
-#include <wmtk/threading/concurrent_priority_queue.hpp>
 #include <wmtk/threading/enumerable_thread_specific.hpp>
 #include <wmtk/threading/parallel_for.hpp>
 #include <wmtk/threading/task_group.hpp>

--- a/src/wmtk/ExecutionScheduler.hpp
+++ b/src/wmtk/ExecutionScheduler.hpp
@@ -3,6 +3,7 @@
 #include <wmtk/TetMesh.h>
 #include <wmtk/TriMesh.h>
 #include <wmtk/threading/concurrent_priority_queue.hpp>
+#include <wmtk/threading/serial_priority_queue.hpp>
 #include <wmtk/threading/task_group.hpp>
 #include <wmtk/utils/Logger.hpp>
 
@@ -74,8 +75,23 @@ struct ExecutePass
         return false; // non-stop, process everything
     };
     /**
-     * @brief checking frequency to decide whether to stop execution given the stopping criterion
+     * @brief Cumulative successful operations before `stopping_criterion` is first consulted.
      *
+     * Despite the name this is a threshold, not a period: the count it is tested against is
+     * never reset, so once the pass has had this many successes the criterion is consulted after
+     * every subsequent operation. Both current users rely on exactly that -- they set the
+     * criterion to `return true` and the threshold to the number of collapses needed to reach a
+     * target vertex count, making this a decimation counter that stops the pass on its first
+     * check. It is not a "check every N operations" knob, and writing a genuinely periodic
+     * criterion against it would evaluate that criterion on every operation forever after.
+     *
+     * Left at the default, the criterion is never consulted at all, which is the case for every
+     * tetwild/triwild/simwild pass.
+     *
+     * (There used to be a `cnt_update` member here that was incremented per success and reset
+     * inside the check, as if the threshold were a period. Nothing ever read it -- the reset was
+     * on a branch the always-true criteria above never reach -- so it was one more contended
+     * atomic on the hot path buying nothing, and it is gone.)
      */
     size_t stopping_criterion_checking_frequency = std::numeric_limits<size_t>::max();
     /**
@@ -274,7 +290,13 @@ public:
         // per-operation dispatch from a string-keyed std::map lookup into an index.
         using OpId = uint32_t;
         using Elem = std::tuple<double, OpId, Tuple, size_t>; // priority, op index, tuple, #retries
-        using Queue = wmtk::threading::concurrent_priority_queue<Elem>;
+        // Each task owns its queue outright -- it is seeded before any thread starts, and the
+        // task both pops from it and pushes its renewed operations back into it -- so those need
+        // no lock. `final_queue` is the one that genuinely crosses threads: tasks push retry
+        // overflow into it while running, and it is drained after the barrier. Both are
+        // std::priority_queue with the same comparator underneath, so pop order is unchanged.
+        using LocalQueue = wmtk::threading::serial_priority_queue<Elem>;
+        using SharedQueue = wmtk::threading::concurrent_priority_queue<Elem>;
 
         std::vector<const Op*> op_name;
         std::vector<std::function<std::optional<std::vector<Tuple>>(AppMesh&, const Tuple&)>*>
@@ -301,12 +323,35 @@ public:
         std::atomic<bool> stop(false);
         cnt_success = 0;
         cnt_fail = 0;
-        cnt_update = 0;
 
-        std::vector<Queue> queues(num_threads);
-        Queue final_queue;
+        // Whether anything actually watches the success count *while the pass runs*. When no
+        // stopping criterion is configured -- the case for every tetwild/triwild/simwild pass --
+        // nobody does, and the counters can be accumulated per task and folded in at the end
+        // instead of hammering one shared cache line from every thread on every operation.
+        const bool track_live_success =
+            stopping_criterion_checking_frequency != std::numeric_limits<size_t>::max();
+        std::atomic<size_t> live_success(0);
 
-        auto run_single_queue = [&](Queue& Q, int task_id) {
+        std::vector<LocalQueue> queues(num_threads);
+        SharedQueue final_queue;
+
+        auto run_single_queue = [&](auto& Q, int task_id) {
+            // Per-task tallies folded into the shared counters once, on the way out. The guard
+            // is RAII rather than a line at the bottom because the loop below has early
+            // returns.
+            struct CountFlusher
+            {
+                std::atomic_int& success_total;
+                std::atomic_int& fail_total;
+                int success = 0;
+                int fail = 0;
+                ~CountFlusher()
+                {
+                    success_total.fetch_add(success, std::memory_order_relaxed);
+                    fail_total.fetch_add(fail, std::memory_order_relaxed);
+                }
+            } counts{cnt_success, cnt_fail};
+
             Elem ele_in_queue;
             while ([&]() { return Q.try_pop(ele_in_queue); }()) {
                 auto& [weight, op, tup, retry] = ele_in_queue;
@@ -342,11 +387,13 @@ public:
                         std::vector<std::pair<Op, Tuple>> renewed_tuples;
                         if (newtup) {
                             renewed_tuples = renew_neighbor_tuples(m, op_str, newtup.value());
-                            cnt_success++;
-                            cnt_update++;
+                            counts.success++;
+                            if (track_live_success) {
+                                live_success.fetch_add(1, std::memory_order_relaxed);
+                            }
                         } else {
                             on_fail(m, op_str, tup);
-                            cnt_fail++;
+                            counts.fail++;
                         }
                         for (const auto& [o, e] : renewed_tuples) {
                             auto val = priority(m, o, e);
@@ -364,12 +411,12 @@ public:
                 if (stop.load(std::memory_order_acquire)) {
                     return;
                 }
-                if (cnt_success > stopping_criterion_checking_frequency) {
+                if (track_live_success && live_success.load(std::memory_order_relaxed) >
+                                              stopping_criterion_checking_frequency) {
                     if (stopping_criterion(m)) {
                         stop.store(true);
                         return;
                     }
-                    cnt_update.store(0, std::memory_order_release);
                 }
             }
         };
@@ -413,7 +460,7 @@ public:
     int get_cnt_fail() const { return cnt_fail; }
 
 private:
-    std::atomic_int cnt_update = 0;
+    // Totals for the whole pass. Written once per task, at the end -- see CountFlusher.
     std::atomic_int cnt_success = 0;
     std::atomic_int cnt_fail = 0;
 };

--- a/src/wmtk/threading/Concurrency.hpp
+++ b/src/wmtk/threading/Concurrency.hpp
@@ -26,5 +26,7 @@
 #include "enumerable_thread_specific.hpp"
 #include "parallel_for.hpp"
 #include "range.hpp"
+#include "serial_priority_queue.hpp"
 #include "spin_mutex.hpp"
 #include "task_group.hpp"
+#include "vertex_mutex.hpp"

--- a/src/wmtk/threading/serial_priority_queue.hpp
+++ b/src/wmtk/threading/serial_priority_queue.hpp
@@ -1,0 +1,49 @@
+#pragma once
+
+#include <queue>
+#include <utility>
+#include <vector>
+
+namespace wmtk::threading {
+// ---------------------------------------------------------------------------
+// serial_priority_queue: the same (used) interface as concurrent_priority_queue,
+// minus the mutex, for queues that only ever have one thread touching them.
+//
+// The scheduler gives every task its own queue and only ever pops from, and pushes
+// renewed operations back into, that one queue; the single queue that genuinely
+// crosses threads is the overflow queue drained after the barrier. Paying for a
+// lock/unlock pair on every pop and every renewal of a thread-private heap is pure
+// overhead, so the private ones use this and only the shared one stays concurrent.
+//
+// Both are std::priority_queue underneath with the same comparator, so swapping one
+// for the other cannot change pop order.
+// ---------------------------------------------------------------------------
+template <typename T, typename Compare = std::less<T>>
+class serial_priority_queue
+{
+    std::priority_queue<T, std::vector<T>, Compare> m_queue;
+
+public:
+    bool try_pop(T& out)
+    {
+        if (m_queue.empty()) {
+            return false;
+        }
+        out = m_queue.top();
+        m_queue.pop();
+        return true;
+    }
+
+    void push(const T& v) { m_queue.push(v); }
+
+    template <typename... Args>
+    void emplace(Args&&... args)
+    {
+        m_queue.emplace(std::forward<Args>(args)...);
+    }
+
+    std::size_t size() const { return m_queue.size(); }
+    bool empty() const { return m_queue.empty(); }
+};
+
+} // namespace wmtk::threading


### PR DESCRIPTION
Stacked on #1036 — **review that one first**; this PR's base is `concurrency-vertex-mutex-race` and it will retarget to `main` once #1036 lands.

Three pieces of per-operation overhead in the scheduler's inner loop, none of which buys anything.

## 1. The per-task queues were locking

Every task gets its own queue, seeded before any thread starts, and both pops from and pushes its renewed operations back into that same queue. The only queue that genuinely crosses threads is `final_queue` (retry overflow, drained after the barrier).

So the thread-private heaps were taking and releasing a `std::mutex` on every pop and every renewal for the benefit of nobody. They now use a new `serial_priority_queue` — same interface, no mutex — and only the shared queue stays concurrent. Both are `std::priority_queue` with the same comparator underneath, so pop order, and therefore output, cannot change.

## 2. `cnt_success` / `cnt_fail` were seq_cst atomics bumped per operation

One shared cache line ping-ponging between all cores, millions of times per pass. Now accumulated per task and folded in once, via an RAII guard so the loop's early returns can't skip the flush.

That wasn't possible for `cnt_success` while the stopping-criterion check read it live mid-pass, so that read goes through a separate counter maintained **only when a stopping criterion is actually configured** — never for tetwild/triwild/simwild, and exactly as before for qslim and shortest_edge_collapse.

## 3. `cnt_update` was dead

Incremented on every success, reset inside the stopping-criterion check, never read anywhere.

The reset made `stopping_criterion_checking_frequency` look like a period. It isn't. Both users set the criterion to `return true` and the threshold to the number of collapses needed to hit a target vertex count — it's a decimation counter that stops the pass on its first check. The member is gone and the field is now documented for what it actually is, including the trap for anyone who later writes a genuinely periodic criterion against it.

## Verification

The decimation path is the one behavior this touches, so I ran all six qslim / shortest_edge_collapse integration configs before and after. **Operation counts identical in every one:**

| config | executed | success / fail |
|---|---:|---|
| qslim_double_sphere | 266 | 259 / 7 |
| qslim_octocat | 17050 | 17050 / 0 |
| shortest_edge_collapse_101633 | 94108 | 78938 / 15170 |
| shortest_edge_collapse_double_sphere | 217 | 115 / 102 |
| shortest_edge_collapse_octocat | 17103 | 17050 / 53 |
| shortest_edge_collapse_sphere_with_env | 39 | 39 / 0 |

All six set `throw_on_fail`, so reaching the target is itself the assertion. Full build clean, all 99 unit test cases pass.

## What is *not* claimed

**No speedup.** These are strictly-less-work changes, but their magnitude against operations that do envelope BVH queries and exact predicates is unmeasured — the shared-cache-line counters are the more plausible of the two, the queue mutex is likely noise. The instrumentation to settle it is the next patch in this stack, and I'll post numbers there rather than assert them here.

Also drops a `concurrent_priority_queue` include from `DelaunayBoxMesh.cpp`, which never instantiated one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)