### PR TITLE
Optionally treat each connected component of an input as its own input

### DIFF
--- a/components/simwild/wmtk/components/simwild/EdgeCollapsing.cpp
+++ b/components/simwild/wmtk/components/simwild/EdgeCollapsing.cpp
@@ -81,12 +81,11 @@ void SimWildMesh::simplify()
         F.row(i) = Vector3i(int(surf_faces[i][0]), int(surf_faces[i][1]), int(surf_faces[i][2]));
     }
 
-    const bool use_exact = m_envelope->use_exact;
     m_envelope = nullptr;
     m_V_envelope.clear();
     m_F_envelope.clear();
     if (V.size() > 0 && F.size() > 0) {
-        init_envelope(V, F, use_exact);
+        init_envelope(V, F);
     } else {
         logger().warn("No surface faces left after simplification, skip re-building envelope");
     }

--- a/components/simwild/wmtk/components/simwild/EmbedSurface.cpp
+++ b/components/simwild/wmtk/components/simwild/EmbedSurface.cpp
@@ -253,8 +253,7 @@ void split_into_connected_components(
 
     Eigen::VectorXi component_of_vertex;
     Eigen::VectorXi component_sizes;
-    const int n_components =
-        igl::connected_components(A, component_of_vertex, component_sizes);
+    const int n_components = igl::connected_components(A, component_of_vertex, component_sizes);
 
     // All three vertices of a triangle are adjacent, so any of them names its component.
     std::vector<std::vector<int>> faces_of_component(n_components);

--- a/components/simwild/wmtk/components/simwild/EmbedSurface.cpp
+++ b/components/simwild/wmtk/components/simwild/EmbedSurface.cpp
@@ -3,6 +3,8 @@
 #include <wmtk/utils/EmbedTriangles.hpp>
 
 // clang-format off
+#include <igl/adjacency_matrix.h>
+#include <igl/connected_components.h>
 #include <igl/remove_unreferenced.h>
 #include <igl/tet_tet_adjacency.h>
 #include <igl/read_triangle_mesh.h>
@@ -230,53 +232,130 @@ void embed_surface(
 }
 
 
+namespace {
+
+/**
+ * @brief Split a triangle mesh into its connected components.
+ *
+ * Components are vertex-connected: two triangles belong to the same one iff a path of shared
+ * vertices joins them. Each piece is returned self-contained -- its own vertex block, indices
+ * rebased -- because each becomes an input in its own right, and the winding number of an
+ * input is evaluated against its own (V, F).
+ */
+void split_into_connected_components(
+    const MatrixXd& V,
+    const MatrixXi& F,
+    std::vector<MatrixXd>& V_out,
+    std::vector<MatrixXi>& F_out)
+{
+    Eigen::SparseMatrix<int> A;
+    igl::adjacency_matrix(F, A);
+
+    Eigen::VectorXi component_of_vertex;
+    Eigen::VectorXi component_sizes;
+    const int n_components =
+        igl::connected_components(A, component_of_vertex, component_sizes);
+
+    // All three vertices of a triangle are adjacent, so any of them names its component.
+    std::vector<std::vector<int>> faces_of_component(n_components);
+    for (int f = 0; f < F.rows(); ++f) {
+        faces_of_component[component_of_vertex(F(f, 0))].push_back(f);
+    }
+
+    for (const auto& faces : faces_of_component) {
+        if (faces.empty()) {
+            continue; // an isolated vertex is a component with no triangles
+        }
+        MatrixXi F_component(faces.size(), 3);
+        for (size_t k = 0; k < faces.size(); ++k) {
+            F_component.row(k) = F.row(faces[k]);
+        }
+
+        MatrixXd V_piece;
+        MatrixXi F_piece;
+        Eigen::VectorXi _I;
+        igl::remove_unreferenced(V, F_component, V_piece, F_piece, _I);
+
+        V_out.push_back(std::move(V_piece));
+        F_out.push_back(std::move(F_piece));
+    }
+}
+
+} // namespace
+
 EmbedSurface::EmbedSurface(
     const std::vector<std::string>& img_filenames,
     const std::vector<Matrix4d>& img_transform,
     const double tol_rel,
-    const double tol_abs)
+    const double tol_abs,
+    const bool split_connected_components)
     : m_img_filenames(img_filenames)
 {
     assert(img_filenames.size() == img_transform.size());
 
-    Vs.resize(m_img_filenames.size());
-    Fs.resize(m_img_filenames.size());
+    // One entry per INPUT, which is one per file unless split_connected_components is on, in
+    // which case a file contributes one per connected component. Everything downstream sizes
+    // itself off Fs.size() -- the tag columns and the per-input winding numbers -- so the split
+    // only has to be made here.
+    Vs.clear();
+    Fs.clear();
+    Vs.reserve(m_img_filenames.size());
+    Fs.reserve(m_img_filenames.size());
 
     for (size_t i = 0; i < m_img_filenames.size(); ++i) {
         if (!std::filesystem::exists(m_img_filenames[i])) {
             log_and_throw_error("Input file {} does not exist", m_img_filenames[i]);
         }
-        MatrixXi F_single;
-        io::read_triangle_mesh(m_img_filenames[i], Vs[i], F_single, tol_rel, tol_abs);
+        MatrixXd V_file;
+        MatrixXi F_file;
+        io::read_triangle_mesh(m_img_filenames[i], V_file, F_file, tol_rel, tol_abs);
 
-        assert(Vs[i].cols() == 3);
-        assert(F_single.cols() == 3);
+        assert(V_file.cols() == 3);
+        assert(F_file.cols() == 3);
 
-        // apply transform to Vs[i]
-        for (size_t j = 0; j < Vs[i].rows(); ++j) {
-            Vector3d v = Vs[i].row(j);
+        // apply transform to V_file
+        for (size_t j = 0; j < V_file.rows(); ++j) {
+            Vector3d v = V_file.row(j);
             Vector4d x = to_homogenuous(v);
             x = img_transform[i] * x;
-            Vs[i].row(j) = from_homogenuous(x);
+            V_file.row(j) = from_homogenuous(x);
         }
 
-        Fs[i] = F_single;
+        // The pieces this file contributes: itself, or one per connected component.
+        std::vector<MatrixXd> V_pieces;
+        std::vector<MatrixXi> F_pieces;
+        if (split_connected_components) {
+            split_into_connected_components(V_file, F_file, V_pieces, F_pieces);
+            logger().info(
+                "Input {} split into {} connected components",
+                m_img_filenames[i],
+                F_pieces.size());
+        } else {
+            V_pieces.push_back(std::move(V_file));
+            F_pieces.push_back(std::move(F_file));
+        }
 
-        const size_t nV_old = m_V_surface.rows();
-        const size_t nF_old = m_F_surface.rows();
+        for (size_t p = 0; p < F_pieces.size(); ++p) {
+            Vs.push_back(V_pieces[p]);
+            Fs.push_back(F_pieces[p]);
 
-        m_V_surface.conservativeResize(m_V_surface.rows() + Vs[i].rows(), 3);
-        m_V_surface.block(nV_old, 0, Vs[i].rows(), 3) = Vs[i];
+            const size_t nV_old = m_V_surface.rows();
+            const size_t nF_old = m_F_surface.rows();
 
-        F_single.array() += nV_old;
-        m_F_surface.conservativeResize(m_F_surface.rows() + F_single.rows(), 3);
-        m_F_surface.block(nF_old, 0, Fs[i].rows(), 3) = F_single;
+            m_V_surface.conservativeResize(nV_old + V_pieces[p].rows(), 3);
+            m_V_surface.block(nV_old, 0, V_pieces[p].rows(), 3) = V_pieces[p];
 
-        // Which input each row of the concatenated soup came from. Kept alongside
-        // m_F_surface from here on -- remove_unreferenced only touches vertices, and
-        // simplify_surface permutes both together -- so it still answers the question
-        // after the surface has been coarsened, which is where the arrangement sees it.
-        m_F_input.resize(m_F_surface.rows(), i);
+            MatrixXi F_offset = F_pieces[p];
+            F_offset.array() += nV_old;
+            m_F_surface.conservativeResize(nF_old + F_offset.rows(), 3);
+            m_F_surface.block(nF_old, 0, F_offset.rows(), 3) = F_offset;
+
+            // Which input each row of the concatenated soup came from. Kept alongside
+            // m_F_surface from here on -- remove_unreferenced only touches vertices, and
+            // simplify_surface permutes both together -- so it still answers the question
+            // after the surface has been coarsened, which is where the arrangement sees it.
+            m_F_input.resize(m_F_surface.rows(), Fs.size() - 1);
+        }
     }
 
 

--- a/components/simwild/wmtk/components/simwild/EmbedSurface.hpp
+++ b/components/simwild/wmtk/components/simwild/EmbedSurface.hpp
@@ -67,12 +67,23 @@ class EmbedSurface
 public:
     /**
      * @brief Input from meshes.
+     *
+     * @param split_connected_components Treat each connected component of an input file as an
+     * input in its own right, rather than the file as a whole. What counts as "an input" is
+     * what gets its own tag column and its own winding-number evaluation, so a file holding
+     * several disjoint closed surfaces is tagged as one region with this off, and as one
+     * region per component with it on. Off by default.
+     *
+     * Note that the inputs then outnumber the files, so `input_names` -- which is applied by
+     * position -- no longer lines up with the filenames; components past the end of that list
+     * fall back to the generic `tag_N` names.
      */
     EmbedSurface(
         const std::vector<std::string>& img_filenames,
         const std::vector<Matrix4d>& img_transform = {},
         const double tol_rel = -1,
-        const double tol_abs = -1);
+        const double tol_abs = -1,
+        const bool split_connected_components = false);
 
     /**
      * @brief Simplify the input surface while staying within the eps envelope.

--- a/components/simwild/wmtk/components/simwild/SimWildMesh.cpp
+++ b/components/simwild/wmtk/components/simwild/SimWildMesh.cpp
@@ -453,7 +453,7 @@ size_t SimWildMesh::refine_sizing_around_worst(double)
 }
 
 
-void SimWildMesh::init_envelope(const MatrixXd& V, const MatrixXi& F, const bool use_exact)
+void SimWildMesh::init_envelope(const MatrixXd& V, const MatrixXi& F)
 {
     if (m_envelope) {
         log_and_throw_error("Envelope was already initialized once.");
@@ -476,9 +476,12 @@ void SimWildMesh::init_envelope(const MatrixXd& V, const MatrixXi& F, const bool
         m_F_envelope[i] = F.row(i);
     }
 
-    m_envelope = std::make_shared<SampleEnvelope>();
-    m_envelope->use_exact = use_exact;
+    m_envelope = std::make_shared<SampleEnvelope>(!m_sim_params.use_sample_envelope);
     m_envelope->init(m_V_envelope, m_F_envelope, m_envelope_eps);
+    logger().info(
+        "Envelope: {} (eps {:.6})",
+        m_envelope->use_exact ? "EXACT" : "sampled",
+        m_envelope_eps);
 }
 
 

--- a/components/simwild/wmtk/components/simwild/SimWildMesh.h
+++ b/components/simwild/wmtk/components/simwild/SimWildMesh.h
@@ -148,7 +148,7 @@ public:
 
     // TODO This should not be here but inside wmtk
     // TODO This should not be here but inside wmtk
-    void init_envelope(const MatrixXd& V, const MatrixXi& F, const bool use_exact);
+    void init_envelope(const MatrixXd& V, const MatrixXi& F);
 
     CellTag string_set_to_cell_tag(const std::set<std::string>& str_set);
 

--- a/components/simwild/wmtk/components/simwild/VolumemesherInsertion.cpp
+++ b/components/simwild/wmtk/components/simwild/VolumemesherInsertion.cpp
@@ -301,6 +301,15 @@ void SimWildMesh::init_surfaces_and_boundaries()
         tempF.emplace_back(v1, v2, v3);
     }
 
+    auto reinit_envelope = [&]() {
+        m_envelope = std::make_shared<SampleEnvelope>(!m_sim_params.use_sample_envelope);
+        m_envelope->init(m_V_envelope, m_F_envelope, m_envelope_eps);
+        logger().info(
+            "Envelope: {} (eps {:.6})",
+            m_envelope->use_exact ? "EXACT" : "sampled",
+            m_envelope_eps);
+    };
+
     if (!m_envelope) {
         logger().info("Init envelope from tet tags");
         // build envelopes
@@ -311,9 +320,7 @@ void SimWildMesh::init_surfaces_and_boundaries()
 
         m_V_envelope = tempV;
         m_F_envelope = tempF;
-        m_envelope = std::make_shared<SampleEnvelope>();
-        m_envelope->use_exact = true;
-        m_envelope->init(m_V_envelope, m_F_envelope, m_envelope_eps);
+        reinit_envelope();
     } else if (m_sim_params.operation == "remeshing") {
         // Deliberately NOT behind check_envelope_at_init, unlike triwild's: the answer is not an
         // assertion but a decision -- if any surface face starts outside, the envelope is rebuilt
@@ -345,13 +352,9 @@ void SimWildMesh::init_surfaces_and_boundaries()
             for (int i = 0; i < vert_capacity(); i++) {
                 tempV[i] = m_vertex_attribute[i].m_posf;
             }
-            bool use_exact = m_envelope->use_exact;
             m_V_envelope = tempV;
             m_F_envelope = tempF;
-            m_envelope = std::make_shared<SampleEnvelope>();
-            m_envelope->use_exact = use_exact;
-            logger().info("is exact = {}", use_exact);
-            m_envelope->init(m_V_envelope, m_F_envelope, m_envelope_eps);
+            reinit_envelope();
         }
     }
 

--- a/components/simwild/wmtk/components/simwild/read_image_msh.cpp
+++ b/components/simwild/wmtk/components/simwild/read_image_msh.cpp
@@ -424,6 +424,7 @@ InputData read_mesh(
     const bool preserve_topology = json_params["preserve_topology"];
     const bool skip_simplify = json_params["skip_simplify"];
     const bool tag_from_winding_number = json_params["tag_from_winding_number"];
+    const bool split_connected_components = json_params["split_connected_components"];
     const double epsr_simplify = json_params["eps_simplify_rel"];
     double eps_simplify = json_params["eps_simplify"];
     const std::vector<std::string> input_names = json_params["input_names"];
@@ -436,7 +437,12 @@ InputData read_mesh(
     }
 
     // convert mesh into tet mesh
-    EmbedSurface image_mesh(input_paths, input_transforms, tol_rel, tol_abs);
+    EmbedSurface image_mesh(
+        input_paths,
+        input_transforms,
+        tol_rel,
+        tol_abs,
+        split_connected_components);
     image_mesh.m_num_threads = NUM_THREADS;
     image_mesh.m_perform_sanity_checks = perform_sanity_checks;
 

--- a/components/simwild/wmtk/components/simwild/simwild.cpp
+++ b/components/simwild/wmtk/components/simwild/simwild.cpp
@@ -221,8 +221,7 @@ void run_3D(const nlohmann::json& json_params, const InputData& input_data)
     wmtk::set_preallocation_factor_from_json(mesh, json_params);
     // first init envelope
     if (input_data.V_envelope.size() != 0) {
-        bool use_exact = !json_params["use_sample_envelope"];
-        mesh.init_envelope(input_data.V_envelope, input_data.F_envelope, use_exact);
+        mesh.init_envelope(input_data.V_envelope, input_data.F_envelope);
     }
     if (input_data.V_input_r.size() == 0) {
         logger().info("Use float input for TetWild");

--- a/components/simwild/wmtk/components/simwild/simwild_spec.json
+++ b/components/simwild/wmtk/components/simwild/simwild_spec.json
@@ -13,6 +13,7 @@
       "input_dir",
       "skip_simplify",
       "tag_from_winding_number",
+      "split_connected_components",
       "use_sample_envelope",
       "num_threads",
       "max_iterations",
@@ -171,6 +172,12 @@
     "type": "bool",
     "default": true,
     "doc": "How the cells of the arrangement are tagged. True evaluates the winding number of every input at each cell's centroid. False propagates the tags across the arrangement's own surface provenance instead: combinatorial and exact, starting from a cell of the padded box (which is outside everything) and flipping membership of an input whenever a face belonging to that input is crossed. The provenance route needs every input surface to be closed, and says which crossings disagree rather than returning a tagging that depends on the traversal order. 3D surface input only -- a .msh input arrives already tagged."
+  },
+  {
+    "pointer": "/split_connected_components",
+    "type": "bool",
+    "default": false,
+    "doc": "Treat each connected component of an input file as an input in its own right, rather than the file as a whole. What counts as an input is what gets its own tag column and its own winding-number evaluation, so a file holding several disjoint closed surfaces is tagged as one region with this off, and as one region per component with it on. Components are vertex-connected. Note that the inputs then outnumber the files, so /input_names -- which is applied by position -- no longer lines up with the filenames, and components past the end of that list fall back to the generic tag_N names. 3D surface input only: a .msh input arrives already tagged, and the 2D curve path has its own reader."
   },
   {
     "pointer": "/use_sample_envelope",

--- a/components/simwild/wmtk/components/simwild/tests/CMakeLists.txt
+++ b/components/simwild/wmtk/components/simwild/tests/CMakeLists.txt
@@ -12,6 +12,7 @@ set(SRC_FILES
     test_expression_parser.cpp
     test_simwild_swap_tags.cpp
     test_wild_conformance.cpp
+    test_embed_surface_components.cpp
     )
 
 target_sources(wmtk_test_${COMPONENT_NAME} PRIVATE ${SRC_FILES})

--- a/components/simwild/wmtk/components/simwild/tests/test_embed_surface_components.cpp
+++ b/components/simwild/wmtk/components/simwild/tests/test_embed_surface_components.cpp
@@ -1,0 +1,53 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include <wmtk/components/simwild/EmbedSurface.hpp>
+
+#include <filesystem>
+#include <fstream>
+
+using namespace wmtk;
+using namespace wmtk::components::simwild;
+
+namespace {
+
+/// Two disjoint closed tetrahedra, written as one OBJ. One file, two connected components.
+std::filesystem::path write_two_tetrahedra()
+{
+    const std::filesystem::path path =
+        std::filesystem::temp_directory_path() / "wmtk_two_tetrahedra.obj";
+    std::ofstream out(path);
+
+    // Tetrahedron A, around the origin.
+    out << "v 0 0 0\nv 1 0 0\nv 0 1 0\nv 0 0 1\n";
+    // Tetrahedron B, well clear of A so the two cannot touch.
+    out << "v 10 10 10\nv 11 10 10\nv 10 11 10\nv 10 10 11\n";
+
+    // Each closed, with outward orientation.
+    out << "f 1 3 2\nf 1 2 4\nf 1 4 3\nf 2 3 4\n";
+    out << "f 5 7 6\nf 5 6 8\nf 5 8 7\nf 6 7 8\n";
+    return path;
+}
+
+/// Number of inputs the embedding ended up with -- one tag column per input.
+int input_count(const std::filesystem::path& path, const bool split)
+{
+    EmbedSurface surf({path.string()}, {Matrix4d::Identity()}, -1, -1, split);
+    surf.embed_surface();
+    return int(surf.T_tags().cols());
+}
+
+} // namespace
+
+TEST_CASE("EmbedSurface can treat each connected component as its own input", "[simwild][embed]")
+{
+    const std::filesystem::path path = write_two_tetrahedra();
+
+    // Off (the default): the file is one input, so the two tetrahedra share a tag and the
+    // region between them cannot be distinguished from the region inside either.
+    REQUIRE(input_count(path, false) == 1);
+
+    // On: each component is an input in its own right, and gets its own tag column.
+    REQUIRE(input_count(path, true) == 2);
+
+    std::filesystem::remove(path);
+}

--- a/components/simwild/wmtk/components/simwild/tests/test_wild_conformance.cpp
+++ b/components/simwild/wmtk/components/simwild/tests/test_wild_conformance.cpp
@@ -687,7 +687,7 @@ TEST_CASE(
     for (size_t vid = 0; vid < kTetRingVertices.size(); ++vid) V.row(vid) = kTetRingVertices[vid];
     Eigen::MatrixXi F(3, 3);
     for (size_t i = 0; i < interface_faces.size(); ++i) F.row(i) = interface_faces[i];
-    sim.init_envelope(V, F, false);
+    sim.init_envelope(V, F);
     sim.init_surfaces_and_boundaries();
     sim.init_vertex_order();
 

--- a/src/wmtk/TetOptimizerMesh.cpp
+++ b/src/wmtk/TetOptimizerMesh.cpp
@@ -189,27 +189,33 @@ std::tuple<double, double> TetOptimizerMesh::local_operations(
                 if (cnt_success == 0) break;
             }
         } else {
-            for (int n = 0; n < ops[i]; ++n) {
-                logger().info("==smoothing {}==", n);
-                smooth_all_vertices();
-            }
+            smooth_all_vertices(size_t(ops[i]));
             if (ops[i] > 0) round_all_vertices();
         }
 
-        if (m_params.debug_output) {
-            write_optimization_debug_output(fmt::format("debug_{}", m_debug_print_counter++));
-        }
-        const auto [max_metric, avg_metric] = optimization_quality_stats();
-        logger()
-            .info("{} max energy = {:.6} avg = {:.6}", names[size_t(i)], max_metric, avg_metric);
-        if (i == 2) {
+        if (ops[i] > 0) {
+            if (m_params.debug_output && i < 3) {
+                // no need to print debug output for smoothing, since it prints already internally
+                write_optimization_debug_output(fmt::format("debug_{}", m_debug_print_counter++));
+            }
+            const auto [max_metric, avg_metric] = optimization_quality_stats();
             logger().info(
-                "cnt_surface_swap (cumulative) = {} [3-2: {}, 4-4: {}, 5-6: {}]",
-                cnt_surface_swap.load(),
-                cnt_surface_swap_32.load(),
-                cnt_surface_swap_44.load(),
-                cnt_surface_swap_56.load());
+                "{} max energy = {:.6} avg = {:.6}",
+                names[size_t(i)],
+                max_metric,
+                avg_metric);
+            if (i == 2) {
+                logger().info(
+                    "cnt_surface_swap (cumulative) = {} [3-2: {}, 4-4: {}, 5-6: {}]",
+                    cnt_surface_swap.load(),
+                    cnt_surface_swap_32.load(),
+                    cnt_surface_swap_44.load(),
+                    cnt_surface_swap_56.load());
+            }
+            sanity_checks();
+            update_attributes();
         }
+
         // A pass that ran out of preallocated slots abandoned operations for want of storage.
         // Consolidating both reclaims the slots removed elements still hold -- the counter only
         // advances during a pass, so churn alone can exhaust it -- and re-derives the storage
@@ -237,9 +243,6 @@ std::tuple<double, double> TetOptimizerMesh::local_operations(
         } else {
             retry_count = 0;
         }
-
-        sanity_checks();
-        update_attributes();
     }
 
     const auto stats = optimization_quality_stats();
@@ -352,6 +355,7 @@ bool TetOptimizerMesh::smooth_after(const Tuple& t)
 void TetOptimizerMesh::smooth_all_vertices(const size_t n_iters)
 {
     for (size_t i = 0; i < n_iters; ++i) {
+        logger().info("==smoothing {}==", i);
         // Preserve TetWild's deterministic serial random-seed progression. The current
         // collector does not consume rand(), but keeping the state transition makes the move
         // behavior-neutral if its ordering is randomized again.
@@ -372,13 +376,17 @@ void TetOptimizerMesh::smooth_all_vertices(const size_t n_iters)
             }
         }
         logger().info("vertex smoothing prepare time: {:.4}s", timer.getElapsedTime());
-        logger().debug("Num verts {}", collect_all_ops.size());
+        logger().debug("#V = {}", collect_all_ops.size());
         run_pass(
             *this,
             PassLock::VertexRing,
             "vertex smoothing operation",
             [&](auto& executor, auto& mesh) { executor(mesh, collect_all_ops); });
         logger().info("\tsmooth: {}", m_smooth_rejects.to_string());
+
+        if (m_params.debug_output) {
+            write_optimization_debug_output(fmt::format("debug_{}", m_debug_print_counter++));
+        }
     }
 }
 


### PR DESCRIPTION
EmbedSurface's constructor took one input per file. A file holding several disjoint closed surfaces was therefore a single region.

The new split_connected_components flag makes each vertex-connected component an input in its own right. Components are extracted with igl::adjacency_matrix + igl::connected_components, and each piece is rebased through igl::remove_unreferenced so it is self-contained -- the winding number of an input is evaluated against its own (V, F), so a piece sharing the file's vertex block would not do.

Exposed as /split_connected_components in simwild_spec.json, default false, and read in read_image_msh.cpp next to /tag_from_winding_number. Off by default, so existing configs are unaffected.

Note that inputs then outnumber files, so /input_names -- applied by position -- no longer lines up with the filenames, and components past the end of that list fall back to the generic tag_N names. Documented on both the constructor and the spec entry rather than guessed at: a naming scheme for components is a separate decision.

Verified end to end on one OBJ holding two disjoint tetrahedra. The written .msh carries the physical groups

    off:  ambient, tag_0,        EnvelopeSurface
    on:   ambient, tag_0, tag_1, EnvelopeSurface

so a component really does become its own tagged region in the output, not just a different count inside the embedder. test_embed_surface_components.cpp pins the same thing through T_tags().cols(), which is the only public observable for the input count.