### PR TITLE
Defer operations that lose a race instead of respinning on them

### DIFF
--- a/src/wmtk/ExecutionScheduler.hpp
+++ b/src/wmtk/ExecutionScheduler.hpp
@@ -21,6 +21,7 @@
 #include <cstddef>
 #include <queue>
 #include <stdexcept>
+#include <thread>
 #include <type_traits>
 
 namespace wmtk {
@@ -119,10 +120,50 @@ struct ExecutePass
     int num_threads = 1;
 
     /**
-     * To Avoid mutual locking, retry limit is set, and then put in a serial queue in the end.
+     * @brief Attempts an operation gets at claiming its ring before it is handed to the serial
+     * queue drained after the barrier.
      *
+     * 10 was swept and left alone. Measured on 128k-tet Thingi10K 103197 at 16 threads, three
+     * reps each, in µs per attempted operation:
+     *
+     *   immediate requeue (before the second-chance deferral below existed):
+     *       1: +17.0%   2: +7.2%   3: +6.2%   5: +4.6%   10: best   20: +6.2%
+     *   with the deferral:
+     *       2: 2.170    3: 1.969    10: 1.974          (baseline at 10 was 2.527)
+     *
+     * So under the old immediate-requeue behaviour the value mattered a lot -- a low limit sent
+     * everything it stopped retrying to the serial queue, and that tail (23% of scheduler time
+     * at 10, 39% at 1) cost more than the spinning it avoided. With the deferral the retries are
+     * nearly free, the overflow pressure disappears, and 3 and 10 become indistinguishable.
+     * Left at 10 because nothing argues for moving it.
+     *
+     * Below about 3 it still hurts: at 2 the overflow rate climbs enough to be visible again.
      */
     size_t max_retry_limit = 10;
+
+    /**
+     * @brief Operations to run before handing deferred operations back to the queue, or 0 to
+     * wait until the queue empties.
+     *
+     * Bounding this is what makes the second-chance list pay. A per-thread queue holds thousands
+     * of operations, so draining only at queue-empty means a deferred operation waits that long,
+     * by which time the mesh around it has moved, `is_weight_up_to_date` rejects it, and the work
+     * has to be rediscovered. That inflates the attempt count by roughly a fifth and eats most of
+     * the per-operation saving.
+     *
+     * Measured at 16 threads, three reps, optimization wall time against the pre-deferral
+     * baseline, with attempts in brackets:
+     *
+     *                    103197 (base 23.0M)      101881 (base 48.8M)
+     *      window 0       -2.2%  [28.5M]          -20.4%  [45.7M]
+     *      window 32     -16.3%  [23.7M]          -21.6%  [43.7M]
+     *      window 128    -17.9%  [23.1M]          -26.4%  [41.9M]
+     *      window 512    -17.0%  [23.7M]          -25.5%  [42.7M]
+     *
+     * 128 is at or near best on both and keeps the attempt count closest to the baseline's. The
+     * result is not sharp between 32 and 512; it is sharp against 0.
+     */
+    size_t deferral_window = 128;
     /**
      * @brief Construct a new Execute Pass object. It contains the name-to-operation map and the
      *functions that define the rules for operations
@@ -370,7 +411,45 @@ public:
             } counts{cnt_success, cnt_fail, lock_failures, overflowed};
 
             Elem ele_in_queue;
-            while ([&]() { return Q.try_pop(ele_in_queue); }()) {
+            // Operations that lost a race for their ring wait here rather than going straight
+            // back into the live queue. Pushing them back immediately is a spin: the element was
+            // just popped as the queue's maximum, `retry` is the last tie-break key in Elem, so
+            // the requeued copy compares strictly greater than what was popped and nothing else
+            // was added -- it comes right back off the top and is retried against a conflict that
+            // has had no time to clear. Deferring lets every other operation this task owns run
+            // first, which is both useful work and the delay the conflict needs.
+            std::vector<Elem> second_chance;
+            // Operations popped since the deferred list was last given back to the queue.
+            // Waiting for the queue to drain completely can mean thousands of operations, by
+            // which time the mesh around a deferred operation has moved and its work has to be
+            // rediscovered. A bounded window gives the conflict time to clear without letting
+            // the operation go stale. 0 = only when the queue empties.
+            size_t since_refill = 0;
+            const auto refill = [&] {
+                for (auto& e : second_chance) {
+                    Q.emplace(std::move(e));
+                }
+                second_chance.clear();
+                since_refill = 0;
+            };
+            for (;;) {
+                if (!second_chance.empty() && deferral_window > 0 &&
+                    since_refill >= deferral_window) {
+                    refill();
+                }
+                if (!Q.try_pop(ele_in_queue)) {
+                    if (second_chance.empty()) {
+                        break;
+                    }
+                    // Queue exhausted: the deferred operations have now had everything else
+                    // run ahead of them, so give them another go. `retry` still increments on
+                    // each attempt and still overflows to final_queue at max_retry_limit, so
+                    // this terminates after at most that many rounds.
+                    refill();
+                    std::this_thread::yield();
+                    continue;
+                }
+                ++since_refill;
                 auto& [weight, op, tup, retry] = ele_in_queue;
                 if (!tup.is_valid(m)) {
                     continue;
@@ -386,7 +465,7 @@ public:
                         counts.lock_failure++;
                         retry++;
                         if (retry < max_retry_limit) {
-                            Q.emplace(ele_in_queue);
+                            second_chance.push_back(ele_in_queue);
                         } else {
                             retry = 0;
                             counts.overflow++;


### PR DESCRIPTION
Stacked on #1038 → #1037 → #1036. Retargets to `main` as those land.

**−15% to −26% optimization wall time at 16 threads, on all four models tested.**

## The bug

An operation that fails to claim its ring was pushed straight back into the queue it had just been popped from:

```cpp
if (retry < max_retry_limit) Q.emplace(ele_in_queue);
```

That's a spin, not a retry. The element came off as the queue's maximum; `retry` is the last tie-break key in `Elem`, so the requeued copy compares **strictly greater** than what was popped; and nothing else was added because the code bailed before doing any work. It comes right back off the top and is retried against a conflict that has had no time to clear.

`max_retry_limit = 10` was never a retry budget. It was the length of a spin loop, each iteration paying a partial ring walk plus lock-and-release.

## The fix

Failed operations wait in a per-thread `second_chance` list and return to the queue after `deferral_window` other operations have run — both useful work and the delay the conflict needs. `retry` still increments per attempt and still overflows to the serial queue at `max_retry_limit`, so it terminates in at most that many rounds. Serial (`kSeq`) never fails a lock, so none of this runs there.

## Results — 16 threads, 3 reps, paired

| model | before | after | change | t | µs/op |
|---|---:|---:|---:|---:|---:|
| octocat | 12.8s | 10.0s | −22.3% | −17.6 | −21.0% |
| 1017012 | 85.4s | 72.4s | −15.2% | −2.3 | −21.4% |
| 103197 | 57.3s | 47.0s | −17.9% | −2.3 | −18.2% |
| 101881 | 83.9s | 61.8s | −26.4% | −4.1 | −14.5% |

The mechanism is recovering the post-barrier serial drain — 22.5% of scheduler time down to 4.4% on 103197 — so it pays in proportion to how much drain exists:

| threads | µs/op | t | baseline serial tail |
|---:|---:|---:|---:|
| 4 | −0.3% | −0.1 | 1.0% |
| 8 | −6.1% | −6.5 | 4.4% |
| 16 | −14% to −21% | −2.3 to −4.1 | 19–23% |

**It does nothing where there is no contention, and never regresses.**

## Why there is a window, and why it is 128

Draining only at queue-empty means a deferred operation waits thousands of operations, by which point the mesh has moved, `is_weight_up_to_date` rejects it, and its work is rediscovered. Attempts inflate ~19% and eat the per-operation saving:

| window | 103197 (base 57.3s, 23.0M) | 101881 (base 83.9s, 48.8M) |
|---:|---:|---:|
| 0 | −2.2% [28.5M] | −20.4% [45.7M] |
| 32 | −16.3% [23.7M] | −21.6% [43.7M] |
| **128** | **−17.9% [23.1M]** | **−26.4% [41.9M]** |
| 512 | −17.0% [23.7M] | −25.5% [42.7M] |

Unbounded deferral is worth −2.2% on 103197; with a window it is −17.9%. The result is not sharp between 32 and 512, it is sharp against 0.

## `max_retry_limit` stays at 10

Swept before and after. Under the old immediate-requeue behaviour the value mattered a lot (1 was +17.0%, 10 was best) because everything a low limit stopped retrying went to the serial queue, and that tail cost more than the spinning it avoided. With deferral the overflow pressure disappears and 3/5/10 become indistinguishable — verified separately on 101881 at 4 and 8 threads, all three within 1%.

I originally staged this PR with `max_retry_limit = 3` and a rationale for why it had to change. That was wrong: the wall-time gap I based it on was trajectory noise, and on µs/op limit 3 and limit 10 are 1.969 vs 1.974. The sweep data is retained in the header comment so the next person doesn't re-derive it.

## Validation

Full integration suite passes (110 assertions). Unit tests pass (99 cases, 146,350 assertions). Final energies unchanged across every run (9.958–9.999).

**Measurement note.** Parallel runs execute wildly different amounts of work — the same binary on the same model ranged 19.2M–30.3M attempted operations, a 35% spread — so raw wall-clock comparison is unreliable at these sample sizes. Everything above is either µs/op-normalised or paired with alternating binaries; wall-time figures are quoted only where the per-operation effect is large enough to dominate that spread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)