### PR TITLE
Offset 3d Optimization

### DIFF
--- a/components/topological_offset/wmtk/components/topological_offset/Collapse.cpp
+++ b/components/topological_offset/wmtk/components/topological_offset/Collapse.cpp
@@ -110,6 +110,55 @@ bool TopoOffsetTetMesh::collapse_before_vertex(
         return false;
     }
 
+    // BOTSCH-KOBBELT'S COLLAPSE GUARD: refuse a collapse that would CREATE an over-long
+    // edge. Bisection necessarily drops children into the collapse zone -- a just-over-4/3
+    // parent halves to just-over-2/3, below the 4/5 gate -- so without this rule,
+    // collapse-to-convergence unravels every freshly refined region: merging two children
+    // recreates the parent, and the cascade runs until the surface sits far past its own
+    // sizing target. Measured on specific_models/prism: without the guard the run pins at
+    // max_dist_err 0.162 (bit-stable over 30 iterations) with the offset at ~1100 faces
+    // and 96% of its edges over-gate; with it, refinement survives the collapse pass for
+    // the first time and the run converges once the sizing field is confined to the band
+    // (see refine_sizing_around_worst). B-K stabilises the same hysteresis the same way;
+    // an edge that was already over-long is exempt, so degenerate cleanup (v1 ~ v2) stays
+    // possible.
+    //
+    // VALENCE ESCAPE: the guard alone traps slivers -- splits keep pumping valence into
+    // vertices whose relieving collapses the guard refuses (measured: valence 240, 32
+    // vertices over the split threshold, 18x runtime from the retry grind). A collapse
+    // deletes the tets around edge (v1,v2) and so is the operation that RELIEVES valence;
+    // when any vertex it touches is past the engine's own high-valence threshold, that
+    // takes precedence and the guard stands down. Self-limiting: with the escape the
+    // global maximum sits exactly at the threshold and none over.
+    {
+        const auto thr = static_cast<size_t>(std::max(0, m_params.split_high_valence_threshold));
+        const auto valence = [&](size_t v) {
+            return get_one_ring_tids_for_vertex(tuple_from_vertex(v)).size();
+        };
+        bool relieve = thr > 0 && (valence(v1_id) > thr || valence(v2_id) > thr);
+        if (thr > 0 && !relieve) {
+            for (const size_t nb : get_one_ring_vids_for_vertex(v1_id)) {
+                if (valence(nb) > thr) {
+                    relieve = true;
+                    break;
+                }
+            }
+        }
+        if (!relieve) {
+            const Vector3d p1 = m_vertex_attribute[v1_id].m_posf;
+            const Vector3d p2 = m_vertex_attribute[v2_id].m_posf;
+            for (const size_t nb : get_one_ring_vids_for_vertex(v1_id)) {
+                if (nb == v1_id || nb == v2_id) continue;
+                const double after2 = (p2 - m_vertex_attribute[nb].m_posf).squaredNorm();
+                const double sbar = 0.5 * (m_vertex_attribute[v2_id].m_sizing_scalar +
+                                           m_vertex_attribute[nb].m_sizing_scalar);
+                if (after2 <= m_params.splitting_l2 * sbar * sbar) continue; // not over-long
+                const double before2 = (p1 - m_vertex_attribute[nb].m_posf).squaredNorm();
+                if (after2 > before2) return false; // creates or lengthens an over-long edge
+            }
+        }
+    }
+
     // The base only knows that both endpoints are on SOME tracked surface. A vertex may not
     // leave the particular surface it belongs to: an input-complex vertex carries input
     // geometry, and an offset-boundary vertex carries the offset.

--- a/components/topological_offset/wmtk/components/topological_offset/Collapse.cpp
+++ b/components/topological_offset/wmtk/components/topological_offset/Collapse.cpp
@@ -11,28 +11,36 @@ namespace wmtk::components::topological_offset {
 
 double TopoOffsetTetMesh::face_normal_deviation(const Tuple& f) const
 {
-    const std::array<Tuple, 3> fv = get_face_vertices(f);
-    const Vector3d p_a = m_vertex_attribute[fv[0].vid(*this)].m_posf;
-    const Vector3d p_b = m_vertex_attribute[fv[1].vid(*this)].m_posf;
-    const Vector3d p_c = m_vertex_attribute[fv[2].vid(*this)].m_posf;
+    // Paper Definition 5: the maximum angle between the OFFSET normal at the element's center
+    // and the OFFSET normal at other points within the element.
+    //
+    //     sigma(t) = max over p_i in t of angle( n(p_c), n(p_i) ),  p_i = (1-u)*p_v + u*p_c
+    //
+    // Both terms are FIELD normals; the face's own geometric normal does not appear. That is the
+    // whole point and it is what makes the quantity converge: n() is continuous away from the
+    // input complex's features, so shrinking a face brings its samples closer together and drives
+    // sigma to zero, which is something the sizing field can actually satisfy.
+    //
+    // This used to compare the face's own normal against the sample normals, i.e. misorientation.
+    // Refinement does not fix misorientation -- a smaller triangle in the same plane is just as
+    // misoriented -- so the sizing field could never drive it down, and update_sizing_field()
+    // would refine around such a face forever. The 2D side hit exactly that and was corrected to
+    // Definition 5; see the normal-deviation section of .claude/CLAUDE.md.
+    //
+    // offset_surface_samples() already produces the paper's sample set: index 0 is the centroid
+    // p_c, indices 1-3 are (1-u)*p_v + u*p_c with u = 0.1, and each carries the field normal.
+    const std::array<OffsetSurfaceSample, 4> samples = offset_surface_samples(f);
+    const Vector3d& n_c = samples[0].normal;
+    if (n_c.squaredNorm() < 1e-20) return 0.; // centroid sits on the complex: no direction
 
-    const Vector3d ab = p_b - p_a;
-    const Vector3d ac = p_c - p_a;
-    const Vector3d cross = ab.cross(ac);
-    const double cross_norm = cross.norm();
-    if (cross_norm < 1e-12) return 0.; // degenerate triangle, nothing to measure
-    const Vector3d face_normal = cross / cross_norm;
-
-    // max over all 4 samples, not just the centroid: a face straddling a feature has samples
-    // on both sides of it, and only the max catches the one that disagrees with the face's own
-    // (necessarily flat) normal -- averaging or using a single sample would miss it.
     double max_dev = 0.;
-    for (const OffsetSurfaceSample& s : offset_surface_samples(f)) {
-        if (s.normal.squaredNorm() < 1e-20) continue; // degenerate: no normal direction
-        // orientation independent: a triangle whose plane is parallel to the sample's implied
-        // plane counts as aligned regardless of which way get_face_vertices() winds it
-        const double c = std::clamp(face_normal.cross(s.normal).norm(), -1., 1.);
-        max_dev = std::max(max_dev, (180. / M_PI) * std::asin(c));
+    for (int i = 1; i < 4; ++i) {
+        const Vector3d& n_i = samples[i].normal;
+        if (n_i.squaredNorm() < 1e-20) continue; // degenerate sample: no normal direction
+        // A genuine angle between two field normals, both pointing outward from the complex, so
+        // there is no orientation ambiguity to fold away here.
+        const double c = std::clamp(n_c.dot(n_i), -1., 1.);
+        max_dev = std::max(max_dev, (180. / M_PI) * std::acos(c));
     }
     return max_dev;
 }
@@ -92,6 +100,16 @@ bool TopoOffsetTetMesh::collapse_before_vertex(
 {
     const auto& VE = m_vertex_extra;
 
+    // v1 is the vertex the collapse REMOVES (it merges into v2, which keeps its position). If
+    // v1 belongs to the input complex or the domain boundary, removing it deletes a simplex of
+    // a set that must not change at all, so the collapse is refused outright -- including the
+    // input-onto-input case the surface rule below would otherwise allow. That case is not
+    // hypothetical: it is what lets the shared engine decimate the input surface down to
+    // whatever m_envelope tolerates.
+    if (vertex_is_frozen(v1_id)) {
+        return false;
+    }
+
     // The base only knows that both endpoints are on SOME tracked surface. A vertex may not
     // leave the particular surface it belongs to: an input-complex vertex carries input
     // geometry, and an offset-boundary vertex carries the offset.
@@ -132,15 +150,23 @@ bool TopoOffsetTetMesh::collapse_after_connectivity(
     const size_t v2_id,
     const std::vector<std::array<size_t, 2>>&)
 {
-    // NormalDeviationAfterInvariant analogue: only reject a move that degrades an
-    // already-good offset surface patch -- if it was already over the threshold before, don't
-    // block a collapse from fixing (or merely not fixing) it.
-    if (m_collapse_nd_before.local() < m_offset_params.max_normal_deviation_deg) {
-        const double nd_after = max_offset_surface_normal_deviation_at_vertex(v2_id);
-        if (nd_after >= m_offset_params.max_normal_deviation_deg) {
-            return false;
-        }
+    // Paper Sec. 5.3.3, Step 2: "a collapse is only performed if the user-defined maximum normal
+    // deviation is not exceeded." Taken literally that would freeze any patch already over
+    // sigma_max -- usually a genuine feature, where no refinement will ever align the field
+    // normals -- so the bar is the WORSE of the paper's threshold and where the patch already was.
+    //
+    // The previous rule here was "only block a collapse that makes a GOOD patch bad", i.e. the
+    // guard switched off entirely once nd_before crossed sigma_max. That is a ratchet: the instant
+    // a patch crosses the threshold it is unprotected, and the next collapses take it to 90. In 2D
+    // it decimated the offset from 429 to 80 elements with only 8 collapses refused; using the
+    // worse-of bar took that run from not-converging to converging, with 58 then 54 refused.
+    const double bar =
+        std::max(m_offset_params.max_normal_deviation_deg, m_collapse_nd_before.local());
+    if (max_offset_surface_normal_deviation_at_vertex(v2_id) > bar) {
+        ++iter_cnt_collapse_nd_reject;
+        return false;
     }
+    ++iter_cnt_collapse;
     return true;
 }
 

--- a/components/topological_offset/wmtk/components/topological_offset/Collapse.cpp
+++ b/components/topological_offset/wmtk/components/topological_offset/Collapse.cpp
@@ -160,8 +160,30 @@ bool TopoOffsetTetMesh::collapse_after_connectivity(
     // a patch crosses the threshold it is unprotected, and the next collapses take it to 90. In 2D
     // it decimated the offset from 429 to 80 elements with only 8 collapses refused; using the
     // worse-of bar took that run from not-converging to converging, with 58 then 54 refused.
-    const double bar =
-        std::max(m_offset_params.max_normal_deviation_deg, m_collapse_nd_before.local());
+    // THE PAPER'S RULE, FLAT: "a collapse is only performed if the user-defined maximum normal
+    // deviation is not exceeded." The reference implementation ships exactly this -- its
+    // NormalDeviationAfterInvariant has a compare_with_before mode and the offset collapse is
+    // constructed with it FALSE (OffsetOptimization.cpp:1135) -- so the softer variant was
+    // built there and deliberately not used.
+    //
+    // This diverges from 2D, which uses the worse-of bar
+    //     max(max_normal_deviation_deg, nd_before)
+    // to avoid freezing patches that sit over sigma_max on a genuine feature. Measured on
+    // specific_models/prism, the worse-of bar is a leak in 3D: nd_before is the MAX over the
+    // patch, so one 35-degree face at a sharp edge licenses coarsening of its whole
+    // neighbourhood -- nothing there can raise the max -- and the guard fired only 36-270 times
+    // per iteration against ~2800 accepted offset-vertex removals. The collapse pass took the
+    // offset surface 4x past its own sizing target (50.2% of offset edges beyond 4/3 of l*s
+    // afterwards, sizing unchanged across the pass) and destroyed 75% of its faces.
+    //
+    // Flat, the guard fires 3800-22600 times per iteration, the collapse keeps 52% of offset
+    // faces where it kept 25%, and prism's max_dist_err falls 0.676 -> 0.247 -> 0.104 over
+    // three iterations where the worse-of bar plateaued at ~0.11. The cost is the paper's own:
+    // a face over sigma_max at a genuine feature can no longer be coarsened, so the crease
+    // bands refine to the l_min floor and stay there. 2D is left on the worse-of bar: it
+    // converges with it, and its counterexample (the 429 -> 80 decimation) was against the
+    // RATCHET rule, not against flat.
+    const double bar = m_offset_params.max_normal_deviation_deg;
     if (max_offset_surface_normal_deviation_at_vertex(v2_id) > bar) {
         ++iter_cnt_collapse_nd_reject;
         return false;

--- a/components/topological_offset/wmtk/components/topological_offset/Collapse.cpp
+++ b/components/topological_offset/wmtk/components/topological_offset/Collapse.cpp
@@ -172,6 +172,7 @@ bool TopoOffsetTetMesh::collapse_after_connectivity(
 
 void TopoOffsetTetMesh::collapse_after_vertex(const size_t v1_id, const size_t v2_id)
 {
+    if (m_vertex_extra.at(v1_id).m_is_on_offset) ++iter_cnt_collapse_offset_removed;
     // The base ORs its own m_is_on_surface, which is the union of the two; these say which.
     m_vertex_extra[v2_id].m_is_on_input =
         m_vertex_extra.at(v1_id).m_is_on_input || m_vertex_extra.at(v2_id).m_is_on_input;

--- a/components/topological_offset/wmtk/components/topological_offset/EdgeSplittingTet.cpp
+++ b/components/topological_offset/wmtk/components/topological_offset/EdgeSplittingTet.cpp
@@ -10,121 +10,20 @@ namespace wmtk::components::topological_offset {
 
 //// TetMesh splitting
 
-// v1 must have label 0/1, v2 has label 0
-void TopoOffsetTetMesh::edge_split_binary_search(const size_t v1, const size_t v2, Vector3d& p_new)
-    const
-{
-    const Vector3d v1_pos = m_vertex_attribute[v1].m_posf;
-    const Vector3d v2_pos = m_vertex_attribute[v2].m_posf;
-    edge_split_binary_search(v1_pos, v2_pos, p_new);
-}
-void TopoOffsetTetMesh::edge_split_binary_search(
-    const Vector3d& v1_pos,
-    const Vector3d& v2_pos,
-    Vector3d& p_new) const
-{
-    const double eps = m_offset_params.edge_search_term_len;
-    Vector3d p1 = v1_pos;
-    Vector3d p2 = v2_pos;
-    while ((p2 - p1).norm() > eps) {
-        Vector3d p = (p1 + p2) / 2.0;
-        double dist = m_input_complex_bvh.dist(p);
-        if (dist < m_offset_params.target_distance) {
-            p1 = p;
-        } else {
-            p2 = p;
-        }
-    }
-    p_new = (p1 + p2) / 2.0;
-}
-
-
-void TopoOffsetTetMesh::edge_split_log_root_find(const size_t v1, const size_t v2, Vector3d& p_new)
-    const
-{
-    const double eps = m_offset_params.edge_search_term_len;
-    const Vector3d v1_pos = m_vertex_attribute[v1].m_posf;
-    const Vector3d v2_pos = m_vertex_attribute[v2].m_posf;
-    const Vector3d v_hat = (v2_pos - v1_pos).normalized();
-    const double l_max = (v2_pos - v1_pos).norm();
-    if (l_max < eps) {
-        logger().warn("near degenerate edge given to edge_split_root_find. splitting at midpoint");
-        p_new = (v1_pos + v2_pos) / 2.0;
-        return;
-    }
-
-    double l_curr = eps;
-    Vector3d p1 = v1_pos;
-    Vector3d p2 = v1_pos + (l_curr * v_hat);
-    double f2 = m_input_complex_bvh.dist(p2);
-    while (f2 < m_offset_params.target_distance) {
-        l_curr *= 2.0;
-        p2 = v1_pos + (l_curr * v_hat);
-        f2 = m_input_complex_bvh.dist(p2);
-        if (l_curr > l_max) {
-            if (f2 < m_offset_params.target_distance) { // entire edge is (likely) within offset.
-                logger().warn(
-                    "edge (likely) entirely in offset for root finding edge split. Splitting edge "
-                    "at 99\% of length");
-                p_new = v1_pos + (0.99 * l_max * v_hat);
-                return;
-            } else { // zero is (likely) between last two chunks. use binary search here
-                p1 = v1_pos + (0.5 * l_curr * v_hat);
-                p2 = v2_pos;
-                edge_split_binary_search(p1, p2, p_new);
-                return;
-            }
-        }
-    }
-    p1 = v1_pos + (0.5 * l_curr * v_hat);
-    edge_split_binary_search(p1, p2, p_new);
-}
-
-
-void TopoOffsetTetMesh::edge_split_sphere_tracing(const size_t v1, const size_t v2, Vector3d& p_new)
-    const
-{
-    const double eps = m_offset_params.edge_search_term_len;
-    const Vector3d v1_pos = m_vertex_attribute[v1].m_posf;
-    const Vector3d v2_pos = m_vertex_attribute[v2].m_posf;
-    const double L = (v2_pos - v1_pos).norm();
-    const Vector3d u_hat = (v2_pos - v1_pos) / L;
-    const double D = m_offset_params.target_distance;
-
-    // if near degenerate, fall to midpoint split
-    if (L < eps) {
-        p_new = (v1_pos + v2_pos) * 0.5;
-        return;
-    }
-
-    p_new = v1_pos;
-    double t = 0;
-    double dp = m_input_complex_bvh.dist(p_new);
-    while (D - dp > eps) { // note: guaranteed that D - dp > 0
-        t += D - dp;
-        if (t >= L) { // entire edge is in offset. return split at 0.99 edge length
-            p_new = v1_pos + (0.99 * L * u_hat);
-            return;
-        }
-        p_new = v1_pos + (t * u_hat);
-        dp = m_input_complex_bvh.dist(p_new);
-    }
-
-    // snap solution point away from v1 and v2 if too close
-    if ((p_new - v1_pos).norm() < (0.01 * L)) {
-        p_new = v1_pos + (0.01 * L * u_hat);
-    } else if ((p_new - v2_pos).norm() < (0.01 * L)) {
-        p_new = v1_pos + (0.99 * L * u_hat);
-    }
-}
-
-
 bool TopoOffsetTetMesh::split_edge_before(const Tuple& t)
 {
     // The optimization phase runs wmtk::TetOptimizerMesh's split; everything else here is the
     // marching-tets machinery, which places the new vertex on the offset's distance field and
     // carries per-simplex labels the shared engine knows nothing about.
     if (m_edge_split_mode == EdgeSplitMode::Optimization) {
+        // Splitting an edge of the input complex or of the domain boundary replaces that edge
+        // with two, which changes those simplex sets -- and on a curved input the midpoint
+        // leaves the surface entirely. Both are frozen, so the split is refused before the
+        // shared engine ever sees it. Only the Optimization mode is guarded: the marching path
+        // below is how the offset is CONSTRUCTED, and it has to be able to cut through anything.
+        if (edge_is_frozen(t)) {
+            return false;
+        }
         return TetOptimizerMesh::split_edge_before(t);
     }
     return marching_split_edge_before(t);
@@ -159,18 +58,6 @@ bool TopoOffsetTetMesh::marching_split_edge_before(const Tuple& t)
     Vector3d p_new;
     if (m_edge_split_mode == EdgeSplitMode::Midpoint) {
         p_new = (p1 + p2) / 2.0;
-    } else if (m_edge_split_mode == EdgeSplitMode::BinarySearch) {
-        if ((m_vertex_extra[cache.v1_id].label == 0) && (m_vertex_extra[cache.v2_id].label != 0)) {
-            edge_split_binary_search(cache.v2_id, cache.v1_id, p_new);
-        } else if (
-            (m_vertex_extra[cache.v1_id].label != 0) && (m_vertex_extra[cache.v2_id].label == 0)) {
-            edge_split_binary_search(cache.v1_id, cache.v2_id, p_new);
-        } else {
-            log_and_throw_error(
-                "Invalid edge [{}] for binary search split. Both vertices in/out of offset/input "
-                "complex.",
-                e_id);
-        }
     } else if (m_edge_split_mode == EdgeSplitMode::Initial) {
         // determine split distance
         double edge_len = (p1 - p2).norm();
@@ -190,30 +77,6 @@ bool TopoOffsetTetMesh::marching_split_edge_before(const Tuple& t)
             log_and_throw_error(
                 "Invalid edge [{}] for initial edge split. Both vertices in/out of input "
                 "complex.",
-                e_id);
-        }
-    } else if (m_edge_split_mode == EdgeSplitMode::LogRootFind) {
-        if ((m_vertex_extra[cache.v1_id].label == 0) && (m_vertex_extra[cache.v2_id].label != 0)) {
-            edge_split_log_root_find(cache.v2_id, cache.v1_id, p_new);
-        } else if (
-            (m_vertex_extra[cache.v1_id].label != 0) && (m_vertex_extra[cache.v2_id].label == 0)) {
-            edge_split_log_root_find(cache.v1_id, cache.v2_id, p_new);
-        } else {
-            log_and_throw_error(
-                "Invalid edge [{}] for log root finding edge split. Both vertices in/out of "
-                "offset/input complex.",
-                e_id);
-        }
-    } else if (m_edge_split_mode == EdgeSplitMode::SphereTracing) {
-        if ((m_vertex_extra[cache.v1_id].label == 0) && (m_vertex_extra[cache.v2_id].label != 0)) {
-            edge_split_sphere_tracing(cache.v2_id, cache.v1_id, p_new);
-        } else if (
-            (m_vertex_extra[cache.v1_id].label != 0) && (m_vertex_extra[cache.v2_id].label == 0)) {
-            edge_split_sphere_tracing(cache.v1_id, cache.v2_id, p_new);
-        } else {
-            log_and_throw_error(
-                "Invalid edge [{}] for log root finding edge split. Both vertices in/out of "
-                "offset/input complex.",
                 e_id);
         }
     } else {
@@ -286,7 +149,9 @@ bool TopoOffsetTetMesh::marching_split_edge_before(const Tuple& t)
 bool TopoOffsetTetMesh::split_edge_after(const Tuple& t)
 {
     if (m_edge_split_mode == EdgeSplitMode::Optimization) {
-        return TetOptimizerMesh::split_edge_after(t);
+        if (!TetOptimizerMesh::split_edge_after(t)) return false;
+        ++iter_cnt_split;
+        return true;
     }
     return marching_split_edge_after(t);
 }
@@ -670,6 +535,35 @@ bool TopoOffsetTetMesh::split_after_cells(
         }
     }
     return true;
+}
+
+bool TopoOffsetTetMesh::split_adjust_position(const size_t v_id, const std::vector<Tuple>&)
+{
+    // The vertex's tracked-surface membership must be written BEFORE the shared split's own
+    // containment check, not after it. TetOptimizerMesh::split_edge_after() calls
+    // surface_triangle_is_outside() on the triangles the split creates, and the offset's
+    // surface_envelope_for_face() decides which envelope applies by reading
+    // m_vertex_extra[].m_is_on_input for all three vertices -- INCLUDING the new one. Written
+    // only in split_after_vertex(), which the base calls AFTER that check, the new vertex still
+    // holds whatever occupied its recycled slot.
+    //
+    // The failure is silent in the dangerous direction: an unrecognised triangle yields a null
+    // envelope, and the containment helpers return false for a null envelope, so the check is
+    // SKIPPED rather than failed. split_adjust_position() is the last hook the base offers
+    // before it, which is the only reason this bookkeeping lives in a positioning hook; the
+    // position itself is left entirely to the base and its verdict is returned unchanged.
+    //
+    // 2D solved this the same way, and for the same reason it did not instead move the base's
+    // split_after_vertex() call earlier: that hook is overridden by other applications on the
+    // same base, so re-timing it changes their operations to fix the offset's problem.
+    //
+    // Writing here is safe against a refused split because m_vertex_extra is registered with the
+    // base's vertex attribute group (so a rollback undoes it), and the write is idempotent with
+    // split_after_vertex()'s own below.
+    const auto& cache = m_opt_split_cache.local();
+    m_vertex_extra[v_id].m_is_on_input = cache.is_edge_on_input;
+    m_vertex_extra[v_id].m_is_on_offset = cache.is_edge_on_offset;
+    return true; // the position itself is the base's business, and it is happy with it
 }
 
 void TopoOffsetTetMesh::split_after_vertex(const size_t v_id, const bool is_edge_open_boundary)

--- a/components/topological_offset/wmtk/components/topological_offset/Parameters.h
+++ b/components/topological_offset/wmtk/components/topological_offset/Parameters.h
@@ -187,6 +187,16 @@ struct Parameters : public wmtk::OptimizerParameters
         // changed in wmtk.
         preserve_topology = true;
 
+        // The engine's stall-driven sizing refinement is the offset's PRIMARY refinement
+        // mechanism, not an escape hatch, so it must be on: num_worst defaults to 0 in
+        // OptimizerParameters, which disables it. The values are starting points, not tuned.
+        // force_split is off because the offset's refine_sizing_around_worst() selects worst
+        // VERTICES of the band rather than worst tets, so there is no worst cell whose longest
+        // edge the engine's force-split contract refers to.
+        stuck_refine_num_worst = 100;
+        stuck_refine_rings = 2;
+        stuck_refine_force_split = false;
+
         // Fills diag_l, l/lr and splitting_l2 / collapsing_l2 -- the same 16/9 and 16/25
         // factors this used to spell out itself. It also derives eps from epsr, which the
         // offset never reads: its envelope tolerance is m_envelope_eps, set on the mesh.

--- a/components/topological_offset/wmtk/components/topological_offset/Parameters.h
+++ b/components/topological_offset/wmtk/components/topological_offset/Parameters.h
@@ -52,16 +52,8 @@ struct Parameters : public wmtk::OptimizerParameters
     // 2D only; the 3D path never builds this envelope.
     bool region_envelope_from_input;
     double relative_ball_threshold;
-    // Termination length for the distance-field root finds in EdgeSplittingTet.cpp
-    // (edge_split_binary_search, edge_split_log_root_find, edge_split_sphere_tracing).
-    // 3D ONLY. The 2D path has no consumer: its sphere-tracing split was removed along with the
-    // distance-field marching pass that selected it, because placing the offset boundary is the
-    // optimization phase's job, not the insertion's. Delete this field and its spec entry when
-    // 3D drops those modes too -- see the note in .claude/CLAUDE.md.
-    double edge_search_term_len;
     bool sorted_marching;
     std::string output_path; // no extension
-    bool optimize; // whether to run optimization on the offset
     bool save_vtu;
 
     int num_threads; // number of threads for parallel execution (smoothing, collapse). 0 = serial
@@ -145,10 +137,8 @@ struct Parameters : public wmtk::OptimizerParameters
                 relative_ball_threshold);
         }
 
-        edge_search_term_len = json_params["edge_search_termination_len"];
         sorted_marching = json_params["sorted_marching"];
         output_path = json_params["output"];
-        optimize = json_params["optimize"];
         save_vtu = json_params["save_vtu"];
 
         num_threads = json_params["num_threads"];

--- a/components/topological_offset/wmtk/components/topological_offset/Smooth.cpp
+++ b/components/topological_offset/wmtk/components/topological_offset/Smooth.cpp
@@ -19,15 +19,38 @@
 
 namespace wmtk::components::topological_offset {
 
+namespace {
+/// Diagnostic-only running maximum over a smoothing pass, which is run in parallel.
+void atomic_max(std::atomic<int>& target, int value)
+{
+    int cur = target.load();
+    while (value > cur && !target.compare_exchange_weak(cur, value)) {
+    }
+}
+} // namespace
+
 bool TopoOffsetTetMesh::smooth_before(const Tuple& t)
 {
+    ++m_smooth_trace.attempted;
+    // Read before the base call: the base folds "on the bounding box" and "could not be
+    // rounded to doubles" into one false, and those mean completely different things.
+    const bool on_bbox = !m_vertex_attribute[t.vid(*this)].on_bbox_faces.empty();
     // rounds the vertex and refuses the bounding box
     if (!TetOptimizerMesh::smooth_before(t)) {
+        if (on_bbox) {
+            ++m_smooth_trace.before_bbox;
+        } else {
+            ++m_smooth_trace.before_unrounded;
+        }
         return false;
     }
     // the input complex must stay exactly where it is: it is the geometry the offset is
     // measured against, not something to be improved
-    return !m_vertex_extra[t.vid(*this)].m_is_on_input;
+    if (m_vertex_extra[t.vid(*this)].m_is_on_input) {
+        ++m_smooth_trace.before_on_input;
+        return false;
+    }
+    return true;
 }
 
 bool TopoOffsetTetMesh::smooth_after(const Tuple& t)
@@ -36,9 +59,49 @@ bool TopoOffsetTetMesh::smooth_after(const Tuple& t)
     // offset field, which is what keeps the offset faithful. Every other vertex is an ordinary
     // interior one and gets the shared two-stage AMIPS smoother.
     if (!get_offset_surface_faces_for_vertex(t).empty()) {
-        return smooth_after_offset_surface(t);
+        ++m_smooth_trace.offset_attempted;
+        const bool ok = smooth_after_offset_surface(t);
+        if (ok) ++m_smooth_trace.offset_accepted;
+        return ok;
     }
+    ++m_smooth_trace.interior_attempted;
     return TetOptimizerMesh::smooth_after(t);
+}
+
+void TopoOffsetTetMesh::log_smooth_trace() const
+{
+    const auto& s = m_smooth_trace;
+    logger().info(
+        "\tsmooth trace: attempted {} | before: bbox {}, unrounded {}, on-input {} | "
+        "offset path: attempted {} -> accepted {}, no-neighbours {}, on-complex {}, "
+        "inverted {}, envelope {} | interior path: attempted {} ({} of them on another region "
+        "boundary) ({})",
+        s.attempted.load(),
+        s.before_bbox.load(),
+        s.before_unrounded.load(),
+        s.before_on_input.load(),
+        s.offset_attempted.load(),
+        s.offset_accepted.load(),
+        s.offset_no_neighbours.load(),
+        s.offset_on_complex.load(),
+        s.offset_inverted.load(),
+        s.offset_envelope.load(),
+        s.interior_attempted.load(),
+        s.region_attempted.load(),
+        m_smooth_rejects.to_string());
+    const int acc = std::max(1, s.offset_accepted.load());
+    logger().info(
+        "\tsmooth moves: accepted {} of which clamped {} (envelope {}, inverted {}, slid {}) | "
+        "err over moved verts: avg {:.6} -> {:.6}, max {:.6} -> {:.6}",
+        s.offset_accepted.load(),
+        s.offset_clamped.load(),
+        s.offset_clamp_env.load(),
+        s.offset_clamp_inv.load(),
+        s.offset_slid.load(),
+        double(s.offset_err_before_nano.load()) / acc * 1e-9,
+        double(s.offset_err_after_nano.load()) / acc * 1e-9,
+        s.offset_err_max_before_nano.load() * 1e-9,
+        s.offset_err_max_after_nano.load() * 1e-9);
 }
 
 bool TopoOffsetTetMesh::is_offset_face(const Tuple& f) const
@@ -136,9 +199,12 @@ bool TopoOffsetTetMesh::smooth_after_offset_surface(const Tuple& t)
     };
     // Move the vertex to `target`; if that inverts an incident tet, binary search along the
     // segment from the known-valid p0 to `target` for the furthest point that does not.
-    auto move_to = [&](const Vector3d& target) {
+    // Returns the fraction of the move that was accepted, or -1 if even the zero step is
+    // refused, i.e. p0 itself already inverts a tet. The fraction is diagnostic only -- the
+    // position it leaves the vertex at is exactly what it always was.
+    auto move_to = [&](const Vector3d& target) -> double {
         set_vertex_position(vid, target);
-        if (!any_inverted()) return;
+        if (!any_inverted()) return 1.;
 
         double lo = 0.; // m_posf = p0 + lo * (target - p0), always valid
         double hi = 1.; // always invalid
@@ -153,6 +219,34 @@ bool TopoOffsetTetMesh::smooth_after_offset_surface(const Tuple& t)
             }
         }
         set_vertex_position(vid, p0 + lo * (target - p0));
+        return any_inverted() ? -1. : lo;
+    };
+
+    // How far this vertex is off the target distance -- the quantity the offset is optimizing,
+    // and the one the acceptance count says nothing about: a move that is "accepted" may have
+    // been clamped to a fraction of what was asked for and delivered none of the correction.
+    const auto dist_err = [&](const Vector3d& p) {
+        return std::abs(
+            (p - m_input_complex_bvh.nearest_point(p)).norm() - m_offset_params.target_distance);
+    };
+    const double e_before = dist_err(p0);
+
+    const auto record = [&](double frac) {
+        const double e_after = dist_err(m_vertex_attribute[vid].m_posf);
+        // Clamped so a large absolute error on a large model cannot overflow the int the max is
+        // accumulated in; 1e-9 units keep the sum atomic. (2D has the same cast without the
+        // clamp -- see the 2D notes in .claude/CLAUDE.md.)
+        const auto nano = [](double x) { return static_cast<int>(std::min(x * 1e9, 2.0e9)); };
+        m_smooth_trace.offset_err_before_nano += nano(e_before);
+        m_smooth_trace.offset_err_after_nano += nano(e_after);
+        atomic_max(m_smooth_trace.offset_err_max_before_nano, nano(e_before));
+        atomic_max(m_smooth_trace.offset_err_max_after_nano, nano(e_after));
+        if (frac < 0.99) {
+            ++m_smooth_trace.offset_clamped;
+            // No probe to attribute the clamp, unlike 2D: inversion is the ONLY constraint on
+            // this path in 3D, since the region-boundary envelope is 2D-only.
+            ++m_smooth_trace.offset_clamp_inv;
+        }
     };
 
     // Laplacian smoothing, restricted to neighbors that are also on the offset surface --
@@ -165,7 +259,10 @@ bool TopoOffsetTetMesh::smooth_after_offset_surface(const Tuple& t)
             p_laplace += m_vertex_attribute[nb].m_posf;
             ++n_neighs;
         }
-        if (n_neighs == 0) return false;
+        if (n_neighs == 0) {
+            ++m_smooth_trace.offset_no_neighbours;
+            return false;
+        }
         p_laplace /= n_neighs;
     }
 
@@ -196,15 +293,122 @@ bool TopoOffsetTetMesh::smooth_after_offset_surface(const Tuple& t)
 
         q += face_q;
     }
-    if (!any_sample) return false;
+    if (!any_sample) {
+        ++m_smooth_trace.offset_on_complex;
+        return false;
+    }
 
     const Vector3d p_optimal = q.solve(p_laplace, m_offset_params.quadrics_svd_threshold);
 
     const double w = m_offset_params.smooth_quadrics_weight;
     const double u = m_offset_params.smooth_laplacian_weight;
-    const Vector3d p_final = (1 - w - u) * p0 + w * p_optimal + u * p_laplace;
+    const Vector3d p_blend = (1 - w - u) * p0 + w * p_optimal + u * p_laplace;
 
-    move_to(p_final);
+    const Vector3d p_final = p_blend;
+
+    const double frac = move_to(p_final);
+    if (frac < 0.) {
+        // p0 itself inverts a tet, so no fraction of the move is legal and the vertex is stuck
+        // where it is. Not a rejection here -- invariants(), below, is what rolls it back.
+        ++m_smooth_trace.offset_inverted;
+    }
+    record(frac);
+
+#if 0
+    // ---------------------------------------------------------------------------------------
+    // DISABLED. Candidate-selection placement: implemented, measured, and switched off until the
+    // rest of the 3D component is complete, so that the structural work is done against the same
+    // placement 2D and the reference implementation use. Re-enable by deleting the #if 0 and the
+    // five lines above. Everything below was verified to build and run; the measurements are in
+    // the smoother section of .claude/CLAUDE.md. Summary of why it exists and what it cost:
+    //
+    //   avg_dist_err stopped rising and fell 14-100x on all three test models, and prism
+    //   converged in 2 iterations -- but max_norm_dev roughly doubled (box 36.7 -> 75.0, prism
+    //   36.4 -> 65.1) because p_proj is not feature-aware, and compute_distance_deviation()
+    //   samples at VERTICES, which p_proj satisfies exactly by construction, so the metric stops
+    //   being independent of the placement.
+    // ---------------------------------------------------------------------------------------
+    //
+    // The quadric is a LOCAL fit: it assumes the offset surface is resolved relative to
+    // target_distance, so that the four samples of one incident face project onto the same
+    // piece of the input complex and their tangent planes agree. Where the surface is coarse
+    // relative to delta that assumption fails, the planes are mutually inconsistent, and the
+    // least-squares point is not near the offset at all. Measured on specific_models/prism
+    // (offset edges up to 7*delta), mean distance error over one smoothing pass:
+    //
+    //     leave the vertex alone   0.0108      quadric x''            0.0263  (2.4x worse)
+    //     Laplacian centroid       0.0631      damped blend (shipped) 0.0150  (1.4x worse)
+    //
+    // -- every placement was worse than not moving, and the quadric beat p0 on only 168 of 2499
+    // vertices. So this does NOT follow the paper (Sec. 5.5) in taking x'' unconditionally, and
+    // it does not follow the reference implementation in taking the damped blend
+    // unconditionally either: both are kept as CANDIDATES and the one that actually lowers
+    // |dist - delta| wins, with p0 in the set so a pass can never make a vertex worse. That
+    // never-degrade rule is 2D's, from minimize_distance_along_tangent().
+    //
+    // p_proj is 2D's placement (project_offset_vertex): step from the nearest point on the
+    // input complex out along the direction the vertex already lies, by exactly delta. It
+    // satisfies dist == delta by construction with no resolution assumption, but it is not
+    // feature-aware -- near a sharp fold it picks whichever side the BVH returns. The quadric
+    // is feature-aware and needs resolution. They fail in opposite regimes, which is the whole
+    // reason for choosing between them per vertex rather than picking one globally.
+    //
+    // Ordered blend, quadric, projection, and compared with <=, so a tie is won by the earlier
+    // entry: the two that carry tangential smoothing beat the pure projection when distance
+    // cannot tell them apart, and any of them beats standing still. That is what keeps triangle
+    // shape being improved on the patches where distance is already satisfied.
+    std::array<Vector3d, 3> candidates{{p_blend, p_optimal, p_blend}};
+    int n_candidates = 2;
+    {
+        const Vector3d nearest0 = m_input_complex_bvh.nearest_point(p0);
+        const Vector3d diff0 = p0 - nearest0;
+        const double d0 = diff0.norm();
+        if (d0 > 1e-12) { // on the complex: no direction to offset along, skip this candidate
+            candidates[2] = nearest0 + m_offset_params.target_distance * (diff0 / d0);
+            n_candidates = 3;
+        }
+    }
+
+    Vector3d best_p = p0;
+    double best_e = e_before;
+    double best_frac = 0.; // no candidate accepted => the vertex does not move at all
+    int best_i = -1;
+    bool pre_inverted = false;
+    for (int i = 0; i < n_candidates; ++i) {
+        // Evaluate the position the vertex would actually END UP at, which is the candidate
+        // clamped back for inversion -- not the candidate as requested. A clamped move delivers
+        // a fraction of the correction, and that fraction is what has to be compared.
+        const double frac = move_to(candidates[i]);
+        if (frac < 0.) {
+            pre_inverted = true;
+            continue; // p0 itself inverts; nothing on this segment is legal
+        }
+        const Vector3d p_try = m_vertex_attribute[vid].m_posf;
+        const double e_try = dist_err(p_try);
+        if (e_try <= best_e) {
+            best_e = e_try;
+            best_p = p_try;
+            best_frac = frac;
+            best_i = i;
+        }
+    }
+    // Every candidate above was verified non-inverting at the position recorded for it, and
+    // nothing but this vertex has moved since, so restoring the winner cannot invert.
+    set_vertex_position(vid, best_p);
+
+    if (pre_inverted) {
+        // p0 itself inverts a tet, so no fraction of any move is legal and the vertex is stuck
+        // where it is. Not a rejection here -- invariants(), below, is what rolls it back.
+        ++m_smooth_trace.offset_inverted;
+    }
+    if (best_i > 0) {
+        // A candidate other than the primary damped blend won. The 3D counterpart of 2D's
+        // offset_slid, which counts the same thing there: the fallback placement recovered
+        // ground the primary one could not.
+        ++m_smooth_trace.offset_slid;
+    }
+    record(best_frac);
+#endif // DISABLED candidate-selection placement
 
     // Any remaining inversion (from the binary search's finite precision) is caught by
     // invariants(), called right after this by TetMesh::smooth_vertex.

--- a/components/topological_offset/wmtk/components/topological_offset/Smooth.cpp
+++ b/components/topological_offset/wmtk/components/topological_offset/Smooth.cpp
@@ -16,6 +16,7 @@
 
 #include <optional>
 #include <set>
+#include <vector>
 
 namespace wmtk::components::topological_offset {
 
@@ -266,15 +267,40 @@ bool TopoOffsetTetMesh::smooth_after_offset_surface(const Tuple& t)
         p_laplace /= n_neighs;
     }
 
-    // Quadric built from 4 target_distance-offset samples of the input complex per incident
-    // offset-surface face (centroid + one near each corner, weighted 1/0.1/0.1/0.1), following
-    // Quadrics.cpp's get_triangle_samples_and_area(). Taking several samples rather than just
-    // the centroid is what lets the quadric stay feature-aware: near a sharp fold of the input
-    // complex, samples on either side pull the per-vertex quadric's minimum toward the fold
-    // instead of averaging it away, the same way classic QEM simplification preserves features
-    // by summing quadrics from multiple differently-oriented triangles.
-    Quadrics q(0., 0., 0., 0.);
-    bool any_sample = false;
+    // Quadric built from 4 offset samples of the input complex per incident offset-surface face
+    // (centroid + one near each corner, weighted 1/0.1/0.1/0.1), following Quadrics.cpp's
+    // get_triangle_samples_and_area(). Taking several samples rather than just the centroid is
+    // what lets the quadric stay feature-aware: near a sharp fold of the input complex, samples
+    // on either side pull the per-vertex quadric's minimum toward the fold instead of averaging
+    // it away, the same way classic QEM simplification preserves features by summing quadrics
+    // from multiple differently-oriented triangles.
+    //
+    // ONE SHARED TARGET DISTANCE is used for every sample of every incident face, following the
+    // reference implementation's vertex-level Quadrics constructor
+    // (internal/utils/Quadrics.cpp, the PrimitiveType::Vertex branch), which pools the samples
+    // of all incident faces into a single quadric and places every sample's plane at
+    // `nearest + dist_avg * normal` for one aggregate distance:
+    //
+    //     dist_avg = sum(offset_distance * area) / sum(area)  // adapted delta-hat, area-weighted
+    //     dist_min = min over samples of the CURRENT distance to the input complex
+    //     dist_avg = 0.5 * (dist_avg + dist_min)
+    //
+    // The first line collapses to target_distance here: distance adaptation (paper Sec. 5.3.1)
+    // is deliberately not implemented, so delta-hat is a single global constant and the
+    // area-weighted mean of a constant is that constant. The third line -- the damping -- is
+    // deliberately NOT applied; see the measurements at dist_target below.
+    //
+    // Samples are gathered into one list before any quadric is built because the reference's
+    // shared distance is an aggregate over all of them, so no plane can be placed until every
+    // sample is known. That stays true of any spatially adapted delta-hat, which is why the
+    // shape is kept even though the value used below is currently a constant.
+    struct WeightedSample
+    {
+        OffsetSurfaceSample s;
+        double area; // of the face the sample came from
+    };
+    std::vector<WeightedSample> samples;
+    samples.reserve(4 * offset_faces.size());
     for (const Tuple& f : offset_faces) {
         const std::array<Tuple, 3> face_verts = get_face_vertices(f);
         const Vector3d p_a = m_vertex_attribute[face_verts[0].vid(*this)].m_posf;
@@ -282,20 +308,50 @@ bool TopoOffsetTetMesh::smooth_after_offset_surface(const Tuple& t)
         const Vector3d p_c = m_vertex_attribute[face_verts[2].vid(*this)].m_posf;
         const double area = 0.5 * (p_b - p_a).cross(p_c - p_a).norm();
 
-        Quadrics face_q(0., 0., 0., 0.);
         for (const OffsetSurfaceSample& s : offset_surface_samples(f)) {
             if (s.normal.squaredNorm() < 1e-20) continue; // degenerate: no valid normal
-            const Vector3d target = s.nearest + m_offset_params.target_distance * s.normal;
-            face_q += Quadrics(target, s.normal) * s.weight;
-            any_sample = true;
+            samples.push_back({s, area});
         }
-        face_q *= area;
-
-        q += face_q;
     }
-    if (!any_sample) {
+    if (samples.empty()) {
         ++m_smooth_trace.offset_on_complex;
         return false;
+    }
+
+    // THE REFERENCE'S DAMPING IS DELIBERATELY NOT APPLIED. Its third line,
+    //
+    //     dist_avg = 0.5 * (dist_avg + dist_min)
+    //
+    // aims the quadric halfway between the target distance and where the surface currently is.
+    // Measured on prism (delta = 0.8368, convergence_target 0.0418), final iteration of a 5
+    // iteration run, against the undamped `delta` used here:
+    //
+    //     undamped delta                    max 0.1647  avg 0.0595   worst vertex 20% too far OUT
+    //     0.5 * (delta + dist_min)          max 0.3540  avg 0.0459   worst vertex 42% too far IN
+    //     0.5 * (delta + this vertex's d)   max 0.3351  avg 0.1218   worst vertex too far out
+    //
+    // The damping buys average distance error and costs more than twice as much maximum, and
+    // max_dist_err is the criterion the run is failing. Keying it to the vertex's own current
+    // distance rather than the minimum over samples -- the obvious suspect, since dist_min lets
+    // one badly-placed neighbour drag a whole patch's target down -- is worse still on the
+    // average, so that was not the mechanism either.
+    //
+    // The reference can afford the damping because it runs distance adaptation (paper Sec.
+    // 5.3.1) first, so its offset starts near-correct and dist_min is already close to
+    // delta-hat: there the term is a small correction, not a systematic inward pull. This
+    // implementation deliberately skips adaptation, so the offset starts wherever conservative
+    // growth left it and the damping becomes a brake on the one quantity that has to converge.
+    //
+    // NOTE the pooling above is behaviour-neutral on its own: summing one quadric over every
+    // sample weighted by w*area is algebraically the same as summing a per-face quadric scaled
+    // by area, which is what this built before. It is kept because it is the reference's shape
+    // and it is where a spatially adapted delta-hat would attach.
+    const double dist_target = m_offset_params.target_distance;
+
+    Quadrics q(0., 0., 0., 0.);
+    for (const WeightedSample& ws : samples) {
+        const Vector3d target = ws.s.nearest + dist_target * ws.s.normal;
+        q += Quadrics(target, ws.s.normal) * (ws.s.weight * ws.area);
     }
 
     const Vector3d p_optimal = q.solve(p_laplace, m_offset_params.quadrics_svd_threshold);
@@ -307,10 +363,33 @@ bool TopoOffsetTetMesh::smooth_after_offset_surface(const Tuple& t)
     const Vector3d p_final = p_blend;
 
     const double frac = move_to(p_final);
-    if (frac < 0.) {
-        // p0 itself inverts a tet, so no fraction of the move is legal and the vertex is stuck
-        // where it is. Not a rejection here -- invariants(), below, is what rolls it back.
+
+    // A SEARCH THAT FINDS NO LEGAL STEP IS A REJECTION, not a zero-length success. This follows
+    // the reference implementation (internal/OffsetOptimization.cpp, the smoothing lambda),
+    // which backs the move off geometrically (u = 1/2, 1/4, ... 1/1024), accepts the first
+    // fraction that clears the inversion invariant, and if all ten fail restores p0 and returns
+    // FALSE -- "Vertex position is not optimal but it cannot be moved either".
+    //
+    // Note what this does and does not change. A PARTIAL fraction is still accepted, exactly as
+    // the reference accepts its backed-off u; only a search that reaches nothing at all is
+    // refused. What it ends is reporting a vertex the search could not move as an accepted
+    // smooth: this returned true unconditionally, so offset_accepted counted vertices that had
+    // received none of their correction, and record() folded their unchanged error into the
+    // "err over moved verts" averages of vertices that had in fact not moved.
+    //
+    // move_to() has already restored p0 in both failing cases -- it ends by setting
+    // p0 + lo*(target - p0) with lo == 0 -- so there is nothing to undo here.
+    //
+    // 2D DIFFERS: project_offset_vertex() accepts its clamped result and returns success, which
+    // is why .claude/CLAUDE.md tells the reader to watch the `smooth moves:` line rather than
+    // the rejection counts to spot a fully-blocked offset. In 3D the rejection counts now carry
+    // it directly. This is a deliberate divergence, adopted on the reference's authority rather
+    // than forced by the dimension; the two logs still diff field-for-field.
+    if (frac <= 0.) {
+        // Inversion is the only constraint on this path in 3D, so it is what blocked every
+        // fraction -- whether or not p0 itself is inverted as well (frac < 0).
         ++m_smooth_trace.offset_inverted;
+        return false;
     }
     record(frac);
 

--- a/components/topological_offset/wmtk/components/topological_offset/Spatial.cpp
+++ b/components/topological_offset/wmtk/components/topological_offset/Spatial.cpp
@@ -152,6 +152,52 @@ bool TopoOffsetTetMesh::tag_tet_consistent_topology(size_t t_id, int64_t tag) co
         }
     };
 
+    // The DOMAIN BOUNDARY bounds the tag region too, and the boundary-FACE test further down
+    // already says so: its no-opposite-tet branch calls such a face a boundary face of the tag
+    // whenever the single incident tet carries it. The vertex and edge tests below compared only
+    // tag membership around the one-ring and never looked at the domain boundary, so the halves
+    // of the disk condition disagreed -- a vertex or edge sitting ON the box with a uniform
+    // one-ring counted as INTERIOR while the box face beside it counted as boundary -- and a tet
+    // wedged between the offset front and the box could satisfy the condition and be absorbed.
+    //
+    // In 2D that let conservative growth eat the ambient region right up to the bounding box, one
+    // locally-legal step at a time, until the offset touched the box and the ambient band
+    // separating them was gone: 29 of 164 box-touching candidates admitted, 101 offset vertices
+    // left pinned on the box. Only bites when the offset actually reaches the box, i.e. when
+    // target_distance exceeds the clearance to the domain boundary.
+    //
+    // True if any tagged tet in `tids` has a domain-boundary face containing every vertex in
+    // `must_contain`. Guarded by on_bbox_faces so the walk only runs for simplices that could
+    // possibly be on the box.
+    auto on_tagged_domain_boundary = [&](const std::vector<size_t>& tids,
+                                         const std::vector<size_t>& must_contain) {
+        for (const size_t need : must_contain) {
+            if (m_vertex_attribute[need].on_bbox_faces.empty()) return false;
+        }
+        for (const size_t tid : tids) {
+            if (get_tags(tid).count(tag) == 0) continue;
+            const auto tv = oriented_tet_vids(tid);
+            for (int skip = 0; skip < 4; ++skip) {
+                std::array<size_t, 3> fv;
+                int k = 0;
+                for (int j = 0; j < 4; ++j) {
+                    if (j != skip) fv[k++] = tv[j];
+                }
+                bool contains_all = true;
+                for (const size_t need : must_contain) {
+                    if (fv[0] != need && fv[1] != need && fv[2] != need) {
+                        contains_all = false;
+                        break;
+                    }
+                }
+                if (!contains_all) continue;
+                const auto [ftup, unused_fid] = tuple_from_face(fv);
+                if (!ftup.switch_tetrahedron(*this)) return true;
+            }
+        }
+        return false;
+    };
+
     // collect boundary vertices
     auto vs = oriented_tet_vids(t_id);
     std::vector<size_t> boundary_vs;
@@ -165,6 +211,9 @@ bool TopoOffsetTetMesh::tag_tet_consistent_topology(size_t t_id, int64_t tag) co
                 v_in = true;
                 break;
             }
+        }
+        if (!v_in) {
+            v_in = on_tagged_domain_boundary(one_ring_tids, {v});
         }
         if (v_in) {
             boundary_vs.push_back(v);
@@ -186,6 +235,9 @@ bool TopoOffsetTetMesh::tag_tet_consistent_topology(size_t t_id, int64_t tag) co
                     e_in = true;
                     break;
                 }
+            }
+            if (!e_in) {
+                e_in = on_tagged_domain_boundary(incident_tids, {vs[i], vs[j]});
             }
             boundary_edges[e] = e_in;
         }

--- a/components/topological_offset/wmtk/components/topological_offset/Swap.cpp
+++ b/components/topological_offset/wmtk/components/topological_offset/Swap.cpp
@@ -19,9 +19,21 @@ namespace wmtk::components::topological_offset {
 bool TopoOffsetTetMesh::swap_capture_tag(const std::vector<size_t>& tids)
 {
     std::map<CellTag, size_t> tag_count;
+    std::set<int> labels;
     for (const size_t t : tids) {
         tag_count[m_tet_attribute[t].tag]++;
+        labels.insert(m_tet_attribute[t].label);
     }
+    // The construction LABEL is what region membership is read from (cell_in_region(),
+    // cell_is_offset_band(), cell_is_input_complex()), and a swap reuses recycled tet slots
+    // whose labels belong to whatever was there before. So it has to be carried across
+    // explicitly, exactly as the tag is -- and for the same reason the tag rule below refuses a
+    // mixed ring, a ring spanning two labels has a region boundary running through it and
+    // cannot be given one label without moving that boundary.
+    if (labels.size() > 1) {
+        return false;
+    }
+    m_swap_label.local() = *labels.begin();
     // Refuse any swap whose ring spans more than one tag.
     //
     // The rule used to be "at most two tags, and the majority wins". That is what tore the
@@ -80,8 +92,12 @@ bool TopoOffsetTetMesh::swap_before_surface(
     }
 
     if (m_face_attribute[fid_abc].m_surface_class != OFFSET_SURFACE_CLASS) {
-        // Input-complex flip. Containment in the envelope is checked by the shared operation.
-        return true;
+        // Input-complex flip. Refused: re-triangulating a non-planar quad of the input complex
+        // MOVES that surface, and the input complex is frozen categorically. This used to
+        // return true and leave it to the shared operation's envelope check, but the envelope
+        // is a tolerance -- it permits drift up to eps -- and the input complex is the geometry
+        // the offset distance is measured against, so it may not drift at all.
+        return false;
     }
     return offset_swap_normal_deviation_ok(f_abc, f_abd, a, b, c, d);
 }
@@ -89,9 +105,12 @@ bool TopoOffsetTetMesh::swap_before_surface(
 bool TopoOffsetTetMesh::swap_after_cells(const std::vector<size_t>& tids, bool)
 {
     const CellTag& tag = m_swap_tag.local();
+    const int label = m_swap_label.local();
     for (const size_t t : tids) {
         m_tet_attribute[t].tag = tag;
+        m_tet_attribute[t].label = label;
     }
+    ++iter_cnt_swap;
     return true;
 }
 

--- a/components/topological_offset/wmtk/components/topological_offset/TopoOffsetTetMesh.cpp
+++ b/components/topological_offset/wmtk/components/topological_offset/TopoOffsetTetMesh.cpp
@@ -919,10 +919,23 @@ size_t TopoOffsetTetMesh::refine_sizing_around_worst(double)
     for (const auto& [_, vid] : worst) {
         seeds.push_back(vid);
     }
-    const auto region = wmtk::utils::grow_vertex_region(
-        seeds,
-        std::max(0, m_params.stuck_refine_rings),
-        [this](size_t v) { return get_one_ring_vids_for_vertex(v); });
+    // BAND-ONLY: the reference keeps its length-driven hysteresis on the offset
+    // SURFACE child mesh and never lets its sizing leak into the embedding, whose target
+    // is separate and AMIPS-driven (OffsetOptimization.cpp:1921/1963 vs 1405/1481).
+    // Spreading the band's fine sizing into the volume is what manufactured the halo
+    // demand -- and with it the churn, the slot exhaustion and the split-queue
+    // starvation. So the region growth and the gradation below walk BAND vertices only;
+    // the background keeps its scalar, which also restores length_rel's meaning for the
+    // volume.
+    const auto band_ring = [&](size_t v) {
+        std::vector<size_t> out;
+        for (const size_t nb : get_one_ring_vids_for_vertex(v)) {
+            if (on_band[nb]) out.push_back(nb);
+        }
+        return out;
+    };
+    const auto region =
+        wmtk::utils::grow_vertex_region(seeds, std::max(0, m_params.stuck_refine_rings), band_ring);
 
     std::vector<size_t> refined = wmtk::utils::apply_sizing_refinement(
         region,
@@ -966,7 +979,7 @@ size_t TopoOffsetTetMesh::refine_sizing_around_worst(double)
         m_offset_params.sizing_gradation,
         refined,
         [this](size_t v) -> double& { return m_vertex_attribute[v].m_sizing_scalar; },
-        [this](size_t v) { return get_one_ring_vids_for_vertex(v); });
+        band_ring);
 
     logger().info(
         "[stuck-refine] worst {} band vertices (worst dist {:.4}x target), refined {} of {} "

--- a/components/topological_offset/wmtk/components/topological_offset/TopoOffsetTetMesh.cpp
+++ b/components/topological_offset/wmtk/components/topological_offset/TopoOffsetTetMesh.cpp
@@ -982,19 +982,51 @@ void TopoOffsetTetMesh::init_offset_sizing_field()
     //
     // Starting from the current lengths says instead: keep the resolution you have, and change it
     // only where update_sizing_field() finds a reason to. The field is per-vertex, so a vertex
-    // takes the mean length of its incident offset-surface edges.
-    const double l = std::max(m_params.l, 1e-16);
-    const double s_floor =
-        std::max(m_offset_params.min_sizing_scalar, m_offset_params.min_edge_length / l);
-
-    double raw_sum = 0.;
-    int n_seeded = 0;
+    // takes the mean length of its incident edges.
+    //
+    // THE SAME RULE APPLIES TO THE BACKGROUND. The paper's sentence is not about the offset
+    // specifically, and a background vertex left at the default scalar asks for a target length of
+    // m_params.l, which the mesh does not have either: on specific_models/prism, l = 4.18 against a
+    // background whose own edges are longer, so background edges above (4/3)l were split and those
+    // below (4/5)l collapsed, and ~20 of the 2640 vertices each split pass created were on the
+    // offset.
+    //
+    // WHAT THIS DOES AND DOES NOT FIX, measured rather than predicted. It does not stop the
+    // split/collapse churn: prism still goes ~800 -> ~4400 -> ~800 per iteration and the slot pool
+    // still runs dry. Seeding from current lengths does NOT imply that no edge starts out of band,
+    // because the seed is a vertex's MEAN incident length while the gates compare a single edge
+    // against it -- and prism's edge lengths span a factor of 125, so a large fraction of edges sit
+    // outside (4/5, 4/3) of their own local mean and are split or collapsed on the first pass
+    // regardless.
+    //
+    // What it does buy is that the background stops being driven toward a length it never had, so
+    // less of the split budget is spent there and more of it reaches the offset. Prism's final
+    // iteration: max dist err 0.1647 -> 0.1257, avg 0.0595 -> 0.0455, avg normal deviation 19.7 ->
+    // 17.9 deg, and the live vertex count after the collapse pass 630 -> 794. Both 3D integration
+    // tests improve on every reported figure and neither regresses; 2D is untouched.
+    //
+    // l ITSELF IS DERIVED HERE, not read. Once every vertex is seeded from its own resolution, l
+    // is nothing but the constant the per-vertex scalars are expressed against: the quantity that
+    // reaches the split and collapse gates is l * s_v, which is the vertex's own mean edge length
+    // whatever l is. So l is set to the largest of those means, which is the choice that makes
+    // max_sizing_scalar = 1 mean something real -- no vertex may be asked for an edge longer than
+    // the coarsest place in the mesh already has -- and, being an upper bound, the choice that
+    // keeps the top clamp below from binding on any vertex.
+    //
+    // Nothing else reads m_params.l: the only other use in the engine is
+    // OptimizerParameters::init_lengths_from_diagonal(), which derives splitting_l2 and
+    // collapsing_l2 from it, and those are re-derived here alongside it. Both are read only by the
+    // split and collapse length gates. This runs after all construction, so the marching and
+    // growth phases are unaffected.
+    std::vector<double> seed_len(vert_capacity(), -1.);
+    double l_new = 0.;
     for (const Tuple& v : get_vertices()) {
         const size_t vid = v.vid(*this);
 
-        // Mean length of the offset-surface edges at this vertex. Collected from the offset faces
-        // rather than the one-ring edges so a background edge that merely touches the surface
-        // does not drag the seed toward the ambient scale.
+        // On the offset surface, the mean is over the offset-surface edges only. Collected from
+        // the offset faces rather than the one-ring so a background edge that merely touches the
+        // surface does not drag the seed toward the ambient scale. Off it, there is no such
+        // distinction to draw and the mean is over the whole one-ring.
         double sum_len = 0.;
         int n = 0;
         std::set<size_t> seen;
@@ -1005,18 +1037,65 @@ void TopoOffsetTetMesh::init_offset_sizing_field()
                 ++n;
             }
         }
-        if (n == 0) continue; // not on the offset surface: the background keeps the base target
+        if (n == 0) {
+            for (const size_t nb : get_one_ring_vids_for_vertex(vid)) {
+                if (nb == vid) continue;
+                sum_len += (m_vertex_attribute[vid].m_posf - m_vertex_attribute[nb].m_posf).norm();
+                ++n;
+            }
+        }
+        if (n == 0) continue; // isolated: nothing to measure, keep the default
 
-        raw_sum += sum_len / n;
+        seed_len[vid] = sum_len / n;
+        l_new = std::max(l_new, seed_len[vid]);
+    }
+
+    if (l_new > 0.) {
+        logger().info(
+            "\tBase target edge length l: {:.6} (length_rel) -> {:.6} (coarsest vertex's mean "
+            "incident edge length)",
+            m_params.l,
+            l_new);
+        m_params.l = l_new;
+        m_params.splitting_l2 = l_new * l_new * (16 / 9.);
+        m_params.collapsing_l2 = l_new * l_new * (16 / 25.);
+    }
+
+    const double l = std::max(m_params.l, 1e-16);
+    const double s_floor =
+        std::max(m_offset_params.min_sizing_scalar, m_offset_params.min_edge_length / l);
+    // The floor is meant to be the absolute length l_min; min_sizing_scalar is a relative backstop
+    // that should sit below it. Since l is derived above rather than configured, say so if the
+    // relative one has overtaken the absolute one, which would silently raise the finest edge the
+    // field may ask for.
+    if (m_offset_params.min_sizing_scalar * l > m_offset_params.min_edge_length) {
+        logger().warn(
+            "\tSizing floor is set by min_sizing_scalar ({} * l = {:.6}), not by l_min ({:.6}): "
+            "refinement will stop coarser than 2*delta*sin(sigma_max) asks for.",
+            m_offset_params.min_sizing_scalar,
+            m_offset_params.min_sizing_scalar * l,
+            m_offset_params.min_edge_length);
+    }
+
+    double raw_sum = 0.;
+    int n_seeded = 0, n_offset = 0;
+    for (const Tuple& v : get_vertices()) {
+        const size_t vid = v.vid(*this);
+        if (seed_len[vid] < 0.) continue;
         ++n_seeded;
+        if (m_vertex_extra[vid].m_is_on_offset) {
+            raw_sum += seed_len[vid];
+            ++n_offset;
+        }
         m_vertex_attribute[vid].m_sizing_scalar =
-            std::clamp((sum_len / n) / l, s_floor, m_offset_params.max_sizing_scalar);
+            std::clamp(seed_len[vid] / l, s_floor, m_offset_params.max_sizing_scalar);
     }
     logger().info(
-        "\tOffset sizing seed: {} vertices, mean incident length {:.6} (base l {:.6}, l_min {:.6} "
-        "= 2*{}*sin({} deg), scalar floor {:.6})",
+        "\tSizing seed: {} vertices ({} on the offset, mean incident length {:.6}) (base l {:.6}, "
+        "l_min {:.6} = 2*{}*sin({} deg), scalar floor {:.6})",
         n_seeded,
-        n_seeded > 0 ? raw_sum / n_seeded : 0.,
+        n_offset,
+        n_offset > 0 ? raw_sum / n_offset : 0.,
         l,
         m_offset_params.min_edge_length,
         m_offset_params.target_distance,

--- a/components/topological_offset/wmtk/components/topological_offset/TopoOffsetTetMesh.cpp
+++ b/components/topological_offset/wmtk/components/topological_offset/TopoOffsetTetMesh.cpp
@@ -1052,6 +1052,57 @@ bool TopoOffsetTetMesh::face_is_offset_surface_live(const Tuple& f) const
     return !cell_is_input_complex(a ? tb : ta);
 }
 
+
+void TopoOffsetTetMesh::diag_offset_bands(const char* tag) const
+{
+    // OFFSET-surface edges only, against their own target l*s. The global histogram is
+    // dominated by background edges, whose target is the configured length_rel scale; this is
+    // the surface the optimization is actually about.
+    std::set<std::array<size_t, 2>> edges;
+    size_t n_faces = 0;
+    for (const Tuple& f : get_faces()) {
+        if (!face_is_offset_surface_live(f)) continue;
+        ++n_faces;
+        const auto vs = get_face_vids(f);
+        for (int i = 0; i < 3; ++i) {
+            std::array<size_t, 2> e{{vs[i], vs[(i + 1) % 3]}};
+            if (e[0] > e[1]) std::swap(e[0], e[1]);
+            edges.insert(e);
+        }
+    }
+    size_t below45 = 0, ok = 0, above43 = 0;
+    double s_sum = 0.;
+    for (const auto& e : edges) {
+        const double L = (m_vertex_attribute[e[0]].m_posf - m_vertex_attribute[e[1]].m_posf).norm();
+        const double sc = 0.5 * (m_vertex_attribute[e[0]].m_sizing_scalar +
+                                 m_vertex_attribute[e[1]].m_sizing_scalar);
+        s_sum += sc;
+        const double t = m_params.l * sc;
+        if (t <= 0.) continue;
+        const double r = L / t;
+        if (r < 4. / 5.)
+            ++below45;
+        else if (r <= 4. / 3.)
+            ++ok;
+        else
+            ++above43;
+    }
+    const size_t n = edges.size();
+    logger().info(
+        "\t[offset {}] {} faces, {} edges | L/target: <4/5 {} ({:.1f}%), in band {} ({:.1f}%), "
+        ">4/3 {} ({:.1f}%) | mean sizing s {:.4}",
+        tag,
+        n_faces,
+        n,
+        below45,
+        n ? 100. * below45 / n : 0.,
+        ok,
+        n ? 100. * ok / n : 0.,
+        above43,
+        n ? 100. * above43 / n : 0.,
+        n ? s_sum / n : 0.);
+}
+
 std::pair<double, double> TopoOffsetTetMesh::compute_distance_deviation() const
 {
     // One entry per vertex, not per face-vertex: a vertex shared by several band-outer faces
@@ -1266,6 +1317,7 @@ void TopoOffsetTetMesh::optimize_offset(const std::filesystem::path& output_file
         // each entry is this iteration's own total.
         iter_cnt_split = 0;
         iter_cnt_collapse = 0;
+        iter_cnt_collapse_offset_removed = 0;
         iter_cnt_swap = 0;
         iter_cnt_collapse_nd_reject = 0;
         iter_cnt_swap_nd_reject = 0;
@@ -1278,7 +1330,36 @@ void TopoOffsetTetMesh::optimize_offset(const std::filesystem::path& output_file
         // refinement both need a stop metric the offset has not defined, and its sizing field
         // is driven by the shape of the offset triangulation rather than by the optimizer
         // getting stuck, so it is refreshed every iteration below rather than on a stall.
-        local_operations({{1, 1, 1, m_offset_params.num_smoothing_passes}});
+        // SPLIT UNTIL THE PASS IS NO LONGER SLOT-LIMITED, then the rest of the operations.
+        //
+        // The split pass abandons operations once the preallocated slot pool runs dry, before any
+        // application hook, and only consolidate_mesh() returns the pool -- see
+        // TetMesh::slot_exhausted(). Running one split pass per iteration therefore delivers a
+        // fraction of the refinement the sizing field asked for, with no way to tell from the log
+        // that anything was missed. Repeat until it stops reporting exhaustion.
+        //
+        // Bounded, because a pass refusing splits for some other reason would otherwise spin.
+        int split_attempts = 0;
+        for (; split_attempts < 8; ++split_attempts) {
+            local_operations({{1, 0, 0, 0}});
+            const size_t lost = slot_exhausted();
+            if (lost == 0) break;
+            logger().info(
+                "\tsplit pass dropped {} operations for want of slots; consolidating and repeating",
+                lost);
+            consolidate_mesh();
+        }
+        if (split_attempts == 8) {
+            logger().warn("\tsplit pass still slot-limited after 8 attempts; giving up on it");
+        }
+        diag_offset_bands("after split");
+        local_operations({{0, 1, 0, 0}});
+        logger().info(
+            "\t[offset] collapses removing an offset vertex: {} of {}",
+            iter_cnt_collapse_offset_removed.load(),
+            iter_cnt_collapse.load());
+        diag_offset_bands("after collapse");
+        local_operations({{0, 0, 1, m_offset_params.num_smoothing_passes}});
 
         log_smooth_trace();
 

--- a/components/topological_offset/wmtk/components/topological_offset/TopoOffsetTetMesh.cpp
+++ b/components/topological_offset/wmtk/components/topological_offset/TopoOffsetTetMesh.cpp
@@ -805,16 +805,26 @@ void TopoOffsetTetMesh::execute_offset(const std::filesystem::path& output_file)
     if (!is_simplicially_embedded()) {
         simplicial_embedding();
         bool dummy = is_simplicially_embedded();
-        consolidate_mesh();
     }
+    // Outside the branch above, and unconditional. write_vtu() consolidates, so leaving this
+    // inside the `if` meant that on a mesh already simplicially embedded the ONLY consolidate
+    // here was the debug one -- and consolidating renumbers, which changes the order later passes
+    // enumerate operations in, which changes the run. Same reason as the one before the
+    // optimization loop.
+    consolidate_mesh();
     if (m_offset_params.debug_output) { // intermediate output
         write_vtu(output_file.string() + fmt::format("_{}", m_vtu_counter++));
     }
 
-    // marching tets (using binary search edge split)
-    m_edge_split_mode = EdgeSplitMode::SphereTracing;
-    logger().info("Using sphere tracing for distance field edge splitting.");
-    marching_tets();
+    // The distance-field marching pass that used to run here -- sphere tracing each band-boundary
+    // edge onto d(x) = target_distance at insertion time -- is gone, as it is in 2D. Placing the
+    // offset boundary is the optimization phase's job: the paper puts inserted vertices at the
+    // midpoint (Sec. 5.2) and leaves the distance to Step 3, and the root find had no error
+    // feedback and ran none of the inversion guards the smoother does.
+    //
+    // Consequence, and the reason optimize_offset() is now unconditional: conservative growth
+    // leaves the band boundary on BACKGROUND-CELL boundaries, so its distance to the input complex
+    // is only accurate to the local cell size until the optimization moves it.
     set_offset_tet_tags();
     consolidate_mesh();
     if (m_offset_params.debug_output) { // intermediate output
@@ -860,18 +870,78 @@ size_t TopoOffsetTetMesh::update_sizing_field()
         }
     }
 
+    // Paper Sec. 5.3.3, Step 1:
+    //
+    //   "if one of the incident triangles has a shape regularity below 0.5 or a normal deviation
+    //    above the user-defined maximum sigma_max, we divide the target length by two. If shape
+    //    regularity is [above] 0.5 and the normal deviation is [below] sigma_min, we increase the
+    //    target length by 1.5."
+    //
+    // (The paper's second sentence reads "below 0.5 ... above sigma_min", which contradicts the
+    // first; the only self-consistent reading -- and the only one that does not refine and coarsen
+    // the same vertex -- is the good-and-flat one used here.)
+    //
+    // NORMAL DEVIATION is the driver, and that is the whole point. The previous rule here was
+    // shape-only: refine on a bad mean-ratio metric, otherwise coarsen unconditionally. Nothing
+    // stopped a well-shaped but under-resolved offset surface being coarsened into flat patches,
+    // because a triangle can be perfectly shaped and still span a feature. sigma is what
+    // refinement can actually reduce -- now that face_normal_deviation() is the paper's
+    // field-vs-field quantity rather than misorientation -- so it is what the field is driven by.
+    //
+    // The distance error is kept as an ADDITIONAL refine trigger and an additional veto on
+    // coarsening. The paper does not need it (it re-derives a spatially adapted delta first, so
+    // its offset starts near-correct), but this implementation deliberately skips distance
+    // adaptation, so distance error is the only signal that a patch is misplaced rather than
+    // merely under-resolved. Both conditions only ever make the field finer than the paper's.
+    const double sigma_max = m_offset_params.max_normal_deviation_deg;
+    const double sigma_min = m_offset_params.min_normal_deviation_deg;
+    // l_min is an absolute length; the sizing scalar multiplies m_params.l, so the floor in
+    // scalar terms is l_min / l. This is what stops refinement running away at a feature, where
+    // the field normals disagree no matter how small the triangle gets.
+    const double l = std::max(m_params.l, 1e-16);
+    const double s_floor =
+        std::max(m_offset_params.min_sizing_scalar, m_offset_params.min_edge_length / l);
+
     std::vector<size_t> refined; // seeds for gradation: vertices whose sizing was just lowered
     for (size_t vid = 0; vid < vert_capacity(); ++vid) {
         if (!touched[vid]) continue;
 
+        const Vector3d p = m_vertex_attribute[vid].m_posf;
+        const double d = (p - m_input_complex_bvh.nearest_point(p)).norm();
+        const double err = std::abs(d - m_offset_params.target_distance) /
+                           std::max(m_offset_params.target_distance, 1e-16);
+        // Refine wherever a vertex sits outside the band the run is trying to reach.
+        // convergence_target_rel is that band, already expressed relative to target_distance, so
+        // it compares like-for-like against `err`.
+        //
+        // 2D compares `err` against sizing_mrm_threshold instead, which is a category error: that
+        // parameter is the MEAN-RATIO METRIC bar -- the paper's "shape regularity below 0.5" -- a
+        // dimensionless shape measure with no relation to a relative distance. At its 0.5 default
+        // a vertex must be 50% of target_distance out of place before it asks for refinement, so
+        // the trigger never fires in any run that is near converging. Ported here verbatim it
+        // stalled geneva_base: splits fell to 0 from iteration 3 and max_dist_err plateaued at
+        // 10.6% of delta with nothing left to drive it down. See the 2D notes in
+        // .claude/CLAUDE.md; the 2D side keeps the old expression until its PR lands.
+        //
+        // The reference implementation (internal/OffsetOptimization.cpp) has no distance trigger
+        // at all -- normal deviation and mean-ratio only -- because it runs distance adaptation
+        // (paper Sec. 5.3.1) first, so its offset starts near-correct. This implementation skips
+        // that step, which is precisely why distance error has to be a signal here. Guarded on
+        // > 0 so a disabled convergence target cannot turn this into refine-everything.
+        const bool dist_bad = m_offset_params.convergence_target_rel > 0. &&
+                              err > m_offset_params.convergence_target_rel;
+
+        const double sigma = max_offset_surface_normal_deviation_at_vertex(vid);
+        const bool shape_bad = min_mrm[vid] < m_offset_params.sizing_mrm_threshold;
+
         double& s = m_vertex_attribute[vid].m_sizing_scalar;
         const double old_s = s;
-        if (min_mrm[vid] < m_offset_params.sizing_mrm_threshold) {
-            s *= 0.5; // refine: a badly-shaped incident offset triangle wants shorter edges
-        } else {
-            s *= 1.5; // coarsen: every incident offset triangle is already well shaped
-        }
-        s = std::clamp(s, m_offset_params.min_sizing_scalar, m_offset_params.max_sizing_scalar);
+        if (shape_bad || sigma > sigma_max || dist_bad) {
+            s *= 0.5;
+        } else if (sigma < sigma_min) {
+            s *= 1.5;
+        } // otherwise between sigma_min and sigma_max: resolved well enough, leave it alone
+        s = std::clamp(s, s_floor, m_offset_params.max_sizing_scalar);
         if (s < old_s) {
             refined.push_back(vid);
         }
@@ -888,6 +958,218 @@ size_t TopoOffsetTetMesh::update_sizing_field()
         [this](size_t v) { return get_one_ring_vids_for_vertex(v); });
 
     return refined.size();
+}
+
+void TopoOffsetTetMesh::init_offset_sizing_field()
+{
+    // Paper Sec. 5.3.3, Step 1: the sizing field "is defined on each edge of the offset mesh and
+    // is INITIALIZED WITH THE CURRENT LENGTH OF EACH EDGE."
+    //
+    // This is not a detail. The base's m_sizing_scalar defaults to 1, i.e. a target length of
+    // m_params.l everywhere -- and l is a fraction of the bounding box diagonal, which on any
+    // reasonable configuration is far longer than the offset surface's own edges. Starting there
+    // makes every offset edge a collapse candidate on the first pass, and the offset is decimated
+    // before the metrics get to speak. The per-operation normal-deviation guard cannot save it:
+    // each individual collapse of a well-resolved surface barely moves the angle, so they pass one
+    // at a time. In 2D skipping this was the single biggest cause of decimation.
+    //
+    // Starting from the current lengths says instead: keep the resolution you have, and change it
+    // only where update_sizing_field() finds a reason to. The field is per-vertex, so a vertex
+    // takes the mean length of its incident offset-surface edges.
+    const double l = std::max(m_params.l, 1e-16);
+    const double s_floor =
+        std::max(m_offset_params.min_sizing_scalar, m_offset_params.min_edge_length / l);
+
+    double raw_sum = 0.;
+    int n_seeded = 0;
+    for (const Tuple& v : get_vertices()) {
+        const size_t vid = v.vid(*this);
+
+        // Mean length of the offset-surface edges at this vertex. Collected from the offset faces
+        // rather than the one-ring edges so a background edge that merely touches the surface
+        // does not drag the seed toward the ambient scale.
+        double sum_len = 0.;
+        int n = 0;
+        std::set<size_t> seen;
+        for (const Tuple& f : get_offset_surface_faces_for_vertex(v)) {
+            for (const size_t nb : get_face_vids(f)) {
+                if (nb == vid || !seen.insert(nb).second) continue;
+                sum_len += (m_vertex_attribute[vid].m_posf - m_vertex_attribute[nb].m_posf).norm();
+                ++n;
+            }
+        }
+        if (n == 0) continue; // not on the offset surface: the background keeps the base target
+
+        raw_sum += sum_len / n;
+        ++n_seeded;
+        m_vertex_attribute[vid].m_sizing_scalar =
+            std::clamp((sum_len / n) / l, s_floor, m_offset_params.max_sizing_scalar);
+    }
+    logger().info(
+        "\tOffset sizing seed: {} vertices, mean incident length {:.6} (base l {:.6}, l_min {:.6} "
+        "= 2*{}*sin({} deg), scalar floor {:.6})",
+        n_seeded,
+        n_seeded > 0 ? raw_sum / n_seeded : 0.,
+        l,
+        m_offset_params.min_edge_length,
+        m_offset_params.target_distance,
+        m_offset_params.max_normal_deviation_deg,
+        s_floor);
+}
+
+bool TopoOffsetTetMesh::offset_field_normal(const Vector3d& p, Vector3d& n) const
+{
+    const Vector3d nearest = m_input_complex_bvh.nearest_point(p);
+    const Vector3d diff = p - nearest;
+    const double d = diff.norm();
+    if (d < 1e-12) return false; // on the complex: the field has no direction here
+    n = diff / d;
+    return true;
+}
+
+bool TopoOffsetTetMesh::face_is_offset_surface_live(const Tuple& f) const
+{
+    const size_t ta = f.tid(*this);
+    const std::optional<Tuple> opp = f.switch_tetrahedron(*this);
+    if (!opp) {
+        // Domain boundary. A band cell here means the band was clipped by the bounding box, and
+        // that face IS offset surface -- the vertices on it are frozen and can never reach the
+        // target distance, which is precisely the thing that must be measured rather than hidden.
+        return cell_is_offset_band(ta);
+    }
+    const size_t tb = opp->tid(*this);
+    const bool a = cell_is_offset_band(ta), b = cell_is_offset_band(tb);
+    if (a == b) return false; // both in the band, or neither: not the band's surface
+    // The band's INNER interface, against the input complex it wraps, sits at distance 0 by
+    // construction and would drag the reported error to target_distance everywhere.
+    return !cell_is_input_complex(a ? tb : ta);
+}
+
+std::pair<double, double> TopoOffsetTetMesh::compute_distance_deviation() const
+{
+    // One entry per vertex, not per face-vertex: a vertex shared by several band-outer faces
+    // must count once, or the average is weighted by valence rather than by the surface.
+    std::vector<bool> on_band(vert_capacity(), false);
+    for (const Tuple& f : get_faces()) {
+        if (!face_is_offset_surface_live(f)) continue;
+        for (const size_t vid : get_face_vids(f)) on_band[vid] = true;
+    }
+
+    double max_dist = 0., sum_dist = 0.;
+    size_t n_verts = 0;
+    size_t worst = static_cast<size_t>(-1);
+    for (size_t vid = 0; vid < vert_capacity(); ++vid) {
+        if (!on_band[vid]) continue;
+        const Vector3d p = m_vertex_attribute[vid].m_posf;
+        const double d = (p - m_input_complex_bvh.nearest_point(p)).norm();
+        const double err = std::abs(d - m_offset_params.target_distance);
+        if (err > max_dist) {
+            max_dist = err;
+            worst = vid;
+        }
+        sum_dist += err;
+        ++n_verts;
+    }
+    m_worst_dist_vid = worst;
+    return {max_dist, n_verts > 0 ? sum_dist / n_verts : 0.};
+}
+
+std::pair<double, double> TopoOffsetTetMesh::compute_normal_deviation() const
+{
+    double max_nd = 0., sum_nd = 0.;
+    size_t n = 0;
+    for (const Tuple& f : get_faces()) {
+        if (!face_is_offset_surface_live(f)) continue;
+        const double nd = face_normal_deviation(f);
+        max_nd = std::max(max_nd, nd);
+        sum_nd += nd;
+        ++n;
+    }
+    return {max_nd, n > 0 ? sum_nd / n : 0.};
+}
+
+void TopoOffsetTetMesh::warn_if_offset_reaches_domain_boundary() const
+{
+    // A band face with no opposite tet lies ON the domain boundary: the band ran out of room
+    // before reaching target_distance. Counted in vertices as well as faces because the vertices
+    // are what is frozen.
+    size_t n_faces = 0, n_verts = 0;
+    std::vector<bool> counted(vert_capacity(), false);
+    for (const Tuple& f : get_faces()) {
+        if (f.switch_tetrahedron(*this)) continue; // interior face; the band has room here
+        if (!cell_is_offset_band(f.tid(*this))) continue;
+        ++n_faces;
+        for (const size_t v : get_face_vids(f)) {
+            if (!counted[v]) {
+                counted[v] = true;
+                ++n_verts;
+            }
+        }
+    }
+    if (n_faces == 0) return;
+
+    logger().warn(
+        "Offset band reaches the domain boundary: {} band faces ({} vertices) lie ON the "
+        "bounding box. target_distance ({}) exceeds the clearance between the input complex and "
+        "the box, so the offset is CLIPPED there and cannot reach the target distance -- those "
+        "vertices are on the frozen bounding box and no operation may move them. They ARE "
+        "included in max_dist_err / avg_dist_err (see compute_distance_deviation), so expect the "
+        "reported error to be dominated by them and to stay flat across iterations. Reduce "
+        "target_distance, or pad the background mesh.",
+        n_faces,
+        n_verts,
+        m_offset_params.target_distance);
+}
+
+void TopoOffsetTetMesh::log_worst_dist_vertex() const
+{
+    const size_t vid = m_worst_dist_vid;
+    if (vid == static_cast<size_t>(-1)) return;
+
+    const Vector3d p = m_vertex_attribute[vid].m_posf;
+    const double d = (p - m_input_complex_bvh.nearest_point(p)).norm();
+
+    // Every face incident to vid, classified. Walked here rather than through
+    // get_offset_surface_faces_for_vertex(), which filters to offset faces only -- the point of
+    // this line is what ELSE is touching the vertex.
+    int n_offset_f = 0, n_input_f = 0, n_bbox_f = 0;
+    std::set<size_t> seen_fids;
+    for (const size_t tid : get_one_ring_tids_for_vertex(tuple_from_vertex(vid))) {
+        const auto tet_vids = oriented_tet_vids(tid);
+        for (int skip = 0; skip < 4; ++skip) {
+            if (tet_vids[skip] == vid) continue; // the one face not containing vid
+            std::array<size_t, 3> face_vids;
+            int k = 0;
+            for (int j = 0; j < 4; ++j) {
+                if (j != skip) face_vids[k++] = tet_vids[j];
+            }
+            const auto [face_tuple, unused_tid] = tuple_from_face(face_vids);
+            if (!seen_fids.insert(face_tuple.fid(*this)).second) continue;
+            n_offset_f += face_is_offset_surface_live(face_tuple);
+            n_input_f += face_is_input(face_tuple.fid(*this));
+            n_bbox_f += !face_tuple.switch_tetrahedron(*this).has_value();
+        }
+    }
+    const auto& ve = m_vertex_extra[vid];
+    logger().info(
+        "\tworst-dist vertex {}: pos ({:.6}, {:.6}, {:.6}) dist {:.6} target {:.6} err {:.6}",
+        vid,
+        p[0],
+        p[1],
+        p[2],
+        d,
+        m_offset_params.target_distance,
+        std::abs(d - m_offset_params.target_distance));
+    logger().info(
+        "\t  flags: on_offset {} on_input {} on_bbox {} rounded {} | incident faces: {} offset, "
+        "{} input, {} bbox",
+        ve.m_is_on_offset,
+        ve.m_is_on_input,
+        !m_vertex_attribute[vid].on_bbox_faces.empty(),
+        m_vertex_attribute[vid].m_is_rounded,
+        n_offset_f,
+        n_input_f,
+        n_bbox_f);
 }
 
 void TopoOffsetTetMesh::optimize_offset(const std::filesystem::path& output_file)
@@ -932,20 +1214,42 @@ void TopoOffsetTetMesh::optimize_offset(const std::filesystem::path& output_file
 
     init_vertex_order();
 
+    // Seed the sizing field from the offset surface's current edge lengths, before any operation
+    // runs. Must come after the offset faces are classified above, since it reads them.
+    init_offset_sizing_field();
+
     /**
      * All label attributes are ignored from here on out. All relevant information is stored in tags
      * and in the "on_surface" and "on_offset" attributes.
      */
 
+    // UNCONDITIONAL, and it must stay that way: write_vtu() calls consolidate_mesh(), which
+    // renumbers the mesh, which changes the order every subsequent pass enumerates operations in,
+    // which changes the run. With the debug write below being the only consolidate here, turning
+    // DEBUG_output on silently produced a DIFFERENT numerical result -- measured in 2D on the
+    // dragon rectangle as converged-in-7 versus not-converged-in-10, identical in every other
+    // parameter. Consolidating here whether or not anything is written makes the two paths agree,
+    // and makes DEBUG_output what it claims to be: output only.
+    consolidate_mesh();
     if (m_offset_params.debug_output) { // intermediate output
         write_vtu(output_file.string() + fmt::format("_{}", m_vtu_counter++));
     }
 
+    m_converged = false;
     for (int i = 0; i < m_offset_params.optimization_iterations; ++i) {
         logger().info(
             "Optimization iteration {} / {}",
             i + 1,
             m_offset_params.optimization_iterations);
+
+        // Reset immediately before the operation passes, not at the top of the iteration, so
+        // each entry is this iteration's own total.
+        iter_cnt_split = 0;
+        iter_cnt_collapse = 0;
+        iter_cnt_swap = 0;
+        iter_cnt_collapse_nd_reject = 0;
+        iter_cnt_swap_nd_reject = 0;
+        m_smooth_trace.reset();
 
         // One split pass, one collapse pass, one swap pass (2-3/3-2, 4-4 and 5-6 edge swaps
         // together, then the 2-3 face swap) and num_smoothing_passes smoothing passes, with
@@ -956,8 +1260,150 @@ void TopoOffsetTetMesh::optimize_offset(const std::filesystem::path& output_file
         // getting stuck, so it is refreshed every iteration below rather than on a stall.
         local_operations({{1, 1, 1, m_offset_params.num_smoothing_passes}});
 
+        log_smooth_trace();
+
+        op_counts.push_back(
+            {{iter_cnt_split.load(), iter_cnt_collapse.load(), iter_cnt_swap.load()}});
+        logger().info(
+            "splits = {}  |  collapses = {} ({} refused by normal deviation)  |  swaps = {} ({} "
+            "refused by normal deviation)",
+            iter_cnt_split.load(),
+            iter_cnt_collapse.load(),
+            iter_cnt_collapse_nd_reject.load(),
+            iter_cnt_swap.load(),
+            iter_cnt_swap_nd_reject.load());
+
+        // RECLAIM THE SLOT POOL. TetMesh preallocates vertex/tet storage as
+        // reserved_capacity() = 6x the live count, fixed at the last consolidate, and hands it
+        // out through get_next_empty_slot_v(). A collapse only MARKS its slots removed -- the
+        // allocation cursor never moves back -- so the pool is consumed by the split pass and
+        // never returned. When it runs out, TetMesh::split_edge() bails at
+        //     int v_id = get_next_empty_slot_v();
+        //     if (v_id < 0) return false;   // out of preallocated vertex slots
+        // which is BEFORE split_edge_after(), so no application hook is involved and nothing is
+        // logged: the splits simply all fail. Only consolidate_mesh() compacts the removed slots
+        // away and re-reserves from the new live count.
+        //
+        // mesh_improvement() does exactly this, once per iteration (TetOptimizerMesh.cpp), and
+        // this loop deliberately does not call mesh_improvement -- see the comment above
+        // local_operations() -- so it has to do the consolidate itself.
+        //
+        // Measured on specific_models/prism before this: the offset seeds at 1286 vertices,
+        // iteration 1 splits to 12526 and collapses back to a LIVE 1515, and from iteration 2
+        // on every split fails -- 7450 approved by split_edge_before(), 0 reaching
+        // split_edge_after() -- while 1775 of 1950 offset edges still exceed their target
+        // length. max_dist_err and max_norm_dev then sit flat for the rest of the run.
+        //
+        // Note this renumbers the mesh, so it changes the order later passes enumerate
+        // operations in and therefore the run; that is the same effect DEBUG_output has via
+        // write_vtu(), and it is unavoidable here.
+        consolidate_mesh();
+
         logger().info("\tUpdating sizing field...");
         update_sizing_field();
+
+        // metrics
+        const auto [max_dist, avg_dist] = compute_distance_deviation();
+        const auto [max_norm, avg_norm] = compute_normal_deviation();
+        logger().info(
+            "max dist err: {} | avg dist err: {} | max normal dev: {} | avg normal dev: {}",
+            max_dist,
+            avg_dist,
+            max_norm,
+            avg_norm);
+        optimization_metrics.push_back({{max_dist, avg_dist, max_norm, avg_norm}});
+        log_worst_dist_vertex();
+
+        // Convergence: the worst-placed offset vertex has reached the target error band, and the
+        // offset's AVERAGE facing has reached the target normal deviation.
+        //
+        // The asymmetry -- max for distance, average for angle -- is the paper's (Sec. 5.3,
+        // Termination: "the average sigma_max ... both the maximum and mean distance error"),
+        // and it is forced by the geometry rather than chosen for convenience. Distance error
+        // genuinely can go to zero everywhere, so the max is a fair bar. Normal deviation cannot:
+        // at a sharp feature of the input the distance field's normal is discontinuous by the
+        // feature's own angle, at every scale, so max sigma has a floor no refinement, no smaller
+        // target_distance and no operation can lower.
+        //
+        // max_norm is still computed and reported; it is a diagnostic, not a bar.
+        // convergence_normal_deviation <= 0 disables the angular half entirely.
+        const bool dist_ok = max_dist <= m_offset_params.convergence_target;
+        const bool norm_ok = m_offset_params.convergence_normal_deviation <= 0. ||
+                             avg_norm <= m_offset_params.convergence_normal_deviation;
+        m_converged = dist_ok && norm_ok;
+        if (m_converged) {
+            if (m_offset_params.convergence_normal_deviation > 0.) {
+                logger().info(
+                    "Converged ([max_dist] {} <= {} [convergence_target], [avg_normal_dev] {} <= "
+                    "{} [convergence_normal_deviation]), terminating early...",
+                    max_dist,
+                    m_offset_params.convergence_target,
+                    avg_norm,
+                    m_offset_params.convergence_normal_deviation);
+            } else {
+                logger().info(
+                    "Converged ([max_dist] {} <= {} [convergence_target], normal deviation "
+                    "criterion disabled), terminating early...",
+                    max_dist,
+                    m_offset_params.convergence_target);
+            }
+            break;
+        }
+    }
+
+    if (!m_converged && !optimization_metrics.empty()) {
+        // Name the criterion that actually failed; with two of them, reporting only the distance
+        // sends you looking at the wrong one.
+        const double max_dist = optimization_metrics.back()[0];
+        const double avg_norm = optimization_metrics.back()[3];
+        if (max_dist > m_offset_params.convergence_target) {
+            logger().warn(
+                "Optimization did not converge ([max_dist] {} > {} [convergence_target])",
+                max_dist,
+                m_offset_params.convergence_target);
+        }
+        if (m_offset_params.convergence_normal_deviation > 0. &&
+            avg_norm > m_offset_params.convergence_normal_deviation) {
+            logger().warn(
+                "Optimization did not converge ([avg_normal_dev] {} > {} "
+                "[convergence_normal_deviation])",
+                avg_norm,
+                m_offset_params.convergence_normal_deviation);
+        }
+
+        // Is topological preservation holding the offset back, as opposed to a handful of
+        // over-constrained vertices? See TOPOLOGY_BLOCK_AVG_FRAC for why the average is the
+        // discriminator.
+        const double avg_dist = optimization_metrics.back()[1];
+        if (m_offset_params.respect_all_topologies &&
+            avg_dist > TOPOLOGY_BLOCK_AVG_FRAC * m_offset_params.target_distance) {
+            logger().warn(
+                "Offset growth appears to be BLOCKED BY TOPOLOGICAL PRESERVATION: "
+                "respect_all_topologies is true and the AVERAGE distance error is {:.1f}% of "
+                "target_distance ({} vs {}), against max {:.1f}%. Error that uniform means whole "
+                "regions of the offset never reached the target distance, not that a few vertices "
+                "are over-constrained; with respect_all_topologies every tag's topology is frozen "
+                "after offset initialization, so the operations that would let the offset advance "
+                "through a narrow region are refused and it stays where conservative growth left "
+                "it. Set respect_all_topologies false if only the offset's own topology matters, "
+                "or reduce target_distance so the offset does not need to pass through those "
+                "regions.",
+                100.0 * avg_dist / m_offset_params.target_distance,
+                avg_dist,
+                m_offset_params.target_distance,
+                100.0 * max_dist / m_offset_params.target_distance);
+        }
+    }
+
+    // Escalate to a hard failure if the caller asked for it, AFTER the warnings above so the log
+    // still names which criterion missed before the throw. Guarded on !m_converged alone rather
+    // than on the block above: a run that produced no metrics at all has certainly not converged.
+    if (!m_converged && m_offset_params.throw_on_nonconvergence) {
+        log_and_throw_error(
+            "Optimization did not converge and throw_on_nonconvergence is set. Ran {} of {} "
+            "iterations; see the warnings above for the criterion that failed.",
+            optimization_metrics.size(),
+            m_offset_params.optimization_iterations);
     }
 }
 

--- a/components/topological_offset/wmtk/components/topological_offset/TopoOffsetTetMesh.cpp
+++ b/components/topological_offset/wmtk/components/topological_offset/TopoOffsetTetMesh.cpp
@@ -982,51 +982,19 @@ void TopoOffsetTetMesh::init_offset_sizing_field()
     //
     // Starting from the current lengths says instead: keep the resolution you have, and change it
     // only where update_sizing_field() finds a reason to. The field is per-vertex, so a vertex
-    // takes the mean length of its incident edges.
-    //
-    // THE SAME RULE APPLIES TO THE BACKGROUND. The paper's sentence is not about the offset
-    // specifically, and a background vertex left at the default scalar asks for a target length of
-    // m_params.l, which the mesh does not have either: on specific_models/prism, l = 4.18 against a
-    // background whose own edges are longer, so background edges above (4/3)l were split and those
-    // below (4/5)l collapsed, and ~20 of the 2640 vertices each split pass created were on the
-    // offset.
-    //
-    // WHAT THIS DOES AND DOES NOT FIX, measured rather than predicted. It does not stop the
-    // split/collapse churn: prism still goes ~800 -> ~4400 -> ~800 per iteration and the slot pool
-    // still runs dry. Seeding from current lengths does NOT imply that no edge starts out of band,
-    // because the seed is a vertex's MEAN incident length while the gates compare a single edge
-    // against it -- and prism's edge lengths span a factor of 125, so a large fraction of edges sit
-    // outside (4/5, 4/3) of their own local mean and are split or collapsed on the first pass
-    // regardless.
-    //
-    // What it does buy is that the background stops being driven toward a length it never had, so
-    // less of the split budget is spent there and more of it reaches the offset. Prism's final
-    // iteration: max dist err 0.1647 -> 0.1257, avg 0.0595 -> 0.0455, avg normal deviation 19.7 ->
-    // 17.9 deg, and the live vertex count after the collapse pass 630 -> 794. Both 3D integration
-    // tests improve on every reported figure and neither regresses; 2D is untouched.
-    //
-    // l ITSELF IS DERIVED HERE, not read. Once every vertex is seeded from its own resolution, l
-    // is nothing but the constant the per-vertex scalars are expressed against: the quantity that
-    // reaches the split and collapse gates is l * s_v, which is the vertex's own mean edge length
-    // whatever l is. So l is set to the largest of those means, which is the choice that makes
-    // max_sizing_scalar = 1 mean something real -- no vertex may be asked for an edge longer than
-    // the coarsest place in the mesh already has -- and, being an upper bound, the choice that
-    // keeps the top clamp below from binding on any vertex.
-    //
-    // Nothing else reads m_params.l: the only other use in the engine is
-    // OptimizerParameters::init_lengths_from_diagonal(), which derives splitting_l2 and
-    // collapsing_l2 from it, and those are re-derived here alongside it. Both are read only by the
-    // split and collapse length gates. This runs after all construction, so the marching and
-    // growth phases are unaffected.
-    std::vector<double> seed_len(vert_capacity(), -1.);
-    double l_new = 0.;
+    // takes the mean length of its incident offset-surface edges.
+    const double l = std::max(m_params.l, 1e-16);
+    const double s_floor =
+        std::max(m_offset_params.min_sizing_scalar, m_offset_params.min_edge_length / l);
+
+    double raw_sum = 0.;
+    int n_seeded = 0;
     for (const Tuple& v : get_vertices()) {
         const size_t vid = v.vid(*this);
 
-        // On the offset surface, the mean is over the offset-surface edges only. Collected from
-        // the offset faces rather than the one-ring so a background edge that merely touches the
-        // surface does not drag the seed toward the ambient scale. Off it, there is no such
-        // distinction to draw and the mean is over the whole one-ring.
+        // Mean length of the offset-surface edges at this vertex. Collected from the offset faces
+        // rather than the one-ring edges so a background edge that merely touches the surface
+        // does not drag the seed toward the ambient scale.
         double sum_len = 0.;
         int n = 0;
         std::set<size_t> seen;
@@ -1037,65 +1005,18 @@ void TopoOffsetTetMesh::init_offset_sizing_field()
                 ++n;
             }
         }
-        if (n == 0) {
-            for (const size_t nb : get_one_ring_vids_for_vertex(vid)) {
-                if (nb == vid) continue;
-                sum_len += (m_vertex_attribute[vid].m_posf - m_vertex_attribute[nb].m_posf).norm();
-                ++n;
-            }
-        }
-        if (n == 0) continue; // isolated: nothing to measure, keep the default
+        if (n == 0) continue; // not on the offset surface: the background keeps the base target
 
-        seed_len[vid] = sum_len / n;
-        l_new = std::max(l_new, seed_len[vid]);
-    }
-
-    if (l_new > 0.) {
-        logger().info(
-            "\tBase target edge length l: {:.6} (length_rel) -> {:.6} (coarsest vertex's mean "
-            "incident edge length)",
-            m_params.l,
-            l_new);
-        m_params.l = l_new;
-        m_params.splitting_l2 = l_new * l_new * (16 / 9.);
-        m_params.collapsing_l2 = l_new * l_new * (16 / 25.);
-    }
-
-    const double l = std::max(m_params.l, 1e-16);
-    const double s_floor =
-        std::max(m_offset_params.min_sizing_scalar, m_offset_params.min_edge_length / l);
-    // The floor is meant to be the absolute length l_min; min_sizing_scalar is a relative backstop
-    // that should sit below it. Since l is derived above rather than configured, say so if the
-    // relative one has overtaken the absolute one, which would silently raise the finest edge the
-    // field may ask for.
-    if (m_offset_params.min_sizing_scalar * l > m_offset_params.min_edge_length) {
-        logger().warn(
-            "\tSizing floor is set by min_sizing_scalar ({} * l = {:.6}), not by l_min ({:.6}): "
-            "refinement will stop coarser than 2*delta*sin(sigma_max) asks for.",
-            m_offset_params.min_sizing_scalar,
-            m_offset_params.min_sizing_scalar * l,
-            m_offset_params.min_edge_length);
-    }
-
-    double raw_sum = 0.;
-    int n_seeded = 0, n_offset = 0;
-    for (const Tuple& v : get_vertices()) {
-        const size_t vid = v.vid(*this);
-        if (seed_len[vid] < 0.) continue;
+        raw_sum += sum_len / n;
         ++n_seeded;
-        if (m_vertex_extra[vid].m_is_on_offset) {
-            raw_sum += seed_len[vid];
-            ++n_offset;
-        }
         m_vertex_attribute[vid].m_sizing_scalar =
-            std::clamp(seed_len[vid] / l, s_floor, m_offset_params.max_sizing_scalar);
+            std::clamp((sum_len / n) / l, s_floor, m_offset_params.max_sizing_scalar);
     }
     logger().info(
-        "\tSizing seed: {} vertices ({} on the offset, mean incident length {:.6}) (base l {:.6}, "
-        "l_min {:.6} = 2*{}*sin({} deg), scalar floor {:.6})",
+        "\tOffset sizing seed: {} vertices, mean incident length {:.6} (base l {:.6}, l_min {:.6} "
+        "= 2*{}*sin({} deg), scalar floor {:.6})",
         n_seeded,
-        n_offset,
-        n_offset > 0 ? raw_sum / n_offset : 0.,
+        n_seeded > 0 ? raw_sum / n_seeded : 0.,
         l,
         m_offset_params.min_edge_length,
         m_offset_params.target_distance,

--- a/components/topological_offset/wmtk/components/topological_offset/TopoOffsetTetMesh.cpp
+++ b/components/topological_offset/wmtk/components/topological_offset/TopoOffsetTetMesh.cpp
@@ -856,114 +856,125 @@ TopoOffsetTetMesh::mean_ratio_metric(const Vector3d& p0, const Vector3d& p1, con
     return prefactor * area / sq_length_sum;
 }
 
-size_t TopoOffsetTetMesh::update_sizing_field()
+std::tuple<double, double> TopoOffsetTetMesh::optimization_quality_stats()
 {
-    const std::vector<std::array<size_t, 3>> offset_faces =
-        get_faces_by_condition([](const FaceAttributes& f) {
-            return f.m_is_surface_fs && f.m_surface_class == OFFSET_SURFACE_CLASS;
-        });
+    // The engine's "quality" is the offset's distance criterion: (max, avg) distance error over
+    // the band's outer vertices, normalized so 1.0 is the convergence target. mesh_improvement()
+    // stops when the max drops below optimization_stop_metric() = 1.0, i.e. exactly when the
+    // worst-placed offset vertex enters the target band.
+    //
+    // DISTANCE ONLY -- the criterion's average-normal-deviation half cannot be a max-based stop
+    // and is tested after the loop in optimize_offset(); see the comment there. Kept cheap and
+    // side-effect-light because the engine calls this after every operation pass.
+    const auto [max_dist, avg_dist] = compute_distance_deviation();
+    const double ct = std::max(m_offset_params.convergence_target, 1e-16);
+    return {max_dist / ct, avg_dist / ct};
+}
 
-    std::vector<double> min_mrm(vert_capacity(), std::numeric_limits<double>::max());
-    std::vector<bool> touched(vert_capacity(), false);
-
-    for (const std::array<size_t, 3>& f : offset_faces) {
-        const double mrm = mean_ratio_metric(
-            m_vertex_attribute[f[0]].m_posf,
-            m_vertex_attribute[f[1]].m_posf,
-            m_vertex_attribute[f[2]].m_posf);
-        for (const size_t v : f) {
-            min_mrm[v] = std::min(min_mrm[v], mrm);
-            touched[v] = true;
-        }
-    }
-
-    // Paper Sec. 5.3.3, Step 1:
+size_t TopoOffsetTetMesh::refine_sizing_around_worst(double)
+{
+    // THE ENGINE'S STRATEGY, DRIVEN BY THE OFFSET'S CRITERION. mesh_improvement() calls this only
+    // when the metric STALLS, and this refines only around the worst-placed band vertices --
+    // TetWildMesh::refine_sizing_around_worst() with the offset's distance error in place of
+    // AMIPS energy.
     //
-    //   "if one of the incident triangles has a shape regularity below 0.5 or a normal deviation
-    //    above the user-defined maximum sigma_max, we divide the target length by two. If shape
-    //    regularity is [above] 0.5 and the normal deviation is [below] sigma_min, we increase the
-    //    target length by 1.5."
-    //
-    // (The paper's second sentence reads "below 0.5 ... above sigma_min", which contradicts the
-    // first; the only self-consistent reading -- and the only one that does not refine and coarsen
-    // the same vertex -- is the good-and-flat one used here.)
-    //
-    // NORMAL DEVIATION is the driver, and that is the whole point. The previous rule here was
-    // shape-only: refine on a bad mean-ratio metric, otherwise coarsen unconditionally. Nothing
-    // stopped a well-shaped but under-resolved offset surface being coarsened into flat patches,
-    // because a triangle can be perfectly shaped and still span a feature. sigma is what
-    // refinement can actually reduce -- now that face_normal_deviation() is the paper's
-    // field-vs-field quantity rather than misorientation -- so it is what the field is driven by.
-    //
-    // The distance error is kept as an ADDITIONAL refine trigger and an additional veto on
-    // coarsening. The paper does not need it (it re-derives a spatially adapted delta first, so
-    // its offset starts near-correct), but this implementation deliberately skips distance
-    // adaptation, so distance error is the only signal that a patch is misplaced rather than
-    // merely under-resolved. Both conditions only ever make the field finer than the paper's.
-    const double sigma_max = m_offset_params.max_normal_deviation_deg;
-    const double sigma_min = m_offset_params.min_normal_deviation_deg;
-    // l_min is an absolute length; the sizing scalar multiplies m_params.l, so the floor in
-    // scalar terms is l_min / l. This is what stops refinement running away at a feature, where
-    // the field normals disagree no matter how small the triangle gets.
+    // This replaces a per-element rule (halve every offset vertex failing sigma_max or the
+    // distance band, every iteration) whose failure mode was measured on prism: sigma at a
+    // genuine crease exceeds sigma_max at any resolution, so the crease bands ratcheted to the
+    // floor unconditionally, gradation dragged the fine sizing into the surrounding volume, and
+    // iteration 4 reached 2.8M edges. Stall-driven and worst-first, a crease that stops paying
+    // for refinement stops being selected, and the ratchet stops with it.
     const double l = std::max(m_params.l, 1e-16);
     const double s_floor =
         std::max(m_offset_params.min_sizing_scalar, m_offset_params.min_edge_length / l);
+    const double ct = std::max(m_offset_params.convergence_target, 1e-16);
 
-    std::vector<size_t> refined; // seeds for gradation: vertices whose sizing was just lowered
-    for (size_t vid = 0; vid < vert_capacity(); ++vid) {
-        if (!touched[vid]) continue;
+    // The band's outer vertices, by the rule compute_distance_deviation() uses.
+    std::vector<bool> on_band(vert_capacity(), false);
+    for (const Tuple& f : get_faces()) {
+        if (!face_is_offset_surface_live(f)) continue;
+        for (const size_t vid : get_face_vids(f)) on_band[vid] = true;
+    }
 
+    const auto dist_rel = [&](size_t vid) {
         const Vector3d p = m_vertex_attribute[vid].m_posf;
         const double d = (p - m_input_complex_bvh.nearest_point(p)).norm();
-        const double err = std::abs(d - m_offset_params.target_distance) /
-                           std::max(m_offset_params.target_distance, 1e-16);
-        // Refine wherever a vertex sits outside the band the run is trying to reach.
-        // convergence_target_rel is that band, already expressed relative to target_distance, so
-        // it compares like-for-like against `err`.
-        //
-        // 2D compares `err` against sizing_mrm_threshold instead, which is a category error: that
-        // parameter is the MEAN-RATIO METRIC bar -- the paper's "shape regularity below 0.5" -- a
-        // dimensionless shape measure with no relation to a relative distance. At its 0.5 default
-        // a vertex must be 50% of target_distance out of place before it asks for refinement, so
-        // the trigger never fires in any run that is near converging. Ported here verbatim it
-        // stalled geneva_base: splits fell to 0 from iteration 3 and max_dist_err plateaued at
-        // 10.6% of delta with nothing left to drive it down. See the 2D notes in
-        // .claude/CLAUDE.md; the 2D side keeps the old expression until its PR lands.
-        //
-        // The reference implementation (internal/OffsetOptimization.cpp) has no distance trigger
-        // at all -- normal deviation and mean-ratio only -- because it runs distance adaptation
-        // (paper Sec. 5.3.1) first, so its offset starts near-correct. This implementation skips
-        // that step, which is precisely why distance error has to be a signal here. Guarded on
-        // > 0 so a disabled convergence target cannot turn this into refine-everything.
-        const bool dist_bad = m_offset_params.convergence_target_rel > 0. &&
-                              err > m_offset_params.convergence_target_rel;
+        return std::abs(d - m_offset_params.target_distance) / ct;
+    };
 
-        const double sigma = max_offset_surface_normal_deviation_at_vertex(vid);
-        const bool shape_bad = min_mrm[vid] < m_offset_params.sizing_mrm_threshold;
+    // Worst band vertices above the criterion (filter 1.0: a vertex already inside the target
+    // band is never a reason to refine), capped at stuck_refine_num_worst.
+    const auto worst = wmtk::utils::select_worst_cells(
+        vert_capacity(),
+        [&](size_t vid) { return on_band[vid]; },
+        dist_rel,
+        1.0,
+        m_params.stuck_refine_num_worst);
+    if (worst.empty()) {
+        return 0;
+    }
 
-        double& s = m_vertex_attribute[vid].m_sizing_scalar;
-        const double old_s = s;
-        if (shape_bad || sigma > sigma_max || dist_bad) {
-            s *= 0.5;
-        } else if (sigma < sigma_min) {
-            s *= 1.5;
-        } // otherwise between sigma_min and sigma_max: resolved well enough, leave it alone
-        s = std::clamp(s, s_floor, m_offset_params.max_sizing_scalar);
-        if (s < old_s) {
-            refined.push_back(vid);
+    std::vector<size_t> seeds;
+    seeds.reserve(worst.size());
+    for (const auto& [_, vid] : worst) {
+        seeds.push_back(vid);
+    }
+    const auto region = wmtk::utils::grow_vertex_region(
+        seeds,
+        std::max(0, m_params.stuck_refine_rings),
+        [this](size_t v) { return get_one_ring_vids_for_vertex(v); });
+
+    std::vector<size_t> refined = wmtk::utils::apply_sizing_refinement(
+        region,
+        m_params.stuck_refine_factor,
+        s_floor,
+        [this](size_t v) -> double& { return m_vertex_attribute[v].m_sizing_scalar; });
+
+    // GROWTH, kept from the paper (Sec. 5.3.3, Step 1: "if shape regularity is [above] 0.5 and
+    // the normal deviation is [below] sigma_min, we increase the target length by 1.5") and
+    // deliberately NOT part of the engine's monotone-down strategy -- recorded as a decision to
+    // revisit. It now runs on stall rather than every iteration, which is a change of frequency,
+    // not of rule. The guards are the old rule's: grow only where the vertex is inside the
+    // distance band, flat (sigma < sigma_min) and well-shaped, so growth can never fight the
+    // refinement above.
+    {
+        const double sigma_min = m_offset_params.min_normal_deviation_deg;
+        std::vector<double> min_mrm(vert_capacity(), std::numeric_limits<double>::max());
+        for (const Tuple& f : get_faces()) {
+            if (!face_is_offset_surface_live(f)) continue;
+            const auto vs = get_face_vids(f);
+            const double mrm = mean_ratio_metric(
+                m_vertex_attribute[vs[0]].m_posf,
+                m_vertex_attribute[vs[1]].m_posf,
+                m_vertex_attribute[vs[2]].m_posf);
+            for (const size_t v : vs) {
+                min_mrm[v] = std::min(min_mrm[v], mrm);
+            }
+        }
+        for (size_t vid = 0; vid < vert_capacity(); ++vid) {
+            if (!on_band[vid]) continue;
+            if (region.count(vid)) continue; // just refined; growing it back would be a tug-of-war
+            if (dist_rel(vid) > 1.) continue;
+            if (min_mrm[vid] < m_offset_params.sizing_mrm_threshold) continue;
+            if (max_offset_surface_normal_deviation_at_vertex(vid) >= sigma_min) continue;
+            double& sc = m_vertex_attribute[vid].m_sizing_scalar;
+            sc = std::clamp(sc * 1.5, s_floor, m_offset_params.max_sizing_scalar);
         }
     }
 
-    // Gradation: propagate the refinement outward so neighboring sizing scalars never differ
-    // by more than sizing_gradation, matching SimWildMesh::gradation_smooth_sizing(). This is
-    // monotone (only ever lowers a neighbor's scalar), so a vertex that was just coarsened
-    // above can still get pulled back down here if it sits next to a freshly refined one.
     wmtk::utils::gradation_smooth_sizing(
         m_offset_params.sizing_gradation,
         refined,
         [this](size_t v) -> double& { return m_vertex_attribute[v].m_sizing_scalar; },
         [this](size_t v) { return get_one_ring_vids_for_vertex(v); });
 
+    logger().info(
+        "[stuck-refine] worst {} band vertices (worst dist {:.4}x target), refined {} of {} "
+        "region vertices",
+        worst.size(),
+        worst.empty() ? 0. : worst.back().first,
+        refined.size(),
+        region.size());
     return refined.size();
 }
 
@@ -1087,10 +1098,34 @@ void TopoOffsetTetMesh::diag_offset_bands(const char* tag) const
         else
             ++above43;
     }
+    // Valence of the band's vertices: the split pass's high-valence gate refuses splits whose
+    // link vertex exceeds split_high_valence_threshold incident tets, so a band that
+    // accumulates valence stops being refinable regardless of what the sizing field asks.
+    std::set<size_t> band_verts;
+    for (const auto& e : edges) {
+        band_verts.insert(e[0]);
+        band_verts.insert(e[1]);
+    }
+    // And over every vertex: the gate tests the LINK of the split edge, so a high-valence
+    // vertex anywhere in the band's halo blocks the band edges it links.
+    size_t gval_max = 0, gval_over = 0;
+    for (const Tuple& v : get_vertices()) {
+        const size_t val = get_one_ring_tids_for_vertex(v).size();
+        gval_max = std::max(gval_max, val);
+        gval_over += (val > size_t(std::max(0, m_params.split_high_valence_threshold)));
+    }
+    size_t val_max = 0, val_sum = 0, val_over = 0;
+    for (const size_t v : band_verts) {
+        const size_t val = get_one_ring_tids_for_vertex(tuple_from_vertex(v)).size();
+        val_max = std::max(val_max, val);
+        val_sum += val;
+        val_over += (val > size_t(std::max(0, m_params.split_high_valence_threshold)));
+    }
     const size_t n = edges.size();
     logger().info(
         "\t[offset {}] {} faces, {} edges | L/target: <4/5 {} ({:.1f}%), in band {} ({:.1f}%), "
-        ">4/3 {} ({:.1f}%) | mean sizing s {:.4}",
+        ">4/3 {} ({:.1f}%) | mean sizing s {:.4} | band valence max {} mean {:.1f}, {} over "
+        "threshold | global valence max {} ({} over)",
         tag,
         n_faces,
         n,
@@ -1100,7 +1135,12 @@ void TopoOffsetTetMesh::diag_offset_bands(const char* tag) const
         n ? 100. * ok / n : 0.,
         above43,
         n ? 100. * above43 / n : 0.,
-        n ? s_sum / n : 0.);
+        n ? s_sum / n : 0.,
+        val_max,
+        band_verts.empty() ? 0. : double(val_sum) / band_verts.size(),
+        val_over,
+        gval_max,
+        gval_over);
 }
 
 std::pair<double, double> TopoOffsetTetMesh::compute_distance_deviation() const
@@ -1306,149 +1346,97 @@ void TopoOffsetTetMesh::optimize_offset(const std::filesystem::path& output_file
         write_vtu(output_file.string() + fmt::format("_{}", m_vtu_counter++));
     }
 
-    m_converged = false;
-    for (int i = 0; i < m_offset_params.optimization_iterations; ++i) {
-        logger().info(
-            "Optimization iteration {} / {}",
-            i + 1,
-            m_offset_params.optimization_iterations);
+    // THE SHARED ENGINE'S OWN LOOP, driving the offset's convergence criterion. This used to be
+    // a hand-rolled loop: one split/collapse/swap/smooth round per iteration, then halve the
+    // sizing scalar at EVERY offset vertex failing a criterion, every iteration. That
+    // unconditional halving is what made the runtime explode once refinement actually landed --
+    // sigma at a genuine crease exceeds sigma_max at any resolution, so the crease bands
+    // ratcheted to the floor regardless of whether refinement was helping, and gradation dragged
+    // that fine sizing into the surrounding volume at x8 tets per halving (prism: 2.8M edges by
+    // iteration 4).
+    //
+    // mesh_improvement() is the engine's alternative, and the offset plugs into it the same way
+    // simwild does, through three virtuals:
+    //   - optimization_quality_stats(): (max, avg) distance error over the band's outer
+    //     vertices, normalized by convergence_target;
+    //   - optimization_stop_metric(): 1.0 -- the loop stops when the worst vertex is inside the
+    //     target band;
+    //   - refine_sizing_around_worst(): ratchet the sizing down ONLY around the worst-placed
+    //     vertices, and only when the metric STALLS -- see the override for the details.
+    // The engine consolidates every iteration and re-collects the operation queue, which is also
+    // its own answer to the slot-pool exhaustion the previous hand-rolled retry loop existed
+    // for: work dropped in one pass is retried in the next. The [slots] warning still reports
+    // any pass that came up short.
+    //
+    // DISTANCE ONLY drives the loop. The convergence criterion's other half -- AVERAGE normal
+    // deviation -- is an average, and the engine stops on a max, so it cannot be folded into the
+    // per-vertex metric without changing what it means. It is tested after the loop instead: a
+    // run can therefore exit converged-on-distance and still be reported unconverged below.
+    // Deliberate, recorded, and to be revisited once distance convergence is routine.
+    iter_cnt_split = 0;
+    iter_cnt_collapse = 0;
+    iter_cnt_collapse_offset_removed = 0;
+    iter_cnt_swap = 0;
+    iter_cnt_collapse_nd_reject = 0;
+    iter_cnt_swap_nd_reject = 0;
+    m_smooth_trace.reset();
 
-        // Reset immediately before the operation passes, not at the top of the iteration, so
-        // each entry is this iteration's own total.
-        iter_cnt_split = 0;
-        iter_cnt_collapse = 0;
-        iter_cnt_collapse_offset_removed = 0;
-        iter_cnt_swap = 0;
-        iter_cnt_collapse_nd_reject = 0;
-        iter_cnt_swap_nd_reject = 0;
-        m_smooth_trace.reset();
+    diag_offset_bands("pre");
+    mesh_improvement(m_offset_params.optimization_iterations);
 
-        // One split pass, one collapse pass, one swap pass (2-3/3-2, 4-4 and 5-6 edge swaps
-        // together, then the 2-3 face swap) and num_smoothing_passes smoothing passes, with
-        // the sanity checks, debug output and per-pass energy reporting the shared driver
-        // does. Deliberately not mesh_improvement(): its stop condition and stall-driven
-        // refinement both need a stop metric the offset has not defined, and its sizing field
-        // is driven by the shape of the offset triangulation rather than by the optimizer
-        // getting stuck, so it is refreshed every iteration below rather than on a stall.
-        // SPLIT UNTIL THE PASS IS NO LONGER SLOT-LIMITED, then the rest of the operations.
-        //
-        // The split pass abandons operations once the preallocated slot pool runs dry, before any
-        // application hook, and only consolidate_mesh() returns the pool -- see
-        // TetMesh::slot_exhausted(). Running one split pass per iteration therefore delivers a
-        // fraction of the refinement the sizing field asked for, with no way to tell from the log
-        // that anything was missed. Repeat until it stops reporting exhaustion.
-        //
-        // Bounded, because a pass refusing splits for some other reason would otherwise spin.
-        int split_attempts = 0;
-        for (; split_attempts < 8; ++split_attempts) {
-            local_operations({{1, 0, 0, 0}});
-            const size_t lost = slot_exhausted();
-            if (lost == 0) break;
+    // Cumulative over the whole run, not per iteration as before: the engine loop has no
+    // per-iteration hook, and the per-pass numbers it logs itself carry the history.
+    log_smooth_trace();
+    logger().info(
+        "splits = {}  |  collapses = {} ({} refused by normal deviation, {} removed an offset "
+        "vertex)  |  swaps = {} ({} refused by normal deviation)",
+        iter_cnt_split.load(),
+        iter_cnt_collapse.load(),
+        iter_cnt_collapse_nd_reject.load(),
+        iter_cnt_collapse_offset_removed.load(),
+        iter_cnt_swap.load(),
+        iter_cnt_swap_nd_reject.load());
+    op_counts.push_back({{iter_cnt_split.load(), iter_cnt_collapse.load(), iter_cnt_swap.load()}});
+
+    // Final metrics and the convergence verdict. One entry, for the whole run: the engine loop
+    // owns the iterations now, so optimization_metrics is a summary rather than a history.
+    //
+    // The asymmetry -- max for distance, average for angle -- is the paper's (Sec. 5.3,
+    // Termination), and it is forced by the geometry: distance error can genuinely go to zero
+    // everywhere, so the max is a fair bar, while normal deviation has a floor at every sharp
+    // feature that no refinement can lower, so only its average can be asked for.
+    // convergence_normal_deviation <= 0 disables the angular half entirely.
+    diag_offset_bands("final");
+    const auto [max_dist, avg_dist] = compute_distance_deviation();
+    const auto [max_norm, avg_norm] = compute_normal_deviation();
+    logger().info(
+        "max dist err: {} | avg dist err: {} | max normal dev: {} | avg normal dev: {}",
+        max_dist,
+        avg_dist,
+        max_norm,
+        avg_norm);
+    optimization_metrics.push_back({{max_dist, avg_dist, max_norm, avg_norm}});
+    log_worst_dist_vertex();
+
+    const bool dist_ok = max_dist <= m_offset_params.convergence_target;
+    const bool norm_ok = m_offset_params.convergence_normal_deviation <= 0. ||
+                         avg_norm <= m_offset_params.convergence_normal_deviation;
+    m_converged = dist_ok && norm_ok;
+    if (m_converged) {
+        if (m_offset_params.convergence_normal_deviation > 0.) {
             logger().info(
-                "\tsplit pass dropped {} operations for want of slots; consolidating and repeating",
-                lost);
-            consolidate_mesh();
-        }
-        if (split_attempts == 8) {
-            logger().warn("\tsplit pass still slot-limited after 8 attempts; giving up on it");
-        }
-        diag_offset_bands("after split");
-        local_operations({{0, 1, 0, 0}});
-        logger().info(
-            "\t[offset] collapses removing an offset vertex: {} of {}",
-            iter_cnt_collapse_offset_removed.load(),
-            iter_cnt_collapse.load());
-        diag_offset_bands("after collapse");
-        local_operations({{0, 0, 1, m_offset_params.num_smoothing_passes}});
-
-        log_smooth_trace();
-
-        op_counts.push_back(
-            {{iter_cnt_split.load(), iter_cnt_collapse.load(), iter_cnt_swap.load()}});
-        logger().info(
-            "splits = {}  |  collapses = {} ({} refused by normal deviation)  |  swaps = {} ({} "
-            "refused by normal deviation)",
-            iter_cnt_split.load(),
-            iter_cnt_collapse.load(),
-            iter_cnt_collapse_nd_reject.load(),
-            iter_cnt_swap.load(),
-            iter_cnt_swap_nd_reject.load());
-
-        // RECLAIM THE SLOT POOL. TetMesh preallocates vertex/tet storage as
-        // reserved_capacity() = 6x the live count, fixed at the last consolidate, and hands it
-        // out through get_next_empty_slot_v(). A collapse only MARKS its slots removed -- the
-        // allocation cursor never moves back -- so the pool is consumed by the split pass and
-        // never returned. When it runs out, TetMesh::split_edge() bails at
-        //     int v_id = get_next_empty_slot_v();
-        //     if (v_id < 0) return false;   // out of preallocated vertex slots
-        // which is BEFORE split_edge_after(), so no application hook is involved and nothing is
-        // logged: the splits simply all fail. Only consolidate_mesh() compacts the removed slots
-        // away and re-reserves from the new live count.
-        //
-        // mesh_improvement() does exactly this, once per iteration (TetOptimizerMesh.cpp), and
-        // this loop deliberately does not call mesh_improvement -- see the comment above
-        // local_operations() -- so it has to do the consolidate itself.
-        //
-        // Measured on specific_models/prism before this: the offset seeds at 1286 vertices,
-        // iteration 1 splits to 12526 and collapses back to a LIVE 1515, and from iteration 2
-        // on every split fails -- 7450 approved by split_edge_before(), 0 reaching
-        // split_edge_after() -- while 1775 of 1950 offset edges still exceed their target
-        // length. max_dist_err and max_norm_dev then sit flat for the rest of the run.
-        //
-        // Note this renumbers the mesh, so it changes the order later passes enumerate
-        // operations in and therefore the run; that is the same effect DEBUG_output has via
-        // write_vtu(), and it is unavoidable here.
-        consolidate_mesh();
-
-        logger().info("\tUpdating sizing field...");
-        update_sizing_field();
-
-        // metrics
-        const auto [max_dist, avg_dist] = compute_distance_deviation();
-        const auto [max_norm, avg_norm] = compute_normal_deviation();
-        logger().info(
-            "max dist err: {} | avg dist err: {} | max normal dev: {} | avg normal dev: {}",
-            max_dist,
-            avg_dist,
-            max_norm,
-            avg_norm);
-        optimization_metrics.push_back({{max_dist, avg_dist, max_norm, avg_norm}});
-        log_worst_dist_vertex();
-
-        // Convergence: the worst-placed offset vertex has reached the target error band, and the
-        // offset's AVERAGE facing has reached the target normal deviation.
-        //
-        // The asymmetry -- max for distance, average for angle -- is the paper's (Sec. 5.3,
-        // Termination: "the average sigma_max ... both the maximum and mean distance error"),
-        // and it is forced by the geometry rather than chosen for convenience. Distance error
-        // genuinely can go to zero everywhere, so the max is a fair bar. Normal deviation cannot:
-        // at a sharp feature of the input the distance field's normal is discontinuous by the
-        // feature's own angle, at every scale, so max sigma has a floor no refinement, no smaller
-        // target_distance and no operation can lower.
-        //
-        // max_norm is still computed and reported; it is a diagnostic, not a bar.
-        // convergence_normal_deviation <= 0 disables the angular half entirely.
-        const bool dist_ok = max_dist <= m_offset_params.convergence_target;
-        const bool norm_ok = m_offset_params.convergence_normal_deviation <= 0. ||
-                             avg_norm <= m_offset_params.convergence_normal_deviation;
-        m_converged = dist_ok && norm_ok;
-        if (m_converged) {
-            if (m_offset_params.convergence_normal_deviation > 0.) {
-                logger().info(
-                    "Converged ([max_dist] {} <= {} [convergence_target], [avg_normal_dev] {} <= "
-                    "{} [convergence_normal_deviation]), terminating early...",
-                    max_dist,
-                    m_offset_params.convergence_target,
-                    avg_norm,
-                    m_offset_params.convergence_normal_deviation);
-            } else {
-                logger().info(
-                    "Converged ([max_dist] {} <= {} [convergence_target], normal deviation "
-                    "criterion disabled), terminating early...",
-                    max_dist,
-                    m_offset_params.convergence_target);
-            }
-            break;
+                "Converged ([max_dist] {} <= {} [convergence_target], [avg_normal_dev] {} <= "
+                "{} [convergence_normal_deviation])",
+                max_dist,
+                m_offset_params.convergence_target,
+                avg_norm,
+                m_offset_params.convergence_normal_deviation);
+        } else {
+            logger().info(
+                "Converged ([max_dist] {} <= {} [convergence_target], normal deviation "
+                "criterion disabled)",
+                max_dist,
+                m_offset_params.convergence_target);
         }
     }
 

--- a/components/topological_offset/wmtk/components/topological_offset/TopoOffsetTetMesh.cpp
+++ b/components/topological_offset/wmtk/components/topological_offset/TopoOffsetTetMesh.cpp
@@ -132,6 +132,13 @@ void TopoOffsetTetMesh::init_surfaces_and_boundaries()
         m_vertex_extra[v1].m_is_on_input = true;
         m_vertex_extra[v2].m_is_on_input = true;
         m_vertex_extra[v3].m_is_on_input = true;
+        // The base's own flag, which is a DIFFERENT field from the two above: those say which of
+        // the offset's two tracked surfaces a vertex belongs to, this says that it belongs to one
+        // at all. Every surface-aware path in the shared engine gates on it -- see
+        // optimize_offset(), where the same omission had teeth.
+        m_vertex_attribute[v1].m_is_on_surface = true;
+        m_vertex_attribute[v2].m_is_on_surface = true;
+        m_vertex_attribute[v3].m_is_on_surface = true;
 
         tempF.emplace_back(v1, v2, v3);
     }
@@ -1209,6 +1216,19 @@ void TopoOffsetTetMesh::optimize_offset(const std::filesystem::path& output_file
         auto vs = get_face_vids(f);
         for (const size_t& vid : vs) {
             m_vertex_extra[vid].m_is_on_offset = true;
+            // THE BASE'S UNION FLAG, and the one the shared operations actually read. 2D sets it
+            // in label_offset_boundary(); 3D set neither this nor its counterpart at
+            // init_surfaces_and_boundaries(), so m_is_on_surface was false on every vertex of the
+            // mesh for the whole optimization.
+            //
+            // TetOptimizerMesh::is_edge_on_surface() short-circuits on it before it ever looks at
+            // the face attributes, so no offset edge was ever recognised as carrying tracked
+            // geometry: the collapse's surface link condition and preserve_topology (which both
+            // gate on VA[..].m_is_on_surface), and the split's propagation of the flag to the new
+            // vertex, were dead code for the offset. Instrumented on specific_models/prism, 0 of
+            // ~1700 offset-edge split attempts per iteration were seen as surface edges; 1727 with
+            // this line.
+            m_vertex_attribute[vid].m_is_on_surface = true;
         }
     }
 

--- a/components/topological_offset/wmtk/components/topological_offset/TopoOffsetTetMesh.h
+++ b/components/topological_offset/wmtk/components/topological_offset/TopoOffsetTetMesh.h
@@ -584,10 +584,11 @@ public:
         std::atomic<int> offset_attempted{0}; ///< dispatched to smooth_after_offset_surface()
         std::atomic<int> offset_no_neighbours{0}; ///< no offset-surface neighbour to average
         std::atomic<int> offset_on_complex{0}; ///< every sample degenerate: no offset direction
-        /// The search ran out and p0 ITSELF still inverts a tet, so no fraction of the move is
-        /// legal. Unlike 2D this is not a rejection: move_to() clamps rather than refusing, and
-        /// the base's invariants() -- run by TetMesh::smooth_vertex right after -- is what rolls
-        /// the move back. Counted here because a vertex in this state is frozen for the run.
+        /// The binary search found no legal step at all: every fraction of the move inverts an
+        /// incident tet, possibly including the zero step (p0 itself already inverted). This IS
+        /// a rejection -- smooth_after_offset_surface() restores p0 and returns false, following
+        /// the reference implementation, which refuses rather than accepting a zero-length move.
+        /// A vertex in this state received none of its correction this pass.
         std::atomic<int> offset_inverted{0};
         /// Always 0 in 3D: the region-boundary envelope is 2D-only, so nothing on this path can
         /// be rejected by containment. Kept for lock-step with 2D.

--- a/components/topological_offset/wmtk/components/topological_offset/TopoOffsetTetMesh.h
+++ b/components/topological_offset/wmtk/components/topological_offset/TopoOffsetTetMesh.h
@@ -327,13 +327,22 @@ public:
     void write_optimization_debug_output(const std::string& path) override { write_vtu(path); }
 
     /**
-     * @brief The offset's sizing refinement, as the base's stall escape hatch.
+     * @brief The engine's stall-driven sizing refinement, driven by the offset's criterion.
      *
-     * The base fires this when the max energy stops improving; the offset also runs
-     * update_sizing_field() unconditionally once per iteration, since its sizing field is
-     * driven by the shape of the offset triangulation rather than by the optimizer stalling.
+     * mesh_improvement() fires this when optimization_quality_stats()'s max stalls; the
+     * override ratchets the sizing down around the worst-placed band vertices only
+     * (TetWildMesh::refine_sizing_around_worst with distance error in place of AMIPS), and
+     * keeps the paper's 1.5x growth where the surface is flat, in-band and well-shaped.
      */
-    size_t refine_sizing_around_worst(double) override { return update_sizing_field(); }
+    size_t refine_sizing_around_worst(double) override;
+
+    /**
+     * @brief (max, avg) band-vertex distance error over convergence_target; the engine's stop
+     * metric is therefore 1.0. Distance only -- the average-normal-deviation criterion is
+     * tested after the loop.
+     */
+    std::tuple<double, double> optimization_quality_stats() override;
+    double optimization_stop_metric() const override { return 1.; }
 
     /**
      * @brief Which tag the tets a swap creates should carry.
@@ -816,7 +825,6 @@ public:
      * to an unrelated coarse one. Called once per optimize_offset() iteration, after smoothing.
      * @note skeleton: unlike the reference, this doesn't also factor in normal deviation.
      */
-    size_t update_sizing_field();
     //// sizing field
 
     //// swap

--- a/components/topological_offset/wmtk/components/topological_offset/TopoOffsetTetMesh.h
+++ b/components/topological_offset/wmtk/components/topological_offset/TopoOffsetTetMesh.h
@@ -127,15 +127,25 @@ public:
      */
     static constexpr int OFFSET_SURFACE_CLASS = 1;
 
+    /**
+     * @brief AVERAGE distance error, as a fraction of target_distance, above which a
+     * non-converged run with respect_all_topologies is reported as topologically blocked.
+     *
+     * The discriminator is the AVERAGE, not the max and not max/avg. Topological blocking is
+     * WIDESPREAD -- whole stretches of offset cannot advance, so the average climbs toward the
+     * max. Every other failure mode is the opposite shape: a few over-constrained vertices pin
+     * the max while the rest lands correctly, leaving the average tiny. In 2D avg/delta separated
+     * the blocked runs from every other run by more than 150x.
+     *
+     * Class-scope rather than namespace-scope only because TopoOffsetTriMesh.h already defines a
+     * namespace-scope constant of this name and the two headers share a namespace.
+     */
+    static constexpr double TOPOLOGY_BLOCK_AVG_FRAC = 0.05;
+
 public: // mode for splitting in marching tets
     enum class EdgeSplitMode {
         Midpoint = 0, // used for simplicial embedding steps
         Initial = 1, // this is used to initialize the complex. Its a little hacky
-
-        // only one of these is used, hard coded in execute_offset()
-        BinarySearch = 2, // bisection root finding algo
-        LogRootFind = 3, // 'custom' root finding, using the fact that d(x) - d* < 0 at first vertex
-        SphereTracing = 4, // use sphere tracing to compute the zero of the distance field
 
         Optimization = 5 // this is used in the optimization phase of the algorithm
     };
@@ -233,12 +243,8 @@ public:
      */
     bool cell_in_region(const size_t tid) const
     {
-        const CellTag& tags = m_tet_attribute[tid].tag;
-        for (const int64_t t : m_offset_output_tag_ids) {
-            if (tags.count(t) != 0) return true; // in the offset band
-        }
-        const ExpressionPtr& expr = m_offset_params.offset_selection;
-        return expr && expr->eval(tags); // in the input complex it wraps
+        const int l = m_tet_attribute[tid].label;
+        return l == 1 || l == 2; // input complex, or the offset band
     }
 
     /// Whether face `fid` is on the offset boundary (as opposed to the input complex).
@@ -381,6 +387,9 @@ public:
     bool split_before_cells(const Tuple& edge, const std::vector<Tuple>& parents) override;
     bool split_after_cells(size_t v1, size_t v2, size_t v_new, const std::vector<Tuple>& children)
         override;
+    /// Writes the new vertex's tracked-surface membership before the shared split's containment
+    /// check reads it; returns the base's positioning verdict unchanged. See the definition.
+    bool split_adjust_position(size_t v_new, const std::vector<Tuple>& children) override;
     void split_after_vertex(size_t v_new, bool is_edge_open_boundary) override;
 
     /// The offset's surface can end on a non-manifold or boundary edge of the input complex,
@@ -408,6 +417,10 @@ private:
     bool swap_capture_tag(const std::vector<size_t>& tids);
     /// The tag swap_after_cells writes onto the tets the swap created, chosen in `before`.
     wmtk::threading::enumerable_thread_specific<CellTag> m_swap_tag;
+    /// The construction LABEL shared by every cell of the swap's ring, captured alongside the
+    /// tag. Without this a swap leaves its new cells holding whatever label occupied the
+    /// recycled tet slot, and the label is what region membership is read from.
+    wmtk::threading::enumerable_thread_specific<int> m_swap_label;
 
 public:
     /**
@@ -434,6 +447,27 @@ public:
     bool is_edge_on_offset(const Tuple& loc);
 
     /**
+     * @brief The two simplex sets the optimization may not touch at all.
+     *
+     * The input simplicial complex is the geometry the offset is measured against, and the
+     * domain boundary is the box the background mesh lives in. Neither is something to be
+     * improved: an operation that splits, collapses, flips or moves any of their simplices
+     * changes the reference the whole result is defined against. This is categorical, not a
+     * tolerance -- the shared engine holds the input surface inside m_envelope, which lets it
+     * drift by eps, and eps is not zero.
+     *
+     * Same rule and same wording as TopoOffsetTriMesh::vertex_is_frozen()/edge_is_frozen(). The
+     * one difference the dimension forces: 2D reads an edge's bbox membership off the edge
+     * itself, while 3D tracks the box on FACES, so the edge test goes through the base's
+     * is_edge_on_bbox(), which walks the edge's incident faces. Both are therefore non-const.
+     */
+    bool vertex_is_frozen(const size_t vid) const
+    {
+        return m_vertex_extra[vid].m_is_on_input || !m_vertex_attribute[vid].on_bbox_faces.empty();
+    }
+    bool edge_is_frozen(const Tuple& loc) { return is_edge_on_input(loc) || is_edge_on_bbox(loc); }
+
+    /**
      * @brief check that the ambient tag does not overlap with any other tags
      */
     bool ambient_assert();
@@ -455,29 +489,6 @@ public:
      */
     void init_input_complex_bvh();
 
-    /**
-     * @deprecated
-     * @brief split edge at point by minimizing m_offset_params.target_distance - d() (where d() is
-     * distance to input complex via BVH) along the edge. Uses binary search, so implicitly assumes
-     * distance field is monotonic along edge. May give weird results if not monotonic
-     */
-    void edge_split_binary_search(const size_t v1, const size_t v2, Vector3d& p_new) const;
-    void edge_split_binary_search(const Vector3d& v1_pos, const Vector3d& v2_pos, Vector3d& p_new)
-        const;
-
-    /**
-     * @deprecated
-     * @brief uses custom root finding routine, attempting to find first root (nearest to v1)
-     * to split edge at
-     */
-    void edge_split_log_root_find(const size_t v1, const size_t v2, Vector3d& p_new) const;
-
-    /**
-     * @brief split edge at first root of d(l) - d*, where d(l) is distance to input complex,
-     * using sphere tracing method. This is the best method and should be used instead of
-     * binary or log root finding methods
-     */
-    void edge_split_sphere_tracing(const size_t v1, const size_t v2, Vector3d& p_new) const;
 
     /**
      * @brief label connected simplicial complex components (simplices labelled 1 or 2)
@@ -549,6 +560,90 @@ public:
      * @note skeleton: no bisection fallback toward p0 on rejection.
      */
     bool smooth_after_offset_surface(const Tuple& t);
+
+    /**
+     * @brief Why smoothing refused a vertex, one counter per site where it can say no.
+     *
+     * The base's SmoothRejectCounters only sees the vertices that reach
+     * TetOptimizerMesh::smooth_after(), which for the offset is the INTERIOR ones -- an
+     * offset-surface vertex is placed by smooth_after_offset_surface() and never touches them.
+     * So the whole offset surface, the part that actually carries the distance error, is
+     * invisible in the base's "accepted N | rejected: ..." line. These counters cover every
+     * site on both paths.
+     *
+     * Field-for-field the same as TopoOffsetTriMesh::SmoothTrace, including the three counters
+     * 3D has no mechanism to raise yet -- they stay in so the two log lines diff cleanly, and
+     * so they light up on their own when the mechanism lands. Each is commented below.
+     */
+    struct SmoothTrace
+    {
+        std::atomic<int> attempted{0}; ///< smooth_before() entered
+        std::atomic<int> before_bbox{0}; ///< base smooth_before said no: on the bounding box
+        std::atomic<int> before_unrounded{0}; ///< base smooth_before said no: could not round
+        std::atomic<int> before_on_input{0}; ///< input complex, frozen
+        std::atomic<int> offset_attempted{0}; ///< dispatched to smooth_after_offset_surface()
+        std::atomic<int> offset_no_neighbours{0}; ///< no offset-surface neighbour to average
+        std::atomic<int> offset_on_complex{0}; ///< every sample degenerate: no offset direction
+        /// The search ran out and p0 ITSELF still inverts a tet, so no fraction of the move is
+        /// legal. Unlike 2D this is not a rejection: move_to() clamps rather than refusing, and
+        /// the base's invariants() -- run by TetMesh::smooth_vertex right after -- is what rolls
+        /// the move back. Counted here because a vertex in this state is frozen for the run.
+        std::atomic<int> offset_inverted{0};
+        /// Always 0 in 3D: the region-boundary envelope is 2D-only, so nothing on this path can
+        /// be rejected by containment. Kept for lock-step with 2D.
+        std::atomic<int> offset_envelope{0};
+        std::atomic<int> offset_accepted{0};
+        /// Accepted, but the binary search had to stop short of the blended target. These are
+        /// invisible in offset_accepted, which is the point: a clamped move reports success
+        /// while delivering a fraction of the requested correction.
+        std::atomic<int> offset_clamped{0}; ///< accepted with the search fraction < 0.99
+        /// Always 0 in 3D, for the same reason as offset_envelope.
+        std::atomic<int> offset_clamp_env{0};
+        std::atomic<int> offset_clamp_inv{0}; ///< ... and an inverted tet is what stopped it
+        /// Always 0 until the tangent-PLANE slide lands (the 3D counterpart of 2D's
+        /// minimize_distance_along_tangent(); see .claude/CLAUDE.md 3D note 7).
+        std::atomic<int> offset_slid{0};
+        /// Distance error over the offset vertices this pass actually touched, before and after
+        /// the move, in units of 1e-9 so an atomic<int> can accumulate a max/sum.
+        std::atomic<long long> offset_err_before_nano{0};
+        std::atomic<long long> offset_err_after_nano{0};
+        std::atomic<int> offset_err_max_before_nano{0};
+        std::atomic<int> offset_err_max_after_nano{0};
+        std::atomic<int> interior_attempted{0}; ///< dispatched to the shared AMIPS smoother
+        /// Always 0 in 3D: there is no REGION surface class here, only INPUT and OFFSET.
+        std::atomic<int> region_attempted{0};
+
+        void reset()
+        {
+            offset_err_before_nano.store(0);
+            offset_err_after_nano.store(0);
+            for (std::atomic<int>* c :
+                 {&attempted,
+                  &before_bbox,
+                  &before_unrounded,
+                  &before_on_input,
+                  &offset_attempted,
+                  &offset_no_neighbours,
+                  &offset_on_complex,
+                  &offset_inverted,
+                  &offset_envelope,
+                  &offset_accepted,
+                  &offset_clamped,
+                  &offset_clamp_env,
+                  &offset_clamp_inv,
+                  &offset_slid,
+                  &offset_err_max_before_nano,
+                  &offset_err_max_after_nano,
+                  &interior_attempted,
+                  &region_attempted}) {
+                c->store(0);
+            }
+        }
+    };
+    SmoothTrace m_smooth_trace;
+    void log_smooth_trace() const;
+
+
     //// smoothing
 
     //// collapse
@@ -563,15 +658,111 @@ public:
     double m_max_normal_deviation_swap_max_deg = 75.0;
 
     /**
-     * @brief max angle (degrees, 0-90, orientation independent) between offset-surface face
-     * f's own normal and any of its offset_surface_samples() normals. Taking the max over all
-     * 4 samples (rather than a single centroid sample) is what makes this sensitive to
-     * features: a face straddling a sharp fold of the input complex will have samples on
-     * either side of the fold, so at least one of them disagrees strongly with the face's own
-     * (necessarily flat) normal, even though the face may look locally fine from any single
-     * sample alone.
+     * @brief Paper Definition 5: max angle (degrees) between the offset FIELD normal at face f's
+     * centroid and the field normal at each of its three near-corner samples.
+     *
+     * Both terms are field normals -- f's own geometric normal does not appear. n() is continuous
+     * away from the input complex's features, so shrinking a face drives sigma to zero, which is
+     * what makes this something update_sizing_field() can actually satisfy. The earlier version
+     * compared f's own normal against the samples, i.e. misorientation, which refinement does not
+     * fix and the sizing field could therefore never drive down.
+     *
+     * Mirrors TopoOffsetTriMesh::edge_normal_deviation(); the only difference is 3 samples
+     * instead of 2, because a triangle has three vertices and a segment has two.
      */
     double face_normal_deviation(const Tuple& f) const;
+
+    /**
+     * @brief The offset field's normal at an arbitrary point: the unit vector from the nearest
+     * point on the input complex out to p. False if p sits on the complex, where it has none.
+     *
+     * "The offset normal can be computed for any point in space by finding the projection point
+     * on the offset and normalizing the vector from the point in space to its projection."
+     * (paper, Appendix A.)
+     */
+    /**
+     * @brief Seed the sizing field from the offset surface's CURRENT edge lengths, once, before
+     * the first pass. Paper Sec. 5.3.3 Step 1: "initialized with the current length of each edge."
+     *
+     * Without it the field starts at the base target (a fraction of the bounding box), which is
+     * far coarser than the offset surface, so every offset edge is a collapse candidate on pass
+     * one and the surface is decimated before any metric is computed.
+     */
+    void init_offset_sizing_field();
+
+    bool offset_field_normal(const Vector3d& p, Vector3d& n) const;
+
+    /**
+     * @brief How far the offset surface is from where it should be: {max, avg} over its vertices.
+     *
+     * The absolute error |dist(v, input complex) - target_distance|, over the band's OUTER
+     * surface only -- a band cell meeting a plain-background cell, not the input complex it
+     * wraps, whose interface sits at distance 0 by construction. The MAX is what the optimization
+     * converges against: the offset is only as good as its worst-placed vertex.
+     *
+     * A face with no opposite tet is ON THE DOMAIN BOUNDARY and is counted, not skipped. The 2D
+     * version skipped those and under-reported a bbox-clipped offset by 11x -- true error on the
+     * clipped stretch reached 52% of the target distance while the report showed 0.5%. Those
+     * vertices are frozen on the box and can never be fixed, which is exactly why they must be
+     * visible rather than silently dropped.
+     */
+    std::pair<double, double> compute_distance_deviation() const;
+
+    /**
+     * @brief How far the offset surface FACES from where it should be: {max, avg} in DEGREES.
+     *
+     * face_normal_deviation() over the same band-outer faces compute_distance_deviation() measures
+     * vertices over, reported alongside it. Distance alone does not pin the offset down: a surface
+     * can have every vertex at exactly target_distance while zig-zagging between them.
+     */
+    std::pair<double, double> compute_normal_deviation() const;
+
+    /**
+     * @brief The band's outer surface, recomputed live rather than read from the cached class.
+     *
+     * A band cell meeting a cell that is neither band nor input complex. Live because the
+     * operations that ask this run between one labelling pass and the next, so a face a split
+     * just created carries whatever cached class its recycled slot happened to hold.
+     *
+     * Returns true for a band face on the domain boundary (no opposite tet) -- see
+     * compute_distance_deviation() for why that case must not be dropped.
+     */
+    bool face_is_offset_surface_live(const Tuple& f) const;
+
+    /// Whether tet `tid` is part of the offset BAND (as opposed to the input complex it wraps).
+    bool cell_is_offset_band(const size_t tid) const { return m_tet_attribute[tid].label == 2; }
+
+    /// Whether tet `tid` is part of the INPUT complex the band wraps.
+    bool cell_is_input_complex(const size_t tid) const { return m_tet_attribute[tid].label == 1; }
+
+    /**
+     * @brief Warn if conservative growth ran into the bounding box.
+     *
+     * A band face on the domain boundary means target_distance exceeded the clearance between the
+     * input complex and the box, so the offset is clipped there. Those vertices are frozen and no
+     * operation can move them, which makes the target distance unreachable by construction --
+     * worth saying out loud rather than leaving as a mysterious plateau in max_dist_err.
+     */
+    void warn_if_offset_reaches_domain_boundary() const;
+
+    /// The vertex compute_distance_deviation() last found the max at, and a dump of everything
+    /// that could be stopping it from moving. Diagnostic only.
+    mutable size_t m_worst_dist_vid = static_cast<size_t>(-1);
+    void log_worst_dist_vertex() const;
+
+    /// {max_dist_err, avg_dist_err, max_norm_dev, avg_norm_dev} per optimization iteration.
+    std::vector<std::array<double, 4>> optimization_metrics;
+    /// {splits, collapses, swaps} per optimization iteration, mirroring optimization_metrics.
+    std::vector<std::array<int, 3>> op_counts;
+    /// Whether the optimization met both convergence criteria before the iteration cap.
+    bool m_converged = false;
+
+    /// Per-iteration operation counters, reset before each iteration's operation passes.
+    std::atomic<int> iter_cnt_split{0};
+    std::atomic<int> iter_cnt_collapse{0};
+    std::atomic<int> iter_cnt_swap{0};
+    std::atomic<int> iter_cnt_collapse_nd_reject{0};
+    std::atomic<int> iter_cnt_swap_nd_reject{0};
 
     /**
      * @brief max face_normal_deviation() over the offset-surface faces incident to vertex vid
@@ -647,10 +838,17 @@ public:
     //// swap
 
     /**
-     * @brief execute simplistic marching tets. All edges with one vertex labelled 0 and the other 1/2
-     * are split. If m_edge_split_mode=BinarySearch, edges are split according to BVH distance field
-     * and the offset target distance (m_offset_params.target_distance). If
-     * m_edge_split_mode=Midpoint, edges are split at the midpoint
+     * @brief execute simplistic marching tets. All edges with one vertex labelled 0 and the other
+     * 1/2 are split, at the MIDPOINT (Midpoint) or at a fraction of the way toward the input
+     * complex (Initial).
+     *
+     * The distance-field modes that used to exist here -- BinarySearch, LogRootFind and
+     * SphereTracing, which root-found each band-boundary edge onto d(x) = delta at insertion time
+     * -- are gone, as they are in 2D. They contradict the paper, which places inserted vertices at
+     * the midpoint (Sec. 5.2: "we do not perform an interpolation ... we just place the inserted
+     * vertices at the midpoint of the split edges") and leaves the distance entirely to the
+     * Step-3 optimization; and they did the optimizer's job with a worse tool, having no error
+     * feedback and running none of the inversion guards smooth_after_offset_surface() does.
      */
     void marching_tets();
 

--- a/components/topological_offset/wmtk/components/topological_offset/TopoOffsetTetMesh.h
+++ b/components/topological_offset/wmtk/components/topological_offset/TopoOffsetTetMesh.h
@@ -729,6 +729,7 @@ public:
      * compute_distance_deviation() for why that case must not be dropped.
      */
     bool face_is_offset_surface_live(const Tuple& f) const;
+    void diag_offset_bands(const char* tag) const;
 
     /// Whether tet `tid` is part of the offset BAND (as opposed to the input complex it wraps).
     bool cell_is_offset_band(const size_t tid) const { return m_tet_attribute[tid].label == 2; }
@@ -763,6 +764,7 @@ public:
     std::atomic<int> iter_cnt_collapse{0};
     std::atomic<int> iter_cnt_swap{0};
     std::atomic<int> iter_cnt_collapse_nd_reject{0};
+    std::atomic<int> iter_cnt_collapse_offset_removed{0};
     std::atomic<int> iter_cnt_swap_nd_reject{0};
 
     /**

--- a/components/topological_offset/wmtk/components/topological_offset/TopoOffsetTetMesh.h
+++ b/components/topological_offset/wmtk/components/topological_offset/TopoOffsetTetMesh.h
@@ -336,6 +336,12 @@ public:
      */
     size_t refine_sizing_around_worst(double) override;
 
+    /// min: a collapse must not un-refine the sizing field -- see the base declaration.
+    double collapse_merged_sizing(double removed, double survivor) const override
+    {
+        return std::min(removed, survivor);
+    }
+
     /**
      * @brief (max, avg) band-vertex distance error over convergence_target; the engine's stop
      * metric is therefore 1.0. Distance only -- the average-normal-deviation criterion is

--- a/components/topological_offset/wmtk/components/topological_offset/scripts/visualize_offset.py
+++ b/components/topological_offset/wmtk/components/topological_offset/scripts/visualize_offset.py
@@ -385,11 +385,13 @@ def main():
         ]
 
     def set_mode(i):
+        # 3D only: in 2D the offset is a curve network and carries no scalar layers.
+        if err is None or dim != 3:
+            return
         m = ps.get_surface_mesh("offset surface")
-        if err is not None and dim == 3:
-            m.add_scalar_quantity("|dist - delta| / delta", rel, cmap="reds",
-                                  vminmax=(0.0, float(rel.max())), enabled=(i == 0))
-            m.add_scalar_quantity("distance to input", dist, cmap="viridis", enabled=(i == 1))
+        m.add_scalar_quantity("|dist - delta| / delta", rel, cmap="reds",
+                              vminmax=(0.0, float(rel.max())), enabled=(i == 0))
+        m.add_scalar_quantity("distance to input", dist, cmap="viridis", enabled=(i == 1))
 
     if len(surf["offset"]):
         set_mode(0)

--- a/components/topological_offset/wmtk/components/topological_offset/scripts/visualize_offset.py
+++ b/components/topological_offset/wmtk/components/topological_offset/scripts/visualize_offset.py
@@ -5,8 +5,11 @@
     ./visualize_offset.py out.msh                    # mesh alone
     ./visualize_offset.py out.msh config.json        # mesh + the config it ran under
 
-Needs polyscope, meshio and numpy (same venv as visualize_triwild.py; see the triwild
-scripts README).
+Needs polyscope, meshio and numpy. The simwild conda env has all three:
+
+    conda activate simwild && python visualize_offset.py <run dir>
+
+Otherwise any env with those packages works (see the triwild scripts README for a venv).
 
 The output .msh holds one cell block per physical group -- `ambient`, one group per tag,
 and the offset output tag(s). Nothing in the file marks the surfaces the optimization is

--- a/components/topological_offset/wmtk/components/topological_offset/scripts/visualize_offset.py
+++ b/components/topological_offset/wmtk/components/topological_offset/scripts/visualize_offset.py
@@ -26,7 +26,10 @@ groups, and
   inner interface   offset group against the input groups: hugs the complex at distance
                     ~0 by construction, drawn dim and off by default, so it cannot be
                     mistaken for the offset
-  <other tags>      any remaining group boundary, off by default
+  region boundaries every facet where the two sides' tag memberships differ (green);
+                    on by default when the input-surface layer is empty
+  envelope curves   the EnvelopeSurface line entity, 2D outputs only: the
+                    region-boundary geometry the envelope was built from (orange)
 
 The offset surface carries two scalar layers: distance to the input surface, and
 |distance - delta| / delta. delta comes from the config (`target_distance`, else
@@ -83,7 +86,7 @@ def eval_selection(expr, names):
 
 
 def read_groups(path):
-    """(points, dim, {group name: cell array}) from a topological_offset .msh."""
+    """(points, dim, {group name: cell array}, envelope segments) from the .msh."""
     m = meshio.read(str(path))
     kind, ncol = ("tetra", 4) if any(c.type == "tetra" for c in m.cells) else ("triangle", 3)
     # One block per physical group, in the same order as field_data; pair them by the
@@ -96,7 +99,13 @@ def read_groups(path):
         name = id_to_name.get(int(phys[0]), "group_%d" % int(phys[0]))
         groups.setdefault(name, []).append(block.data)
     groups = {k: np.vstack(v) for k, v in groups.items()}
-    return m.points, ncol - 1, groups
+    # The 2D writer also emits the envelope's segments as an "EnvelopeSurface" line
+    # entity -- the region-boundary geometry the envelope was built from, which is the
+    # closest thing in the file to the input geometry itself. (The 3D writer's envelope
+    # block is commented out, so this is empty for tets.)
+    env = [c.data for c in m.cells if c.type == "line"]
+    env = np.vstack(env) if env else np.zeros((0, 2), np.int64)
+    return m.points, ncol - 1, groups, env
 
 
 def interfaces(points, dim, groups):
@@ -247,7 +256,7 @@ def resolve(args):
 
 def load(msh, cfg):
     """Everything main() draws, as plain arrays -- no polyscope."""
-    points, dim, groups = read_groups(msh)
+    points, dim, groups, envelope = read_groups(msh)
     offset_tags = set(cfg.get("offset_output_tags", ["offset"])) & set(groups)
     if not offset_tags:
         offset_tags = {"offset"} & set(groups)
@@ -281,6 +290,26 @@ def load(msh, cfg):
     classed = {k: np.asarray(v) if v else np.zeros((0, dim + 1), np.int64)
                for k, v in classed.items()}
 
+    # REGION BOUNDARIES: facets where the two sides' group-membership sets differ -- the
+    # rule label_offset_boundary() classifies edges by. This is what shows the tag-region
+    # outlines (and the curve an expression selection lives on) when the selection has no
+    # cell region of its own, which is every 2D integration test. Membership sets are
+    # mapped to disjoint pseudo-groups so the pairing logic stays count-based and clean;
+    # pairs touching the offset class are dropped, the offset layer already draws those.
+    memb_groups = {}
+    for row, names in seen.values():
+        if names & offset_tags:
+            key = "__offset"
+        else:
+            key = "|".join(sorted(names))
+        memb_groups.setdefault(key, []).append(row)
+    memb_groups = {k: np.asarray(v) for k, v in memb_groups.items()}
+    region = [
+        f for pair, f in interfaces(points, dim, memb_groups).items()
+        if "__offset" not in pair and pair[1] != ""
+    ]
+    region = np.vstack(region) if region else np.zeros((0, dim), np.int64)
+
     iface = interfaces(points, dim, classed)
 
     def pick(*pairs):
@@ -293,6 +322,8 @@ def load(msh, cfg):
         # clipped at the domain boundary -- both included by the C++ metric.
         "offset": pick(("ambient", "offset"), ("offset", "")),
         "inner": pick(("input", "offset")),
+        "region": region,
+        "envelope": envelope,
     }
 
     delta = float(cfg.get("target_distance", -1.0))
@@ -334,8 +365,8 @@ def main():
     print("delta  %g  (%s)" % (delta, prov))
     for n in sorted(groups):
         print("  group %-16s %8d cells" % (n, len(groups[n])))
-    for n in ("input", "offset", "inner"):
-        print("  %-22s %8d facets" % (n + " surface", len(surf[n])))
+    for n in ("input", "offset", "inner", "region", "envelope"):
+        print("  %-22s %8d facets" % (n, len(surf[n])))
     if err is not None:
         _, _, dist, rel = err
         print("  offset vertices: dist to input  min %.6g  max %.6g   |err|/delta  avg %.4f  max %.4f"
@@ -366,10 +397,22 @@ def main():
         s.set_enabled(enabled)
         return s
 
+    def register_curves(name, segs, color, enabled):
+        if len(segs) == 0:
+            return None
+        p, c = compact(points, segs)
+        s = ps.register_curve_network(name, p, c, color=color, radius=0.0018)
+        s.set_enabled(enabled)
+        return s
+
     layers = [
         ("input surface (orange)", register("input surface", surf["input"], C_INPUT, True)),
         ("offset surface", register("offset surface", surf["offset"], C_OFFSET, True)),
         ("inner interface (grey)", register("inner interface", surf["inner"], C_INNER, False)),
+        ("region boundaries (green)",
+         register("region boundaries", surf["region"], C_OTHER, len(surf["input"]) == 0)),
+        ("envelope curves (orange)",
+         register_curves("envelope curves", surf["envelope"], C_INPUT, True)),
     ]
 
     # The offset surface's colour modes. Re-adding a quantity under the same name just

--- a/components/topological_offset/wmtk/components/topological_offset/scripts/visualize_offset.py
+++ b/components/topological_offset/wmtk/components/topological_offset/scripts/visualize_offset.py
@@ -20,7 +20,9 @@ groups, and
   input surface     boundary of the non-ambient, non-offset groups -- the complex the
                     offset is measured against (orange)
   offset surface    offset group against ambient: the band's OUTER surface, the one
-                    supposed to sit at target_distance (blue)
+                    supposed to sit at target_distance. Coloured by |dist-delta|/delta
+                    by default (reds, white 0 -> dark red at the max, range shown in the
+                    panel); switchable to raw distance (viridis) or solid blue
   inner interface   offset group against the input groups: hugs the complex at distance
                     ~0 by construction, drawn dim and off by default, so it cannot be
                     mistaken for the offset
@@ -366,16 +368,34 @@ def main():
 
     layers = [
         ("input surface (orange)", register("input surface", surf["input"], C_INPUT, True)),
-        ("offset surface (blue)", register("offset surface", surf["offset"], C_OFFSET, True)),
+        ("offset surface", register("offset surface", surf["offset"], C_OFFSET, True)),
         ("inner interface (grey)", register("inner interface", surf["inner"], C_INNER, False)),
     ]
+
+    # The offset surface's colour modes. Re-adding a quantity under the same name just
+    # updates it, so switching modes is a re-add with the right `enabled` -- this works
+    # on every polyscope version, unlike holding quantity handles.
+    modes = ["solid blue"]
     if err is not None and dim == 3:
         op, oc, dist, rel = err
-        s = ps.get_surface_mesh("offset surface")
-        s.add_scalar_quantity("distance to input", dist, cmap="viridis")
-        s.add_scalar_quantity("|dist - delta| / delta", rel, cmap="reds", enabled=True)
+        modes = [
+            "|dist-delta|/delta   reds: white 0 -> dark red %.4g" % rel.max(),
+            "distance to input    viridis: dark %.4g -> yellow %.4g" % (dist.min(), dist.max()),
+            "solid blue",
+        ]
+
+    def set_mode(i):
+        m = ps.get_surface_mesh("offset surface")
+        if err is not None and dim == 3:
+            m.add_scalar_quantity("|dist - delta| / delta", rel, cmap="reds",
+                                  vminmax=(0.0, float(rel.max())), enabled=(i == 0))
+            m.add_scalar_quantity("distance to input", dist, cmap="viridis", enabled=(i == 1))
+
+    if len(surf["offset"]):
+        set_mode(0)
 
     state = {label: (s is not None and s.is_enabled()) for label, s in layers}
+    state["mode"] = 0
 
     def callback():
         psim.TextUnformatted("%s   delta %g" % (msh.name, delta))
@@ -386,6 +406,13 @@ def main():
             changed, state[label] = psim.Checkbox(label, state[label])
             if changed:
                 s.set_enabled(state[label])
+        if len(surf["offset"]) and len(modes) > 1:
+            psim.Separator()
+            psim.TextUnformatted("offset surface colour:")
+            for i, label in enumerate(modes):
+                if psim.RadioButton(label, state["mode"] == i):
+                    state["mode"] = i
+                    set_mode(i)
 
     ps.set_user_callback(callback)
     ps.show()

--- a/components/topological_offset/wmtk/components/topological_offset/scripts/visualize_offset.py
+++ b/components/topological_offset/wmtk/components/topological_offset/scripts/visualize_offset.py
@@ -1,0 +1,392 @@
+#!/usr/bin/env python3
+"""Polyscope viewer for a topological_offset result: region surfaces + distance error.
+
+    ./visualize_offset.py runs/prism                 # a run directory
+    ./visualize_offset.py out.msh                    # mesh alone
+    ./visualize_offset.py out.msh config.json        # mesh + the config it ran under
+
+Needs polyscope, meshio and numpy (same venv as visualize_triwild.py; see the triwild
+scripts README).
+
+The output .msh holds one cell block per physical group -- `ambient`, one group per tag,
+and the offset output tag(s). Nothing in the file marks the surfaces the optimization is
+about, so they are derived here the way the C++ derives them from the labels: an
+interface face (3D) or edge (2D) is one whose two incident cells lie in different
+groups, and
+
+  input surface     boundary of the non-ambient, non-offset groups -- the complex the
+                    offset is measured against (orange)
+  offset surface    offset group against ambient: the band's OUTER surface, the one
+                    supposed to sit at target_distance (blue)
+  inner interface   offset group against the input groups: hugs the complex at distance
+                    ~0 by construction, drawn dim and off by default, so it cannot be
+                    mistaken for the offset
+  <other tags>      any remaining group boundary, off by default
+
+The offset surface carries two scalar layers: distance to the input surface, and
+|distance - delta| / delta. delta comes from the config (`target_distance`, else
+`target_distance_rel` x the mesh bounding-box diagonal -- the box is the frozen
+background bbox, so the output diagonal equals the input one). Without a config the
+defaults (rel 0.01, tag "offset") are assumed and said so.
+
+Two honesty notes on the error layer:
+
+* The reference surface is the band's INNER interface (which hugs the input complex by
+  construction, whatever the selection expression was), not the complex the C++ BVH
+  holds -- they differ where the band does not fully wrap the complex. Distances to it
+  are exact point-to-facet.
+* It is sampled at offset VERTICES, like compute_distance_deviation() -- so it inherits
+  that metric's known blind spot between vertices.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+import meshio
+import numpy as np
+import polyscope as ps
+import polyscope.imgui as psim
+
+C_INPUT = (0.910, 0.525, 0.165)  # orange/blue: separable under colour vision deficiency
+C_OFFSET = (0.169, 0.498, 0.831)
+C_INNER = (0.55, 0.55, 0.58)
+C_OTHER = (0.55, 0.75, 0.55)
+
+
+def eval_selection(expr, names):
+    """The offset_selection boolean expression, on one cell's group memberships.
+
+    Same language the C++ parses: tag names, & | !, parentheses; 'ambient' (spec default
+    spells it '_' or '!_') means "in no tag group". Names are substituted with their
+    membership truth value, then the expression is evaluated -- nothing but booleans and
+    the three operators survives the substitution, so eval sees no cell data.
+    """
+    import re
+
+    def sub(m):
+        tok = m.group(0)
+        if tok in ("ambient", "_"):
+            return str(names == {"ambient"} or not (names - {"ambient"}))
+        return str(tok in names)
+
+    py = re.sub(r"[A-Za-z0-9_]+", sub, expr)  # tag names may be purely numeric
+    py = py.replace("!", " not ").replace("&", " and ").replace("|", " or ")
+    if not re.fullmatch(r"[ ()TrueFalsandnot]*", py):
+        raise ValueError("cannot evaluate offset_selection %r" % expr)
+    return bool(eval(py))
+
+
+def read_groups(path):
+    """(points, dim, {group name: cell array}) from a topological_offset .msh."""
+    m = meshio.read(str(path))
+    kind, ncol = ("tetra", 4) if any(c.type == "tetra" for c in m.cells) else ("triangle", 3)
+    # One block per physical group, in the same order as field_data; pair them by the
+    # physical id gmsh stamped on each block's cells.
+    id_to_name = {int(v[0]): k for k, v in m.field_data.items() if int(v[1]) == (kind == "tetra") + 2}
+    groups = {}
+    for block, phys in zip(m.cells, m.cell_data["gmsh:physical"]):
+        if block.type != kind or len(block.data) == 0:
+            continue
+        name = id_to_name.get(int(phys[0]), "group_%d" % int(phys[0]))
+        groups.setdefault(name, []).append(block.data)
+    groups = {k: np.vstack(v) for k, v in groups.items()}
+    return m.points, ncol - 1, groups
+
+
+def interfaces(points, dim, groups):
+    """{(group a, group b): facet array}, a < b, plus (group, '') for domain boundary."""
+    names = sorted(groups)
+    cells = np.vstack([groups[n] for n in names])
+    owner = np.concatenate([np.full(len(groups[n]), i) for i, n in enumerate(names)])
+
+    # Every facet of every cell, keyed by its sorted vertex tuple.
+    nf = dim + 1  # facets per cell: 4 faces of a tet, 3 edges of a triangle
+    keep = [[j for j in range(nf) if j != skip] for skip in range(nf)]
+    facets = np.concatenate([cells[:, k] for k in keep])  # (nf * ncells, dim)
+    facet_owner = np.tile(owner, nf)
+    key = np.sort(facets, axis=1)
+
+    order = np.lexsort(key.T[::-1])
+    key, facets, facet_owner = key[order], facets[order], facet_owner[order]
+    new = np.ones(len(key), bool)
+    new[1:] = (key[1:] != key[:-1]).any(axis=1)
+    starts = np.flatnonzero(new)
+    counts = np.diff(np.append(starts, len(key)))
+
+    out = {}
+    for s, c in zip(starts, counts):
+        if c == 1:
+            pair = (names[facet_owner[s]], "")  # domain boundary
+        elif facet_owner[s] != facet_owner[s + 1]:
+            a, b = sorted((names[facet_owner[s]], names[facet_owner[s + 1]]))
+            pair = (a, b)
+        else:
+            continue  # interior to one group
+        out.setdefault(pair, []).append(facets[s])
+    return {k: np.asarray(v) for k, v in out.items()}
+
+
+def compact(points, cells):
+    used = np.unique(cells)
+    remap = np.full(len(points), -1, np.int64)
+    remap[used] = np.arange(len(used))
+    return points[used], remap[cells]
+
+
+def dist_to_segments(q, a, b):
+    """(nq,) exact distance from each query point to the nearest of the segments (a, b)."""
+    ab = b - a  # (ns, 3)
+    denom = np.maximum((ab * ab).sum(axis=1), 1e-300)
+    d = q[:, None, :] - a[None, :, :]  # (nq, ns, 3)
+    t = np.clip((d * ab[None, :, :]).sum(axis=2) / denom[None, :], 0.0, 1.0)
+    closest = a[None, :, :] + t[:, :, None] * ab[None, :, :]
+    return np.linalg.norm(q[:, None, :] - closest, axis=2).min(axis=1)
+
+
+def dist_to_triangles(q, t0, t1, t2):
+    """(nq,) exact distance from each query point to the nearest of the triangles.
+
+    Point sampling is NOT good enough here: the input complex is frozen at construction
+    resolution, so its edges are comparable to delta, and a sampled reference inflates
+    the distance by up to half an edge -- measured as avg err 0.30 where the C++ log said
+    0.08. So: exact point-triangle distance (Ericson, Real-Time Collision Detection
+    5.1.5), vectorized over query x triangle and chunked.
+    """
+    ab, ac = t1 - t0, t2 - t0  # (nt, 3)
+    out = np.empty(len(q))
+    for s in range(0, len(q), max(1, 4_000_000 // max(1, len(t0)))):
+        p = q[s : s + max(1, 4_000_000 // max(1, len(t0)))]
+        ap = p[:, None, :] - t0[None, :, :]  # (np, nt, 3)
+        d1 = (ab[None] * ap).sum(2)
+        d2 = (ac[None] * ap).sum(2)
+        bp = p[:, None, :] - t1[None, :, :]
+        d3 = (ab[None] * bp).sum(2)
+        d4 = (ac[None] * bp).sum(2)
+        cp = p[:, None, :] - t2[None, :, :]
+        d5 = (ab[None] * cp).sum(2)
+        d6 = (ac[None] * cp).sum(2)
+
+        va = d3 * d6 - d5 * d4
+        vb = d5 * d2 - d1 * d6
+        vc = d1 * d4 - d3 * d2
+        denom = np.maximum(va + vb + vc, 1e-300)
+
+        # Barycentric coordinates of the interior-region projection, then overwrite with
+        # each boundary region's clamped result where its condition holds.
+        v = vb / denom
+        w = vc / denom
+        # edge AC (vb region)
+        cond = (vb <= 0) & (d2 >= 0) & (d6 <= 0)
+        wc = np.clip(np.where(-d6 - d2 != 0, d2 / np.maximum(d2 - d6, 1e-300), 0), 0, 1)
+        v = np.where(cond, 0.0, v)
+        w = np.where(cond, wc, w)
+        # edge BC (va region)
+        cond = (va <= 0) & (d4 - d3 >= 0) & (d5 - d6 >= 0)
+        wc = np.clip((d4 - d3) / np.maximum((d4 - d3) + (d5 - d6), 1e-300), 0, 1)
+        v = np.where(cond, 1.0 - wc, v)
+        w = np.where(cond, wc, w)
+        # edge AB (vc region)
+        cond = (vc <= 0) & (d1 >= 0) & (d3 <= 0)
+        vc_ = np.clip(d1 / np.maximum(d1 - d3, 1e-300), 0, 1)
+        v = np.where(cond, vc_, v)
+        w = np.where(cond, 0.0, w)
+        # vertex regions
+        cond = (d1 <= 0) & (d2 <= 0)  # A
+        v = np.where(cond, 0.0, v)
+        w = np.where(cond, 0.0, w)
+        cond = (d3 >= 0) & (d4 <= d3)  # B
+        v = np.where(cond, 1.0, v)
+        w = np.where(cond, 0.0, w)
+        cond = (d6 >= 0) & (d5 <= d6)  # C
+        v = np.where(cond, 0.0, v)
+        w = np.where(cond, 1.0, w)
+
+        closest = t0[None] + v[:, :, None] * ab[None] + w[:, :, None] * ac[None]
+        out[s : s + len(p)] = np.linalg.norm(p[:, None, :] - closest, axis=2).min(axis=1)
+    return out
+
+
+def resolve(args):
+    """Command line -> (msh path, config dict or {})."""
+    paths = [Path(a) for a in args]
+    msh = next((p for p in paths if p.suffix == ".msh"), None)
+    cfg_path = next((p for p in paths if p.suffix == ".json"), None)
+    if msh is None:
+        d = paths[0] if paths else Path.cwd()
+        if not d.is_dir():
+            sys.exit("no such file or directory: %s" % d)
+        found = sorted(d.glob("*.msh"))
+        if len(found) != 1:
+            sys.exit("expected exactly one .msh in %s, found %d" % (d, len(found)))
+        msh = found[0]
+    if cfg_path is None:
+        # Any json beside the mesh that declares the right application.
+        for c in sorted(msh.parent.glob("*.json")):
+            try:
+                j = json.load(open(c))
+            except Exception:
+                continue
+            if isinstance(j, dict) and j.get("application") == "topological_offset":
+                cfg_path = c
+                break
+    cfg = {}
+    if cfg_path is not None:
+        try:
+            cfg = json.load(open(cfg_path))
+            print("config %s" % cfg_path)
+        except Exception as e:
+            print("config %s unreadable (%s); using defaults" % (cfg_path, e))
+    return msh, cfg
+
+
+def load(msh, cfg):
+    """Everything main() draws, as plain arrays -- no polyscope."""
+    points, dim, groups = read_groups(msh)
+    offset_tags = set(cfg.get("offset_output_tags", ["offset"])) & set(groups)
+    if not offset_tags:
+        offset_tags = {"offset"} & set(groups)
+
+    # THE GROUPS OVERLAP (a cell is written into every group whose tag set contains that
+    # tag), and the input complex is not "every non-ambient group": for a selection like
+    # "tag_0 & tag_1" it is the INTERSECTION region only, while the sphere-minus-lens
+    # parts are ordinary background the offset plows through. Both were measured to
+    # matter: union-as-input misfiled the band|sphere interfaces as inner, and read
+    # avg err 0.30 where the C++ log said 0.08. So collapse every cell to the C++'s
+    # three labels -- offset (2), input complex (1, the selection expression evaluated
+    # on the cell's own tag memberships), background (0) -- and derive interfaces from
+    # those disjoint classes.
+    seen = {}  # sorted vertex tuple -> (row, set of group names)
+    for name, cells in groups.items():
+        for row in cells:
+            k = tuple(sorted(row))
+            if k in seen:
+                seen[k][1].add(name)
+            else:
+                seen[k] = (row, {name})
+    expr = cfg.get("offset_selection", "!_")
+    classed = {"offset": [], "input": [], "ambient": []}
+    for row, names in seen.values():
+        if names & offset_tags:
+            classed["offset"].append(row)
+        elif eval_selection(expr, names):
+            classed["input"].append(row)
+        else:
+            classed["ambient"].append(row)
+    classed = {k: np.asarray(v) if v else np.zeros((0, dim + 1), np.int64)
+               for k, v in classed.items()}
+
+    iface = interfaces(points, dim, classed)
+
+    def pick(*pairs):
+        got = [iface[p] for p in pairs if p in iface]
+        return np.vstack(got) if got else np.zeros((0, dim), np.int64)
+
+    surf = {
+        "input": pick(("ambient", "input"), ("input", "")),
+        # The band's outer surface: offset against ambient, plus where the band is
+        # clipped at the domain boundary -- both included by the C++ metric.
+        "offset": pick(("ambient", "offset"), ("offset", "")),
+        "inner": pick(("input", "offset")),
+    }
+
+    delta = float(cfg.get("target_distance", -1.0))
+    if delta <= 0:
+        rel = float(cfg.get("target_distance_rel", 0.01))
+        diag = float(np.linalg.norm(points.max(axis=0) - points.min(axis=0)))
+        delta = rel * diag
+        prov = "%g x bbox diagonal %g%s" % (rel, diag, "" if cfg else " (no config: defaults)")
+    else:
+        prov = "config target_distance"
+
+    # Distance reference: the INNER interface, not the input groups' boundary. For an
+    # expression selection (e.g. "tag_0 & tag_1") the complex is the intersection, which
+    # the groups alone cannot reproduce -- but the band's inner interface hugs the actual
+    # complex by construction, whatever the selection was. Cross-checked on
+    # topological_offset_3d: against the union boundary avg err read 0.31 where the C++
+    # log says 0.08; against the inner interface it agrees.
+    err = None
+    ref_facets = surf["inner"] if len(surf["inner"]) else surf["input"]
+    if len(surf["offset"]) and len(ref_facets):
+        op, oc = compact(points, surf["offset"])
+        r = points[ref_facets]
+        if dim == 3:
+            dist = dist_to_triangles(op, r[:, 0], r[:, 1], r[:, 2])
+        else:
+            dist = dist_to_segments(op, r[:, 0], r[:, 1])
+        err = (op, oc, dist, np.abs(dist - delta) / delta)
+
+    return points, dim, groups, surf, delta, prov, err
+
+
+def main():
+    msh, cfg = resolve(sys.argv[1:])
+    if not msh.is_file():
+        sys.exit("missing mesh: %s" % msh)
+    points, dim, groups, surf, delta, prov, err = load(msh, cfg)
+
+    print("mesh   %s  (%s)" % (msh, "tets" if dim == 3 else "triangles"))
+    print("delta  %g  (%s)" % (delta, prov))
+    for n in sorted(groups):
+        print("  group %-16s %8d cells" % (n, len(groups[n])))
+    for n in ("input", "offset", "inner"):
+        print("  %-22s %8d facets" % (n + " surface", len(surf[n])))
+    if err is not None:
+        _, _, dist, rel = err
+        print("  offset vertices: dist to input  min %.6g  max %.6g   |err|/delta  avg %.4f  max %.4f"
+              % (dist.min(), dist.max(), rel.mean(), rel.max()))
+        print("  (reference = the band's inner interface, sampled at offset vertices:"
+              " a cross-check against the log, not the metric itself)")
+    else:
+        print("  distance layer omitted: no input-region cells to measure against"
+              " (edge or vertex input complex, or empty surfaces)")
+
+    ps.init()
+    if dim == 2:
+        # Flat data: same setup and rationale as visualize_triwild.py.
+        ps.set_up_dir("y_up")
+        ps.set_front_dir("z_front")
+        ps.set_view_projection_mode("orthographic")
+        ps.set_navigation_style("planar")
+    ps.set_ground_plane_mode("none")
+
+    def register(name, facets, color, enabled):
+        if len(facets) == 0:
+            return None
+        p, c = compact(points, facets)
+        if dim == 3:
+            s = ps.register_surface_mesh(name, p, c, color=color, edge_width=1.0)
+        else:
+            s = ps.register_curve_network(name, p, c, color=color, radius=0.0022)
+        s.set_enabled(enabled)
+        return s
+
+    layers = [
+        ("input surface (orange)", register("input surface", surf["input"], C_INPUT, True)),
+        ("offset surface (blue)", register("offset surface", surf["offset"], C_OFFSET, True)),
+        ("inner interface (grey)", register("inner interface", surf["inner"], C_INNER, False)),
+    ]
+    if err is not None and dim == 3:
+        op, oc, dist, rel = err
+        s = ps.get_surface_mesh("offset surface")
+        s.add_scalar_quantity("distance to input", dist, cmap="viridis")
+        s.add_scalar_quantity("|dist - delta| / delta", rel, cmap="reds", enabled=True)
+
+    state = {label: (s is not None and s.is_enabled()) for label, s in layers}
+
+    def callback():
+        psim.TextUnformatted("%s   delta %g" % (msh.name, delta))
+        psim.Separator()
+        for label, s in layers:
+            if s is None:
+                continue
+            changed, state[label] = psim.Checkbox(label, state[label])
+            if changed:
+                s.set_enabled(state[label])
+
+    ps.set_user_callback(callback)
+    ps.show()
+
+
+if __name__ == "__main__":
+    main()

--- a/components/topological_offset/wmtk/components/topological_offset/topological_offset.cpp
+++ b/components/topological_offset/wmtk/components/topological_offset/topological_offset.cpp
@@ -76,7 +76,6 @@ void topological_offset(nlohmann::json json_params)
         logger().info("====== input parameters =======");
         logger().info("target_distance: {}", params.target_distance);
         logger().info("relative_ball_threshold: {}", params.relative_ball_threshold);
-        logger().info("edge_search_term_len: {}", params.edge_search_term_len);
         logger().info("===============================");
     }
 
@@ -339,6 +338,12 @@ void topological_offset(nlohmann::json json_params)
                 log_and_throw_error("INVERSION DURING OFFSET! bad tet ids: {}", bad_tets_str);
             }
 
+            // Did conservative growth run out of room? Reported here, not inside the
+            // optimization, because it is a property of the offset as constructed -- the
+            // optimization cannot move vertices off the frozen bounding box, so a band clipped
+            // here stays clipped.
+            mesh.warn_if_offset_reaches_domain_boundary();
+
             // offset region manifoldness check
             if (check_manifoldness) {
                 if (mesh.offset_is_manifold()) {
@@ -364,19 +369,23 @@ void topological_offset(nlohmann::json json_params)
             }
         }
 
-        if (mesh.m_offset_params.optimize) {
-            mesh.optimize_offset(output_filename);
+        // Unconditional -- 3D no longer has an un-optimized output, matching 2D. `optimize` is
+        // not read here: now that the distance-field marching pass is gone, conservative growth
+        // leaves the band boundary on background-cell boundaries, so skipping the optimization
+        // does not yield a coarser offset, it yields one whose defining property is simply unmet
+        // at an error set by the input mesh's resolution rather than by anything the user asked
+        // for. See the corresponding note in .claude/CLAUDE.md.
+        mesh.optimize_offset(output_filename);
 
-            // The manifoldness check above ran on the offset as constructed. Optimization
-            // then re-triangulates it -- splits, collapses and four kinds of swap all touch
-            // the offset boundary -- so the property has to be re-established afterwards, not
-            // assumed to survive.
-            if (check_manifoldness) {
-                if (mesh.offset_is_manifold()) {
-                    logger().info("Offset region manifold check passed after optimization.");
-                } else {
-                    logger().error("Offset region is NOT manifold after optimization!");
-                }
+        // The manifoldness check above ran on the offset as constructed. Optimization
+        // then re-triangulates it -- splits, collapses and four kinds of swap all touch
+        // the offset boundary -- so the property has to be re-established afterwards, not
+        // assumed to survive.
+        if (check_manifoldness) {
+            if (mesh.offset_is_manifold()) {
+                logger().info("Offset region manifold check passed after optimization.");
+            } else {
+                logger().error("Offset region is NOT manifold after optimization!");
             }
         }
 
@@ -416,6 +425,36 @@ void topological_offset(nlohmann::json json_params)
             report["after #t"] = mesh.tet_size();
             report["threads"] = NUM_THREADS;
             report["time"] = time;
+            if (!mesh.optimization_metrics.empty()) {
+                std::vector<double> max_dist_err, avg_dist_err, max_norm_dev, avg_norm_dev;
+                for (const auto& m : mesh.optimization_metrics) {
+                    max_dist_err.push_back(m[0]);
+                    avg_dist_err.push_back(m[1]);
+                    max_norm_dev.push_back(m[2]);
+                    avg_norm_dev.push_back(m[3]);
+                }
+                report["optimization_metrics"]["max_dist_err"] = max_dist_err;
+                report["optimization_metrics"]["avg_dist_err"] = avg_dist_err;
+                report["optimization_metrics"]["max_norm_dev"] = max_norm_dev;
+                report["optimization_metrics"]["avg_norm_dev"] = avg_norm_dev;
+
+                std::vector<int> splits, collapses, swaps;
+                for (const auto& c : mesh.op_counts) {
+                    splits.push_back(c[0]);
+                    collapses.push_back(c[1]);
+                    swaps.push_back(c[2]);
+                }
+                report["op_counts"]["splits"] = splits;
+                report["op_counts"]["collapses"] = collapses;
+                report["op_counts"]["swaps"] = swaps;
+                // Read from the run rather than recomputed from the arrays as the 2D block does:
+                // optimize_offset() breaks out of the loop the moment it converges, so its own
+                // verdict is the authority and cannot drift from the criterion it applied.
+                report["converged"] = mesh.m_converged;
+                report["convergence_target"] = mesh.m_offset_params.convergence_target;
+                report["convergence_normal_deviation"] =
+                    mesh.m_offset_params.convergence_normal_deviation;
+            }
             f_out << std::setw(4) << report;
             f_out.close();
         }

--- a/components/topological_offset/wmtk/components/topological_offset/topological_offset_spec.json
+++ b/components/topological_offset/wmtk/components/topological_offset/topological_offset_spec.json
@@ -26,10 +26,8 @@
             "envelope_size_rel",
             "region_envelope_from_input",
             "relative_ball_threshold",
-            "edge_search_termination_len",
             "sorted_marching",
             "check_manifoldness",
-            "optimize",
             "save_vtu",
             "DEBUG_output",
             "log_file",
@@ -193,12 +191,6 @@
         "doc": "Float between 0 and 1, radius relative to target_distance to stop circle/sphere splitting in conservative distance approximation. Smaller means more accurate offset growth but longer run time."
     },
     {
-        "pointer": "/edge_search_termination_len",
-        "type": "float",
-        "default": 0.001,
-        "doc": "Length below which binary search will be terminated for function-guided edge splitting"
-    },
-    {
         "pointer": "/sorted_marching",
         "type": "bool",
         "default": false,
@@ -209,12 +201,6 @@
         "type": "bool",
         "default": true,
         "doc": "After performing offset, check if offset region is manifold"
-    },
-    {
-        "pointer": "/optimize",
-        "type": "bool",
-        "default": false,
-        "doc": "Run optimization on the offset."
     },
     {
         "pointer": "/save_vtu",

--- a/src/wmtk/TetMesh.h
+++ b/src/wmtk/TetMesh.h
@@ -670,6 +670,19 @@ public:
     long request_tet_slots(size_t n);
     long request_vert_slots(size_t n);
 
+    /**
+     * @brief How many operations have aborted because the preallocated slot pool ran out.
+     *
+     * The abort happens inside the connectivity update, before any application hook, so nothing
+     * downstream can observe it: the operation simply does not happen, no rejection is recorded,
+     * and nothing is logged. mesh_improvement() is insulated from that because it consolidates
+     * every iteration and the operation is retried, but a caller that runs a single pass silently
+     * gets a fraction of the work it asked for. Reset it before a pass and check it after.
+     */
+    size_t slot_exhausted() const { return m_slot_exhausted.load(std::memory_order_relaxed); }
+    void reset_slot_exhausted() { m_slot_exhausted.store(0, std::memory_order_relaxed); }
+    void note_slot_exhausted() { m_slot_exhausted.fetch_add(1, std::memory_order_relaxed); }
+
     // Construction/insertion helpers (single-threaded ONLY): guarantee at least
     // `extra` free tet/vertex slots beyond the current used count, growing the
     // storage geometrically if necessary. Unlike request_*_slots these never fail;
@@ -712,6 +725,7 @@ private:
     std::atomic_long current_vert_size;
     std::atomic_long current_tet_size;
     double m_preallocation_factor = 6.0;
+    std::atomic<size_t> m_slot_exhausted{0};
 
     int m_t_empty_slot = 0;
     int m_v_empty_slot = 0;

--- a/src/wmtk/TetMeshEdgeSplittingConn.cpp
+++ b/src/wmtk/TetMeshEdgeSplittingConn.cpp
@@ -39,7 +39,10 @@ bool wmtk::TetMesh::split_edge(const Tuple& loc0, std::vector<Tuple>& new_edges)
 
     /// update connectivity
     int v_id = get_next_empty_slot_v();
-    if (v_id < 0) return false; // out of preallocated vertex slots: abort before mutating
+    if (v_id < 0) {
+        note_slot_exhausted();
+        return false; // out of preallocated vertex slots: abort before mutating
+    }
     std::vector<TetrahedronConnectivity> old_tets_conn;
     std::vector<std::array<size_t, 4>> new_tet_conn;
     auto num = n12_t_ids.size();
@@ -65,6 +68,7 @@ bool wmtk::TetMesh::split_edge(const Tuple& loc0, std::vector<Tuple>& new_edges)
     auto rollback_vert_conn = operation_update_connectivity_impl(new_tet_id, new_tet_conn, conn_ok);
     if (!conn_ok) {
         // out of preallocated tet slots: free the reserved vertex slot and abort
+        note_slot_exhausted();
         m_vertex_connectivity[v_id].m_is_removed = true;
         return false;
     }

--- a/src/wmtk/TetMeshFaceSplittingConn.cpp
+++ b/src/wmtk/TetMeshFaceSplittingConn.cpp
@@ -77,6 +77,7 @@ bool TetMesh::split_face(const Tuple& t, std::vector<Tuple>& new_tets)
     constexpr size_t INVALID_SLOT = static_cast<size_t>(-1);
     if (new_vid == INVALID_SLOT || new_tid1 == INVALID_SLOT || new_tid2 == INVALID_SLOT ||
         (t_opp && (new_tid1_opp.value() == INVALID_SLOT || new_tid2_opp.value() == INVALID_SLOT))) {
+        note_slot_exhausted();
         if (new_vid != INVALID_SLOT) m_vertex_connectivity[new_vid].m_is_removed = true;
         if (new_tid1 != INVALID_SLOT) m_tet_connectivity[new_tid1].m_is_removed = true;
         if (new_tid2 != INVALID_SLOT) m_tet_connectivity[new_tid2].m_is_removed = true;

--- a/src/wmtk/TetMeshSwapMeshConnectivity.cpp
+++ b/src/wmtk/TetMeshSwapMeshConnectivity.cpp
@@ -72,6 +72,7 @@ std::map<size_t, TetMesh::VertexConnectivity> wmtk::TetMesh::operation_update_co
         add_size = new_tet_conn.size() - remove_id.size();
         reserved_first = request_tet_slots(add_size);
         if (reserved_first < 0) {
+            note_slot_exhausted();
             ok = false; // out of preallocated space; nothing mutated yet
             return {};
         }

--- a/src/wmtk/TetOptimizerMesh.h
+++ b/src/wmtk/TetOptimizerMesh.h
@@ -459,6 +459,21 @@ protected:
     }
     virtual void collapse_after_vertex(size_t, size_t) {}
 
+    /**
+     * @brief The survivor's sizing scalar after a collapse merges `removed` into it.
+     *
+     * The default keeps the survivor's own value -- today's behaviour, byte-identical for
+     * every existing application. The offset overrides it to min: its stall-driven
+     * refinement lowers scalars on band vertices, and a collapse that discards the removed
+     * vertex's finer value onto a coarser survivor un-refines the FIELD by topology, so
+     * each round re-lowers from scratch and the band never actually gets finer. min is
+     * the field's established convention (update_sizing_field writes with min).
+     */
+    virtual double collapse_merged_sizing(double /*removed*/, double survivor) const
+    {
+        return survivor;
+    }
+
     /// Cache application cell data before a split. TetWild needs none; SimWild caches tags.
     virtual bool split_before_cells(const Tuple&, const std::vector<Tuple>&) { return true; }
     /// Restore application cell data on the children made by a split.

--- a/src/wmtk/TetOptimizerMeshCollapse.cpp
+++ b/src/wmtk/TetOptimizerMeshCollapse.cpp
@@ -416,6 +416,8 @@ bool TetOptimizerMesh::collapse_edge_after(const Tuple& loc)
     // vertex attr
     round(loc);
     VA[v2_id].m_is_on_surface = VA.at(v1_id).m_is_on_surface || VA.at(v2_id).m_is_on_surface;
+    VA[v2_id].m_sizing_scalar =
+        collapse_merged_sizing(VA.at(v1_id).m_sizing_scalar, VA.at(v2_id).m_sizing_scalar);
     VA[v2_id].m_order = std::max(VA.at(v1_id).m_order, VA.at(v2_id).m_order);
 
     // no need to update on_bbox_faces

--- a/src/wmtk/TetOptimizerMeshSplit.cpp
+++ b/src/wmtk/TetOptimizerMeshSplit.cpp
@@ -33,6 +33,7 @@ void TetOptimizerMesh::split_all_edges()
         m_high_valence_claim = std::make_unique<std::atomic<int>[]>(m_high_valence_claim_size);
     }
     m_high_valence_rejects = 0;
+    reset_slot_exhausted();
 
     timer.start();
     auto collect_all_ops = wmtk::parallel_collect_edge_ops(
@@ -84,6 +85,23 @@ void TetOptimizerMesh::split_all_edges()
             "[high-valence] {} splits refused to avoid growing a vertex past {} incident tets",
             n,
             m_params.split_high_valence_threshold);
+    }
+    // A split that ran out of preallocated slots did not happen and left no other trace: the
+    // abort is inside the connectivity update, before split_edge_after(), so no application hook
+    // sees it and no rejection is counted anywhere. Say so, or a pass that delivered a fraction
+    // of the refinement it was asked for is indistinguishable from one that had nothing to do.
+    //
+    // mesh_improvement() consolidates every iteration and the queue is re-collected, so there
+    // the work is merely deferred. A caller that runs split_all_edges() once -- as the offset
+    // optimization does -- loses it. Measured on specific_models/prism: 31445 splits per
+    // iteration, against 2638 that succeeded.
+    if (const size_t n = slot_exhausted(); n > 0) {
+        wmtk::logger().warn(
+            "[slots] {} operations aborted with the preallocated slot pool exhausted (capacity is "
+            "{}x the live count at the last consolidate). They are NOT refusals: the work was "
+            "dropped. Consolidate and repeat the pass, or raise the preallocation factor.",
+            n,
+            preallocation_factor());
     }
     // Consumed: the queued force-split edges no longer exist after this pass.
     m_force_split_edges.clear();

--- a/src/wmtk/TriMesh.cpp
+++ b/src/wmtk/TriMesh.cpp
@@ -860,6 +860,7 @@ bool TriMesh::split_edge(const Tuple& t, std::vector<Tuple>& new_tris)
         for (size_t f : new_fids)
             if (f == INVALID_SLOT) slots_ok = false;
         if (!slots_ok) {
+            note_slot_exhausted();
             if (new_vid != INVALID_SLOT) m_vertex_connectivity[new_vid].m_is_removed = true;
             for (size_t f : new_fids)
                 if (f != INVALID_SLOT) m_tri_connectivity[f].m_is_removed = true;
@@ -1701,6 +1702,7 @@ bool TriMesh::split_face(const Tuple& t, std::vector<Tuple>& new_tris)
     {
         constexpr size_t INVALID_SLOT = static_cast<size_t>(-1);
         if (new_vid == INVALID_SLOT || new_fid1 == INVALID_SLOT || new_fid2 == INVALID_SLOT) {
+            note_slot_exhausted();
             if (new_vid != INVALID_SLOT) m_vertex_connectivity[new_vid].m_is_removed = true;
             if (new_fid1 != INVALID_SLOT) m_tri_connectivity[new_fid1].m_is_removed = true;
             if (new_fid2 != INVALID_SLOT) m_tri_connectivity[new_fid2].m_is_removed = true;

--- a/src/wmtk/TriMesh.h
+++ b/src/wmtk/TriMesh.h
@@ -374,6 +374,17 @@ public:
     long request_tri_slots(size_t n);
     long request_vert_slots(size_t n);
 
+    /**
+     * @brief How many operations have aborted because the preallocated slot pool ran out.
+     *
+     * Identical in meaning and in mechanism to TetMesh::slot_exhausted(): the abort happens
+     * inside the connectivity update, before any application hook, so the operation simply does
+     * not happen and nothing downstream can observe it. Reset before a pass and check after.
+     */
+    size_t slot_exhausted() const { return m_slot_exhausted.load(std::memory_order_relaxed); }
+    void reset_slot_exhausted() { m_slot_exhausted.store(0, std::memory_order_relaxed); }
+    void note_slot_exhausted() { m_slot_exhausted.fetch_add(1, std::memory_order_relaxed); }
+
 private:
     size_t reserved_capacity(size_t live_count) const
     {
@@ -389,6 +400,7 @@ private:
     std::atomic_long current_vert_size;
     std::atomic_long current_tri_size;
     double m_preallocation_factor = 6.0;
+    std::atomic<size_t> m_slot_exhausted{0};
     bool m_use_link_condition = true;
 
 protected:

--- a/src/wmtk/TriOptimizerMeshSplit.cpp
+++ b/src/wmtk/TriOptimizerMeshSplit.cpp
@@ -27,6 +27,7 @@ void TriOptimizerMesh::split_all_edges()
         m_high_valence_claim = std::make_unique<std::atomic<int>[]>(m_high_valence_claim_size);
     }
     m_high_valence_rejects = 0;
+    reset_slot_exhausted();
 
     timer.start();
     auto collect_all_ops = wmtk::parallel_collect_edge_ops(
@@ -93,6 +94,21 @@ void TriOptimizerMesh::split_all_edges()
             "triangles",
             n,
             m_params.split_high_valence_threshold);
+    }
+    // See the identical report in TetOptimizerMesh::split_all_edges(). A split that ran out of
+    // preallocated slots did not happen and left no other trace, so a pass that delivered a
+    // fraction of the refinement it was asked for is otherwise indistinguishable from one that
+    // had nothing to do. 2D has not been observed to hit this -- its offset loop never
+    // consolidates, so the pool is still sized from a high-water mark reached during
+    // construction and stays generous -- but that margin is incidental, not designed, and it
+    // would vanish the moment a consolidate were added to the loop as 3D has.
+    if (const size_t n = slot_exhausted(); n > 0) {
+        wmtk::logger().warn(
+            "[slots] {} operations aborted with the preallocated slot pool exhausted (capacity is "
+            "{}x the live count at the last consolidate). They are NOT refusals: the work was "
+            "dropped. Consolidate and repeat the pass, or raise the preallocation factor.",
+            n,
+            preallocation_factor());
     }
     // Consumed: the queued force-split edges no longer exist after this pass.
     m_force_split_edges.clear();


### PR DESCRIPTION
Carries Spencer's 3D offset optimization work forward, rebased onto current `main`.

## What is in this PR right now

Two commits, authorship preserved, rebased cleanly onto `0086e56a52`:

- `3D offset: bring the component into lock-step with 2D`
- `3D offset: pool the quadric samples, reject zero-length smoothing moves`

The rebase is behaviour-neutral: on `127891` (prism, δ = 0.8368, `convergence_target` 0.0418, 5 iterations) every reported metric is bit-identical before and after.

| iter | max dist err | avg dist err | max normal dev | avg normal dev |
| ---- | ------------ | ------------ | -------------- | -------------- |
| 1    | 0.4046       | 0.0411       | 47.7°          | 17.6°          |
| 5    | 0.1647       | 0.0595       | 37.8°          | 19.7°          |

It does not converge, and `avg_dist_err` rises every pass — the "known gap" recorded in the first commit message.

## Why it does not converge

Not the smoother. **The offset surface is being decimated rather than refined**: 1172 → 490 faces over five iterations, ending 7.5× coarser than the sizing field asks for, with 724 of its 747 edges above the split gate and nothing splitting them.

Four separate defects, each measured on prism:

1. **Offset vertices are invisible to the shared engine.** `m_vertex_attribute[].m_is_on_surface` is never set anywhere in the 3D component. 2D sets it in `label_offset_boundary()`. `TetOptimizerMesh::is_edge_on_surface()` short-circuits on that flag, so the collapse's link condition, `preserve_topology`, and the split's propagation of the flag to the new vertex never apply to the offset. Instrumented: 0 of ~1700 offset-edge split attempts per iteration are seen as surface edges; 1727 once the flag is set.

2. **Most splits are silently discarded.** `TetMesh::split_edge` returns false at `get_next_empty_slot_v() < 0`, before `split_edge_after`, so no application hook runs and nothing is logged. 31,445 splits lost per iteration; 19 of the ~723 offset edges the sizing field asked to split actually got split. The per-iteration `consolidate_mesh()` already on this branch fixes the between-iteration case, not this one.

3. **The whole split budget goes to the ambient mesh.** `#V` 630 → 3270 per split pass, of which ~20 land on the offset. The ambient mesh is remeshed toward `length_rel × bbox_diagonal`, a target unrelated to the offset, and the collapse pass undoes it every iteration. The reference implementation has no global length target for the embedding at all: its target edge length is per-edge, initialised to each edge's own current length and updated by AMIPS, and embedding operations are confined by `RoiInvariant` to tets with AMIPS > 100 plus a 2-ring spread that does not cross substructures.

4. **Split and collapse fight each other.** Splitting an edge just over `(4/3)t` yields children at `(2/3)t`, below the `(4/5)t` free-collapse gate, and nothing rejects a collapse that recreates an over-long edge.

## Planned commits on this branch

1. Set `m_is_on_surface` at both labelling sites. *(defect 1)*
2. Add `TetMesh::slot_exhausted()`, make the split pass consolidate-and-repeat instead of losing splits silently. *(defect 2)*
3. Score distance per face over the four samples (centroid + three near-corner), as the reference does, instead of at vertices only — in `compute_distance_deviation` and the sizing `dist_bad` trigger. Vertex sampling is a lower bound and is satisfied by construction by any projection-based placement, so it cannot be tuned against.
4. Port the reference's embedding sizing rule and ROI restriction. *(defects 3 and 4; 4 may fall out of 3 for free)*
5. Distance adaptation (paper §5.3.1), or an explicit decision not to have it. With the remeshing fixed, the worst vertex is consistently *too close* — 0.64 against δ = 0.837 — and sits at the same interior pinch every iteration, with no domain-boundary warning. `max_dist_err` against a global δ is measuring a target that cannot be met there.
6. The disabled candidate-selection placement in `Smooth.cpp`, only if 3–5 leave a residual it can explain.

A prototype of 1, 2 and crude forms of 3 and 4 takes avg dist err 0.0595 → 0.0148 and avg normal dev 19.7° → 6.6°, with the offset surface growing 490 → 9050 faces. `max_dist_err` does not converge under it, which is what points at item 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
