### PR TITLE
Remove the parameter for the envelope sanity check from SimWild. The …

### DIFF
--- a/components/simwild/wmtk/components/simwild/Parameters.h
+++ b/components/simwild/wmtk/components/simwild/Parameters.h
@@ -43,19 +43,6 @@ struct Parameters : public wmtk::OptimizerParameters
     VectorXd box_max;
     bool stop_at_float = false;
 
-    /**
-     * Verify at init that every surface edge starts inside the envelope (2D remeshing only).
-     *
-     * The same check triwild carries, and the same trade: the invariant is real, but it
-     * costs one sampled segment query per surface edge, serially, on every run. Measured in
-     * triwild's 2D sweep at 22s on a 3.5M-edge input and 5m07s on a 7.6M-edge one -- 8.5% of
-     * that model's entire budget, spent before the first iteration. Off by default.
-     *
-     * The 3D counterpart in VolumemesherInsertion is deliberately NOT gated by this: it is
-     * not a check but a decision, feeding the "rebuild the envelope from tet tags" branch.
-     */
-    bool check_envelope_at_init = false;
-
     std::string operation = "remeshing";
 
     /**
@@ -115,7 +102,6 @@ struct Parameters : public wmtk::OptimizerParameters
 
         debug_output = json_params["DEBUG_output"];
         perform_sanity_checks = json_params["DEBUG_sanity_checks"];
-        check_envelope_at_init = json_params["DEBUG_envelope_sanity_check"];
 
         verbose_quality_stats = json_params["verbose_quality_stats"];
 

--- a/components/simwild/wmtk/components/simwild/SimWildMeshTri.cpp
+++ b/components/simwild/wmtk/components/simwild/SimWildMeshTri.cpp
@@ -226,7 +226,7 @@ void SimWildMeshTri::init_surfaces_and_boundaries()
         tempE.emplace_back(v1, v2);
     }
 
-    if (!m_envelope) {
+    auto env_from_face_tags = [&]() {
         logger().info("Init envelope from face tags");
         // build envelopes
         std::vector<Vector2d> tempV(vert_capacity());
@@ -242,19 +242,33 @@ void SimWildMeshTri::init_surfaces_and_boundaries()
             "Envelope: {} (eps {:.6})",
             m_envelope->use_exact ? "EXACT" : "sampled",
             m_envelope_eps);
-    } else if (m_sim_params.operation == "remeshing" && m_sim_params.check_envelope_at_init) {
-        // All surface edges must be inside the envelope. Opt-in: see
-        // Parameters::check_envelope_at_init for why it is not worth its cost by default.
+    };
+
+    if (!m_envelope) {
+        env_from_face_tags();
+    } else if (m_sim_params.operation == "remeshing") {
+        // All surface edges must be inside the envelope. This check is NOT OPTIONAL. As the tracked
+        // surface is created from tags, the input surface might be a different one. In that case,
+        // the envelope must be rebuilt from the tags.
         logger().info("Envelope sanity check");
         const auto surf_edges = get_edges_by_condition([](auto& f) { return f.m_is_surface_fs; });
+        bool is_outside = false;
         for (const auto& verts : surf_edges) {
             std::array<Vector2d, 2> pp = {
                 {m_vertex_attribute[verts[0]].m_posf, m_vertex_attribute[verts[1]].m_posf}};
             if (m_envelope->is_outside(pp)) {
-                log_and_throw_error("Edge {} is outside!", verts);
+                is_outside = true;
+                break;
             }
         }
         logger().info("Envelope sanity check done");
+        if (!is_outside) {
+            logger().info("All surface faces are inside the envelope.");
+        } else {
+            logger().warn(
+                "Some surface edges are outside the envelope. Rebuilding envelope from face tags.");
+            env_from_face_tags();
+        }
     }
 
     // track bounding box
@@ -712,16 +726,18 @@ void SimWildMeshTri::write_vtu(const std::string& path) const
     const auto& faces = get_faces();
     const auto edges = get_edges_by_condition([](auto& f) { return f.m_is_surface_fs; });
 
-    Eigen::MatrixXd V(vert_capacity(), 2);
-    Eigen::MatrixXi F(tri_capacity(), 3);
-    Eigen::MatrixXi E(edges.size(), 2);
+    MatrixXd V(vert_capacity(), 2);
+    MatrixXi F(tri_capacity(), 3);
+    MatrixXi E(edges.size(), 2);
 
     V.setZero();
     F.setZero();
     E.setZero();
 
-    Eigen::VectorXd v_sizing_field(vert_capacity());
+    VectorXd v_sizing_field(vert_capacity());
     v_sizing_field.setZero();
+    VectorXd v_rounded(vert_capacity());
+    v_rounded.setZero();
 
     std::vector<MatrixXd> tags(m_tags_count, MatrixXd(tri_capacity(), 1));
     VectorXd amips(tri_capacity());
@@ -754,6 +770,7 @@ void SimWildMeshTri::write_vtu(const std::string& path) const
         const size_t vid = v.vid(*this);
         V.row(vid) = m_vertex_attribute[vid].m_posf;
         v_sizing_field[vid] = m_vertex_attribute[vid].m_sizing_scalar;
+        v_rounded[vid] = m_vertex_attribute[vid].m_is_rounded ? 1.0 : 0.0;
     }
 
     std::shared_ptr<paraviewo::ParaviewWriter> writer;
@@ -766,6 +783,7 @@ void SimWildMeshTri::write_vtu(const std::string& path) const
     writer->add_cell_field("quality_target", amips_target);
     writer->add_cell_field("quality_rel", amips_rel);
     writer->add_field("sizing_field", v_sizing_field);
+    writer->add_field("is_rounded", v_rounded);
     writer->write_mesh(path + ".vtu", V, F, paraviewo::CellType::Triangle);
 
     // surface
@@ -774,6 +792,7 @@ void SimWildMeshTri::write_vtu(const std::string& path) const
         std::shared_ptr<paraviewo::ParaviewWriter> surf_writer;
         surf_writer = std::make_shared<paraviewo::VTUWriter>();
         surf_writer->add_field("sizing_field", v_sizing_field);
+        surf_writer->add_field("is_rounded", v_rounded);
 
         logger().info("Write {}", surf_out_path);
         surf_writer->write_mesh(surf_out_path, V, E, paraviewo::CellType::Line);
@@ -931,37 +950,183 @@ bool SimWildMeshTri::collapse_quality_allowed(
            quality <= ring_max;
 }
 
-void SimWildMeshTri::collapse_after_vertex(size_t, size_t v2)
+bool SimWildMeshTri::check_interface_edges_tagged(const bool verbose) const
 {
-    // SimWild's tracked edges are derived from neighboring cell tags. Rebuild the local
-    // interface instead of retaining an OR-merge of the two old edge flags.
-    std::set<size_t> affected_vertices;
-    affected_vertices.insert(v2);
+    size_t num_interface = 0; // edges between unlike tags
+    size_t num_surface = 0; // edges marked m_is_surface_fs
+    size_t num_missing = 0; // unlike tags, not marked
+    size_t num_spurious = 0; // marked, but tags are equal
+    size_t num_boundary = 0; // marked, but only one incident triangle
+    // Only the first few are worth naming; a systematic failure would otherwise flood the log.
+    constexpr size_t max_reported = 10;
 
-    for (const size_t fid : get_one_ring_fids_for_vertex(v2)) {
-        if (!tuple_from_tri(fid).is_valid(*this)) continue;
-        for (int j = 0; j < 3; ++j) {
-            const Tuple edge = tuple_from_edge(fid, j);
-            const auto opposite = edge.switch_face(*this);
-            const bool is_interface =
-                opposite.has_value() &&
-                m_face_attribute[fid].tags != m_face_attribute[opposite->fid(*this)].tags;
-            m_edge_attribute[edge.eid(*this)].m_is_surface_fs = is_interface;
-            const auto evs = get_edge_vids(edge);
-            affected_vertices.insert(evs.begin(), evs.end());
+    for (const Tuple& edge : get_edges()) {
+        const size_t fid = edge.fid(*this);
+        const size_t eid = edge.eid(*this);
+        const bool marked = m_edge_attribute[eid].m_is_surface_fs;
+        const auto opposite = edge.switch_face(*this);
+
+        if (!opposite.has_value()) {
+            // Boundary edge: it has no second tag to differ from, so it cannot be an
+            // interface. Counted apart from the interior edges below -- whether the domain
+            // boundary ought to carry the flag is a convention, not a corruption.
+            if (marked) {
+                num_surface++;
+                num_boundary++;
+                if (verbose && num_boundary <= max_reported) {
+                    logger().warn(
+                        "Surface edge {} on boundary, incident to triangle {} only",
+                        eid,
+                        fid);
+                }
+            }
+            continue;
         }
-    }
+        const size_t other = opposite->fid(*this);
 
-    for (const size_t vid : affected_vertices) {
-        bool on_interface = false;
-        for (const Tuple& edge : get_one_ring_edges_for_vertex(vid)) {
-            if (m_edge_attribute[edge.eid(*this)].m_is_surface_fs) {
-                on_interface = true;
-                break;
+        if (marked) {
+            num_surface++;
+        }
+
+        if (m_face_attribute[fid].tags != m_face_attribute[other].tags) {
+            num_interface++;
+            if (!marked) {
+                num_missing++;
+                if (verbose && num_missing <= max_reported) {
+                    logger().error(
+                        "Untagged interface edge {} between triangles {} and {}",
+                        eid,
+                        fid,
+                        other);
+                }
+            }
+        } else if (marked) {
+            num_spurious++;
+            if (verbose && num_spurious <= max_reported) {
+                logger().error(
+                    "Surface edge {} between like-tagged triangles {} and {}",
+                    eid,
+                    fid,
+                    other);
             }
         }
-        m_vertex_attribute[vid].m_is_on_surface = on_interface;
     }
+
+    if (verbose) {
+        const auto elided = [](size_t n) {
+            if (n > max_reported) {
+                logger().error("({} further offending edges not listed)", n - max_reported);
+            }
+        };
+        if (num_missing == 0 && num_spurious == 0) {
+            logger().info(
+                "Interface edges: {} of {} tagged, {} surface edges, all between unlike tags",
+                num_interface,
+                num_interface,
+                num_surface);
+        } else {
+            if (num_missing > 0) {
+                logger().error(
+                    "Interface edges: {} of {} NOT tagged as surface",
+                    num_missing,
+                    num_interface);
+                elided(num_missing);
+            }
+            if (num_spurious > 0) {
+                logger().error(
+                    "Surface edges: {} of {} between LIKE-tagged triangles",
+                    num_spurious,
+                    num_surface);
+                elided(num_spurious);
+            }
+        }
+        if (num_boundary > 0) {
+            logger().warn(
+                "{} surface edges lie on the domain boundary (not counted as violations)",
+                num_boundary);
+        }
+    }
+    return num_missing == 0 && num_spurious == 0;
+}
+
+void SimWildMeshTri::update_attributes()
+{
+    if (m_params.preserve_topology) {
+        // If we are preserving topology, we don't need to update the attributes.
+        return;
+    }
+
+    // Vertices are accumulated from the edges below, so clear first and OR in afterwards --
+    // a vertex is on the surface iff at least one incident edge is.
+    for (size_t vid = 0; vid < vert_capacity(); ++vid) {
+        if (!tuple_from_vertex(vid).is_valid(*this)) {
+            continue;
+        }
+        m_vertex_attribute[vid].m_is_on_surface = false;
+    }
+
+    for (const Tuple& edge : get_edges()) {
+        const size_t eid = edge.eid(*this);
+        if (!m_edge_attribute[eid].m_is_surface_fs) {
+            // only surface edges are of interest
+            continue;
+        }
+        const auto opposite = edge.switch_face(*this);
+
+        // A boundary edge has no second tag to differ from, so it is not an interface.
+        const bool is_interface =
+            opposite.has_value() &&
+            m_face_attribute[edge.fid(*this)].tags != m_face_attribute[opposite->fid(*this)].tags;
+
+        if (is_interface) {
+            for (const size_t vid : get_edge_vids(edge)) {
+                m_vertex_attribute[vid].m_is_on_surface = true;
+            }
+            continue;
+        }
+
+        // This edge no longer is on the surface
+        m_edge_attribute[eid].m_is_surface_fs = false;
+    }
+
+    if (m_params.perform_sanity_checks) {
+        check_interface_edges_tagged(true);
+    }
+}
+
+void SimWildMeshTri::collapse_after_vertex(size_t v1, size_t v2)
+{
+    // // SimWild's tracked edges are derived from neighboring cell tags. Rebuild the local
+    // // interface instead of retaining an OR-merge of the two old edge flags.
+    // std::set<size_t> affected_vertices;
+    // affected_vertices.insert(v2);
+
+    // for (const size_t fid : get_one_ring_fids_for_vertex(v2)) {
+    //     if (!tuple_from_tri(fid).is_valid(*this)) continue;
+    //     for (int j = 0; j < 3; ++j) {
+    //         const Tuple edge = tuple_from_edge(fid, j);
+    //         const auto opposite = edge.switch_face(*this);
+    //         const bool is_interface =
+    //             opposite.has_value() &&
+    //             m_face_attribute[fid].tags != m_face_attribute[opposite->fid(*this)].tags;
+    //         m_edge_attribute[edge.eid(*this)].m_is_surface_fs = is_interface;
+    //         const auto evs = get_edge_vids(edge);
+    //         affected_vertices.insert(evs.begin(), evs.end());
+    //     }
+    // }
+
+    // for (const size_t vid : affected_vertices) {
+    //     bool on_interface = false;
+    //     for (const Tuple& edge : get_one_ring_edges_for_vertex(vid)) {
+    //         if (m_edge_attribute[edge.eid(*this)].m_is_surface_fs) {
+    //             on_interface = true;
+    //             break;
+    //         }
+    //     }
+    //     m_vertex_attribute[vid].m_is_on_surface = on_interface;
+    // }
+    m_vertex_attribute[v2].m_sizing_scalar =
+        std::min(m_vertex_attribute[v1].m_sizing_scalar, m_vertex_attribute[v2].m_sizing_scalar);
 }
 
 std::shared_ptr<polysolve::nonlinear::Problem> SimWildMeshTri::get_envelope_energy(

--- a/components/simwild/wmtk/components/simwild/SimWildMeshTri.hpp
+++ b/components/simwild/wmtk/components/simwild/SimWildMeshTri.hpp
@@ -127,6 +127,35 @@ public:
     double quality_rel(const size_t tid) const override;
     double quality_rel(const Tuple& t) const;
     bool check_mesh_quality(double& max_rel_quality, const bool verbose = false) const;
+
+    /**
+     * @brief Verify that every interface between unlike tags carries a surface edge.
+     *
+     * The 2D counterpart of SimWildMesh::check_interface_faces_tagged. A SimWild surface IS the
+     * interface between unlike cell tags, so for any two triangles sharing an edge whose `tags`
+     * differ, that edge must be marked `m_is_surface_fs` -- and, in the other direction, a
+     * marked edge must separate unlike tags.
+     *
+     * Boundary edges (one incident triangle) have no second tag to differ from; a marked one is
+     * counted and reported apart from the interior edges rather than as a violation.
+     *
+     * @param verbose Log a summary line, and the first few offending edges.
+     * @return true if every interface edge is tagged and no tagged edge sits between like tags.
+     */
+    bool check_interface_edges_tagged(const bool verbose = false) const;
+
+    /**
+     * @brief Update the attributes of the mesh after an iteration of operations.
+     *
+     * The 2D counterpart of SimWildMesh::update_attributes: walks the edges already marked as
+     * surface and clears the ones whose two triangles no longer disagree on their tags, then
+     * rebuilds `m_is_on_surface` from the edges that survive. Like the 3D version it only
+     * retires stale flags -- an edge that was never a surface edge does not become one here --
+     * and it runs between passes, single-threaded, where reading both sides of an edge is safe.
+     *
+     * @see check_interface_edges_tagged, which verifies the post-condition in both directions.
+     */
+    void update_attributes() override;
     std::vector<size_t> active_vertices() const override;
 
     /**

--- a/components/simwild/wmtk/components/simwild/VolumemesherInsertion.cpp
+++ b/components/simwild/wmtk/components/simwild/VolumemesherInsertion.cpp
@@ -315,10 +315,10 @@ void SimWildMesh::init_surfaces_and_boundaries()
         m_envelope->use_exact = true;
         m_envelope->init(m_V_envelope, m_F_envelope, m_envelope_eps);
     } else if (m_sim_params.operation == "remeshing") {
-        // Deliberately NOT behind check_envelope_at_init, unlike its 2D counterpart and
-        // triwild's: the answer is not an assertion but a decision -- if any surface face
-        // starts outside, the envelope is rebuilt from the tet tags below. Skipping it would
-        // change the envelope the run uses, not just what it reports.
+        // Deliberately NOT behind check_envelope_at_init, unlike triwild's: the answer is not an
+        // assertion but a decision -- if any surface face starts outside, the envelope is rebuilt
+        // from the tet tags below. Skipping it would change the envelope the run uses, not just
+        // what it reports.
         logger().info("Envelope sanity check");
         bool is_outside = false;
         for_each_face([&](const Tuple& t) {

--- a/components/simwild/wmtk/components/simwild/simwild_spec.json
+++ b/components/simwild/wmtk/components/simwild/simwild_spec.json
@@ -49,7 +49,6 @@
       "report",
       "DEBUG_output",
       "DEBUG_sanity_checks",
-      "DEBUG_envelope_sanity_check",
       "allow_surface_swap",
       "check_surface_topology",
       "verbose_quality_stats",
@@ -391,12 +390,6 @@
     "type": "bool",
     "default": false,
     "doc": "Perform sanity checks after every operation. This can be very slow and should only be used for debugging."
-  },
-  {
-    "pointer": "/DEBUG_envelope_sanity_check",
-    "type": "bool",
-    "default": false,
-    "doc": "Sanity Check: for the 2D remeshing path, verify at init that every surface edge already lies inside the envelope, and abort if one does not. Everything downstream assumes it -- an operation vetoed by the envelope only means something if the mesh started inside it -- but the check costs one sampled segment query per surface edge, serially, on every run. Measured in triwild's 2D sweep, where the same check cost 22s on a 3.5M-edge input and 5m07s on a 7.6M-edge one, the latter 8.5% of that model's entire budget. Off by default; turn it on when changing the input simplification or the envelope. Note the 3D path's superficially similar check is not governed by this flag: there the result selects whether to rebuild the envelope from the tet tags, so it is a decision rather than an assertion and always runs."
   },
   {
     "pointer": "/allow_surface_swap",

--- a/src/wmtk/OptimizerParameters.h
+++ b/src/wmtk/OptimizerParameters.h
@@ -2,6 +2,7 @@
 
 #include <limits>
 #include <string>
+#include <wmtk/utils/Logger.hpp>
 
 namespace wmtk {
 
@@ -322,6 +323,8 @@ struct OptimizerParameters
         } else {
             eps = epsr * diag_l;
         }
+
+        logger().info("PARAMS: eps = {}, l = {}", eps, l);
     }
 };
 

--- a/src/wmtk/TriOptimizerMesh.cpp
+++ b/src/wmtk/TriOptimizerMesh.cpp
@@ -38,6 +38,11 @@ void TriOptimizerMesh::mesh_improvement(int max_its)
     }
 
     partition_mesh_morton();
+
+    if (m_params.debug_output) {
+        write_smoothing_debug_output(fmt::format("debug_{}", m_debug_print_counter++));
+    }
+
     logger().info("========it pre========");
     local_operations({{0, 1, 0, 0}}, false);
 
@@ -127,6 +132,8 @@ std::tuple<double, double> TriOptimizerMesh::local_operations(
 {
     igl::Timer timer;
 
+    static constexpr std::array<const char*, 4> names = {{"split", "collapse", "swap", "smooth"}};
+
     auto sanity_checks = [this]() {
         if (!m_params.perform_sanity_checks) return;
         logger().info("Perform sanity checks...");
@@ -148,7 +155,8 @@ std::tuple<double, double> TriOptimizerMesh::local_operations(
     };
 
     sanity_checks();
-    for (int i = 0; i < int(ops.size()); ++i) {
+    update_attributes();
+    for (size_t i = 0; i < ops.size(); ++i) {
         timer.start();
         if (i == 0) {
             for (int n = 0; n < ops[i]; ++n) {
@@ -173,21 +181,21 @@ std::tuple<double, double> TriOptimizerMesh::local_operations(
                 logger().info("==swapping {}==", n);
                 if (swap_all_edges() == 0) break;
             }
-        } else {
-            logger().info("==smoothing ==");
+        } else if (i == 3) {
             smooth_all_vertices(size_t(ops[i]));
             if (ops[i] > 0) round_all_vertices();
         }
 
-        if (m_params.debug_output) {
-            write_smoothing_debug_output(fmt::format("debug_{}", m_debug_print_counter++));
+        if (ops[i] > 0) {
+            if (m_params.debug_output && i < 3) {
+                // no need to print debug output for smoothing, since it prints already internally
+                write_smoothing_debug_output(fmt::format("debug_{}", m_debug_print_counter++));
+            }
+            const auto [max_metric, avg_metric] = optimization_quality_stats();
+            logger().info("{} max energy = {:.6} avg = {:.6}", names[i], max_metric, avg_metric);
+            sanity_checks();
+            update_attributes();
         }
-        const auto [max_metric, avg_metric] = optimization_quality_stats();
-        static constexpr std::array<const char*, 4> names = {
-            {"split", "collapse", "swap", "smooth"}};
-        logger()
-            .info("{} max energy = {:.6} avg = {:.6}", names[size_t(i)], max_metric, avg_metric);
-        sanity_checks();
     }
 
     const auto stats = optimization_quality_stats();

--- a/src/wmtk/TriOptimizerMesh.h
+++ b/src/wmtk/TriOptimizerMesh.h
@@ -204,6 +204,15 @@ public:
 
     std::tuple<double, double> get_max_avg_energy();
 
+    /**
+     * @brief Update the attributes of the mesh after an iteration of operations.
+     *
+     * This is necessary in SimWild to update the surface flags of edges and vertices as
+     * operations might have collapsed away regions that are now no longer on the surface. In
+     * TriWild, this is a no-op.
+     */
+    virtual void update_attributes() {}
+
     /// Shared TriWild/SimWild outer optimization schedule.
     int m_iterations_used = 0;
     void mesh_improvement(int max_its = 80);

--- a/src/wmtk/TriOptimizerMeshSmooth.cpp
+++ b/src/wmtk/TriOptimizerMeshSmooth.cpp
@@ -62,6 +62,7 @@ void TriOptimizerMesh::set_smoothing_position(const size_t vid, const Vector2d& 
 void TriOptimizerMesh::smooth_all_vertices(const size_t n_iters)
 {
     for (size_t i = 0; i < n_iters; ++i) {
+        logger().info("==smoothing {}==", i);
         igl::Timer timer;
         timer.start();
         m_smooth_rejects.reset();


### PR DESCRIPTION
…envelope sanity check is not optional here as the tagged surface might be a different one than the input surface.