### PR TITLE
Seed triwild's sizing field from the input's local feature size

### DIFF
--- a/components/simwild/wmtk/components/simwild/Parameters.h
+++ b/components/simwild/wmtk/components/simwild/Parameters.h
@@ -106,6 +106,8 @@ struct Parameters : public wmtk::OptimizerParameters
         coarsen_max_inner_passes = json_params["coarsen_max_inner_passes"];
         collapse_quality_margin = json_params["collapse_quality_margin"];
         debug_edge_length_match = json_params["debug_edge_length_match"];
+        sizing_field_from_features = json_params["sizing_field_from_features"];
+        sizing_field_min_eps_ratio = json_params["sizing_field_min_eps_ratio"];
 
         debug_output = json_params["DEBUG_output"];
         perform_sanity_checks = json_params["DEBUG_sanity_checks"];

--- a/components/simwild/wmtk/components/simwild/simwild_spec.json
+++ b/components/simwild/wmtk/components/simwild/simwild_spec.json
@@ -47,6 +47,8 @@
       "coarsen_max_inner_passes",
       "collapse_quality_margin",
       "debug_edge_length_match",
+      "sizing_field_from_features",
+      "sizing_field_min_eps_ratio",
       "write_vtu",
       "write_envelope",
       "log_file",
@@ -651,6 +653,18 @@
     "type": "bool",
     "default": false,
     "doc": "Diagnostic. At the end of the optimization, log the distribution of each edge's length divided by its own target length (l times the sizing scalar averaged over its endpoints) -- the exact quantity the split and collapse length gates compare, where 1.0 is an edge exactly at target. Reports mean, sd, percentiles, and the fractions below, inside and above [4/5, 4/3], the interval the two gates bound. Costs one pass over the edges."
+  },
+  {
+    "pointer": "/sizing_field_from_features",
+    "type": "bool",
+    "default": false,
+    "doc": "Seed the sizing field from the local feature size of the input curve network before optimizing, instead of leaving the sizing scalar at 1 until the optimizer stalls. Without it the target edge length is a flat length_rel that detailed regions can never reach, because the envelope refuses collapses long before an edge grows to the target. triwild only for now."
+  },
+  {
+    "pointer": "/sizing_field_min_eps_ratio",
+    "type": "float",
+    "default": 5.0,
+    "doc": "Floor on the sizing scalar seeded by sizing_field_from_features, as a multiple of l_min / l. The natural floor of l_min (= eps) is far finer than the envelope actually requires, so raising it prevents the element count running away."
   },
   {
     "pointer": "/coarsen_unbounded",

--- a/components/tetwild/wmtk/components/tetwild/tetwild.cpp
+++ b/components/tetwild/wmtk/components/tetwild/tetwild.cpp
@@ -126,6 +126,8 @@ TetWildMesh::ExportStruct tetwild_with_export(nlohmann::json json_params)
     params.coarsen_max_inner_passes = json_params["coarsen_max_inner_passes"];
     params.collapse_quality_margin = json_params["collapse_quality_margin"];
     params.debug_edge_length_match = json_params["debug_edge_length_match"];
+    params.sizing_field_from_features = json_params["sizing_field_from_features"];
+    params.sizing_field_min_eps_ratio = json_params["sizing_field_min_eps_ratio"];
     params.w_amips = json_params["w_amips"];
     params.smoothing_mode = json_params["smoothing_mode"];
     params.project_line_search_steps = json_params["project_line_search_steps"];

--- a/components/tetwild/wmtk/components/tetwild/tetwild_spec.json
+++ b/components/tetwild/wmtk/components/tetwild/tetwild_spec.json
@@ -42,6 +42,8 @@
       "coarsen_max_inner_passes",
       "collapse_quality_margin",
       "debug_edge_length_match",
+      "sizing_field_from_features",
+      "sizing_field_min_eps_ratio",
       "preserve_topology",
       "remove_duplicate_eps",
       "allow_surface_swap",
@@ -448,6 +450,18 @@
     "type": "bool",
     "default": false,
     "doc": "Diagnostic. At the end of the optimization, log the distribution of each edge's length divided by its own target length (l times the sizing scalar averaged over its endpoints) -- the exact quantity the split and collapse length gates compare, where 1.0 is an edge exactly at target. Reports mean, sd, percentiles, and the fractions below, inside and above [4/5, 4/3], the interval the two gates bound. Costs one pass over the edges."
+  },
+  {
+    "pointer": "/sizing_field_from_features",
+    "type": "bool",
+    "default": false,
+    "doc": "Seed the sizing field from the local feature size of the input curve network before optimizing, instead of leaving the sizing scalar at 1 until the optimizer stalls. Without it the target edge length is a flat length_rel that detailed regions can never reach, because the envelope refuses collapses long before an edge grows to the target. triwild only for now."
+  },
+  {
+    "pointer": "/sizing_field_min_eps_ratio",
+    "type": "float",
+    "default": 5.0,
+    "doc": "Floor on the sizing scalar seeded by sizing_field_from_features, as a multiple of l_min / l. The natural floor of l_min (= eps) is far finer than the envelope actually requires, so raising it prevents the element count running away."
   },
   {
     "pointer": "/coarsen_unbounded",

--- a/components/triwild/wmtk/components/triwild/Parameters.h
+++ b/components/triwild/wmtk/components/triwild/Parameters.h
@@ -111,6 +111,8 @@ struct Parameters : public wmtk::OptimizerParameters
         coarsen_max_inner_passes = json_params["coarsen_max_inner_passes"];
         collapse_quality_margin = json_params["collapse_quality_margin"];
         debug_edge_length_match = json_params["debug_edge_length_match"];
+        sizing_field_from_features = json_params["sizing_field_from_features"];
+        sizing_field_min_eps_ratio = json_params["sizing_field_min_eps_ratio"];
 
         // Stuck-element sizing refinement.
         stuck_refine_stall_eps = json_params["stuck_refine_stall_eps"];

--- a/components/triwild/wmtk/components/triwild/TriWildMesh.cpp
+++ b/components/triwild/wmtk/components/triwild/TriWildMesh.cpp
@@ -373,9 +373,8 @@ void TriWildMesh::init_sizing_field()
     // OptimizerParameters::debug_edge_length_match for how to measure the result.
     const double min_refine_scalar =
         m_params.sizing_field_min_eps_ratio * m_params.l_min / m_params.l;
-    // Same 1.8 as tetwild: the radius the refinement is graded out over.
-    const double R = m_params.l * 1.8;
 
+    std::vector<size_t> seeds;
     for (const Tuple& v : get_vertices()) {
         const size_t vid = v.vid(*this);
         if (!m_vertex_attribute[vid].m_is_on_surface) continue;
@@ -419,32 +418,20 @@ void TriWildMesh::init_sizing_field()
 
         const double refine_scalar = std::max(min_dist / m_params.l, min_refine_scalar);
         double& own = m_vertex_attribute[vid].m_sizing_scalar;
-        own = std::min(refine_scalar, own);
-
-        // Grade it out to R so the interior does not jump from a refined boundary straight
-        // back to the global target. Monotone: only ever lowers.
-        std::vector<bool> visited(vert_capacity(), false);
-        visited[vid] = true;
-        std::queue<size_t> q;
-        for (const Tuple& u : get_one_ring_edges_for_vertex(v)) {
-            q.push(u.vid(*this));
-        }
-        while (!q.empty()) {
-            const size_t uid = q.front();
-            q.pop();
-            if (visited[uid]) continue;
-            visited[uid] = true;
-            const double dist = (m_vertex_attribute[uid].m_posf - p).norm();
-            if (dist > R) continue;
-            m_vertex_attribute[uid].m_sizing_scalar = std::min(
-                dist / R * (1 - refine_scalar) + refine_scalar,
-                m_vertex_attribute[uid].m_sizing_scalar);
-            for (const Tuple& n : get_one_ring_edges_for_vertex(uid)) {
-                const size_t nid = n.vid(*this);
-                if (!visited[nid]) q.push(nid);
-            }
+        if (refine_scalar < own) {
+            own = refine_scalar;
+            seeds.push_back(vid);
         }
     }
+
+    // Grade outward with the shared routine rather than a ball per seed. A ball of radius
+    // 1.8 * l, as tetwild's version used, covers most of a mesh that is far finer than `l`,
+    // and repeating it for every seed -- each allocating its own O(V) visited array -- is
+    // quadratic: on challenging_triwild_191874 that alone ran over four minutes without
+    // finishing, and the model went from 115s to 6514s end to end. This is one multi-source
+    // sweep, O(E) amortized, and it is what stuck-refine already uses, so both paths grade
+    // the field the same way.
+    gradation_smooth_sizing(m_params.stuck_refine_gradation, seeds);
 }
 
 size_t TriWildMesh::refine_sizing_around_worst(double max_energy)

--- a/components/triwild/wmtk/components/triwild/TriWildMesh.cpp
+++ b/components/triwild/wmtk/components/triwild/TriWildMesh.cpp
@@ -1,7 +1,7 @@
 
-#include <queue>
-#include <algorithm>
 #include "TriWildMesh.h"
+#include <algorithm>
+#include <queue>
 
 #include <tuple>
 

--- a/components/triwild/wmtk/components/triwild/TriWildMesh.cpp
+++ b/components/triwild/wmtk/components/triwild/TriWildMesh.cpp
@@ -1,4 +1,6 @@
 
+#include <queue>
+#include <algorithm>
 #include "TriWildMesh.h"
 
 #include <tuple>
@@ -329,8 +331,121 @@ void TriWildMesh::init_mesh(
     } else {
         logger().info("All rounded!", cnt_round, vert_capacity());
     }
+
+    // Last, because it reads positions and the surface tags set above.
+    if (m_params.sizing_field_from_features) {
+        init_sizing_field();
+    }
 }
 
+
+namespace {
+/// Distance from `p` to the segment `a`-`b`.
+double point_segment_distance(const Vector2d& p, const Vector2d& a, const Vector2d& b)
+{
+    const Vector2d ab = b - a;
+    const double l2 = ab.squaredNorm();
+    if (l2 <= 0.) return (p - a).norm();
+    const double t = std::clamp((p - a).dot(ab) / l2, 0., 1.);
+    return (p - (a + t * ab)).norm();
+}
+} // namespace
+
+void TriWildMesh::init_sizing_field()
+{
+    // The 2D counterpart of TetWildMesh::init_sizing_field. Two differences from that one,
+    // both deliberate:
+    //
+    //  * That function is dead code -- nothing calls it -- and its edge-distance half never
+    //    contributed anyway: `min_ev_dist` starts at 100000 and is only assigned when
+    //    `min_ev_dist < ev_dist`, so it takes a MAXIMUM and the value never moves off its
+    //    sentinel. Only the vertex-distance term ever reached `min_dist`. Here the edge term
+    //    is a real minimum, and it skips edges incident to the vertex -- whose distance is
+    //    zero by construction, which is presumably what the inverted test was hiding.
+    //
+    //  * It is actually called, from init_mesh, so the field carries geometry before the
+    //    first pass rather than staying at 1 until the optimizer stalls.
+    //
+    // What it measures is local feature size: how finely the curve network is resolved at a
+    // vertex, and how close another branch of it passes. Without this the sizing scalar is
+    // 1 everywhere, so the target length is a flat `l` that detailed regions can never reach
+    // -- the envelope refuses every collapse long before the length gate is satisfied. See
+    // OptimizerParameters::debug_edge_length_match for how to measure the result.
+    const double min_refine_scalar =
+        m_params.sizing_field_min_eps_ratio * m_params.l_min / m_params.l;
+    // Same 1.8 as tetwild: the radius the refinement is graded out over.
+    const double R = m_params.l * 1.8;
+
+    for (const Tuple& v : get_vertices()) {
+        const size_t vid = v.vid(*this);
+        if (!m_vertex_attribute[vid].m_is_on_surface) continue;
+        const Vector2d& p = m_vertex_attribute[vid].m_posf;
+
+        double min_dist = std::numeric_limits<double>::max();
+
+        // How close a DIFFERENT branch of the network passes, vertex-wise. A neighbour joined
+        // to v by a feature edge is the same branch, and its distance is only how finely the
+        // input happens to be sampled there -- seeding the field with that makes the output
+        // inherit the input's tessellation instead of its geometry. Measured on
+        // challenging_triwild_162463: including them grew the mesh 12x (16174 -> 198064
+        // elements) and left 52% of edges LONGER than target. Skip them.
+        for (const Tuple& u : get_one_ring_edges_for_vertex(v)) {
+            const size_t uid = u.vid(*this);
+            if (uid == vid || !m_vertex_attribute[uid].m_is_on_surface) continue;
+            if (m_edge_attribute[u.eid(*this)].m_is_surface_fs) continue; // same branch
+            min_dist = std::min(min_dist, (p - m_vertex_attribute[uid].m_posf).norm());
+        }
+
+        // How close another branch of the network comes: distance to the feature edges of the
+        // incident triangles that do not touch v.
+        for (const Tuple& f : get_one_ring_tris_for_vertex(v)) {
+            const std::array<Tuple, 3> fvs = oriented_tri_vertices(f);
+            for (int i = 0; i < 3; ++i) {
+                const Tuple e = fvs[i];
+                if (!m_edge_attribute[e.eid(*this)].m_is_surface_fs) continue;
+                const size_t a = e.vid(*this);
+                const size_t b = e.switch_vertex(*this).vid(*this);
+                if (a == vid || b == vid) continue; // distance zero, says nothing
+                min_dist = std::min(
+                    min_dist,
+                    point_segment_distance(
+                        p,
+                        m_vertex_attribute[a].m_posf,
+                        m_vertex_attribute[b].m_posf));
+            }
+        }
+
+        if (min_dist == std::numeric_limits<double>::max()) continue;
+
+        const double refine_scalar = std::max(min_dist / m_params.l, min_refine_scalar);
+        double& own = m_vertex_attribute[vid].m_sizing_scalar;
+        own = std::min(refine_scalar, own);
+
+        // Grade it out to R so the interior does not jump from a refined boundary straight
+        // back to the global target. Monotone: only ever lowers.
+        std::vector<bool> visited(vert_capacity(), false);
+        visited[vid] = true;
+        std::queue<size_t> q;
+        for (const Tuple& u : get_one_ring_edges_for_vertex(v)) {
+            q.push(u.vid(*this));
+        }
+        while (!q.empty()) {
+            const size_t uid = q.front();
+            q.pop();
+            if (visited[uid]) continue;
+            visited[uid] = true;
+            const double dist = (m_vertex_attribute[uid].m_posf - p).norm();
+            if (dist > R) continue;
+            m_vertex_attribute[uid].m_sizing_scalar = std::min(
+                dist / R * (1 - refine_scalar) + refine_scalar,
+                m_vertex_attribute[uid].m_sizing_scalar);
+            for (const Tuple& n : get_one_ring_edges_for_vertex(uid)) {
+                const size_t nid = n.vid(*this);
+                if (!visited[nid]) q.push(nid);
+            }
+        }
+    }
+}
 
 size_t TriWildMesh::refine_sizing_around_worst(double max_energy)
 {

--- a/components/triwild/wmtk/components/triwild/TriWildMesh.h
+++ b/components/triwild/wmtk/components/triwild/TriWildMesh.h
@@ -205,6 +205,15 @@ public:
      *
      * @return the number of vertices refined.
      */
+    /**
+     * @brief Seed the sizing field from the local feature size of the curve network.
+     *
+     * Called at the end of init_mesh. Without it the sizing scalar stays 1 until the
+     * optimizer stalls, so the target edge length is a flat `l` that detailed regions
+     * cannot reach. See the definition for how it differs from tetwild's namesake.
+     */
+    void init_sizing_field();
+
     size_t refine_sizing_around_worst(double max_energy) override;
 
     void write_msh_groups(std::string file, const bool write_envelope = true);

--- a/components/triwild/wmtk/components/triwild/triwild_spec.json
+++ b/components/triwild/wmtk/components/triwild/triwild_spec.json
@@ -39,6 +39,8 @@
       "coarsen_max_inner_passes",
       "collapse_quality_margin",
       "debug_edge_length_match",
+      "sizing_field_from_features",
+      "sizing_field_min_eps_ratio",
       "preserve_topology",
       "preserve_feature_points",
       "allow_junction_cleanup",
@@ -448,6 +450,18 @@
     "type": "bool",
     "default": false,
     "doc": "Diagnostic. At the end of the optimization, log the distribution of each edge's length divided by its own target length (l times the sizing scalar averaged over its endpoints) -- the exact quantity the split and collapse length gates compare, where 1.0 is an edge exactly at target. Reports mean, sd, percentiles, and the fractions below, inside and above [4/5, 4/3], the interval the two gates bound. Costs one pass over the edges."
+  },
+  {
+    "pointer": "/sizing_field_from_features",
+    "type": "bool",
+    "default": false,
+    "doc": "Seed the sizing field from the local feature size of the input curve network before optimizing, instead of leaving the sizing scalar at 1 until the optimizer stalls. Without it the target edge length is a flat length_rel that detailed regions can never reach, because the envelope refuses collapses long before an edge grows to the target. triwild only for now."
+  },
+  {
+    "pointer": "/sizing_field_min_eps_ratio",
+    "type": "float",
+    "default": 5.0,
+    "doc": "Floor on the sizing scalar seeded by sizing_field_from_features, as a multiple of l_min / l. The natural floor of l_min (= eps) is far finer than the envelope actually requires, so raising it prevents the element count running away."
   },
   {
     "pointer": "/coarsen_unbounded",

--- a/src/wmtk/OptimizerParameters.h
+++ b/src/wmtk/OptimizerParameters.h
@@ -338,6 +338,39 @@ struct OptimizerParameters
      * Diagnostic only; costs one pass over the edges at the end of the optimization. See
      * wmtk::utils::log_edge_length_match for what the reported quantities mean.
      */
+    /**
+     * @brief Seed the sizing field from the local feature size of the input, before optimizing.
+     *
+     * With this off the sizing scalar is 1 everywhere until the optimizer stalls, so the
+     * target edge length is a flat `l`. In a detailed region that target is unreachable --
+     * the envelope refuses collapses long before an edge grows to `4/5 * l` -- and the length
+     * gates end up describing a size the mesh will never have. Measured on triwild's
+     * challenging set, only 21% of edges land inside [4/5, 4/3] of their nominal target, and
+     * on challenging_triwild_162463 the median edge is a ninth of it.
+     *
+     * On, the field is initialized from how finely the input is resolved at each feature
+     * vertex and how close another branch of the input passes, then graded outward, so the
+     * target the gates test is one the geometry actually permits.
+     *
+     * Currently implemented by triwild only (TriWildMesh::init_sizing_field); tetwild has a
+     * namesake that nothing calls and simwild has none, so the flag does nothing there.
+     */
+    bool sizing_field_from_features = false;
+
+    /**
+     * @brief Floor on the seeded sizing scalar, as a multiple of l_min / l.
+     *
+     * sizing_field_from_features sets a vertex's target to the distance to the nearest other
+     * branch of the input, floored at l_min (which both wild-meshing 2D apps set to eps). That
+     * floor is far below what the envelope actually permits: measured on
+     * challenging_triwild_162463 by sweeping eps_rel alone, the mesh settles at a median edge
+     * of about 5.7 * eps, so a target of 1 * eps demands a mesh several times finer than the
+     * geometry needs and the element count runs away: on that model a floor of 1 gives
+     * 7.7x the elements and leaves 70% of edges LONGER than target, while the default 5
+     * gives 1.5x the elements with 67% of edges in band, against 3% with the field off.
+     * Sweeping it there: 1 -> 30% in band, 3 -> 48%, 5 -> 67%, 8 -> 36%.
+     */
+    double sizing_field_min_eps_ratio = 5.0;
     bool debug_edge_length_match = false;
     bool debug_output = false;
     bool perform_sanity_checks = false;


### PR DESCRIPTION
**Stacked on #1050** (base is `collapse-quality-margin`). Review that one first.

## The problem

triwild and simwild have a sizing field that both length gates faithfully honour, but **nothing ever gives it geometric content**. `m_sizing_scalar` starts at 1 and is only ever lowered by `refine_sizing_around_worst` — the stuck-refine stall heuristic, which reacts to *energy*, not geometry. The target edge length is a flat `l` everywhere.

In a detailed region that target is unreachable. What actually bounds element size is the **envelope**, which refuses a collapse long before the edge grows to `4/5 · l`. Sweeping `eps_rel` alone on `challenging_triwild_162463`, with `l` held at 39.8, the median edge tracks `eps` and not `l`:

| eps_rel | eps | median edge | median / l |
|---|---|---|---|
| 0.0002 | 0.159 | 2.19 | 0.055 |
| 0.001 *(default)* | 0.796 | 4.53 | 0.114 |
| 0.005 | 3.98 | 25.74 | 0.646 |
| 0.02 | 15.93 | 43.47 | 1.092 |

Only once `eps ≈ 0.4·l` does `l` bind at all. Across the challenging 2D set, just **21%** of edges land within `[4/5, 4/3]` of their nominal target. (Measured with `debug_edge_length_match`, added in #1050.)

## The change

Seed the field from geometry before the first pass: for each feature vertex, the distance to the nearest **other branch** of the curve network — by vertex and by segment — then grade outward with `utils::gradation_smooth_sizing`, the same one multi-source sweep stuck-refine uses. `sizing_field_from_features`, **off by default**.

Three deliberate departures from `TetWildMesh::init_sizing_field`, which this was modelled on (and which #1052 deletes):

- **That function is dead code** — nothing calls it — and its edge-distance half never worked anyway: `min_ev_dist` starts at 100000 and is assigned only when `min_ev_dist < ev_dist`, so it takes a **maximum** and never leaves its sentinel. Here the edge term is a real minimum over segments *not incident* to the vertex.
- **Neighbours joined by a feature edge are skipped.** Their distance measures how finely the input happens to be *sampled*, not its geometry; seeding with it makes the output inherit the input's tessellation. On 162463 that grew the mesh 12× and still left 52% of edges longer than target.
- **The grading is one sweep, not a ball per seed.** tetwild's per-seed Euclidean ball of radius `1.8·l` is quadratic — on a mesh far finer than `l`, which is precisely the case this exists to fix, it covers most of the mesh and was repeated per feature vertex, each allocating its own O(V) visited array. That took 191874 from 115s to **6514s** and 193153 from 104s to **6582s**; the shared sweep brings them to 132s and 128s for the same result.

The natural floor on the seeded scalar, `l_min = eps`, is also far below what the envelope needs, so it is scaled by `sizing_field_min_eps_ratio` (default 5). Sweep on 162463 — elements, then fraction in band: 1 → 7.7×, 30%; 3 → 2.5×, 48%; **5 → 1.5×, 67%**; 8 → 1.2×, 36%. 5 is close to the 5.7·eps the eps sweep says that model settles at.

## Result on all 16 challenging 2D cases

| model | in band | iterations | elements | wall |
|---|---|---|---|---|
| 162463 | 3.1% → **63.3%** | 9 → 4 | 16 174 → 26 805 | 62s → 66s |
| 191265 | 5.4% → **44.0%** | 8 → 3 | 10 310 → 26 490 | 87s → 109s |
| 177469 | 7.9% → **54.3%** | 8 → 3 | 8 832 → 25 359 | 53s → 62s |
| 169900 | 11.3% → **54.9%** | 20 → 7 | 20 039 → 41 049 | 105s → 110s |
| 190586 | 11.4% → **46.5%** | 8 → 2 | 4 167 → 21 209 | 77s → 66s |
| 184836 | 15.7% → **49.7%** | 6 → 4 | 2 354 → 15 355 | 3s → 9s |
| 166331 | 17.5% → **43.6%** | 11 → 2 | 24 821 → 48 555 | 99s → 80s |
| 193105 | 18.8% → **53.5%** | 18 → 4 | 5 359 → 19 546 | 21s → 20s |
| 194286 | 26.2% → **50.0%** | 9 → 5 | 9 688 → 24 931 | 13s → 19s |
| 202260 | 26.2% → **46.6%** | 13 → 9 | 13 099 → 21 588 | 74s → 77s |
| 202302 | 26.3% → **61.4%** | 11 → 5 | 18 454 → 46 164 | 52s → 70s |
| 189017 | 30.9% → **61.9%** | 12 → 5 | 12 000 → 35 370 | 16s → 26s |
| 193153 | 32.3% → **54.9%** | 9 → 7 | 16 142 → 39 035 | 104s → 146s |
| **191015** | **32.7% → 23.3%** | 5 → 1 | 1 426 → 10 060 | 2s → 3s |
| 191874 | 33.4% → **54.9%** | 10 → 8 | 16 464 → 37 079 | 115s → 149s |
| 196407 | 43.1% → **55.7%** | 5 → 2 | 1 096 → 18 331 | 30s → 40s |
| **total / mean** | **21.4% → 51.2%** | **162 → 71** | 180 425 → 456 926 | 913s → 1051s **(+15%)** |

All 16 still meet the energy target and Hausdorff is essentially unchanged. Iterations fall by 56% in aggregate.

## What to weigh

- **Elements grow 2.5× in aggregate**, and much more on the small meshes (196407 16.7×, 191015 7.1×). The floor is a single global constant while the right size is per-model.
- **191015 regresses**: in-band 32.7% → 23.3%. It over-refines (1 426 → 10 060) and then stops after one iteration, ending with 76% of edges *longer* than their now very small target. It is the smallest mesh in the set.
- A curvature/sagitta bound would target the size better than a flat floor. This change is the smaller step; the flat floor is the main thing I would want reviewed.

117/117 local tests pass. Default-off, so no behaviour change until enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)