### PR TITLE
Dzint/simwild fixes

### DIFF
--- a/components/simwild/wmtk/components/simwild/EdgeCollapsing.cpp
+++ b/components/simwild/wmtk/components/simwild/EdgeCollapsing.cpp
@@ -58,12 +58,17 @@ void SimWildMesh::simplify()
     m_envelope->use_exact = false;
     m_envelope->init(m_V_envelope, m_F_envelope, m_sim_params.eps_simplify);
 
-    m_collapse_check_quality = false;
+    /**
+     * Not checking the quality here can lead to horrible elements that take forever to fix in the
+     * optimization stage. The quality check reduces the amount of simplification, but the overall
+     * convergence is faster because the optimizer does not have to fix the mess.
+     */
+    // m_collapse_check_quality = false;
     collapse_all_edges();
     if (m_params.debug_output) {
         write_vtu(fmt::format("debug_{}", m_debug_print_counter++));
     }
-    m_collapse_check_quality = true;
+    // m_collapse_check_quality = true;
 
     logger().warn("Update envelope");
     MatrixXd V(vert_capacity(), 3);

--- a/components/tetwild/wmtk/components/tetwild/tetwild_spec.json
+++ b/components/tetwild/wmtk/components/tetwild/tetwild_spec.json
@@ -20,7 +20,7 @@
       "use_legacy_code",
       "num_threads",
       "max_iterations",
-    "max_expected_iterations",
+      "max_expected_iterations",
       "filter",
       "eps_rel",
       "length_rel",
@@ -212,7 +212,7 @@
   {
     "pointer": "/split_high_valence_threshold",
     "type": "int",
-    "default": 200,
+    "default": 0,
     "doc": "Incident-tet count above which a vertex accepts only one valence-increasing split per split pass, or 0 to disable. A well-shaped tet mesh has valence around 20-30; a split cascade can drive one vertex into the thousands, at which point every operation touching it is O(valence) and the pass stalls. Splitting an edge leaves its endpoints' counts unchanged and adds one to each vertex in the edge's link, so the gate applies to the link."
   },
   {
@@ -220,21 +220,21 @@
     "type": "int",
     "default": 12,
     "doc": "Bisections tried by the projected line search before it gives up on a vertex: the step along the Newton direction is halved this many times, each candidate projected onto the input, and the first that does not invert and lowers the worst incident element is taken."
-},
-{
+  },
+  {
     "pointer": "/project_line_search_nested_steps",
     "type": "int",
     "default": 0,
     "doc": "After the projected line search gives up, revisit each candidate and bisect between the interpolated point and its projection this many times, taking the longest step toward the input that still does not invert and still lowers the worst element. Lets a vertex whose one-ring cannot tolerate a full projection still travel toward the input, instead of being refused every pass from the same place. 0 disables the pass."
-},
-{
+  },
+  {
     "pointer": "/smoothing_mode",
     "type": "string",
     "default": "projected",
     "options": ["projected", "exact"],
     "doc": "How smoothing places a surface vertex. 'projected': smooth with AMIPS alone as if interior, then walk back toward the start projecting each candidate onto the input; accept the first projected candidate that does not invert and strictly lowers the worst incident element, else do not move. Lands exactly on the input; no weights. 'exact': minimize w_amips * AMIPS + (1-w_amips) * (d/eps)^2 with the true region-wise Hessian of the distance to the piecewise-linear input; sliding is free where the input is flat, held at corners, constrained along 3D edges and curve segments. Rests a w_amips-proportional distance off the input."
-},
-{
+  },
+  {
     "pointer": "/w_amips",
     "type": "float",
     "default": 0.0001,
@@ -331,11 +331,10 @@
     "doc": "Diagnostic only. Disables every envelope containment check during the tetrahedralisation, after the input simplification has run. The envelope is the only thing that rejects an operation for geometric rather than combinatorial reasons, so this answers whether a stalled optimization is blocked by the envelope or by the mesh. The output has no containment guarantee and must not be used."
   },
   {
-
-      "pointer": "/max_expected_iterations",
-      "type": "int",
-      "default": 0,
-      "doc": "Fail the run if mesh_improvement needed more than this many iterations, even if it did reach stop_energy. 0 disables the check. This is a regression guard rather than a quality target: an input that normally converges in a handful of iterations and suddenly needs the whole budget means the sizing-refinement trigger stopped firing when it should, which is a silent slowdown that no energy or envelope assertion catches."
+    "pointer": "/max_expected_iterations",
+    "type": "int",
+    "default": 0,
+    "doc": "Fail the run if mesh_improvement needed more than this many iterations, even if it did reach stop_energy. 0 disables the check. This is a regression guard rather than a quality target: an input that normally converges in a handful of iterations and suddenly needs the whole budget means the sizing-refinement trigger stopped firing when it should, which is a silent slowdown that no energy or envelope assertion catches."
   },
   {
     "pointer": "/stuck_refine_stall_eps",

--- a/components/topological_offset/wmtk/components/topological_offset/topological_offset_spec.json
+++ b/components/topological_offset/wmtk/components/topological_offset/topological_offset_spec.json
@@ -1,382 +1,375 @@
 [
-    {
-        "doc": "",
-        "pointer": "/",
-        "type": "object",
-        "required": [
-            "application",
-            "input"
-        ],
-        "optional": [
-            "output",
-            "input_dir",
-            "offset_selection",
-            "offset_output_tags",
-            "protected_tags",
-            "respect_all_topologies",
-            "offset_in",
-            "offset_out",
-            "target_distance",
-            "target_distance_rel",
-            "convergence_target",
-            "convergence_target_rel",
-            "convergence_normal_deviation",
-            "throw_on_nonconvergence",
-            "envelope_size",
-            "envelope_size_rel",
-            "region_envelope_from_input",
-            "relative_ball_threshold",
-            "edge_search_termination_len",
-            "sorted_marching",
-            "check_manifoldness",
-            "optimize",
-            "save_vtu",
-            "DEBUG_output",
-            "log_file",
-            "report",
-            "num_threads",
-            "smoothing_iterations",
-            "optimization_iterations",
-            "length_rel",
-            "length",
-            "stop_energy",
-            "max_normal_deviation_deg",
-            "min_normal_deviation_deg",
-            "min_edge_length",
-            "smooth_quadrics_weight",
-            "smooth_laplacian_weight",
-            "quadrics_svd_threshold",
-            "min_sizing_scalar",
-            "max_sizing_scalar",
-            "sizing_mrm_threshold",
-            "sizing_gradation",
-            "split_high_valence_threshold",
-            "skip_good_regions",
-            "w_amips",
-            "smoothing_mode",
-            "project_line_search_steps",
-            "project_line_search_nested_steps",
-            "perform_sanity_checks"
-        ]
-    },
-    {
-        "pointer": "/application",
-        "type": "string",
-        "options": [
-            "topological_offset"
-        ],
-        "doc": "Application name must be topological_offset."
-    },
-    {
-        "pointer": "/input",
-        "type": "string",
-        "doc": "Tetrahedral input mesh."
-    },
-    {
-        "pointer": "/output",
-        "type": "string",
-        "default": "out",
-        "doc": "Output file name (without extension)."
-    },
-    {
-        "pointer": "/input_dir",
-        "type": "string",
-        "default": "",
-        "doc": "Directory where the input files are located. This is injected by the application and should not be set by the user."
-    },
-    {
-        "pointer": "/offset_selection",
-        "type": "string",
-        "default": "!_",
-        "doc": "Boolean expression for input simplicial complex to offset. If a single tag (ie 'tag_0') is given, single body mode is used."
-    },
-    {
-        "pointer": "/offset_output_tags",
-        "type": "list",
-        "default": [
-            "newtag"
-        ],
-        "doc": "Tags to add to elements in the resulting offset region."
-    },
-    {
-        "pointer": "/offset_output_tags/*",
-        "type": "string",
-        "doc": "A tag."
-    },
-    {
-        "pointer": "/protected_tags",
-        "type": "list",
-        "default": [],
-        "doc": "Set of tags that will not be overwritten by the offset."
-    },
-    {
-        "pointer": "/protected_tags/*",
-        "type": "string",
-        "doc": "A tag."
-    },
-    {
-        "pointer": "/offset_in",
-        "type": "bool",
-        "default": false,
-        "doc": "Only relevant for single body mode. Whether to create offset inside body"
-    },
-    {
-        "pointer": "/offset_out",
-        "type": "bool",
-        "default": true,
-        "doc": "Only relevant for single body mode. Whether to create offset outside body"
-    },
-    {
-        "pointer": "/respect_all_topologies",
-        "type": "bool",
-        "default": false,
-        "doc": "If true, the topology (after offset initialization) of every tag is respected as if the offset was to replace all tags. If false, only the topology of the offset is respected."
-    },
-    {
-        "pointer": "/target_distance_rel",
-        "type": "float",
-        "default": 0.01,
-        "doc": "Target offset distance relative to bounding box of mesh."
-    },
-    {
-        "pointer": "/target_distance",
-        "type": "float",
-        "default": -1.0,
-        "doc": "Target distance for offset. If < 0, the relative target distance is used to compute this one."
-    },
-    {
-        "pointer": "/convergence_target_rel",
-        "type": "float",
-        "default": 0.1,
-        "doc": "Optimization terminates early once max_dist_err drops to or below this fraction of target_distance. Ignored if convergence_target >= 0."
-    },
-    {
-        "pointer": "/convergence_target",
-        "type": "float",
-        "default": -1.0,
-        "doc": "Absolute max_dist_err threshold for early termination of optimization. If < 0, computed from convergence_target_rel (relative to target_distance, not the bounding box)."
-    },
-    {
-        "pointer": "/convergence_normal_deviation",
-        "type": "float",
-        "default": -1.0,
-        "doc": "AVERAGE normal deviation threshold, IN DEGREES, for early termination of optimization. Tested against avg_norm_dev, not max_norm_dev -- the paper's Termination criterion is the same way round ('the average sigma_max ... both the maximum and mean distance error'), because max normal deviation has a floor set by the input's sharpest reentrant corner, where the distance field's normal is discontinuous at every scale, and no refinement or smaller target_distance can lower it. max_norm_dev is still reported, as a diagnostic. The offset must reach both this and convergence_target before the run may stop early. An angle has no natural relative form, so unlike convergence_target there is no _rel counterpart. If <= 0 the criterion is disabled and max_dist_err alone decides convergence, which is the 3D behaviour."
-    },
-    {
-        "pointer": "/throw_on_nonconvergence",
-        "type": "bool",
-        "default": false,
-        "doc": "If true, a run that finishes without meeting the convergence criteria raises an error instead of logging a warning. Default false: a non-converged offset is still a usable one, and the warnings already name which criterion failed. Set true in integration tests so a convergence regression fails the run rather than passing with a warning nobody reads. 2D only -- the 3D path does not read it."
-    },
-    {
-        "pointer": "/region_envelope_from_input",
-        "type": "bool",
-        "default": true,
-        "doc": "Build the region-boundary envelope from the INPUT mesh, before the offset is constructed, rather than from the mesh the offset construction leaves behind. The band's tags REPLACE a face's own rather than joining them, so a region the band grows through loses its tag there and its boundary curve is truncated at whatever contour conservative growth stopped on; an envelope built afterwards caps the triple junction where a region boundary meets the offset at a position that is an artefact of relative_ball_threshold. Building it from the input follows the region's original, untruncated curve, which relaxes the constraint only along the stretch the band later swallows. Set false for the older behaviour. 2D only."
-    },
-    {
-        "pointer": "/envelope_size_rel",
-        "type": "float",
-        "default": 0.001,
-        "doc": "Half-width, relative to the bounding box diagonal, of the envelope containing every tag-region boundary during optimization. Any operation that would push a region boundary outside it is rejected. Ignored if envelope_size >= 0."
-    },
-    {
-        "pointer": "/envelope_size",
-        "type": "float",
-        "default": -1.0,
-        "doc": "Absolute half-width of the tag-region boundary envelope. If < 0, computed from envelope_size_rel."
-    },
-    {
-        "pointer": "/relative_ball_threshold",
-        "type": "float",
-        "default": 0.1,
-        "doc": "Float between 0 and 1, radius relative to target_distance to stop circle/sphere splitting in conservative distance approximation. Smaller means more accurate offset growth but longer run time."
-    },
-    {
-        "pointer": "/edge_search_termination_len",
-        "type": "float",
-        "default": 0.001,
-        "doc": "Length below which binary search will be terminated for function-guided edge splitting"
-    },
-    {
-        "pointer": "/sorted_marching",
-        "type": "bool",
-        "default": false,
-        "doc": "Execute marching tets in decreasing order of edge length. Increases run time, may increase output mesh quality."
-    },
-    {
-        "pointer": "/check_manifoldness",
-        "type": "bool",
-        "default": true,
-        "doc": "After performing offset, check if offset region is manifold"
-    },
-    {
-        "pointer": "/optimize",
-        "type": "bool",
-        "default": false,
-        "doc": "Run optimization on the offset."
-    },
-    {
-        "pointer": "/save_vtu",
-        "type": "bool",
-        "default": false,
-        "doc": "Save .vtu of output mesh"
-    },
-    {
-        "pointer": "/DEBUG_output",
-        "type": "bool",
-        "default": false,
-        "doc": "Write the tet mesh as out_{}.vtu after every operation."
-    },
-    {
-        "pointer": "/log_file",
-        "type": "string",
-        "default": "",
-        "doc": "Logs are not just printed on the terminal but also saved in this file."
-    },
-    {
-        "pointer": "/report",
-        "type": "string",
-        "default": "",
-        "doc": "A JSON file that stores information about the result and the method execution, e.g., runtime."
-    },
-    {
-        "pointer": "/num_threads",
-        "type": "int",
-        "default": 0,
-        "doc": "Number of threads used for parallel execution (smoothing, edge collapse). 0 means single-threaded."
-    },
-    {
-        "pointer": "/smoothing_iterations",
-        "type": "int",
-        "default": 3,
-        "doc": "Number of smoothing passes run during offset optimization (only used if optimize is true)."
-    },
-    {
-        "pointer": "/length_rel",
-        "type": "float",
-        "default": 0.05,
-        "doc": "Target edge length relative to the bounding box diagonal. Used to bound which edges edge collapse is allowed to touch (only edges shorter than 4/5 of this length are collapsed). Ignored if length >= 0."
-    },
-    {
-        "pointer": "/length",
-        "type": "float",
-        "default": -1.0,
-        "doc": "Target edge length (absolute). If < 0, computed from length_rel."
-    },
-    {
-        "pointer": "/stop_energy",
-        "type": "float",
-        "default": 10.0,
-        "doc": "Target AMIPS quality for tets. Edge collapse will not push an already-on-target region's quality back above this."
-    },
-    {
-        "pointer": "/optimization_iterations",
-        "type": "int",
-        "default": 3,
-        "doc": "Number of split/collapse/swap/smooth passes run during offset optimization (only used if optimize is true)."
-    },
-    {
-        "pointer": "/max_normal_deviation_deg",
-        "type": "float",
-        "default": 15.0,
-        "doc": "sigma_max. Max normal deviation (degrees, 0-90) allowed across one offset-surface element. Collapse and swap reject moves that would push an already-aligned patch of the offset surface further out of alignment than this, and the sizing field refines wherever it is exceeded. Also sets the derived min_edge_length."
-    },
-    {
-        "pointer": "/min_normal_deviation_deg",
-        "type": "float",
-        "default": 2.0,
-        "doc": "sigma_min. Normal deviation (degrees) below which a stretch of offset surface counts as planar, so the sizing field may coarsen it. Paper value is 2 degrees. 2D only."
-    },
-    {
-        "pointer": "/min_edge_length",
-        "type": "float",
-        "default": -1.0,
-        "doc": "l_min: the shortest edge the sizing field may ask for, in absolute units. If < 0, derived as 2 * target_distance * sin(max_normal_deviation_deg), the paper's formula -- tied to the offset distance rather than the bounding box, because the offset is what has to be resolved. This is a floor on REFINEMENT, so raising it makes the offset coarser (paper Fig. 18). 2D only."
-    },
-    {
-        "pointer": "/smooth_quadrics_weight",
-        "type": "float",
-        "default": 0.5,
-        "doc": "Blend weight (0-1) toward the quadrics-optimal target vertex during offset-surface smoothing. The remaining weight (1 - smooth_quadrics_weight - smooth_laplacian_weight) stays with the vertex's previous position."
-    },
-    {
-        "pointer": "/smooth_laplacian_weight",
-        "type": "float",
-        "default": 0.01,
-        "doc": "Blend weight (0-1) toward the Laplacian of neighboring offset-surface vertices during offset-surface smoothing. The remaining weight (1 - smooth_quadrics_weight - smooth_laplacian_weight) stays with the vertex's previous position."
-    },
-    {
-        "pointer": "/quadrics_svd_threshold",
-        "type": "float",
-        "default": 0.01,
-        "doc": "SVD threshold used when solving for the quadrics-optimal target vertex during offset-surface smoothing. Controls sensitivity to feature edges: lower means more sensitive."
-    },
-    {
-        "pointer": "/min_sizing_scalar",
-        "type": "float",
-        "default": 0.01,
-        "doc": "Lower bound for the per-vertex sizing field (see max_sizing_scalar). Refinement stops once a vertex's sizing scalar reaches this fraction of the base target length."
-    },
-    {
-        "pointer": "/max_sizing_scalar",
-        "type": "float",
-        "default": 1.0,
-        "doc": "Upper bound for the per-vertex sizing field, a multiplier on the target edge length (splitting_l2/collapsing_l2) refined/coarsened once per optimize_offset() iteration based on the mean ratio metric of the offset triangulation (see sizing_mrm_threshold). 1.0 means never coarser than the base target length."
-    },
-    {
-        "pointer": "/sizing_mrm_threshold",
-        "type": "float",
-        "default": 0.5,
-        "doc": "Mean ratio metric threshold used to update the sizing field once per optimize_offset() iteration: for each offset-surface vertex, the sizing scalar is halved (refine) if the worst incident offset triangle's mean ratio metric is below this, or multiplied by 1.5 (coarsen) if above."
-    },
-    {
-        "pointer": "/sizing_gradation",
-        "type": "float",
-        "default": 2.0,
-        "doc": "Gradation cap for the sizing field: neighboring vertices' sizing scalars may differ by at most this factor. After each mean-ratio-metric refinement pass, the refined vertices' lower sizing scalar is propagated outward (monotone, only ever lowers a neighbor's scalar) so the mesh doesn't jump straight from fine to coarse. <= 1 disables gradation."
-    },
-    {
-        "pointer": "/split_high_valence_threshold",
-        "type": "int",
-        "default": 200,
-        "doc": "Incident-tet count above which a vertex in a split edge's link accepts only one valence-increasing split per pass, or 0 to disable. Spreads refinement instead of letting it pile onto one vertex (only used if optimize is true)."
-    },
-    {
-        "pointer": "/skip_good_regions",
-        "type": "bool",
-        "default": false,
-        "doc": "Only smooth vertices incident to a tet whose energy is still far from stop_energy. Smoothing a vertex surrounded by good tets does nothing, so skipping it is free (only used if optimize is true)."
-    },
-    {
-        "pointer": "/project_line_search_steps",
-        "type": "int",
-        "default": 12,
-        "doc": "Bisections tried by the projected line search before it gives up on a vertex: the step along the Newton direction is halved this many times, each candidate projected onto the input, and the first that does not invert and lowers the worst incident element is taken."
-    },
-    {
-        "pointer": "/project_line_search_nested_steps",
-        "type": "int",
-        "default": 0,
-        "doc": "After the projected line search gives up, revisit each candidate and bisect between the interpolated point and its projection this many times, taking the longest step toward the input that still does not invert and still lowers the worst element. Lets a vertex whose one-ring cannot tolerate a full projection still travel toward the input, instead of being refused every pass from the same place. 0 disables the pass."
-    },
-    {
+  {
+    "doc": "",
+    "pointer": "/",
+    "type": "object",
+    "required": ["application", "input"],
+    "optional": [
+      "output",
+      "input_dir",
+      "offset_selection",
+      "offset_output_tags",
+      "protected_tags",
+      "respect_all_topologies",
+      "offset_in",
+      "offset_out",
+      "target_distance",
+      "target_distance_rel",
+      "convergence_target",
+      "convergence_target_rel",
+      "convergence_normal_deviation",
+      "throw_on_nonconvergence",
+      "envelope_size",
+      "envelope_size_rel",
+      "region_envelope_from_input",
+      "relative_ball_threshold",
+      "edge_search_termination_len",
+      "sorted_marching",
+      "check_manifoldness",
+      "optimize",
+      "save_vtu",
+      "DEBUG_output",
+      "log_file",
+      "report",
+      "num_threads",
+      "smoothing_iterations",
+      "optimization_iterations",
+      "length_rel",
+      "length",
+      "stop_energy",
+      "max_normal_deviation_deg",
+      "min_normal_deviation_deg",
+      "min_edge_length",
+      "smooth_quadrics_weight",
+      "smooth_laplacian_weight",
+      "quadrics_svd_threshold",
+      "min_sizing_scalar",
+      "max_sizing_scalar",
+      "sizing_mrm_threshold",
+      "sizing_gradation",
+      "split_high_valence_threshold",
+      "skip_good_regions",
+      "w_amips",
+      "smoothing_mode",
+      "project_line_search_steps",
+      "project_line_search_nested_steps",
+      "perform_sanity_checks"
+    ]
+  },
+  {
+    "pointer": "/application",
+    "type": "string",
+    "options": ["topological_offset"],
+    "doc": "Application name must be topological_offset."
+  },
+  {
+    "pointer": "/input",
+    "type": "string",
+    "doc": "Tetrahedral input mesh."
+  },
+  {
+    "pointer": "/output",
+    "type": "string",
+    "default": "out",
+    "doc": "Output file name (without extension)."
+  },
+  {
+    "pointer": "/input_dir",
+    "type": "string",
+    "default": "",
+    "doc": "Directory where the input files are located. This is injected by the application and should not be set by the user."
+  },
+  {
+    "pointer": "/offset_selection",
+    "type": "string",
+    "default": "!_",
+    "doc": "Boolean expression for input simplicial complex to offset. If a single tag (ie 'tag_0') is given, single body mode is used."
+  },
+  {
+    "pointer": "/offset_output_tags",
+    "type": "list",
+    "default": ["newtag"],
+    "doc": "Tags to add to elements in the resulting offset region."
+  },
+  {
+    "pointer": "/offset_output_tags/*",
+    "type": "string",
+    "doc": "A tag."
+  },
+  {
+    "pointer": "/protected_tags",
+    "type": "list",
+    "default": [],
+    "doc": "Set of tags that will not be overwritten by the offset."
+  },
+  {
+    "pointer": "/protected_tags/*",
+    "type": "string",
+    "doc": "A tag."
+  },
+  {
+    "pointer": "/offset_in",
+    "type": "bool",
+    "default": false,
+    "doc": "Only relevant for single body mode. Whether to create offset inside body"
+  },
+  {
+    "pointer": "/offset_out",
+    "type": "bool",
+    "default": true,
+    "doc": "Only relevant for single body mode. Whether to create offset outside body"
+  },
+  {
+    "pointer": "/respect_all_topologies",
+    "type": "bool",
+    "default": false,
+    "doc": "If true, the topology (after offset initialization) of every tag is respected as if the offset was to replace all tags. If false, only the topology of the offset is respected."
+  },
+  {
+    "pointer": "/target_distance_rel",
+    "type": "float",
+    "default": 0.01,
+    "doc": "Target offset distance relative to bounding box of mesh."
+  },
+  {
+    "pointer": "/target_distance",
+    "type": "float",
+    "default": -1.0,
+    "doc": "Target distance for offset. If < 0, the relative target distance is used to compute this one."
+  },
+  {
+    "pointer": "/convergence_target_rel",
+    "type": "float",
+    "default": 0.1,
+    "doc": "Optimization terminates early once max_dist_err drops to or below this fraction of target_distance. Ignored if convergence_target >= 0."
+  },
+  {
+    "pointer": "/convergence_target",
+    "type": "float",
+    "default": -1.0,
+    "doc": "Absolute max_dist_err threshold for early termination of optimization. If < 0, computed from convergence_target_rel (relative to target_distance, not the bounding box)."
+  },
+  {
+    "pointer": "/convergence_normal_deviation",
+    "type": "float",
+    "default": -1.0,
+    "doc": "AVERAGE normal deviation threshold, IN DEGREES, for early termination of optimization. Tested against avg_norm_dev, not max_norm_dev -- the paper's Termination criterion is the same way round ('the average sigma_max ... both the maximum and mean distance error'), because max normal deviation has a floor set by the input's sharpest reentrant corner, where the distance field's normal is discontinuous at every scale, and no refinement or smaller target_distance can lower it. max_norm_dev is still reported, as a diagnostic. The offset must reach both this and convergence_target before the run may stop early. An angle has no natural relative form, so unlike convergence_target there is no _rel counterpart. If <= 0 the criterion is disabled and max_dist_err alone decides convergence, which is the 3D behaviour."
+  },
+  {
+    "pointer": "/throw_on_nonconvergence",
+    "type": "bool",
+    "default": false,
+    "doc": "If true, a run that finishes without meeting the convergence criteria raises an error instead of logging a warning. Default false: a non-converged offset is still a usable one, and the warnings already name which criterion failed. Set true in integration tests so a convergence regression fails the run rather than passing with a warning nobody reads. 2D only -- the 3D path does not read it."
+  },
+  {
+    "pointer": "/region_envelope_from_input",
+    "type": "bool",
+    "default": true,
+    "doc": "Build the region-boundary envelope from the INPUT mesh, before the offset is constructed, rather than from the mesh the offset construction leaves behind. The band's tags REPLACE a face's own rather than joining them, so a region the band grows through loses its tag there and its boundary curve is truncated at whatever contour conservative growth stopped on; an envelope built afterwards caps the triple junction where a region boundary meets the offset at a position that is an artefact of relative_ball_threshold. Building it from the input follows the region's original, untruncated curve, which relaxes the constraint only along the stretch the band later swallows. Set false for the older behaviour. 2D only."
+  },
+  {
+    "pointer": "/envelope_size_rel",
+    "type": "float",
+    "default": 0.001,
+    "doc": "Half-width, relative to the bounding box diagonal, of the envelope containing every tag-region boundary during optimization. Any operation that would push a region boundary outside it is rejected. Ignored if envelope_size >= 0."
+  },
+  {
+    "pointer": "/envelope_size",
+    "type": "float",
+    "default": -1.0,
+    "doc": "Absolute half-width of the tag-region boundary envelope. If < 0, computed from envelope_size_rel."
+  },
+  {
+    "pointer": "/relative_ball_threshold",
+    "type": "float",
+    "default": 0.1,
+    "doc": "Float between 0 and 1, radius relative to target_distance to stop circle/sphere splitting in conservative distance approximation. Smaller means more accurate offset growth but longer run time."
+  },
+  {
+    "pointer": "/edge_search_termination_len",
+    "type": "float",
+    "default": 0.001,
+    "doc": "Length below which binary search will be terminated for function-guided edge splitting"
+  },
+  {
+    "pointer": "/sorted_marching",
+    "type": "bool",
+    "default": false,
+    "doc": "Execute marching tets in decreasing order of edge length. Increases run time, may increase output mesh quality."
+  },
+  {
+    "pointer": "/check_manifoldness",
+    "type": "bool",
+    "default": true,
+    "doc": "After performing offset, check if offset region is manifold"
+  },
+  {
+    "pointer": "/optimize",
+    "type": "bool",
+    "default": false,
+    "doc": "Run optimization on the offset."
+  },
+  {
+    "pointer": "/save_vtu",
+    "type": "bool",
+    "default": false,
+    "doc": "Save .vtu of output mesh"
+  },
+  {
+    "pointer": "/DEBUG_output",
+    "type": "bool",
+    "default": false,
+    "doc": "Write the tet mesh as out_{}.vtu after every operation."
+  },
+  {
+    "pointer": "/log_file",
+    "type": "string",
+    "default": "",
+    "doc": "Logs are not just printed on the terminal but also saved in this file."
+  },
+  {
+    "pointer": "/report",
+    "type": "string",
+    "default": "",
+    "doc": "A JSON file that stores information about the result and the method execution, e.g., runtime."
+  },
+  {
+    "pointer": "/num_threads",
+    "type": "int",
+    "default": 0,
+    "doc": "Number of threads used for parallel execution (smoothing, edge collapse). 0 means single-threaded."
+  },
+  {
+    "pointer": "/smoothing_iterations",
+    "type": "int",
+    "default": 3,
+    "doc": "Number of smoothing passes run during offset optimization (only used if optimize is true)."
+  },
+  {
+    "pointer": "/length_rel",
+    "type": "float",
+    "default": 0.05,
+    "doc": "Target edge length relative to the bounding box diagonal. Used to bound which edges edge collapse is allowed to touch (only edges shorter than 4/5 of this length are collapsed). Ignored if length >= 0."
+  },
+  {
+    "pointer": "/length",
+    "type": "float",
+    "default": -1.0,
+    "doc": "Target edge length (absolute). If < 0, computed from length_rel."
+  },
+  {
+    "pointer": "/stop_energy",
+    "type": "float",
+    "default": 10.0,
+    "doc": "Target AMIPS quality for tets. Edge collapse will not push an already-on-target region's quality back above this."
+  },
+  {
+    "pointer": "/optimization_iterations",
+    "type": "int",
+    "default": 3,
+    "doc": "Number of split/collapse/swap/smooth passes run during offset optimization (only used if optimize is true)."
+  },
+  {
+    "pointer": "/max_normal_deviation_deg",
+    "type": "float",
+    "default": 15.0,
+    "doc": "sigma_max. Max normal deviation (degrees, 0-90) allowed across one offset-surface element. Collapse and swap reject moves that would push an already-aligned patch of the offset surface further out of alignment than this, and the sizing field refines wherever it is exceeded. Also sets the derived min_edge_length."
+  },
+  {
+    "pointer": "/min_normal_deviation_deg",
+    "type": "float",
+    "default": 2.0,
+    "doc": "sigma_min. Normal deviation (degrees) below which a stretch of offset surface counts as planar, so the sizing field may coarsen it. Paper value is 2 degrees. 2D only."
+  },
+  {
+    "pointer": "/min_edge_length",
+    "type": "float",
+    "default": -1.0,
+    "doc": "l_min: the shortest edge the sizing field may ask for, in absolute units. If < 0, derived as 2 * target_distance * sin(max_normal_deviation_deg), the paper's formula -- tied to the offset distance rather than the bounding box, because the offset is what has to be resolved. This is a floor on REFINEMENT, so raising it makes the offset coarser (paper Fig. 18). 2D only."
+  },
+  {
+    "pointer": "/smooth_quadrics_weight",
+    "type": "float",
+    "default": 0.5,
+    "doc": "Blend weight (0-1) toward the quadrics-optimal target vertex during offset-surface smoothing. The remaining weight (1 - smooth_quadrics_weight - smooth_laplacian_weight) stays with the vertex's previous position."
+  },
+  {
+    "pointer": "/smooth_laplacian_weight",
+    "type": "float",
+    "default": 0.01,
+    "doc": "Blend weight (0-1) toward the Laplacian of neighboring offset-surface vertices during offset-surface smoothing. The remaining weight (1 - smooth_quadrics_weight - smooth_laplacian_weight) stays with the vertex's previous position."
+  },
+  {
+    "pointer": "/quadrics_svd_threshold",
+    "type": "float",
+    "default": 0.01,
+    "doc": "SVD threshold used when solving for the quadrics-optimal target vertex during offset-surface smoothing. Controls sensitivity to feature edges: lower means more sensitive."
+  },
+  {
+    "pointer": "/min_sizing_scalar",
+    "type": "float",
+    "default": 0.01,
+    "doc": "Lower bound for the per-vertex sizing field (see max_sizing_scalar). Refinement stops once a vertex's sizing scalar reaches this fraction of the base target length."
+  },
+  {
+    "pointer": "/max_sizing_scalar",
+    "type": "float",
+    "default": 1.0,
+    "doc": "Upper bound for the per-vertex sizing field, a multiplier on the target edge length (splitting_l2/collapsing_l2) refined/coarsened once per optimize_offset() iteration based on the mean ratio metric of the offset triangulation (see sizing_mrm_threshold). 1.0 means never coarser than the base target length."
+  },
+  {
+    "pointer": "/sizing_mrm_threshold",
+    "type": "float",
+    "default": 0.5,
+    "doc": "Mean ratio metric threshold used to update the sizing field once per optimize_offset() iteration: for each offset-surface vertex, the sizing scalar is halved (refine) if the worst incident offset triangle's mean ratio metric is below this, or multiplied by 1.5 (coarsen) if above."
+  },
+  {
+    "pointer": "/sizing_gradation",
+    "type": "float",
+    "default": 2.0,
+    "doc": "Gradation cap for the sizing field: neighboring vertices' sizing scalars may differ by at most this factor. After each mean-ratio-metric refinement pass, the refined vertices' lower sizing scalar is propagated outward (monotone, only ever lowers a neighbor's scalar) so the mesh doesn't jump straight from fine to coarse. <= 1 disables gradation."
+  },
+  {
+    "pointer": "/split_high_valence_threshold",
+    "type": "int",
+    "default": 0,
+    "doc": "Incident-tet count above which a vertex in a split edge's link accepts only one valence-increasing split per pass, or 0 to disable. Spreads refinement instead of letting it pile onto one vertex (only used if optimize is true)."
+  },
+  {
+    "pointer": "/skip_good_regions",
+    "type": "bool",
+    "default": false,
+    "doc": "Only smooth vertices incident to a tet whose energy is still far from stop_energy. Smoothing a vertex surrounded by good tets does nothing, so skipping it is free (only used if optimize is true)."
+  },
+  {
+    "pointer": "/project_line_search_steps",
+    "type": "int",
+    "default": 12,
+    "doc": "Bisections tried by the projected line search before it gives up on a vertex: the step along the Newton direction is halved this many times, each candidate projected onto the input, and the first that does not invert and lowers the worst incident element is taken."
+  },
+  {
+    "pointer": "/project_line_search_nested_steps",
+    "type": "int",
+    "default": 0,
+    "doc": "After the projected line search gives up, revisit each candidate and bisect between the interpolated point and its projection this many times, taking the longest step toward the input that still does not invert and still lowers the worst element. Lets a vertex whose one-ring cannot tolerate a full projection still travel toward the input, instead of being refused every pass from the same place. 0 disables the pass."
+  },
+  {
     "pointer": "/smoothing_mode",
     "type": "string",
     "default": "projected",
     "options": ["projected", "exact"],
     "doc": "How smoothing places a surface vertex. 'projected': smooth with AMIPS alone as if interior, then walk back toward the start projecting each candidate onto the input; accept the first projected candidate that does not invert and strictly lowers the worst incident element, else do not move. Lands exactly on the input; no weights. 'exact': minimize w_amips * AMIPS + (1-w_amips) * (d/eps)^2 with the true region-wise Hessian of the distance to the piecewise-linear input; sliding is free where the input is flat, held at corners, constrained along 3D edges and curve segments. Rests a w_amips-proportional distance off the input."
-},
-    {
-        "pointer": "/w_amips",
-        "type": "float",
-        "default": 0.0001,
-        "doc": "Relative weight of the AMIPS quality term against the envelope term during smoothing of non-offset-surface vertices. The envelope weight is derived as 1 - w_amips (only used if optimize is true)."
-    },
-    {
-        "pointer": "/perform_sanity_checks",
-        "type": "bool",
-        "default": false,
-        "doc": "Check after every operation pass that no tet is inverted and no tracked-surface triangle left its envelope. Slow; for debugging (only used if optimize is true)."
-    }
+  },
+  {
+    "pointer": "/w_amips",
+    "type": "float",
+    "default": 0.0001,
+    "doc": "Relative weight of the AMIPS quality term against the envelope term during smoothing of non-offset-surface vertices. The envelope weight is derived as 1 - w_amips (only used if optimize is true)."
+  },
+  {
+    "pointer": "/perform_sanity_checks",
+    "type": "bool",
+    "default": false,
+    "doc": "Check after every operation pass that no tet is inverted and no tracked-surface triangle left its envelope. Slow; for debugging (only used if optimize is true)."
+  }
 ]

--- a/components/triwild/wmtk/components/triwild/triwild_spec.json
+++ b/components/triwild/wmtk/components/triwild/triwild_spec.json
@@ -10,7 +10,7 @@
       "input_dir",
       "num_threads",
       "max_iterations",
-    "max_expected_iterations",
+      "max_expected_iterations",
       "skip_simplify",
       "simplify_use_link_condition",
       "simplify_envelope_ratio",
@@ -223,7 +223,7 @@
   {
     "pointer": "/split_high_valence_threshold",
     "type": "int",
-    "default": 200,
+    "default": 0,
     "doc": "Incident-triangle count above which a vertex accepts only one valence-increasing split per split pass, or 0 to disable. A well-shaped triangle mesh has vertex valence around 6; a split cascade can drive one vertex much higher, at which point every operation touching it is O(valence) and the pass stalls. Splitting an edge leaves its endpoints' counts unchanged and adds one to each vertex opposite the edge, so the gate applies to those. Expect this to fire far less often than in 3D, where the edge's link is a whole ring rather than one or two vertices."
   },
   {
@@ -231,21 +231,21 @@
     "type": "int",
     "default": 12,
     "doc": "Bisections tried by the projected line search before it gives up on a vertex: the step along the Newton direction is halved this many times, each candidate projected onto the input, and the first that does not invert and lowers the worst incident element is taken."
-},
-{
+  },
+  {
     "pointer": "/project_line_search_nested_steps",
     "type": "int",
     "default": 0,
     "doc": "After the projected line search gives up, revisit each candidate and bisect between the interpolated point and its projection this many times, taking the longest step toward the input that still does not invert and still lowers the worst element. Lets a vertex whose one-ring cannot tolerate a full projection still travel toward the input, instead of being refused every pass from the same place. 0 disables the pass."
-},
-{
+  },
+  {
     "pointer": "/smoothing_mode",
     "type": "string",
     "default": "projected",
     "options": ["projected", "exact"],
     "doc": "How smoothing places a surface vertex. 'projected': smooth with AMIPS alone as if interior, then walk back toward the start projecting each candidate onto the input; accept the first projected candidate that does not invert and strictly lowers the worst incident element, else do not move. Lands exactly on the input; no weights. 'exact': minimize w_amips * AMIPS + (1-w_amips) * (d/eps)^2 with the true region-wise Hessian of the distance to the piecewise-linear input; sliding is free where the input is flat, held at corners, constrained along 3D edges and curve segments. Rests a w_amips-proportional distance off the input."
-},
-{
+  },
+  {
     "pointer": "/w_amips",
     "type": "float",
     "default": 0.0001,
@@ -331,11 +331,10 @@
     "doc": "Mesh storage (connectivity + attributes) is preallocated to this factor times the live element count at init and consolidation. Operations take fresh slots from that headroom and are retried once it is exhausted. Lower it for pure-decimation runs, raise it for aggressive refinement."
   },
   {
-
-      "pointer": "/max_expected_iterations",
-      "type": "int",
-      "default": 0,
-      "doc": "Fail the run if mesh_improvement needed more than this many iterations, even if it did reach stop_energy. 0 disables the check. This is a regression guard rather than a quality target: an input that normally converges in a handful of iterations and suddenly needs the whole budget means the sizing-refinement trigger stopped firing when it should, which is a silent slowdown that no energy or envelope assertion catches."
+    "pointer": "/max_expected_iterations",
+    "type": "int",
+    "default": 0,
+    "doc": "Fail the run if mesh_improvement needed more than this many iterations, even if it did reach stop_energy. 0 disables the check. This is a regression guard rather than a quality target: an input that normally converges in a handful of iterations and suddenly needs the whole budget means the sizing-refinement trigger stopped firing when it should, which is a silent slowdown that no energy or envelope assertion catches."
   },
   {
     "pointer": "/stuck_refine_stall_eps",

--- a/src/wmtk/OptimizerParameters.h
+++ b/src/wmtk/OptimizerParameters.h
@@ -68,7 +68,7 @@ struct OptimizerParameters
      * per pass, or 0 to disable the gate. Shared by the 2D and 3D Wild optimizers; SimWild uses
      * the same protection so tag-homogeneous runs follow the Wild path.
      */
-    int split_high_valence_threshold = 200;
+    int split_high_valence_threshold = 0;
 
     // ---- Stuck-element sizing refinement --------------------------------
     // Trigger threshold: fire when the last iteration's improvement is small compared

--- a/src/wmtk/TetOptimizerMesh.cpp
+++ b/src/wmtk/TetOptimizerMesh.cpp
@@ -41,7 +41,8 @@ void TetOptimizerMesh::mesh_improvement(int max_its)
     compute_vertex_partition_morton();
 
     logger().info("========it pre========");
-    local_operations({{0, 1, 0, 0}}, false);
+    // Performing swaps after the initial collapse improves quality and convergence.
+    local_operations({{0, 1, 1, 0}}, false);
 
     double pre_max_metric = std::get<0>(optimization_quality_stats());
     logger().info("max energy {:.6} | stop {:.6}", pre_max_metric, optimization_stop_metric());

--- a/src/wmtk/TetOptimizerMeshSplit.cpp
+++ b/src/wmtk/TetOptimizerMeshSplit.cpp
@@ -29,6 +29,8 @@ void TetOptimizerMesh::split_all_edges()
         // valence-increasing splits in a single pass, where the gate allows one, reaching
         // valence ~700 while the max energy climbed with it. The attribute collections are
         // resized to the reservation, so their size is the capacity to use.
+        // UPDATE (dzint): This seems to be no longer necessary. At least model 509315 passes
+        // without this.
         m_high_valence_claim_size = std::max(vert_capacity(), m_vertex_attribute.size());
         m_high_valence_claim = std::make_unique<std::atomic<int>[]>(m_high_valence_claim_size);
     }


### PR DESCRIPTION
In the SimWild test runs with topology preservation on, I found cases where the optimization got stuck. These changes fixed it, and they should also help improve performance on TetWild.