### PR TITLE
Test Linux on arm64, and stop shipping the build tree to Docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,33 @@
+# Without this, `COPY . .` ships the whole working tree to the daemon -- 5.2 GB here,
+# almost all of it local build directories that the image rebuilds from scratch anyway.
+
+# Local build trees (host-specific absolute paths in their CMake caches; useless in the image)
+build*/
+cmake-build-*/
+out/
+
+# Version control. There are no submodules, so the Dockerfile's
+# `git submodule update --init --recursive` step is a no-op and .git is dead weight (643 MB).
+.git/
+.gitignore
+.github/
+
+# Editor / agent scratch
+.claude/
+.vscode/
+.idea/
+.DS_Store
+
+# Test and run output that accumulates in the working tree
+Testing/
+*.log
+*.obj
+*.msh
+*.vtu
+*.stl
+
+# Python
+__pycache__/
+*.pyc
+.venv/
+venv/

--- a/.github/workflows/continuous.yml
+++ b/.github/workflows/continuous.yml
@@ -29,6 +29,19 @@ jobs:
             config: Release
             integration_tests_flag: &integration_tests_on "-DWMTK_BUILD_INTEGRATION_TESTS=ON"
             name: Linux
+          # arm64 runners. Until these existed the matrix covered Linux only on x86-64 and
+          # arm64 only on macOS, so no job compiled the combination -- which is exactly where
+          # a `char` signedness bug in VolumeRemesher hid: `char` is signed on x86-64 and on
+          # Apple's arm64 ABI, but unsigned under AAPCS64, so a stored orient3d of -1 read
+          # back as 255 and every constraint was silently discarded.
+          - os: ubuntu-24.04-arm
+            config: Debug
+            integration_tests_flag: *integration_tests_off
+            name: Linux arm64
+          - os: ubuntu-24.04-arm
+            config: Release
+            integration_tests_flag: *integration_tests_on
+            name: Linux arm64
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/cmake/recipes/volumeremesher.cmake
+++ b/cmake/recipes/volumeremesher.cmake
@@ -22,16 +22,23 @@ message(STATUS "Third-party: creating target 'VolumeRemesher::VolumeRemesher'")
 # is exact: the built-in bigrational::get_str() emits the fraction in base 2, the base
 # init_from_bin parses.
 #
-# Pinned at main. The previous pin (ba8a7329) is this one's first parent; the only change
-# between them is VolumeRemesher PR #24, which adds an output to embed_tri_in_poly_mesh --
-# out_triangle_group, mapping each input triangle to its coplanar group, i.e. to its index
-# into out_triangle_provenance. Nothing existing changes behaviour, but the signature grows,
-# so every caller of that function must be updated in the same commit.
+# Pinned at main. The previous pin (64c52aa5) is this one's first parent; the only change
+# between them is VolumeRemesher PR #25, which stores cached orient3D results in a
+# `signed char` rather than a `char`. That is a correctness fix for Linux on arm64, where
+# `char` is unsigned (AAPCS64) and a cached -1 read back as 255: every constraint was then
+# judged not to split its cell and the input surface was silently never embedded. It has no
+# effect on x86-64 or on macOS, where `char` is already signed.
+#
+# Before that (ba8a7329 -> 64c52aa5) came PR #24, which added an output to
+# embed_tri_in_poly_mesh -- out_triangle_group, mapping each input triangle to its coplanar
+# group, i.e. to its index into out_triangle_provenance. Nothing existing changed behaviour,
+# but the signature grew, so every caller of that function had to be updated in the same
+# commit.
 include(CPM)
 CPMAddPackage(
     NAME VolumeRemesher
     GITHUB_REPOSITORY wildmeshing/VolumeRemesher
-    GIT_TAG 64c52aa54d39a5ed821c6cd3b120a55fad2790f7
+    GIT_TAG 609e32c43a52336f087c608ce5f1bd73b41e5845
     OPTIONS
     "VOLUMEREMESHER_BUILD_TESTS OFF"
 )


### PR DESCRIPTION
Two independent changes, both found while reproducing a tetwild test that fails **only** on Linux/arm64.

> [!IMPORTANT]
> **The new arm64 job will fail on this PR until [VolumeRemesher#25](https://github.com/wildmeshing/VolumeRemesher/pull/25) lands** and the pin in `cmake/recipes/volumeremesher.cmake` is bumped. That failure is the bug this job exists to catch. I'll push the pin bump here once the upstream PR merges.

## 1. The CI gap

| | x86-64 | arm64 |
|---|---|---|
| **Linux** | ✅ | ❌ **no job** |
| macOS | — | ✅ |
| Windows | ✅ | — |

No job ever compiled Linux on arm64 — and that is precisely where the failure lived.

`VolumeRemesher` cached `orient3D` results (`-1`, `0`, `+1`) in a `std::vector<char>` and read them back comparing against `-1`. **`char` is signed on x86-64 and under Apple's arm64 ABI, but unsigned under AAPCS64.** On Linux/arm64 a stored `-1` reads back as `255`, the comparison never matches, every constraint is judged not to split its cell, and the input surface is silently never embedded.

Symptom: `wmtk_test_tetwild` / `vertex_order` (shark-fin) finds **0 order-3 vertices where it expects 2**. 1 of 117 tests; everything else passes.

Reproduced natively on aarch64 Ubuntu 24.04 with GCC 13:

| | initial cells | final cells | tets |
|---|---:|---:|---:|
| macOS/arm64 | 12162 | 13884 | 20753 |
| Linux/arm64 before | 12162 | **12162** | 12162 |
| Linux/arm64 after | 12162 | 13884 | 20753 |

With the upstream fix: **117/117 wmtk tests pass** on linux/arm64, and VolumeRemesher's own suite goes from 22/28 to 28/28.

This adds `ubuntu-24.04-arm` in Debug and Release. These runners are free for public repos.

## 2. Docker build context

There was no `.dockerignore`, so `COPY . .` shipped the entire working tree — **5.2 GB**, of which 4.5 GB is local `build*` directories the image rebuilds from scratch anyway and 643 MB is `.git`. Now ~60 MB.

Dropping `.git` is safe: there is no `.gitmodules`, so the Dockerfile's `git submodule update --init --recursive` is a no-op on this repository.

## Note on the Dockerfile

The committed `Dockerfile` is fine — it uses `Release` and builds clean on arm64 (verified end to end). A modified copy circulating with `-DCMAKE_BUILD_TYPE=Developer` and appended `make test` steps is **not** what's in this repo. Worth knowing that `Developer` is not a build type this project defines: CMake accepts it silently and drops `-DNDEBUG`, compiling in all 413 assertions. That is not the cause of this bug, and needs no change here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)