### PR TITLE
Charge the envelope budget only for a simplification that actually ran

### DIFF
--- a/components/simwild/wmtk/components/simwild/simwild.cpp
+++ b/components/simwild/wmtk/components/simwild/simwild.cpp
@@ -11,6 +11,7 @@
 #include <wmtk/utils/Logger.hpp>
 #include <wmtk/utils/resolve_path.hpp>
 
+#include <wmtk/utils/EnvelopeBudget.hpp>
 #include <wmtk/utils/Preallocation.hpp>
 #include "Parameters.h"
 #include "SimWildMesh.h"
@@ -155,6 +156,29 @@ void apply_operation(MeshT& mesh, const nlohmann::json& json_params)
 namespace {
 
 /**
+ * @brief Does a simplification actually run, and so have to be charged against eps?
+ *
+ * SimWild simplifies in one of two places, and which one applies turns on preserve_topology:
+ *
+ *  - BEFORE insertion, in read_mesh / read_curves (read_image_msh.cpp), when
+ *    `!preserve_topology && !skip_simplify`. Simplification can change the topology of the
+ *    input, so this route only runs where the caller has said that is acceptable.
+ *  - AFTER insertion, SimWildMesh::simplify() from run_3D, when
+ *    `preserve_topology && !skip_simplify && operation == "remeshing"`. It collapses at
+ *    eps_simplify with the quality check off and then REBUILDS the envelope around the
+ *    result, so it displaces the envelope geometry exactly as the pre-insertion route does.
+ *
+ * The 2D route has no post-insertion counterpart -- SimWildMeshTri has no simplify() -- so
+ * under preserve_topology nothing simplifies there.
+ */
+bool simplification_runs(const Parameters& params, bool is_3d)
+{
+    if (params.skip_simplify) return false;
+    if (!params.preserve_topology) return true; // pre-insertion, both dimensions
+    return is_3d && params.operation == "remeshing"; // post-insertion, 3D only
+}
+
+/**
  * @brief The eps the optimizer's envelope should use.
  *
  * SimWild already builds its envelope around the SIMPLIFIED geometry -- read_mesh in 3D and
@@ -168,33 +192,16 @@ namespace {
  * only the remainder, which makes the total deviation eps as advertised.
  *
  * Narrowing here rather than at each init_envelope call is deliberate: every later rebuild
- * reads m_envelope_eps, so doing it once at construction covers them all and cannot
- * double-subtract.
+ * reads m_envelope_eps, so doing it once at construction covers them all -- including the
+ * rebuild at the end of SimWildMesh::simplify() -- and cannot double-subtract.
  */
-double optimization_envelope_eps(const Parameters& params)
+double optimization_envelope_eps(const Parameters& params, bool is_3d)
 {
-    if (!params.optimize_envelope_around_simplified) return params.eps;
-    if (params.preserve_topology || params.skip_simplify) {
-        // No simplification ran -- the envelope geometry IS the input, so the full eps is
-        // already centred on it and there is nothing to charge.
-        return params.eps;
-    }
-    const double remaining = params.eps - params.eps_simplify;
-    if (remaining <= 0) {
-        logger().warn(
-            "optimize_envelope_around_simplified: eps_simplify {:.6} leaves nothing of eps "
-            "{:.6}; keeping the full eps",
-            params.eps_simplify,
-            params.eps);
-        return params.eps;
-    }
-    logger().info(
-        "optimization envelope: eps {:.6} (eps {:.6} - eps_simplify {:.6}) around the "
-        "simplified input",
-        remaining,
+    return wmtk::utils::optimization_envelope_eps(
         params.eps,
-        params.eps_simplify);
-    return remaining;
+        params.eps_simplify,
+        params.optimize_envelope_around_simplified,
+        simplification_runs(params, is_3d));
 }
 
 } // namespace
@@ -207,7 +214,10 @@ void run_3D(const nlohmann::json& json_params, const InputData& input_data)
     igl::Timer timer;
     timer.start();
 
-    simwild::SimWildMesh mesh(params, optimization_envelope_eps(params), params.NUM_THREADS);
+    simwild::SimWildMesh mesh(
+        params,
+        optimization_envelope_eps(params, /*is_3d=*/true),
+        params.NUM_THREADS);
     wmtk::set_preallocation_factor_from_json(mesh, json_params);
     // first init envelope
     if (input_data.V_envelope.size() != 0) {
@@ -299,7 +309,7 @@ void run_2D(const nlohmann::json& json_params, const InputData& input_data)
 
     simwild::tri::SimWildMeshTri mesh(
         params,
-        optimization_envelope_eps(params),
+        optimization_envelope_eps(params, /*is_3d=*/false),
         params.NUM_THREADS);
     wmtk::set_preallocation_factor_from_json(mesh, json_params);
     // first init envelope

--- a/components/tetwild/wmtk/components/tetwild/tetwild.cpp
+++ b/components/tetwild/wmtk/components/tetwild/tetwild.cpp
@@ -29,6 +29,7 @@
 #include <igl/remove_unreferenced.h>
 #include <igl/write_triangle_mesh.h>
 #include <spdlog/common.h>
+#include <wmtk/utils/EnvelopeBudget.hpp>
 #include <wmtk/utils/predicates.hpp>
 
 #include <tetwild_spec.hpp>
@@ -343,8 +344,19 @@ TetWildMesh::ExportStruct tetwild_with_export(nlohmann::json json_params)
     // surface handed over already close to the boundary has most of its moves refused, and
     // deliberately starving that headroom (simplify_envelope_ratio 0.95) was enough to turn a
     // converging run into a diverging one on 1368052.
+    //
+    // The narrowing is charged for the simplification's deviation, so it applies only when a
+    // simplification actually ran. Under skip_simplify the "simplified" surface IS the input,
+    // there is nothing to charge, and subtracting anyway would confine the optimizer to a
+    // fraction of the tolerance its result is judged against -- for no gain, since the
+    // geometry already starts centred in the full envelope.
     const bool env_around_simplified = json_params["optimize_envelope_around_simplified"];
-    const double opt_eps = env_around_simplified ? (tet_eps - simplify_eps) : tet_eps;
+    const bool charge_simplify = env_around_simplified && !skip_simplify;
+    const double opt_eps = wmtk::utils::optimization_envelope_eps(
+        tet_eps,
+        simplify_eps,
+        env_around_simplified,
+        /*simplification_ran=*/!skip_simplify);
 
     auto tet_envelope = std::make_shared<wmtk::SampleEnvelope>(!use_sample_envelope);
     {
@@ -382,7 +394,9 @@ TetWildMesh::ExportStruct tetwild_with_export(nlohmann::json json_params)
         "tetrahedralisation envelope: {} (eps {:.6}) around the {}",
         tet_envelope->use_exact ? "EXACT" : "sampled",
         std::sqrt(tet_envelope->eps2),
-        env_around_simplified ? "SIMPLIFIED surface" : "input");
+        !env_around_simplified ? "input"
+        : charge_simplify      ? "SIMPLIFIED surface"
+                               : "input (skip_simplify: nothing to charge, full eps)");
 
     if (json_params["DEBUG_disable_envelope"]) {
         logger().warn(

--- a/components/triwild/wmtk/components/triwild/triwild.cpp
+++ b/components/triwild/wmtk/components/triwild/triwild.cpp
@@ -10,6 +10,8 @@
 #include <wmtk/utils/resolve_path.hpp>
 
 #include <wmtk/utils/EmbedSegments.hpp>
+#include <wmtk/utils/EnvelopeBudget.hpp>
+
 #include "Parameters.h"
 #include "TriWildMesh.h"
 
@@ -311,7 +313,8 @@ void triwild(nlohmann::json json_params)
 
     MatrixXd V_simp = V_in;
     MatrixXi E_simp = E_in;
-    if (json_params["skip_simplify"]) {
+    const bool skip_simplify = json_params["skip_simplify"];
+    if (skip_simplify) {
         logger().info("skip simplification");
     } else {
         SampleEnvelope simplify_envelope(!simplify_use_sample_envelope);
@@ -410,14 +413,27 @@ void triwild(nlohmann::json json_params)
     // rather than somewhere inside it. The envelope is a hard veto rather than a penalty, so a
     // mesh handed over close to the boundary has most of its moves refused. See the tetwild
     // driver for the measurements.
+    //
+    // The narrowing is charged for the simplification's deviation, so it applies only when a
+    // simplification actually ran. Under skip_simplify the "simplified" curves ARE the input,
+    // there is nothing to charge, and subtracting anyway would confine the optimizer to a
+    // fraction of the tolerance its result is judged against -- for no gain, since the
+    // geometry already starts centred in the full envelope.
     const bool env_around_simplified = json_params["optimize_envelope_around_simplified"];
-    const double opt_eps = env_around_simplified ? (envelope_eps - simplify_eps) : envelope_eps;
+    const bool charge_simplify = env_around_simplified && !skip_simplify;
+    const double opt_eps = wmtk::utils::optimization_envelope_eps(
+        envelope_eps,
+        simplify_eps,
+        env_around_simplified,
+        /*simplification_ran=*/!skip_simplify);
     const MatrixXd& V_env = env_around_simplified ? V_simp : V_in;
     const MatrixXi& E_env = env_around_simplified ? E_simp : E_in;
     if (env_around_simplified) {
         logger().info(
-            "optimization envelope: eps {:.6} around the SIMPLIFIED curves (#V {}, #E {})",
+            "optimization envelope: eps {:.6} ({}) around the {} curves (#V {}, #E {})",
             opt_eps,
+            charge_simplify ? "full eps minus the simplification's share" : "the full eps",
+            charge_simplify ? "SIMPLIFIED" : "input, un-simplified,",
             V_env.rows(),
             E_env.rows());
     }

--- a/src/wmtk/utils/EnvelopeBudget.cpp
+++ b/src/wmtk/utils/EnvelopeBudget.cpp
@@ -1,0 +1,45 @@
+#include <wmtk/utils/EnvelopeBudget.hpp>
+
+#include <wmtk/utils/Logger.hpp>
+
+namespace wmtk::utils {
+
+double optimization_envelope_eps(
+    const double eps,
+    const double simplify_eps,
+    const bool envelope_around_simplified,
+    const bool simplification_ran)
+{
+    if (!envelope_around_simplified) {
+        // The envelope measures against the input, which is what the promise is about, so
+        // there is nothing to share: the optimizer gets the whole budget.
+        return eps;
+    }
+    if (!simplification_ran) {
+        // The "simplified" geometry IS the input. Nothing has been spent.
+        return eps;
+    }
+
+    const double remaining = eps - simplify_eps;
+    if (remaining <= 0) {
+        logger().warn(
+            "optimize_envelope_around_simplified: the simplification's eps {:.6} leaves nothing "
+            "of eps {:.6}; keeping the full eps. The output may deviate by up to {:.6} rather "
+            "than {:.6}.",
+            simplify_eps,
+            eps,
+            eps + simplify_eps,
+            eps);
+        return eps;
+    }
+
+    logger().info(
+        "optimization envelope: eps {:.6} (eps {:.6} - the simplification's {:.6}) around the "
+        "simplified geometry",
+        remaining,
+        eps,
+        simplify_eps);
+    return remaining;
+}
+
+} // namespace wmtk::utils

--- a/src/wmtk/utils/EnvelopeBudget.hpp
+++ b/src/wmtk/utils/EnvelopeBudget.hpp
@@ -1,0 +1,50 @@
+#pragma once
+
+namespace wmtk::utils {
+
+/**
+ * @brief How much of the deviation budget the optimizer's envelope may spend.
+ *
+ * Every app in the toolkit promises the same thing to its caller: the output stays within
+ * `eps` of the ORIGINAL input. Two stages move geometry, and the promise is about their sum.
+ *
+ *  - The simplification moves the input by up to `simplify_eps`.
+ *  - The optimizer then moves that by up to whatever its own envelope allows.
+ *
+ * When the optimizer's envelope is built around the *input*, the two are not additive -- the
+ * envelope measures against the thing the promise is about -- and the optimizer gets the whole
+ * `eps`. When it is built around the *simplified* geometry instead, they are: by the triangle
+ * inequality anything within `eps - simplify_eps` of the simplification is within `eps` of the
+ * input, so that remainder is what the optimizer may spend.
+ *
+ * Building around the simplified geometry is otherwise the better choice, which is why the
+ * option exists: the mesh then starts at the CENTRE of the envelope it is judged against
+ * rather than somewhere inside it, and since the envelope is a hard veto rather than a
+ * penalty, a mesh handed over close to the boundary has most of its moves refused.
+ *
+ * @param eps                       the total tolerance, as advertised to the caller
+ * @param simplify_eps              what the simplification was allowed to spend
+ * @param envelope_around_simplified whether the optimizer's envelope is built around the
+ *                                  simplified geometry rather than the input
+ * @param simplification_ran        whether a simplification actually ran. Charging for one
+ *                                  that did not run confines the optimizer to a fraction of
+ *                                  the tolerance its result is judged against, for no gain:
+ *                                  the geometry is the input, already centred in the full
+ *                                  envelope. Which config settings imply this is per-app --
+ *                                  `skip_simplify` in tetwild and triwild, and in simwild also
+ *                                  `preserve_topology` outside the remeshing operation.
+ *
+ * @return the eps to build the optimizer's envelope with; always > 0.
+ *
+ * A `simplify_eps` at or above `eps` leaves nothing to spend. That is a misconfiguration, and
+ * this warns and returns the full `eps` rather than failing: the alternative is worse than it
+ * looks, because SampleEnvelope::init squares its argument, so a *negative* eps becomes a
+ * positive eps2 and yields a silently smaller envelope instead of an error.
+ */
+double optimization_envelope_eps(
+    double eps,
+    double simplify_eps,
+    bool envelope_around_simplified,
+    bool simplification_ran);
+
+} // namespace wmtk::utils

--- a/tests/test_envelope.cpp
+++ b/tests/test_envelope.cpp
@@ -20,7 +20,10 @@
 // answers, and in particular the two places where the backends legitimately disagree: the band
 // the sampled test gives up to its own conservatism, and a gap narrower than the sample
 // spacing, where the sampled test is simply wrong.
+#include <catch2/catch_approx.hpp>
 #include <catch2/catch_test_macros.hpp>
+
+#include <wmtk/utils/EnvelopeBudget.hpp>
 
 #include <wmtk/Types.hpp>
 #include <wmtk/envelope/Envelope.hpp>
@@ -248,5 +251,52 @@ TEST_CASE("an exact query against the wrong kind of envelope throws", "[envelope
         const std::array<Eigen::Vector3d, 2> e = {
             {Eigen::Vector3d(1, 0, 0), Eigen::Vector3d(3, 0, 0)}};
         CHECK_NOTHROW(sampled.is_outside(e));
+    }
+}
+
+// The deviation budget: which eps the optimizer's envelope is allowed to spend.
+//
+// Every app promises the output stays within eps of the ORIGINAL input, and two stages move
+// geometry towards that limit. These pin the arithmetic that shares the budget between them,
+// and in particular the two ways of getting it wrong that this function exists to prevent:
+// charging for a simplification that never ran, and letting the remainder go non-positive.
+TEST_CASE("envelope_budget", "[envelope]")
+{
+    using wmtk::utils::optimization_envelope_eps;
+    const double eps = 1e-3;
+    const double simplify_eps = 4e-4;
+
+    SECTION("envelope around the input gets the whole budget")
+    {
+        // The envelope measures against the thing the promise is about, so the two stages do
+        // not add up and there is nothing to share -- whether or not a simplification ran.
+        CHECK(optimization_envelope_eps(eps, simplify_eps, false, true) == eps);
+        CHECK(optimization_envelope_eps(eps, simplify_eps, false, false) == eps);
+    }
+
+    SECTION("envelope around the simplified geometry gets the remainder")
+    {
+        CHECK(
+            optimization_envelope_eps(eps, simplify_eps, true, true) ==
+            Catch::Approx(eps - simplify_eps));
+    }
+
+    SECTION("nothing is charged when no simplification ran")
+    {
+        // The regression this function was extracted for. The "simplified" geometry IS the
+        // input, so it already sits at the centre of the full envelope; narrowing would
+        // confine the optimizer to a fraction of the tolerance its result is judged against,
+        // and buy nothing.
+        CHECK(optimization_envelope_eps(eps, simplify_eps, true, false) == eps);
+    }
+
+    SECTION("a remainder that would be non-positive falls back to the full eps")
+    {
+        // Never returns <= 0. SampleEnvelope::init SQUARES its argument, so a negative eps
+        // would come back as a positive eps2 -- a silently smaller envelope rather than an
+        // error -- and a zero one vetoes every operation.
+        CHECK(optimization_envelope_eps(eps, eps, true, true) == eps);
+        CHECK(optimization_envelope_eps(eps, 1.5 * eps, true, true) == eps);
+        CHECK(optimization_envelope_eps(eps, 0.999999 * eps, true, true) > 0);
     }
 }


### PR DESCRIPTION
## What

An audit of how the `eps` deviation budget is shared between the simplification and the optimizer, across triwild, tetwild and simwild — and fixes for the three places the answer was wrong.

## The rule

Every app promises the same thing: the output stays within `eps` of the **original input**. Two stages move geometry towards that limit.

- When the optimizer's envelope is built around the **input**, the two stages do not add up — the envelope measures against the thing the promise is about — so the optimizer gets the whole `eps`.
- When it is built around the **simplified** geometry (`optimize_envelope_around_simplified`), they do add up. By the triangle inequality anything within `eps - simplify_eps` of the simplification is within `eps` of the input, so that remainder is the optimizer's share.

Building around the simplified geometry is otherwise the better choice, which is why the option exists: the mesh then starts at the *centre* of the envelope it is judged against rather than somewhere inside it. Since the envelope is a hard veto rather than a penalty, a mesh handed over near the boundary has most of its moves refused.

## What was wrong

**tetwild and triwild charged for a simplification that never ran.** `opt_eps = env_around_simplified ? (eps - simplify_eps) : eps` never consulted `skip_simplify`. With `skip_simplify` on, the "simplified" geometry *is* the input, and the subtraction confined the optimizer to a fraction of the tolerance its result is judged against — buying nothing, since the geometry already starts centred in the full envelope.

**simwild had the opposite defect, on its default path.** `optimization_envelope_eps` skipped the charge whenever `preserve_topology` was set, reasoning "no simplification ran". But `preserve_topology` is precisely the case where `SimWildMesh::simplify()` runs *after* insertion (`run_3D`, `operation == "remeshing"`) — collapsing at `eps_simplify` and then **rebuilding the envelope around the result**. Uncharged, the total deviation could reach `eps + eps_simplify` rather than the advertised `eps`. simwild's default is `preserve_topology: true`, so this was the common path.

The 2D route has no post-insertion counterpart (`SimWildMeshTri` has no `simplify()`), so there `preserve_topology` genuinely does mean no simplification. `simplification_runs(params, is_3d)` now distinguishes them:

| | `!preserve_topology` | `preserve_topology` |
|---|---|---|
| 3D, `remeshing` | pre-insertion simplify → charge | post-insertion simplify → **charge (was not)** |
| 3D, other ops | pre-insertion simplify → charge | nothing runs → no charge |
| 2D | pre-insertion simplify → charge | nothing runs → no charge |

(`skip_simplify` overrides all of it.)

**Neither tetwild nor triwild guarded the remainder.** `simplify_envelope_ratio >= 1` makes it zero or negative, and `SampleEnvelope::init` **squares** its argument — so a negative eps comes back as a positive `eps2`, a silently *smaller* envelope rather than an error. triwild warned above ratio 1 and carried on; tetwild did not warn at all. The helper now warns and keeps the full eps, which is the honest failure: it says what the deviation may actually reach.

## Where the rule lives now

One function, `wmtk::utils::optimization_envelope_eps(eps, simplify_eps, envelope_around_simplified, simplification_ran)`, with each driver supplying its own "did a simplification run" predicate — the part that is genuinely per-app. Always returns `> 0`.

## Measurements

`optimize_envelope_around_simplified` is `false` by default in all three specs and no config sets it, so everything below is opt-in. Serial, `num_threads: 0`.

**`skip_simplify: true` + the flag on** — the tetwild/triwild fix. The optimizer gets back the tolerance it was entitled to:

| | main | this branch |
|---|---|---|
| `tetwild_sphere` opt_eps | 0.00121 (½·eps) | **0.00242 (eps)** |
| max energy | 6.681 | **5.950** (−11%) |
| hausdorff | 0.00068 | 0.00138 — 57% of eps, inside |
| `triwild_puzzle` opt_eps | 0.409 (½·eps) | **0.818 (eps)** |
| #f / #v | 579 / 323 | **478 / 263** (−17% / −19%) |
| avg energy | 2.466 | **2.316** (−6%), max unchanged |

**simwild, defaults + the flag on** (`simwild_double_sphere_3d`, `preserve_topology: true`, `remeshing`, `eps_simplify_rel: 5e-3` against `eps_rel: 1e-2`). On main the flag was silently a no-op — no `optimization envelope` line is even logged — because `preserve_topology` short-circuited it:

| | main | this branch |
|---|---|---|
| opt_eps | 0.0321 (full eps, uncharged) | **0.0161 (eps − eps_simplify)** |
| total budget | up to 1.5·eps | **eps, as advertised** |
| #t | 16,664 | 19,900 (+19%) |
| max energy | 16.73 | **9.79** |
| time | 4.6s | 8.9s |

This arm is a tightening, so more tets is the expected cost of the correctness. The energy improving alongside it was not expected and is not something this PR claims a mechanism for.

## Validation

**Inertness.** 10 configs across the three apps at defaults, main binary vs branch binary: every produced mesh **byte-identical** by md5, and the only report differences are wall-clock keys (`time`, `insertion_and_preprocessing`). That is also true by construction — with the flag off the helper returns `eps` immediately, which is what all three drivers did before.

**Unit suites**, all passing: `wmtk_tests` 146,333 assertions / 97 cases, `wmtk_test_tetwild` 813/18, `wmtk_test_triwild` 8,926/19, `wmtk_test_simwild` 1,170/29.

**New test**, `envelope_budget` in `tests/test_envelope.cpp`: the four flag/ran combinations, and that the return is never `<= 0` at `simplify_eps` equal to and above `eps`.

## One thing deliberately not changed

The parameter's direction. `simplify_envelope_ratio` is the share given to the **simplification** (`simplify_eps = x·eps`), so the optimizer gets `(1-x)·eps` — the mirror of "optimization gets `x·eps`". The name matches the current meaning, both defaults are `0.5` so nothing differs numerically today, and flipping it would silently change what every existing non-0.5 config means. Say the word and it is a one-line change.

simwild is also parameterized differently: `eps_simplify_rel` is an independent absolute tolerance (default `2e-4` against `eps_rel` `2e-3`, so a 10%/90% split) rather than a ratio of `eps`. Left alone — it is a defensible interface, and changing it would move simwild's defaults.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
