### PR TITLE
Add collapse_quality_margin to gate collapses on real improvement

### DIFF
--- a/components/simwild/wmtk/components/simwild/Parameters.h
+++ b/components/simwild/wmtk/components/simwild/Parameters.h
@@ -105,6 +105,7 @@ struct Parameters : public wmtk::OptimizerParameters
         coarsen_max_rounds = json_params["coarsen_max_rounds"];
         coarsen_max_inner_passes = json_params["coarsen_max_inner_passes"];
         collapse_quality_margin = json_params["collapse_quality_margin"];
+        debug_edge_length_match = json_params["debug_edge_length_match"];
 
         debug_output = json_params["DEBUG_output"];
         perform_sanity_checks = json_params["DEBUG_sanity_checks"];

--- a/components/simwild/wmtk/components/simwild/Parameters.h
+++ b/components/simwild/wmtk/components/simwild/Parameters.h
@@ -104,6 +104,7 @@ struct Parameters : public wmtk::OptimizerParameters
         coarsen_global_smoothing_passes = json_params["coarsen_global_smoothing_passes"];
         coarsen_max_rounds = json_params["coarsen_max_rounds"];
         coarsen_max_inner_passes = json_params["coarsen_max_inner_passes"];
+        collapse_quality_margin = json_params["collapse_quality_margin"];
 
         debug_output = json_params["DEBUG_output"];
         perform_sanity_checks = json_params["DEBUG_sanity_checks"];

--- a/components/simwild/wmtk/components/simwild/simwild_spec.json
+++ b/components/simwild/wmtk/components/simwild/simwild_spec.json
@@ -45,6 +45,7 @@
       "coarsen_global_smoothing_passes",
       "coarsen_max_rounds",
       "coarsen_max_inner_passes",
+      "collapse_quality_margin",
       "write_vtu",
       "write_envelope",
       "log_file",
@@ -637,6 +638,12 @@
     "type": "int",
     "default": 1,
     "doc": "Cap on the collapse pass's own dirty-epoch retry loop within one coarsening round; 0 is uncapped. Distinct from coarsen_max_rounds, which counts collapse+global-smoothing alternations. This counts the passes the retry loop makes inside a single collapse pass, re-offering failures whose neighbourhood a successful collapse disturbed. That filter asks only whether the neighbourhood MOVED, not whether it moved helpfully, so a productive first pass re-offers most of the mesh. 1 by default, i.e. one pass per round and no retry within it: on octocat the first pass found 5110 collapses in 135.8s and the three that followed found 27 in 38.4s. Rounds still repeat the pass, and those do pay off, because the global smoothing between them moves the fixed point in a way this filter cannot see."
+  },
+  {
+    "pointer": "/collapse_quality_margin",
+    "type": "float",
+    "default": 1.0,
+    "doc": "How much better than its neighbourhood's worst cell a collapse must leave things: the admission test is quality <= ring_max * margin, where ring_max is the worst quality among the cells incident to the removed vertex and quality is AMIPS^dim (larger is worse). 1.0 is the historical 'no worse than what is already here', which for a short edge is the only thing limiting the collapse pass, since short edges are not gated on length. Below 1.0 the collapse must strictly improve the ring's worst by that factor, which stops the collapse pass from undoing the split pass while still admitting repairs (the ceiling is set by cells the collapse deletes). Not applied by the coarsening pass."
   },
   {
     "pointer": "/coarsen_unbounded",

--- a/components/simwild/wmtk/components/simwild/simwild_spec.json
+++ b/components/simwild/wmtk/components/simwild/simwild_spec.json
@@ -46,6 +46,7 @@
       "coarsen_max_rounds",
       "coarsen_max_inner_passes",
       "collapse_quality_margin",
+      "debug_edge_length_match",
       "write_vtu",
       "write_envelope",
       "log_file",
@@ -644,6 +645,12 @@
     "type": "float",
     "default": 1.0,
     "doc": "How much better than its neighbourhood's worst cell a collapse must leave things: the admission test is quality <= ring_max * margin, where ring_max is the worst quality among the cells incident to the removed vertex and quality is AMIPS^dim (larger is worse). 1.0 is the historical 'no worse than what is already here', which for a short edge is the only thing limiting the collapse pass, since short edges are not gated on length. Below 1.0 the collapse must strictly improve the ring's worst by that factor, which stops the collapse pass from undoing the split pass while still admitting repairs (the ceiling is set by cells the collapse deletes). Not applied by the coarsening pass."
+  },
+  {
+    "pointer": "/debug_edge_length_match",
+    "type": "bool",
+    "default": false,
+    "doc": "Diagnostic. At the end of the optimization, log the distribution of each edge's length divided by its own target length (l times the sizing scalar averaged over its endpoints) -- the exact quantity the split and collapse length gates compare, where 1.0 is an edge exactly at target. Reports mean, sd, percentiles, and the fractions below, inside and above [4/5, 4/3], the interval the two gates bound. Costs one pass over the edges."
   },
   {
     "pointer": "/coarsen_unbounded",

--- a/components/tetwild/wmtk/components/tetwild/tetwild.cpp
+++ b/components/tetwild/wmtk/components/tetwild/tetwild.cpp
@@ -125,6 +125,7 @@ TetWildMesh::ExportStruct tetwild_with_export(nlohmann::json json_params)
     params.coarsen_max_rounds = json_params["coarsen_max_rounds"];
     params.coarsen_max_inner_passes = json_params["coarsen_max_inner_passes"];
     params.collapse_quality_margin = json_params["collapse_quality_margin"];
+    params.debug_edge_length_match = json_params["debug_edge_length_match"];
     params.w_amips = json_params["w_amips"];
     params.smoothing_mode = json_params["smoothing_mode"];
     params.project_line_search_steps = json_params["project_line_search_steps"];

--- a/components/tetwild/wmtk/components/tetwild/tetwild.cpp
+++ b/components/tetwild/wmtk/components/tetwild/tetwild.cpp
@@ -124,6 +124,7 @@ TetWildMesh::ExportStruct tetwild_with_export(nlohmann::json json_params)
     params.coarsen_global_smoothing_passes = json_params["coarsen_global_smoothing_passes"];
     params.coarsen_max_rounds = json_params["coarsen_max_rounds"];
     params.coarsen_max_inner_passes = json_params["coarsen_max_inner_passes"];
+    params.collapse_quality_margin = json_params["collapse_quality_margin"];
     params.w_amips = json_params["w_amips"];
     params.smoothing_mode = json_params["smoothing_mode"];
     params.project_line_search_steps = json_params["project_line_search_steps"];

--- a/components/tetwild/wmtk/components/tetwild/tetwild_spec.json
+++ b/components/tetwild/wmtk/components/tetwild/tetwild_spec.json
@@ -40,6 +40,7 @@
       "coarsen_global_smoothing_passes",
       "coarsen_max_rounds",
       "coarsen_max_inner_passes",
+      "collapse_quality_margin",
       "preserve_topology",
       "remove_duplicate_eps",
       "allow_surface_swap",
@@ -434,6 +435,12 @@
     "type": "int",
     "default": 1,
     "doc": "Cap on the collapse pass's own dirty-epoch retry loop within one coarsening round; 0 is uncapped. Distinct from coarsen_max_rounds, which counts collapse+global-smoothing alternations. This counts the passes the retry loop makes inside a single collapse pass, re-offering failures whose neighbourhood a successful collapse disturbed. That filter asks only whether the neighbourhood MOVED, not whether it moved helpfully, so a productive first pass re-offers most of the mesh. 1 by default, i.e. one pass per round and no retry within it: on octocat the first pass found 5110 collapses in 135.8s and the three that followed found 27 in 38.4s. Rounds still repeat the pass, and those do pay off, because the global smoothing between them moves the fixed point in a way this filter cannot see."
+  },
+  {
+    "pointer": "/collapse_quality_margin",
+    "type": "float",
+    "default": 1.0,
+    "doc": "How much better than its neighbourhood's worst cell a collapse must leave things: the admission test is quality <= ring_max * margin, where ring_max is the worst quality among the cells incident to the removed vertex and quality is AMIPS^dim (larger is worse). 1.0 is the historical 'no worse than what is already here', which for a short edge is the only thing limiting the collapse pass, since short edges are not gated on length. Below 1.0 the collapse must strictly improve the ring's worst by that factor, which stops the collapse pass from undoing the split pass while still admitting repairs (the ceiling is set by cells the collapse deletes). Not applied by the coarsening pass."
   },
   {
     "pointer": "/coarsen_unbounded",

--- a/components/tetwild/wmtk/components/tetwild/tetwild_spec.json
+++ b/components/tetwild/wmtk/components/tetwild/tetwild_spec.json
@@ -41,6 +41,7 @@
       "coarsen_max_rounds",
       "coarsen_max_inner_passes",
       "collapse_quality_margin",
+      "debug_edge_length_match",
       "preserve_topology",
       "remove_duplicate_eps",
       "allow_surface_swap",
@@ -441,6 +442,12 @@
     "type": "float",
     "default": 1.0,
     "doc": "How much better than its neighbourhood's worst cell a collapse must leave things: the admission test is quality <= ring_max * margin, where ring_max is the worst quality among the cells incident to the removed vertex and quality is AMIPS^dim (larger is worse). 1.0 is the historical 'no worse than what is already here', which for a short edge is the only thing limiting the collapse pass, since short edges are not gated on length. Below 1.0 the collapse must strictly improve the ring's worst by that factor, which stops the collapse pass from undoing the split pass while still admitting repairs (the ceiling is set by cells the collapse deletes). Not applied by the coarsening pass."
+  },
+  {
+    "pointer": "/debug_edge_length_match",
+    "type": "bool",
+    "default": false,
+    "doc": "Diagnostic. At the end of the optimization, log the distribution of each edge's length divided by its own target length (l times the sizing scalar averaged over its endpoints) -- the exact quantity the split and collapse length gates compare, where 1.0 is an edge exactly at target. Reports mean, sd, percentiles, and the fractions below, inside and above [4/5, 4/3], the interval the two gates bound. Costs one pass over the edges."
   },
   {
     "pointer": "/coarsen_unbounded",

--- a/components/triwild/wmtk/components/triwild/Parameters.h
+++ b/components/triwild/wmtk/components/triwild/Parameters.h
@@ -109,6 +109,7 @@ struct Parameters : public wmtk::OptimizerParameters
         coarsen_global_smoothing_passes = json_params["coarsen_global_smoothing_passes"];
         coarsen_max_rounds = json_params["coarsen_max_rounds"];
         coarsen_max_inner_passes = json_params["coarsen_max_inner_passes"];
+        collapse_quality_margin = json_params["collapse_quality_margin"];
 
         // Stuck-element sizing refinement.
         stuck_refine_stall_eps = json_params["stuck_refine_stall_eps"];

--- a/components/triwild/wmtk/components/triwild/Parameters.h
+++ b/components/triwild/wmtk/components/triwild/Parameters.h
@@ -110,6 +110,7 @@ struct Parameters : public wmtk::OptimizerParameters
         coarsen_max_rounds = json_params["coarsen_max_rounds"];
         coarsen_max_inner_passes = json_params["coarsen_max_inner_passes"];
         collapse_quality_margin = json_params["collapse_quality_margin"];
+        debug_edge_length_match = json_params["debug_edge_length_match"];
 
         // Stuck-element sizing refinement.
         stuck_refine_stall_eps = json_params["stuck_refine_stall_eps"];

--- a/components/triwild/wmtk/components/triwild/triwild_spec.json
+++ b/components/triwild/wmtk/components/triwild/triwild_spec.json
@@ -37,6 +37,7 @@
       "coarsen_global_smoothing_passes",
       "coarsen_max_rounds",
       "coarsen_max_inner_passes",
+      "collapse_quality_margin",
       "preserve_topology",
       "preserve_feature_points",
       "allow_junction_cleanup",
@@ -434,6 +435,12 @@
     "type": "int",
     "default": 1,
     "doc": "Cap on the collapse pass's own dirty-epoch retry loop within one coarsening round; 0 is uncapped. Distinct from coarsen_max_rounds, which counts collapse+global-smoothing alternations. This counts the passes the retry loop makes inside a single collapse pass, re-offering failures whose neighbourhood a successful collapse disturbed. That filter asks only whether the neighbourhood MOVED, not whether it moved helpfully, so a productive first pass re-offers most of the mesh. 1 by default, i.e. one pass per round and no retry within it: on octocat the first pass found 5110 collapses in 135.8s and the three that followed found 27 in 38.4s. Rounds still repeat the pass, and those do pay off, because the global smoothing between them moves the fixed point in a way this filter cannot see."
+  },
+  {
+    "pointer": "/collapse_quality_margin",
+    "type": "float",
+    "default": 1.0,
+    "doc": "How much better than its neighbourhood's worst cell a collapse must leave things: the admission test is quality <= ring_max * margin, where ring_max is the worst quality among the cells incident to the removed vertex and quality is AMIPS^dim (larger is worse). 1.0 is the historical 'no worse than what is already here', which for a short edge is the only thing limiting the collapse pass, since short edges are not gated on length. Below 1.0 the collapse must strictly improve the ring's worst by that factor, which stops the collapse pass from undoing the split pass while still admitting repairs (the ceiling is set by cells the collapse deletes). Not applied by the coarsening pass."
   },
   {
     "pointer": "/coarsen_unbounded",

--- a/components/triwild/wmtk/components/triwild/triwild_spec.json
+++ b/components/triwild/wmtk/components/triwild/triwild_spec.json
@@ -38,6 +38,7 @@
       "coarsen_max_rounds",
       "coarsen_max_inner_passes",
       "collapse_quality_margin",
+      "debug_edge_length_match",
       "preserve_topology",
       "preserve_feature_points",
       "allow_junction_cleanup",
@@ -441,6 +442,12 @@
     "type": "float",
     "default": 1.0,
     "doc": "How much better than its neighbourhood's worst cell a collapse must leave things: the admission test is quality <= ring_max * margin, where ring_max is the worst quality among the cells incident to the removed vertex and quality is AMIPS^dim (larger is worse). 1.0 is the historical 'no worse than what is already here', which for a short edge is the only thing limiting the collapse pass, since short edges are not gated on length. Below 1.0 the collapse must strictly improve the ring's worst by that factor, which stops the collapse pass from undoing the split pass while still admitting repairs (the ceiling is set by cells the collapse deletes). Not applied by the coarsening pass."
+  },
+  {
+    "pointer": "/debug_edge_length_match",
+    "type": "bool",
+    "default": false,
+    "doc": "Diagnostic. At the end of the optimization, log the distribution of each edge's length divided by its own target length (l times the sizing scalar averaged over its endpoints) -- the exact quantity the split and collapse length gates compare, where 1.0 is an edge exactly at target. Reports mean, sd, percentiles, and the fractions below, inside and above [4/5, 4/3], the interval the two gates bound. Costs one pass over the edges."
   },
   {
     "pointer": "/coarsen_unbounded",

--- a/src/wmtk/OptimizerParameters.h
+++ b/src/wmtk/OptimizerParameters.h
@@ -332,6 +332,13 @@ struct OptimizerParameters
      */
     int coarsen_max_inner_passes = 1;
 
+    /**
+     * @brief Log how well the final edge lengths match `l * sizing_scalar`.
+     *
+     * Diagnostic only; costs one pass over the edges at the end of the optimization. See
+     * wmtk::utils::log_edge_length_match for what the reported quantities mean.
+     */
+    bool debug_edge_length_match = false;
     bool debug_output = false;
     bool perform_sanity_checks = false;
 

--- a/src/wmtk/OptimizerParameters.h
+++ b/src/wmtk/OptimizerParameters.h
@@ -146,6 +146,42 @@ struct OptimizerParameters
     double stop_energy = 100;
 
     /**
+     * @brief How much better than the neighbourhood's worst cell a collapse must leave things.
+     *
+     * The admission test for a collapse is `quality <= ring_max * collapse_quality_margin`,
+     * where `ring_max` is the worst quality among the cells incident to the vertex being
+     * removed and `quality` is that of each cell the collapse would create. Quality is
+     * AMIPS^dim, so larger is worse and the margin scales the ceiling the new cells must come
+     * in under; because the ceiling is set by how bad the neighbourhood ALREADY is, the test
+     * is strict in a healthy region and lax around a defect.
+     *
+     * At the default 1.0 the rule is merely "no worse than what is already here", which is
+     * permissive: it asks nothing about whether the collapse is useful. Edge length does not
+     * enter into it -- an edge shorter than the collapse length threshold is not gated on
+     * length at all -- so for short edges this is the ONLY thing standing between the collapse
+     * pass and the elements the split pass just created. Measured on tetwild's octocat at
+     * stop_energy 10, 72% of what each split pass adds is removed by the collapse pass that
+     * follows it.
+     *
+     * Below 1.0 the collapse must strictly improve the ring's worst by that factor. The
+     * useful range is well under 1: the effect on the energy you read is the dim'th root, so
+     * 0.999 demands a 0.03% improvement and changes nothing, while 0.5 demands ~21% in 3D and
+     * takes that 72% churn to 22% at an unchanged iteration count, max energy and wall time,
+     * for a 56% denser mesh.
+     *
+     * Lowering it does not cost the pass its essential job. Collapse is the only operation
+     * that can remove a shape defect -- AMIPS is scale-invariant, so refining a sliver leaves
+     * it a sliver -- and `ring_max` is measured over every cell incident to the removed
+     * vertex, INCLUDING the ones the collapse deletes. When the worst cell in the ring is the
+     * one being removed, the ceiling is set by a cell that will not exist afterwards and the
+     * repair is admitted regardless of the margin.
+     *
+     * Not applied by the coarsening pass, which deliberately replaces this test with a
+     * regional one taken after re-smoothing.
+     */
+    double collapse_quality_margin = 1.0;
+
+    /**
      * Relative weight of the AMIPS (quality) term against the envelope (stay-on-surface)
      * term during smoothing. w_envelope is derived as 1 - w_amips in each mesh's
      * constructor, so the small default means the envelope dominates and AMIPS acts as a

--- a/src/wmtk/TetOptimizerMesh.cpp
+++ b/src/wmtk/TetOptimizerMesh.cpp
@@ -1,5 +1,5 @@
-#include <wmtk/utils/EdgeLengthMatch.hpp>
 #include <wmtk/TetOptimizerMesh.h>
+#include <wmtk/utils/EdgeLengthMatch.hpp>
 
 #include <wmtk/utils/AMIPS.h>
 #include <wmtk/utils/GeoUtils.h>

--- a/src/wmtk/TetOptimizerMesh.cpp
+++ b/src/wmtk/TetOptimizerMesh.cpp
@@ -1,3 +1,4 @@
+#include <wmtk/utils/EdgeLengthMatch.hpp>
 #include <wmtk/TetOptimizerMesh.h>
 
 #include <wmtk/utils/AMIPS.h>
@@ -121,6 +122,10 @@ void TetOptimizerMesh::mesh_improvement(int max_its)
     // interleave: it trades cells for nothing but the guarantee that the max energy does not
     // rise, which is only worth taking once the energy is where it is going to end up.
     coarsen_mesh();
+
+    if (m_params.debug_edge_length_match) {
+        log_edge_length_match_stats();
+    }
 }
 
 std::tuple<double, double> TetOptimizerMesh::local_operations(
@@ -679,6 +684,23 @@ bool TetOptimizerMesh::face_is_on_surface(const size_t fid) const
 size_t TetOptimizerMesh::get_order_of_vertex(const size_t vid) const
 {
     return m_vertex_attribute.at(vid).m_order;
+}
+
+void TetOptimizerMesh::log_edge_length_match_stats() const
+{
+    std::vector<double> ratios;
+    ratios.reserve(get_edges().size());
+    for (const Tuple& e : get_edges()) {
+        const size_t v1 = e.vid(*this);
+        const size_t v2 = e.switch_vertex(*this).vid(*this);
+        const double len = (m_vertex_attribute[v1].m_posf - m_vertex_attribute[v2].m_posf).norm();
+        // The same average the split and collapse length gates take.
+        const double s =
+            (m_vertex_attribute[v1].m_sizing_scalar + m_vertex_attribute[v2].m_sizing_scalar) / 2;
+        const double target = m_params.l * s;
+        if (target > 0.) ratios.push_back(len / target);
+    }
+    utils::log_edge_length_match(std::move(ratios), "tet");
 }
 
 double TetOptimizerMesh::get_length2(const Tuple& l) const

--- a/src/wmtk/TetOptimizerMesh.h
+++ b/src/wmtk/TetOptimizerMesh.h
@@ -212,6 +212,9 @@ public:
     }
 
     double get_length2(const Tuple& l) const;
+    /// Diagnostic: log the distribution of edge length / (l * sizing_scalar). Gated on
+    /// OptimizerParameters::debug_edge_length_match by the caller.
+    void log_edge_length_match_stats() const;
 
     bool is_inverted(const std::array<size_t, 4>& vs) const;
     bool is_inverted(const Tuple& loc) const;

--- a/src/wmtk/TetOptimizerMesh.h
+++ b/src/wmtk/TetOptimizerMesh.h
@@ -449,7 +449,8 @@ protected:
     virtual bool collapse_before_vertex(size_t, size_t, double) { return true; }
     virtual bool collapse_quality_allowed(size_t v1, double quality, double ring_max) const
     {
-        return !m_vertex_attribute.at(v1).m_is_rounded || quality <= ring_max;
+        return !m_vertex_attribute.at(v1).m_is_rounded ||
+               quality <= ring_max * m_params.collapse_quality_margin;
     }
     virtual bool collapse_is_order_2_edge(const std::array<size_t, 2>&) { return false; }
     virtual bool

--- a/src/wmtk/TriOptimizerMesh.cpp
+++ b/src/wmtk/TriOptimizerMesh.cpp
@@ -1,3 +1,4 @@
+#include <wmtk/utils/EdgeLengthMatch.hpp>
 #include <wmtk/TriOptimizerMesh.h>
 
 #include <wmtk/utils/AMIPS2D.h>
@@ -119,6 +120,10 @@ void TriOptimizerMesh::mesh_improvement(int max_its)
     // interleave: it trades vertices for nothing but the guarantee that the max energy does
     // not rise, which is only worth taking once the energy is where it is going to end up.
     coarsen_mesh();
+
+    if (m_params.debug_edge_length_match) {
+        log_edge_length_match_stats();
+    }
 }
 
 std::tuple<double, double> TriOptimizerMesh::local_operations(
@@ -361,6 +366,23 @@ void TriOptimizerMesh::partition_mesh_morton()
     for (size_t i = 0; i < partition_id.size(); i++) {
         m_vertex_attribute[i].partition_id = partition_id[i];
     }
+}
+
+void TriOptimizerMesh::log_edge_length_match_stats() const
+{
+    std::vector<double> ratios;
+    ratios.reserve(get_edges().size());
+    for (const Tuple& e : get_edges()) {
+        const size_t v1 = e.vid(*this);
+        const size_t v2 = e.switch_vertex(*this).vid(*this);
+        const double len = (m_vertex_attribute[v1].m_posf - m_vertex_attribute[v2].m_posf).norm();
+        // The same average the split and collapse length gates take.
+        const double s =
+            (m_vertex_attribute[v1].m_sizing_scalar + m_vertex_attribute[v2].m_sizing_scalar) / 2;
+        const double target = m_params.l * s;
+        if (target > 0.) ratios.push_back(len / target);
+    }
+    utils::log_edge_length_match(std::move(ratios), "tri");
 }
 
 double TriOptimizerMesh::get_length2(const Tuple& l) const

--- a/src/wmtk/TriOptimizerMesh.cpp
+++ b/src/wmtk/TriOptimizerMesh.cpp
@@ -1,5 +1,5 @@
-#include <wmtk/utils/EdgeLengthMatch.hpp>
 #include <wmtk/TriOptimizerMesh.h>
+#include <wmtk/utils/EdgeLengthMatch.hpp>
 
 #include <wmtk/utils/AMIPS2D.h>
 #include <wmtk/utils/PartitionMesh.h>

--- a/src/wmtk/TriOptimizerMesh.h
+++ b/src/wmtk/TriOptimizerMesh.h
@@ -182,6 +182,9 @@ public:
     void partition_mesh_morton();
 
     double get_length2(const Tuple& l) const;
+    /// Diagnostic: log the distribution of edge length / (l * sizing_scalar). Gated on
+    /// OptimizerParameters::debug_edge_length_match by the caller.
+    void log_edge_length_match_stats() const;
 
     /**
      * @brief Orientation check, exact for the coordinates the vertices actually carry.

--- a/src/wmtk/TriOptimizerMesh.h
+++ b/src/wmtk/TriOptimizerMesh.h
@@ -334,7 +334,7 @@ protected:
     virtual bool collapse_quality_allowed(size_t v1, size_t, double q, double ring_max) const
     {
         return !m_vertex_attribute.at(v1).m_is_rounded || q <= m_params.stop_energy ||
-               q <= ring_max;
+               q <= ring_max * m_params.collapse_quality_margin;
     }
     virtual void collapse_after_vertex(size_t, size_t) {}
 

--- a/src/wmtk/utils/EdgeLengthMatch.hpp
+++ b/src/wmtk/utils/EdgeLengthMatch.hpp
@@ -1,0 +1,74 @@
+#pragma once
+
+#include <wmtk/utils/Logger.hpp>
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <string>
+#include <vector>
+
+namespace wmtk::utils {
+
+/**
+ * @brief Report how well a mesh's edge lengths match their prescribed targets.
+ *
+ * @param ratios  one entry per edge: its length divided by its own target length, which is
+ *                `l * sizing_scalar` averaged over the endpoints -- the exact quantity the
+ *                split and collapse length gates compare. 1.0 is an edge exactly at target.
+ * @param tag     which mesh produced it, so a run covering both can be told apart.
+ *
+ * `short` / `inband` / `long` are the fractions below, inside and above [4/5, 4/3], the
+ * interval the two length gates bound: the split gate refuses to split below 4/3 and the
+ * collapse gate stops requiring a quality improvement below 4/5. An optimizer honouring its
+ * sizing field would leave most edges inside it, so the fractions outside -- and their
+ * asymmetry, since only the split side is enforced by a hard threshold -- say how far the
+ * result is from the size it was asked for.
+ */
+inline void log_edge_length_match(std::vector<double> ratios, const std::string& tag)
+{
+    if (ratios.empty()) {
+        logger().info("[edge-match] {} n=0", tag);
+        return;
+    }
+    std::sort(ratios.begin(), ratios.end());
+    const double n = double(ratios.size());
+    const auto q = [&](double f) { return ratios[std::min(ratios.size() - 1, size_t(f * n))]; };
+
+    double sum = 0., sumsq = 0.;
+    for (const double x : ratios) {
+        sum += x;
+        sumsq += x * x;
+    }
+    const double mean = sum / n;
+    const double sd = std::sqrt(std::max(0., sumsq / n - mean * mean));
+
+    size_t below = 0, above = 0;
+    for (const double x : ratios) {
+        if (x < 4. / 5.) ++below;
+        if (x > 4. / 3.) ++above;
+    }
+
+    logger().info(
+        "[edge-match] {} n={} mean={:.4f} sd={:.4f} min={:.4f} p01={:.4f} p05={:.4f} p25={:.4f} "
+        "p50={:.4f} p75={:.4f} p95={:.4f} p99={:.4f} max={:.4f} short={:.4f} inband={:.4f} "
+        "long={:.4f}",
+        tag,
+        ratios.size(),
+        mean,
+        sd,
+        ratios.front(),
+        q(0.01),
+        q(0.05),
+        q(0.25),
+        q(0.50),
+        q(0.75),
+        q(0.95),
+        q(0.99),
+        ratios.back(),
+        double(below) / n,
+        (n - double(below) - double(above)) / n,
+        double(above) / n);
+}
+
+} // namespace wmtk::utils


### PR DESCRIPTION
## What

The collapse admission test in `collapse_quality_allowed` accepts a collapse when every cell it would create is no worse than the worst cell already incident to the vertex being removed:

```cpp
return !m_is_rounded(v1) || quality <= ring_max;
```

This adds a multiplier on that bound:

```cpp
return !m_is_rounded(v1) || quality <= ring_max * collapse_quality_margin;
```

**The default is 1.0, which is the old expression exactly — no behaviour change until the parameter is set.** Wired through the tetwild, triwild and simwild specs.

A second commit adds `debug_edge_length_match` (default off), which reports how well the final edge lengths match `l * sizing_scalar` — the quantity both length gates compare. That is what the measurements below are taken with.

## Why

The existing rule is permissive. It asks nothing about whether the collapse is *useful*, and it never consults edge length — an edge shorter than the collapse length threshold isn't gated on length at all — so for short edges it is the only thing standing between the collapse pass and the elements the split pass just built.

Measured on tetwild's octocat at `stop_energy 10`, **72% of what each split pass adds is removed by the collapse pass that immediately follows it.**

Investigating this also showed the collapse *length* threshold is inert here: holding the split threshold at `4l/3` and moving the collapse threshold from `4l/5` to `2l/3` produces a bit-identical run, because an edge under the threshold is never gated on length in the first place. The quality margin is the lever that actually binds.

## Measured effect on octocat

octocat @ `stop_energy 10`, serial, everything else default. Quality is AMIPS³, so the margin's effect on the energy you read is its cube root:

| margin | required improvement | churn | final #T | its | maxE | Hausdorff | wall |
|---|---|---|---|---|---|---|---|
| **1.0** (default) | 0% | 72.2% | 49 644 | 8 | 9.974 | 0.08959 | 69.8s |
| 0.999 | 0.03% | 72.9% | 50 929 | 9 | 9.995 | 0.07794 | 76.5s |
| 0.9 | 3.4% | 67.4% | 50 960 | 9 | 9.857 | 0.07994 | 72.4s |
| 0.5 | 21% | **22.1%** | 77 267 | 8 | 9.971 | 0.07825 | 67.5s |
| 0.25 | 37% | 9.1% | 91 443 | 11 | 9.975 | 0.07789 | 93.8s |
| 0.1 | 54% | 3.8% | 102 892 | 12 | 9.980 | 0.08101 | 105.0s |

That `0.999` does nothing is the useful diagnostic: the accepted collapses aren't marginal, they produce cells well under the ceiling, so only a real factor bites.

## On the challenging set, 0.5 is much weaker — and breaks one model

Full `challenging_low_stop_energy_models` group, one thread per run, margin 1.0 vs 0.5.

**tetwild, 15 cases:**

| | baseline | margin 0.5 |
|---|---|---|
| mean churn | 78.3% | 45.1% |
| total elements | +39.6% | |
| total wall | +24.1% | |
| **energy target met** | **15/15** | **14/15** |

**`challenging_tetwild_46024` fails to converge with the margin:**

| | iterations | elements | maxE | target met |
|---|---|---|---|---|
| baseline | **15** | 63 415 | **9.951** | yes |
| margin 0.5 | **80 (exhausted)** | 126 941 | **12.115** | **no** |

It is the largest model in the group. The baseline converges comfortably; at 0.5 the run burns all 80 iterations and still misses `stop_energy 10`.

The benefit is also very uneven. Cases below ~82% baseline churn respond strongly — 1047980 69.4→**14.6%**, 101954 70.9→**18.5%**, 101955 66.0→**22.5%** — while cases already above ~85% barely move or worsen: 1017012 90.5→**92.9%**, 1053397 90.6→76.6%, 103197 87.2→74.5%.

**triwild, 16 cases: nearly inert** (+4.6% elements), because `collapse_quality_allowed` in 2D carries an extra `q <= stop_energy` escape that lets almost every collapse bypass the margin.

## Why it doesn't break sliver removal

Collapse is the only operation that can remove a shape defect — AMIPS is scale-invariant, so refining a sliver leaves it a sliver. Two properties preserve that:

- `ring_max` is measured over **every** cell incident to the removed vertex, **including the ones the collapse deletes**, while the test applies only to survivors. When the ring's worst cell is the one being removed, the ceiling is set by a cell that won't exist afterwards and the repair is admitted whatever the margin. The length gate's improvement test already relies on this same asymmetry.
- The ceiling scales with how bad the neighbourhood already is, so the test tightens in healthy regions and stays lax around defects.

The coarsening pass is unaffected (`!m_coarsen_mode`); it deliberately uses a regional test taken after re-smoothing instead.

## Recommendation

Land the parameter, but **do not change the default**. 0.5 is a good setting on some meshes and a convergence hazard on others; 46024 is the counterexample. Anyone using it should check convergence on their own inputs.

117/117 local tests pass. No behaviour change at the default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)