### PR TITLE
Default the coarsening pass off, and make it ~40x cheaper when it is on

### DIFF
--- a/components/simwild/wmtk/components/simwild/Parameters.h
+++ b/components/simwild/wmtk/components/simwild/Parameters.h
@@ -103,6 +103,7 @@ struct Parameters : public wmtk::OptimizerParameters
         coarsen_smooth_ring = json_params["coarsen_smooth_ring"];
         coarsen_global_smoothing_passes = json_params["coarsen_global_smoothing_passes"];
         coarsen_max_rounds = json_params["coarsen_max_rounds"];
+        coarsen_max_inner_passes = json_params["coarsen_max_inner_passes"];
 
         debug_output = json_params["DEBUG_output"];
         perform_sanity_checks = json_params["DEBUG_sanity_checks"];

--- a/components/simwild/wmtk/components/simwild/simwild_spec.json
+++ b/components/simwild/wmtk/components/simwild/simwild_spec.json
@@ -44,6 +44,7 @@
       "coarsen_smooth_ring",
       "coarsen_global_smoothing_passes",
       "coarsen_max_rounds",
+      "coarsen_max_inner_passes",
       "write_vtu",
       "write_envelope",
       "log_file",
@@ -610,14 +611,14 @@
   {
     "pointer": "/coarsen_local_smoothing_passes",
     "type": "int",
-    "default": 2,
-    "doc": "Smoothing sweeps over the ring inside each candidate coarsening collapse, before its max energy is measured. This is what gives the collapse a chance to be judged on a relaxed neighbourhood rather than on the configuration it lands in."
+    "default": 0,
+    "doc": "Smoothing sweeps over the ring, inside each candidate collapse, before judging it. 0 by default, which means the pass judges the collapse on its raw post-collapse geometry and never smooths inside the operation. At the level of a single candidate that matters -- the composite's reject rate rises from 25% to 39% without it -- but it does not cost coarsening, because the pass runs to a fixed point: a candidate the smoothing would have rescued is replaced by another the pass finds instead, and the relaxation the mesh actually needs comes from the global smoothing between rounds. What it costs is time. The smoothed ball averaged 98 vertices on tetwild's octocat, so at the old default of 2 sweeps one candidate ran ~200 nonlinear smoothing solves and the pass ran 1.4 million of them to accept 5173 collapses. Over seven tetwild models, dropping this to 0 (with coarsen_max_inner_passes 1) made the pass 9.7x to 31.9x faster for about 1 percentage point of cell reduction."
   },
   {
     "pointer": "/coarsen_smooth_ring",
     "type": "int",
-    "default": 2,
-    "doc": "Radius, in edges from the merged vertex, of the neighbourhood re-smoothed inside a coarsening collapse. The parallel lock claims one ring more than this, because smoothing a vertex reads its one-ring and writes the quality of its incident faces."
+    "default": 1,
+    "doc": "Radius smoothed inside the collapse, and the radius the accept test measures over. The lock claims one more ring than this. With coarsen_local_smoothing_passes at 0 nothing is smoothed, so this only sets how wide a region the accept test compares; a wider region is a more permissive test (it admits untouched cells to both the before and after maxima, which is still sound) so ring 2 coarsens slightly more, but it also makes the pass lock 3 rings per operation where the ordinary collapse locks 2, which is the worst thing for its parallel scaling. 1 by default: on octocat that is 2.3x faster than ring 2 for 1.5 percentage points of cell reduction, and it puts the lock footprint back in line with every other pass."
   },
   {
     "pointer": "/coarsen_global_smoothing_passes",
@@ -630,6 +631,12 @@
     "type": "int",
     "default": 2,
     "doc": "Cap on the coarsen/smooth alternation; the pass also stops as soon as a round accepts no collapse. A round does NOT exist to finish what the previous one started: within a round the collapse pass already runs to a fixed point, so repeating the collapse alone finds nothing. What a round adds is the global smoothing in between, which moves that fixed point -- the dirty-epoch retry only re-offers failures next to a SUCCESSFUL collapse, so a whole-mesh smoothing pass is invisible to it, and a rejected composite is rolled back in full so rejections never accumulate progress within a round. Returns decay fast: measured over the 16 challenging triwild models at five rounds, accepted collapses by round were 68.8% / 21.7% / 7.2% / 1.8% / 0.5%. Every round costs a full pre-check sweep over all edges plus a smoothing pass, so the default is two -- they carry 90.5% of the coarsening, and the three that would follow are worth 9.5% for 60% of the pass's budget."
+  },
+  {
+    "pointer": "/coarsen_max_inner_passes",
+    "type": "int",
+    "default": 1,
+    "doc": "Cap on the collapse pass's own dirty-epoch retry loop within one coarsening round; 0 is uncapped. Distinct from coarsen_max_rounds, which counts collapse+global-smoothing alternations. This counts the passes the retry loop makes inside a single collapse pass, re-offering failures whose neighbourhood a successful collapse disturbed. That filter asks only whether the neighbourhood MOVED, not whether it moved helpfully, so a productive first pass re-offers most of the mesh. 1 by default, i.e. one pass per round and no retry within it: on octocat the first pass found 5110 collapses in 135.8s and the three that followed found 27 in 38.4s. Rounds still repeat the pass, and those do pay off, because the global smoothing between them moves the fixed point in a way this filter cannot see."
   },
   {
     "pointer": "/coarsen_unbounded",

--- a/components/simwild/wmtk/components/simwild/simwild_spec.json
+++ b/components/simwild/wmtk/components/simwild/simwild_spec.json
@@ -604,7 +604,7 @@
   {
     "pointer": "/coarsen_pass",
     "type": "bool",
-    "default": true,
+    "default": false,
     "doc": "Run a final coarsening pass after the optimization has converged. The ordinary collapse judges a candidate on the raw post-collapse geometry -- the worst moment in the operation's life, before smoothing has absorbed any of the damage -- so a collapse that would be fine once its neighbourhood relaxes is never taken, and the converged mesh keeps vertices it does not need. This pass takes the collapse optimistically, re-smooths coarsen_smooth_ring around the merged vertex, and keeps it only if the worst element in the region it touched is no worse than before; every element outside that region is untouched, so 'no worse locally' is exactly 'no worse globally'. Alternates with ordinary smoothing passes, as the main optimization does."
   },
   {

--- a/components/tetwild/wmtk/components/tetwild/tetwild.cpp
+++ b/components/tetwild/wmtk/components/tetwild/tetwild.cpp
@@ -123,6 +123,7 @@ TetWildMesh::ExportStruct tetwild_with_export(nlohmann::json json_params)
     params.coarsen_smooth_ring = json_params["coarsen_smooth_ring"];
     params.coarsen_global_smoothing_passes = json_params["coarsen_global_smoothing_passes"];
     params.coarsen_max_rounds = json_params["coarsen_max_rounds"];
+    params.coarsen_max_inner_passes = json_params["coarsen_max_inner_passes"];
     params.w_amips = json_params["w_amips"];
     params.smoothing_mode = json_params["smoothing_mode"];
     params.project_line_search_steps = json_params["project_line_search_steps"];

--- a/components/tetwild/wmtk/components/tetwild/tetwild_spec.json
+++ b/components/tetwild/wmtk/components/tetwild/tetwild_spec.json
@@ -39,6 +39,7 @@
       "coarsen_smooth_ring",
       "coarsen_global_smoothing_passes",
       "coarsen_max_rounds",
+      "coarsen_max_inner_passes",
       "preserve_topology",
       "remove_duplicate_eps",
       "allow_surface_swap",
@@ -407,14 +408,14 @@
   {
     "pointer": "/coarsen_local_smoothing_passes",
     "type": "int",
-    "default": 2,
-    "doc": "Smoothing sweeps over the ring inside each candidate coarsening collapse, before its max energy is measured. This is what gives the collapse a chance to be judged on a relaxed neighbourhood rather than on the configuration it lands in."
+    "default": 0,
+    "doc": "Smoothing sweeps over the ring, inside each candidate collapse, before judging it. 0 by default, which means the pass judges the collapse on its raw post-collapse geometry and never smooths inside the operation. At the level of a single candidate that matters -- the composite's reject rate rises from 25% to 39% without it -- but it does not cost coarsening, because the pass runs to a fixed point: a candidate the smoothing would have rescued is replaced by another the pass finds instead, and the relaxation the mesh actually needs comes from the global smoothing between rounds. What it costs is time. The smoothed ball averaged 98 vertices on tetwild's octocat, so at the old default of 2 sweeps one candidate ran ~200 nonlinear smoothing solves and the pass ran 1.4 million of them to accept 5173 collapses. Over seven tetwild models, dropping this to 0 (with coarsen_max_inner_passes 1) made the pass 9.7x to 31.9x faster for about 1 percentage point of cell reduction."
   },
   {
     "pointer": "/coarsen_smooth_ring",
     "type": "int",
-    "default": 2,
-    "doc": "Radius, in edges from the merged vertex, of the neighbourhood re-smoothed inside a coarsening collapse. The parallel lock claims one ring more than this, because smoothing a vertex reads its one-ring and writes the quality of its incident cells."
+    "default": 1,
+    "doc": "Radius smoothed inside the collapse, and the radius the accept test measures over. The lock claims one more ring than this. With coarsen_local_smoothing_passes at 0 nothing is smoothed, so this only sets how wide a region the accept test compares; a wider region is a more permissive test (it admits untouched cells to both the before and after maxima, which is still sound) so ring 2 coarsens slightly more, but it also makes the pass lock 3 rings per operation where the ordinary collapse locks 2, which is the worst thing for its parallel scaling. 1 by default: on octocat that is 2.3x faster than ring 2 for 1.5 percentage points of cell reduction, and it puts the lock footprint back in line with every other pass."
   },
   {
     "pointer": "/coarsen_global_smoothing_passes",
@@ -427,6 +428,12 @@
     "type": "int",
     "default": 2,
     "doc": "Cap on the coarsen/smooth alternation; the pass also stops as soon as a round accepts no collapse. A round does NOT exist to finish what the previous one started: within a round the collapse pass already runs to a fixed point, so repeating the collapse alone finds nothing. What a round adds is the global smoothing in between, which moves that fixed point -- the dirty-epoch retry only re-offers failures next to a SUCCESSFUL collapse, so a whole-mesh smoothing pass is invisible to it, and a rejected composite is rolled back in full so rejections never accumulate progress within a round. Returns decay fast: measured over the 16 challenging triwild models at five rounds, accepted collapses by round were 68.8% / 21.7% / 7.2% / 1.8% / 0.5%. Every round costs a full pre-check sweep over all edges plus a smoothing pass, so the default is two -- they carry 90.5% of the coarsening, and the three that would follow are worth 9.5% for 60% of the pass's budget."
+  },
+  {
+    "pointer": "/coarsen_max_inner_passes",
+    "type": "int",
+    "default": 1,
+    "doc": "Cap on the collapse pass's own dirty-epoch retry loop within one coarsening round; 0 is uncapped. Distinct from coarsen_max_rounds, which counts collapse+global-smoothing alternations. This counts the passes the retry loop makes inside a single collapse pass, re-offering failures whose neighbourhood a successful collapse disturbed. That filter asks only whether the neighbourhood MOVED, not whether it moved helpfully, so a productive first pass re-offers most of the mesh. 1 by default, i.e. one pass per round and no retry within it: on octocat the first pass found 5110 collapses in 135.8s and the three that followed found 27 in 38.4s. Rounds still repeat the pass, and those do pay off, because the global smoothing between them moves the fixed point in a way this filter cannot see."
   },
   {
     "pointer": "/coarsen_unbounded",

--- a/components/tetwild/wmtk/components/tetwild/tetwild_spec.json
+++ b/components/tetwild/wmtk/components/tetwild/tetwild_spec.json
@@ -401,7 +401,7 @@
   {
     "pointer": "/coarsen_pass",
     "type": "bool",
-    "default": true,
+    "default": false,
     "doc": "Run a final coarsening pass after the optimization has converged. The ordinary collapse judges a candidate on the raw post-collapse geometry -- the worst moment in the operation's life, before smoothing has absorbed any of the damage -- so a collapse that would be fine once its neighbourhood relaxes is never taken, and the converged mesh keeps vertices it does not need. This pass takes the collapse optimistically, re-smooths coarsen_smooth_ring around the merged vertex, and keeps it only if the worst element in the region it touched is no worse than before; every element outside that region is untouched, so 'no worse locally' is exactly 'no worse globally'. Alternates with ordinary smoothing passes, as the main optimization does."
   },
   {

--- a/components/triwild/wmtk/components/triwild/Parameters.h
+++ b/components/triwild/wmtk/components/triwild/Parameters.h
@@ -108,6 +108,7 @@ struct Parameters : public wmtk::OptimizerParameters
         coarsen_smooth_ring = json_params["coarsen_smooth_ring"];
         coarsen_global_smoothing_passes = json_params["coarsen_global_smoothing_passes"];
         coarsen_max_rounds = json_params["coarsen_max_rounds"];
+        coarsen_max_inner_passes = json_params["coarsen_max_inner_passes"];
 
         // Stuck-element sizing refinement.
         stuck_refine_stall_eps = json_params["stuck_refine_stall_eps"];

--- a/components/triwild/wmtk/components/triwild/triwild_spec.json
+++ b/components/triwild/wmtk/components/triwild/triwild_spec.json
@@ -401,7 +401,7 @@
   {
     "pointer": "/coarsen_pass",
     "type": "bool",
-    "default": true,
+    "default": false,
     "doc": "Run a final coarsening pass after the optimization has converged. The ordinary collapse judges a candidate on the raw post-collapse geometry -- the worst moment in the operation's life, before smoothing has absorbed any of the damage -- so a collapse that would be fine once its neighbourhood relaxes is never taken, and the converged mesh keeps vertices it does not need. This pass takes the collapse optimistically, re-smooths coarsen_smooth_ring around the merged vertex, and keeps it only if the worst element in the region it touched is no worse than before; every element outside that region is untouched, so 'no worse locally' is exactly 'no worse globally'. Alternates with ordinary smoothing passes, as the main optimization does."
   },
   {

--- a/components/triwild/wmtk/components/triwild/triwild_spec.json
+++ b/components/triwild/wmtk/components/triwild/triwild_spec.json
@@ -36,6 +36,7 @@
       "coarsen_smooth_ring",
       "coarsen_global_smoothing_passes",
       "coarsen_max_rounds",
+      "coarsen_max_inner_passes",
       "preserve_topology",
       "preserve_feature_points",
       "allow_junction_cleanup",
@@ -407,14 +408,14 @@
   {
     "pointer": "/coarsen_local_smoothing_passes",
     "type": "int",
-    "default": 2,
-    "doc": "Smoothing sweeps over the ring inside each candidate coarsening collapse, before its max energy is measured. This is what gives the collapse a chance to be judged on a relaxed neighbourhood rather than on the configuration it lands in."
+    "default": 0,
+    "doc": "Smoothing sweeps over the ring, inside each candidate collapse, before judging it. 0 by default, which means the pass judges the collapse on its raw post-collapse geometry and never smooths inside the operation. At the level of a single candidate that matters -- the composite's reject rate rises from 25% to 39% without it -- but it does not cost coarsening, because the pass runs to a fixed point: a candidate the smoothing would have rescued is replaced by another the pass finds instead, and the relaxation the mesh actually needs comes from the global smoothing between rounds. What it costs is time. The smoothed ball averaged 98 vertices on tetwild's octocat, so at the old default of 2 sweeps one candidate ran ~200 nonlinear smoothing solves and the pass ran 1.4 million of them to accept 5173 collapses. Over seven tetwild models, dropping this to 0 (with coarsen_max_inner_passes 1) made the pass 9.7x to 31.9x faster for about 1 percentage point of cell reduction."
   },
   {
     "pointer": "/coarsen_smooth_ring",
     "type": "int",
-    "default": 2,
-    "doc": "Radius, in edges from the merged vertex, of the neighbourhood re-smoothed inside a coarsening collapse. The parallel lock claims one ring more than this, because smoothing a vertex reads its one-ring and writes the quality of its incident faces."
+    "default": 1,
+    "doc": "Radius smoothed inside the collapse, and the radius the accept test measures over. The lock claims one more ring than this. With coarsen_local_smoothing_passes at 0 nothing is smoothed, so this only sets how wide a region the accept test compares; a wider region is a more permissive test (it admits untouched cells to both the before and after maxima, which is still sound) so ring 2 coarsens slightly more, but it also makes the pass lock 3 rings per operation where the ordinary collapse locks 2, which is the worst thing for its parallel scaling. 1 by default: on octocat that is 2.3x faster than ring 2 for 1.5 percentage points of cell reduction, and it puts the lock footprint back in line with every other pass."
   },
   {
     "pointer": "/coarsen_global_smoothing_passes",
@@ -427,6 +428,12 @@
     "type": "int",
     "default": 2,
     "doc": "Cap on the coarsen/smooth alternation; the pass also stops as soon as a round accepts no collapse. A round does NOT exist to finish what the previous one started: within a round the collapse pass already runs to a fixed point, so repeating the collapse alone finds nothing. What a round adds is the global smoothing in between, which moves that fixed point -- the dirty-epoch retry only re-offers failures next to a SUCCESSFUL collapse, so a whole-mesh smoothing pass is invisible to it, and a rejected composite is rolled back in full so rejections never accumulate progress within a round. Returns decay fast: measured over the 16 challenging triwild models at five rounds, accepted collapses by round were 68.8% / 21.7% / 7.2% / 1.8% / 0.5%. Every round costs a full pre-check sweep over all edges plus a smoothing pass, so the default is two -- they carry 90.5% of the coarsening, and the three that would follow are worth 9.5% for 60% of the pass's budget."
+  },
+  {
+    "pointer": "/coarsen_max_inner_passes",
+    "type": "int",
+    "default": 1,
+    "doc": "Cap on the collapse pass's own dirty-epoch retry loop within one coarsening round; 0 is uncapped. Distinct from coarsen_max_rounds, which counts collapse+global-smoothing alternations. This counts the passes the retry loop makes inside a single collapse pass, re-offering failures whose neighbourhood a successful collapse disturbed. That filter asks only whether the neighbourhood MOVED, not whether it moved helpfully, so a productive first pass re-offers most of the mesh. 1 by default, i.e. one pass per round and no retry within it: on octocat the first pass found 5110 collapses in 135.8s and the three that followed found 27 in 38.4s. Rounds still repeat the pass, and those do pay off, because the global smoothing between them moves the fixed point in a way this filter cannot see."
   },
   {
     "pointer": "/coarsen_unbounded",

--- a/src/wmtk/OptimizerParameters.h
+++ b/src/wmtk/OptimizerParameters.h
@@ -180,8 +180,16 @@ struct OptimizerParameters
      * the merged vertex, and only then a decision -- keep it if the worst cell in the region
      * touched is no worse than before, undo the whole block otherwise. Because every cell
      * outside that region is untouched, "no worse locally" is exactly "no worse globally".
+     *
+     * Off by default: it is expensive. Every candidate collapse runs
+     * coarsen_local_smoothing_passes sweeps over the coarsen_smooth_ring before it can be
+     * judged, and a rejected one has all of that undone, so the pass pays full smoothing cost
+     * for the collapses it does not keep as well as the ones it does -- and it repeats that for
+     * coarsen_max_rounds. That is worth it when element count is what matters, but it is a
+     * large addition to the wall time of an otherwise converged run, so it is opt-in rather
+     * than something every caller pays for without asking.
      */
-    bool coarsen_pass = true;
+    bool coarsen_pass = false;
     /**
      * Coarsen as far as the quality guarantee allows, instead of stopping at the target edge
      * length.

--- a/src/wmtk/OptimizerParameters.h
+++ b/src/wmtk/OptimizerParameters.h
@@ -181,13 +181,11 @@ struct OptimizerParameters
      * touched is no worse than before, undo the whole block otherwise. Because every cell
      * outside that region is untouched, "no worse locally" is exactly "no worse globally".
      *
-     * Off by default: it is expensive. Every candidate collapse runs
-     * coarsen_local_smoothing_passes sweeps over the coarsen_smooth_ring before it can be
-     * judged, and a rejected one has all of that undone, so the pass pays full smoothing cost
-     * for the collapses it does not keep as well as the ones it does -- and it repeats that for
-     * coarsen_max_rounds. That is worth it when element count is what matters, but it is a
-     * large addition to the wall time of an otherwise converged run, so it is opt-in rather
-     * than something every caller pays for without asking.
+     * Off by default. It is much cheaper than it used to be -- see
+     * coarsen_local_smoothing_passes, whose default is now 0 -- but it still costs a full
+     * collapse sweep over every edge, which on tetwild's models is several seconds on top of an
+     * otherwise converged run. That is worth paying when element count is what matters, and not
+     * worth paying silently for every caller, so it stays opt-in.
      */
     bool coarsen_pass = false;
     /**
@@ -214,11 +212,40 @@ struct OptimizerParameters
      * are larger than length_rel nominally asked for. Turn it off to hold the target size.
      */
     bool coarsen_unbounded = true;
-    /// Smoothing sweeps over the ring, inside each candidate collapse, before judging it.
-    int coarsen_local_smoothing_passes = 2;
-    /// Radius smoothed inside the collapse. The lock claims one more ring than this, because
-    /// smoothing a vertex reads its one-ring and writes the quality of its incident cells.
-    int coarsen_smooth_ring = 2;
+    /**
+     * Smoothing sweeps over the ring, inside each candidate collapse, before judging it.
+     *
+     * 0 by default, which means the pass judges the collapse on its raw post-collapse geometry
+     * and never smooths inside the operation. That sounds like it gives up the pass's whole
+     * premise, and at the level of a single candidate it does: without the smoothing the
+     * composite's reject rate rises from 25% to 39%. It does not cost coarsening, because the
+     * pass runs to a fixed point -- a candidate the smoothing would have rescued is simply
+     * replaced by another the pass finds instead, and the relaxation the mesh actually needs
+     * comes from the ordinary global smoothing between rounds (coarsen_global_smoothing_passes).
+     *
+     * What it does cost is time, and enormously. The smoothed ball averaged 98 vertices on
+     * tetwild's octocat, so at the old default of 2 sweeps a single candidate ran ~200 nonlinear
+     * smoothing solves, and the pass ran 1.4 million of them to accept 5173 collapses. Measured
+     * over seven tetwild models, dropping this to 0 (with coarsen_max_inner_passes 1) made the
+     * pass 9.7x to 31.9x faster for about 1 percentage point of cell reduction.
+     */
+    int coarsen_local_smoothing_passes = 0;
+    /**
+     * Radius smoothed inside the collapse, and the radius the accept test measures over. The
+     * lock claims one more ring than this, because smoothing a vertex reads its one-ring and
+     * writes the quality of its incident cells.
+     *
+     * With coarsen_local_smoothing_passes at 0 nothing is smoothed, so this only sets how wide a
+     * region the accept test compares. A wider region is a more permissive test -- it admits
+     * untouched cells to both the before and after maxima, which is still sound, since an
+     * untouched cell holds the global max up on both sides of the comparison -- so ring 2
+     * coarsens slightly more. It also makes the pass lock 3 rings per operation where the
+     * ordinary collapse locks 2, which is the single worst thing for its parallel scaling.
+     *
+     * 1 by default: on octocat that is 2.3x faster than ring 2 for 1.5 percentage points of
+     * cell reduction, and it puts the pass's lock footprint back in line with every other pass.
+     */
+    int coarsen_smooth_ring = 1;
     /**
      * Ordinary whole-mesh smoothing passes between coarsening rounds.
      *
@@ -250,6 +277,24 @@ struct OptimizerParameters
      * worth 9.5% for 60% of the pass's budget.
      */
     int coarsen_max_rounds = 2;
+    /**
+     * Cap on the collapse pass's own dirty-epoch retry loop inside one round; 0 is uncapped.
+     *
+     * Distinct from coarsen_max_rounds, which counts collapse+global-smoothing alternations.
+     * This counts the passes run_localized_to_convergence makes within a single collapse pass,
+     * re-offering failures whose neighbourhood a successful collapse disturbed. That filter
+     * asks only whether the neighbourhood MOVED, not whether it moved helpfully, so a
+     * productive first pass re-offers most of the mesh -- and here every re-offer that clears
+     * the cheap checks pays the whole collapse pre-check chain before failing again.
+     *
+     * 1 by default, i.e. one pass per round and no retry within it. Measured on octocat, the
+     * first pass found 5110 collapses in 135.8s and the three that followed found 27 in 38.4s;
+     * the second round then found 36 more in 28s. Capping the inner loop keeps the first pass
+     * and drops the rest, which is worth 1.2x on its own and more once the composite is cheap.
+     * Rounds still repeat the pass (coarsen_max_rounds), and those DO pay off, because the
+     * global smoothing between them moves the fixed point in a way this retry filter cannot see.
+     */
+    int coarsen_max_inner_passes = 1;
 
     bool debug_output = false;
     bool perform_sanity_checks = false;

--- a/src/wmtk/TetOptimizerMesh.h
+++ b/src/wmtk/TetOptimizerMesh.h
@@ -560,7 +560,7 @@ private:
     /// One smoothing attempt on @p vid, restoring everything it wrote if it is rejected.
     bool smooth_vertex_reversible(size_t vid, CoarsenScratch& scr);
 
-    size_t collapse_all_edges_impl(bool is_limit_length, int lock_ring);
+    size_t collapse_all_edges_impl(bool is_limit_length, int lock_ring, size_t max_passes = 0);
 };
 
 } // namespace wmtk

--- a/src/wmtk/TetOptimizerMeshCollapse.cpp
+++ b/src/wmtk/TetOptimizerMeshCollapse.cpp
@@ -21,7 +21,8 @@ void TetOptimizerMesh::collapse_all_edges(bool is_limit_length)
     collapse_all_edges_impl(is_limit_length, wmtk::default_ring(wmtk::PassLock::EdgeRing));
 }
 
-size_t TetOptimizerMesh::collapse_all_edges_impl(bool is_limit_length, int lock_ring)
+size_t
+TetOptimizerMesh::collapse_all_edges_impl(bool is_limit_length, int lock_ring, size_t max_passes)
 {
     m_collapse_limit_length = is_limit_length;
     igl::Timer timer;
@@ -67,7 +68,8 @@ size_t TetOptimizerMesh::collapse_all_edges_impl(bool is_limit_length, int lock_
             };
             // Retry a failed collapse only where the mesh actually changed this round
             // (dirty-epoch localized retry), instead of re-testing every failure every pass.
-            accepted = wmtk::run_localized_to_convergence(mesh, executor, collect_all_ops);
+            accepted =
+                wmtk::run_localized_to_convergence(mesh, executor, collect_all_ops, max_passes);
         });
     return accepted;
 }
@@ -592,9 +594,15 @@ size_t TetOptimizerMesh::coarsen_mesh()
     size_t total = 0;
     for (int round = 0; round < m_params.coarsen_max_rounds; ++round) {
         m_coarsen_mode = true;
-        // The lock claims one ring more than the smoothing reaches: smoothing a vertex at
-        // distance r reads its one-ring and writes the quality of its incident cells.
-        const size_t accepted = collapse_all_edges_impl(false, m_params.coarsen_smooth_ring + 1);
+        // The lock claims one ring more than coarsen_smooth_ring. With smoothing on that is
+        // what the writes reach (smoothing a vertex at distance r reads its one-ring and
+        // writes the quality of its incident cells); with coarsen_local_smoothing_passes at 0
+        // it is what the accept test READS, since a cell incident to a distance-r vertex has
+        // vertices at r+1. Either way the +1 is required.
+        const size_t accepted = collapse_all_edges_impl(
+            false,
+            m_params.coarsen_smooth_ring + 1,
+            size_t(m_params.coarsen_max_inner_passes));
         m_coarsen_mode = false;
         total += accepted;
 

--- a/src/wmtk/TriOptimizerMesh.h
+++ b/src/wmtk/TriOptimizerMesh.h
@@ -491,7 +491,7 @@ private:
     /// One smoothing attempt on @p vid, restoring everything it wrote if it is rejected.
     bool smooth_vertex_reversible(size_t vid, CoarsenScratch& scr);
 
-    size_t collapse_all_edges_impl(bool is_limit_length, int lock_ring);
+    size_t collapse_all_edges_impl(bool is_limit_length, int lock_ring, size_t max_passes = 0);
 };
 
 } // namespace wmtk

--- a/src/wmtk/TriOptimizerMeshCollapse.cpp
+++ b/src/wmtk/TriOptimizerMeshCollapse.cpp
@@ -20,7 +20,8 @@ void TriOptimizerMesh::collapse_all_edges(bool is_limit_length)
     collapse_all_edges_impl(is_limit_length, wmtk::default_ring(wmtk::PassLock::EdgeRing));
 }
 
-size_t TriOptimizerMesh::collapse_all_edges_impl(bool is_limit_length, int lock_ring)
+size_t
+TriOptimizerMesh::collapse_all_edges_impl(bool is_limit_length, int lock_ring, size_t max_passes)
 {
     m_collapse_limit_length = is_limit_length;
     collapse_pass_begin();
@@ -78,7 +79,7 @@ size_t TriOptimizerMesh::collapse_all_edges_impl(bool is_limit_length, int lock_
             // list from get_edges() after every pass and re-ran the expensive geometric
             // pre-checks on every failure, even where nothing could have changed.
             const size_t total_success =
-                wmtk::run_localized_to_convergence(mesh, executor, all_ops);
+                wmtk::run_localized_to_convergence(mesh, executor, all_ops, max_passes);
             logger().info("collapse success: {}", total_success);
             collapse_pass_end(total_success);
             accepted = total_success;
@@ -520,9 +521,15 @@ size_t TriOptimizerMesh::coarsen_mesh()
     size_t total = 0;
     for (int round = 0; round < m_params.coarsen_max_rounds; ++round) {
         m_coarsen_mode = true;
-        // The lock claims one ring more than the smoothing reaches: smoothing a vertex at
-        // distance r reads its one-ring and writes the quality of its incident faces.
-        const size_t accepted = collapse_all_edges_impl(false, m_params.coarsen_smooth_ring + 1);
+        // The lock claims one ring more than coarsen_smooth_ring. With smoothing on that is
+        // what the writes reach (smoothing a vertex at distance r reads its one-ring and
+        // writes the quality of its incident faces); with coarsen_local_smoothing_passes at 0
+        // it is what the accept test READS, since a face incident to a distance-r vertex has
+        // vertices at r+1. Either way the +1 is required.
+        const size_t accepted = collapse_all_edges_impl(
+            false,
+            m_params.coarsen_smooth_ring + 1,
+            size_t(m_params.coarsen_max_inner_passes));
         m_coarsen_mode = false;
         total += accepted;
 

--- a/src/wmtk/utils/LocalizedRetry.hpp
+++ b/src/wmtk/utils/LocalizedRetry.hpp
@@ -33,12 +33,21 @@ namespace wmtk {
  * `renew_neighbor_tuples` -- i.e. exactly the region the driver already considers
  * "affected" and re-enqueues within a pass -- so this stays consistent with the existing
  * intra-pass renewal logic.
+ *
+ * `max_passes` caps the loop; 0 means "until convergence". A cap is worth setting when a
+ * retry is expensive relative to what it finds. The dirty-epoch filter only asks whether a
+ * failure's neighbourhood MOVED, not whether it moved in a direction that helps, so after a
+ * productive first pass it re-offers most of the mesh. For a pass whose failures are cheap
+ * (pre-checks only) that is a good trade. For one whose every failure runs a full smoothing
+ * composite and rolls it back, it is not: measured on tetwild's octocat, passes 2+ of the
+ * coarsening loop cost 38.4s to find 27 collapses after pass 1 found 5110 in 135.8s.
  */
 template <class Mesh>
 size_t run_localized_to_convergence(
     Mesh& m,
     ExecutePass<Mesh>& executor,
-    std::vector<std::pair<Op, typename Mesh::Tuple>> ops)
+    std::vector<std::pair<Op, typename Mesh::Tuple>> ops,
+    size_t max_passes = 0)
 {
     using Tuple = typename Mesh::Tuple;
 
@@ -99,7 +108,8 @@ size_t run_localized_to_convergence(
                 ops.emplace_back(pr);
             }
         }
-    } while (executor.get_cnt_success() > 0 && !ops.empty());
+    } while (executor.get_cnt_success() > 0 && !ops.empty() &&
+             (max_passes == 0 || round < max_passes));
     return total_success;
 }
 


### PR DESCRIPTION
Two commits. The first turns the coarsening pass off by default; the second makes it ~40× cheaper for the callers who turn it back on.

## 1. Default the pass off

`coarsen_pass` has been on by default since it landed, and it is slow enough that callers have been paying for it without asking. The default is declared in `OptimizerParameters.h` **and** in the tetwild, triwild and simwild JSON specs, which are embedded into the binaries at build time — all four move together, since changing only the header would leave the specs advertising `true` and the JSON layer overriding it straight back.

The pass itself is untouched: set `coarsen_pass: true` to get it back. What it buys is element count, which is worth having when that is what you're optimizing for; it just shouldn't be silently charged to every run.

## 2. Make it cheap enough to be worth turning on

Profiling it on octocat found the pass was not part of the run, it *was* the run — **202.9 s of 213.3 s**, and **86–96% of total wall time across seven tetwild models**. Independently visible in this repo's own CI: the Release integration suite takes 1h42m with the pass on and 15m with it off.

Almost all of that went to a local smoothing composite that turns out not to buy the coarsening it was added for.

Each candidate collapse smoothed a ball around the merged vertex before it could be judged. **That ball averaged 98 vertices**, so at two sweeps one candidate ran ~200 nonlinear smoothing solves, and the pass ran **1.4 million of them to accept 5173 collapses**.

| default | old | new |
|---|---|---|
| `coarsen_local_smoothing_passes` | 2 | **0** |
| `coarsen_smooth_ring` | 2 | **1** |
| `coarsen_max_inner_passes` | *(new)* | **1** |

**`coarsen_local_smoothing_passes = 0`** costs nothing measurable. It matters per candidate — the composite's reject rate rises from 25% to 39% — but the pass runs to a fixed point, so a candidate the smoothing would have rescued is replaced by another the pass finds instead, and the relaxation the mesh actually needs still comes from the global smoothing between rounds. On octocat that alone is **11.2× for 0.2 pp** of cell reduction, inside the run-to-run spread.

**`coarsen_smooth_ring = 1`.** With nothing being smoothed this only sets how wide a region the accept test compares. Ring 2 is the more permissive test and coarsens slightly more, but it also makes the pass lock **3 rings** per operation where every other pass locks 2 — which is why the pass got **1.75× out of 8 threads**, and non-monotonically (4 threads was slower than 2). Ring 1 is 2.3× faster for 1.5 pp.

**`coarsen_max_inner_passes = 1`** (new parameter, `0` = uncapped = previous behaviour). The dirty-epoch retry loop asks only whether a failure's neighbourhood *moved*, not whether it moved helpfully, so a productive first pass re-offers most of the mesh. On octocat the first pass found 5110 collapses in 135.8 s and the three that followed found **27 in 38.4 s**. Rounds still repeat the pass, and those do pay off, because the global smoothing between them moves the fixed point in a way this filter cannot see.

### Measured

Coarsening time, median of 3 runs at 8 threads on octocat:

| config | coarsening | cell reduction |
|---|---|---|
| old defaults | 226.8 s | 66.2% |
| `local 0` | 20.3 s | 66.0% |
| `local 0 + cap 1` | 12.2 s | 65.5% |
| **new defaults** | **5.2 s** | **64.1%** |

Across seven models, base → new is **9.7× to 31.9×** faster for about 1 pp of cell reduction, one model unchanged and one slightly better. Octocat end to end: **213.3 s → 16.8 s**, max energy unchanged.

The pass's guarantee is untouched by any of this — "the region's worst element did not get worse" *is* its accept test, not something these knobs can weaken.

## Verification

**117/117 tests pass.** `test_coarsen_pass.cpp` sets these parameters explicitly in both directions, so the pass stays exercised regardless of the defaults.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
