### PR TITLE
Stop cube-rooting winding numbers and part ids into the msh

### DIFF
--- a/components/tetwild/wmtk/components/tetwild/TetWildMesh.cpp
+++ b/components/tetwild/wmtk/components/tetwild/TetWildMesh.cpp
@@ -719,22 +719,24 @@ void TetWildMesh::output_mesh(std::string file)
     msh.add_tet_attribute<1>("t energy", [&](size_t i) {
         return std::cbrt(m_tet_attribute[i].m_quality);
     });
+    // No cube root on any of these: only m_quality stores AMIPS^3, and the cbrt above is what
+    // turns it back into the energy the logs and the vtu report. A winding number and a
+    // flood-fill id are neither cubed nor continuous, so cube-rooting them just corrupts the
+    // value. write_vtu writes all four raw, and it is the one that was right.
     msh.add_tet_attribute<1>("winding_number_input", [&](size_t i) {
-        return std::cbrt(m_tet_attribute[i].m_winding_number_input);
+        return m_tet_attribute[i].m_winding_number_input;
     });
     msh.add_tet_attribute<1>("winding_number_tracked", [&](size_t i) {
-        return std::cbrt(m_tet_attribute[i].m_winding_number_tracked);
+        return m_tet_attribute[i].m_winding_number_tracked;
     });
-    msh.add_tet_attribute<1>("part", [&](size_t i) {
-        return std::cbrt(m_tet_attribute[i].part_id);
-    });
+    msh.add_tet_attribute<1>("part", [&](size_t i) { return double(m_tet_attribute[i].part_id); });
 
     // per input winding number
     if (!tets.empty()) {
         const size_t n = m_tet_attribute[tets[0].tid(*this)].m_winding_number_per_input.size();
         for (size_t j = 0; j < n; ++j) {
             msh.add_tet_attribute<1>(fmt::format("wn_{}", j), [&](size_t i) {
-                return std::cbrt(m_tet_attribute[i].m_winding_number_per_input[j]);
+                return m_tet_attribute[i].m_winding_number_per_input[j];
             });
         }
     }


### PR DESCRIPTION
TetWildMesh::write_msh runs every per-tet attribute through std::cbrt:

    "t energy"               cbrt(m_quality)                 correct
    "winding_number_input"   cbrt(m_winding_number_input)    wrong
    "winding_number_tracked" cbrt(m_winding_number_tracked)  wrong
    "part"                   cbrt(part_id)                   wrong
    "wn_{j}"                 cbrt(m_winding_number_per_input[j])  wrong

Only m_quality is cubed -- it stores AMIPS^3, because AMIPS in 3D divides by det(J)^(2/3) and the rational evaluator cannot take a cube root, so the code stores the cube and undoes it on the way out. Nothing else in that list is a cubed quantity. A winding number is integer-valued and a part_id is a flood-fill index; cube-rooting them writes a different number than the one held.

write_vtu, 250 lines further down, writes all four raw and cube-roots only m_quality. Two writers, same four fields, disagreeing -- and the vtu one is right.

Introduced in dac93bb900, which added the winding-number and part attributes directly beneath the pre-existing "t energy" lambda and carried its cbrt along.

Mostly invisible until now because cbrt(0) = 0 and cbrt(1) = 1, so a closed manifold's binary inside/outside winding numbers survive untouched. What does not survive is anything else: part_id 8 is written as 2, and per-input winding numbers on overlapping inputs land at 1.26 and 1.44 instead of 2 and 3.

Build clean, 117/117.