### PR TITLE
2D offset

### DIFF
--- a/cmake/wmtk_data.cmake
+++ b/cmake/wmtk_data.cmake
@@ -38,8 +38,15 @@ ExternalProject_Add(
     # At 1a130a3 (2026-09-07) _dragon moves from target_distance_rel 0.01 to 0.001: at 0.01 the front
     # grazes the released tag_0 boundary at the pinch and the final quality pass stalls; at 0.001 the
     # case converges in 4 turns with max AMIPS under the stop energy.
+    # At ddf5cb1 (2026-09-08) _dragon is back at 0.01 with throw_on_nonconvergence: under the wall +
+    # input-complex envelope setup the final quality pass gets under stop_energy, and the fixture
+    # now asserts convergence (front placed AND final quality) instead of merely running.
+    # At b59e130 (2026-09-08) every case listed in topological_offset_models.json sets the flag.
+    # At 9c2144c (2026-09-08) _two_circles moves to absolute target 0.15 with spec defaults (converges
+    # through a 15-iteration final pass), and _dragon_held is added: the dragon at 1e-3 with
+    # deform_others false, a converging case for the per-tag envelope setup.
     #
-    GIT_TAG 1a130a3d91bec719302a09d1f7f921bb4f3f052b
+    GIT_TAG 9c2144c3bfb30ff2fe607aa5ad9acb67585c868b
 
     CONFIGURE_COMMAND ""
     BUILD_COMMAND ""

--- a/cmake/wmtk_data.cmake
+++ b/cmake/wmtk_data.cmake
@@ -35,8 +35,11 @@ ExternalProject_Add(
     # At 0514682 (2026-09-01) _annots_tag4_in drops its front_conv_rel 0.001 override -- it predates
     # the rule that offset_envelope_rel may not exceed front_conv_rel, and the run refused to start;
     # with the default accuracy 0.025 the case converges.
+    # At 1a130a3 (2026-09-07) _dragon moves from target_distance_rel 0.01 to 0.001: at 0.01 the front
+    # grazes the released tag_0 boundary at the pinch and the final quality pass stalls; at 0.001 the
+    # case converges in 4 turns with max AMIPS under the stop energy.
     #
-    GIT_TAG 0514682dee2e0229f38638e00cefb535c15f8fc9
+    GIT_TAG 1a130a3d91bec719302a09d1f7f921bb4f3f052b
 
     CONFIGURE_COMMAND ""
     BUILD_COMMAND ""

--- a/components/topological_offset/wmtk/components/topological_offset/Optimize2d.cpp
+++ b/components/topological_offset/wmtk/components/topological_offset/Optimize2d.cpp
@@ -312,14 +312,9 @@ bool TopoOffsetTriMesh::project_into_containment(const size_t vid, Vector2d& x) 
 
 bool TopoOffsetTriMesh::face_is_deformable(const size_t fid) const
 {
-    if (m_deform_tags.empty()) return false;
-    if (m_face_extra[fid].label != 0) return false;
-    const auto& tags = m_face_attribute[fid].tags;
-    if (tags.empty()) return false;
-    for (const int64_t t : tags) {
-        if (m_deform_tags.count(t) == 0) return false;
-    }
-    return true;
+    // deform_others: the whole medium outside the band deforms, the input complex's interior
+    // included -- its boundary is what the complex tube holds. Same set as face_is_plastic().
+    return face_is_plastic(fid);
 }
 
 bool TopoOffsetTriMesh::face_is_released_band(const size_t fid) const
@@ -430,147 +425,42 @@ bool TopoOffsetTriMesh::smooth_plastic_vertex(const Tuple& t)
 
 void TopoOffsetTriMesh::release_deformable_regions()
 {
-    // Held: any tag on an input-complex face or on a wall face, and the curve group. Everything
-    // else with an envelope is an object the offset merely shares the scene with, and
-    // deform_others releases it -- tube dropped, faces given a rest shape, smoothing deforming it
-    // against RestAMIPSEnergy2D instead of a tube refusing every move. Dangling mask bits are
-    // already the envelope machinery's normal case, so the queries need no change.
-    //
-    // Never released, whatever else it touches: every tag the offset_selection expression names.
-    // The complex is defined by that expression, so those tags are the geometry the offset
-    // measures from, faces of their own or not. Do not go back to a heuristic over complex faces;
-    // measured worse -- see git history of this file.
-    std::set<int64_t> kept;
+    // deform_others: from here on the only region-class envelopes are the domain wall and the
+    // input complex boundary (EnvelopeSetup::WallComplex), and every other tag region is
+    // released: it deforms as plastic medium, see face_is_plastic(). The released set is every
+    // input tag the selection does not name, ambient included; it drives face_is_released_band()
+    // and the diagnostics. The tubes and the masks come from build_boundary_envelopes().
     std::set<int64_t> source_tags;
     if (m_offset_params.offset_selection) {
         for (const int64_t t : m_offset_params.offset_selection->tags_involved()) {
-            kept.insert(t);
             source_tags.insert(t);
         }
     }
-    for (const Tuple& e : get_edges()) {
-        if (e.switch_face(*this)) continue; // wall edges only
-        for (const int64_t t : m_face_attribute[e.fid(*this)].tags) kept.insert(t);
-    }
-    if (m_curve_tag >= 0) kept.insert(m_curve_tag);
-    // protected_tags is not consulted here, and the two keys must stay orthogonal: protected_tags
-    // is a tagging decision (whether a band cell overwrites the object's tag or carries both) and
-    // deform_others is a geometry decision (whether other objects may deform).
-
+    m_source_tags = source_tags;
     m_deform_tags.clear();
-    for (const auto& [tag, env] : m_tag_envelopes) {
-        if (kept.count(tag) == 0) m_deform_tags.insert(tag);
+    for (const auto& [tag, name] : m_tag_id_to_name) {
+        if (source_tags.count(tag) || m_offset_output_tag_ids.count(tag)) continue;
+        m_deform_tags.insert(tag);
     }
-    m_source_tags = source_tags; // the ops-only tube's classification applies the same rule
-    if (m_deform_tags.empty()) {
-        logger().info("[deform_others] nothing to release: every tagged region is held");
-        return;
-    }
+    build_boundary_envelopes("deform_others", EnvelopeSetup::WallComplex);
+    // No released tube: a released boundary is held by nothing, in the operations too.
+    m_released_envelope = nullptr;
+    m_released_tube_dirty.store(false, std::memory_order_release);
 
-    // No tube is ever edited: releasing a boundary is a property of its vertices' masks (the loop
-    // below), and every tag's envelope, released tags included, keeps its as-loaded segments. A
-    // tube held by nobody constrains nothing, while a tube that no longer covers geometry whose
-    // bits some vertex still carries measures that vertex against the far side of the scene. Do
-    // not re-add either edit -- dropping released segments from kept tags' tubes, or reducing a
-    // released tag's own tube; both measured worse -- see git history of this file.
     std::string released;
-    for (const int64_t t : m_deform_tags) {
-        released += " " + m_tag_id_to_name.at(t);
-    }
-
-    // Edit the masks in place, never recompute them: a mask is seeded at construction and
-    // propagated by every operation since (a split ANDs its endpoints, a collapse ORs them), so
-    // it carries history no rebuild from the current edge set can reproduce. The loop below
-    // reduces a freed vertex's mask to its source bits -- held by released geometry alone it ends
-    // at 0, while a junction vertex where the released boundary crosses the source keeps the
-    // source's hold, so the source's own crossing edges stay contained.
-    uint64_t released_bits = 0;
-    for (const int64_t t : m_deform_tags) {
-        const auto it = m_tag_bit.find(t);
-        if (it != m_tag_bit.end()) released_bits |= (uint64_t(1) << it->second);
-    }
-    if (released_bits) {
-        // Free a released boundary's vertices down to their source bits. Clearing only the
-        // released tag's bit leaves them pinned in the other side's tube (an interface edge
-        // contributes bits for both of its sides); clearing the source bits too leaves the
-        // source's own crossing edges contained by nothing.
-        //
-        // Never freed: an edge that also borders a source tag (it is the source's own boundary),
-        // an edge both of whose faces carry a source tag (complex-internal, and the front cannot
-        // enter the complex, so it must stay where it was loaded), or a wall vertex.
-        uint64_t source_bits = 0;
-        for (const int64_t t : source_tags) {
-            const auto it = m_tag_bit.find(t);
-            if (it != m_tag_bit.end()) source_bits |= (uint64_t(1) << it->second);
-        }
-        const auto face_has_source = [&](const size_t fid) {
-            for (const int64_t t : m_face_attribute[fid].tags) {
-                if (source_tags.count(t)) return true;
-            }
-            return false;
-        };
-        size_t n_freed = 0;
-        for (const Tuple& e : get_edges()) {
-            const size_t eid = e.eid(*this);
-            if (!m_edge_attribute[eid].m_is_surface_fs) continue;
-            const std::optional<Tuple> f_opp = e.switch_face(*this);
-            if (!f_opp) continue; // the domain wall
-            CellTag edge_tags;
-            const auto& t0 = m_face_attribute[e.fid(*this)].tags;
-            const auto& t1 = m_face_attribute[f_opp->fid(*this)].tags;
-            std::set_symmetric_difference(
-                t0.begin(),
-                t0.end(),
-                t1.begin(),
-                t1.end(),
-                std::inserter(edge_tags, edge_tags.begin()));
-            bool released_here = false, touches_source = false;
-            for (const int64_t t : edge_tags) {
-                if (m_deform_tags.count(t)) released_here = true;
-                if (source_tags.count(t)) touches_source = true;
-            }
-            if (!released_here || touches_source) continue;
-            if (face_has_source(e.fid(*this)) && face_has_source(f_opp->fid(*this))) {
-                continue; // complex-internal: anchored, never freed
-            }
-            for (const size_t v : {e.vid(*this), e.switch_vertex(*this).vid(*this)}) {
-                if (!m_vertex_attribute[v].on_bbox_faces.empty()) continue; // wall stays held
-                const uint64_t kept = m_vertex_extra[v].m_boundary_mask & source_bits;
-                if (m_vertex_extra[v].m_boundary_mask != kept) ++n_freed;
-                m_vertex_extra[v].m_boundary_mask = kept;
-            }
-        }
-        logger().info(
-            "[deform_others] {} boundary vertices freed down to their source bits",
-            n_freed);
-    }
-
-    size_t n_faces = 0;
-    for (const Tuple& f : get_faces()) {
-        const size_t fid = f.fid(*this);
-        if (face_is_deformable(fid)) {
-            stamp_rest_face(fid);
-            ++n_faces;
-        }
-    }
+    for (const int64_t t : m_deform_tags) released += " " + envelope_key_name(t);
     logger().info(
-        "[deform_others] released:{} | {} deformable faces stamped with their rest shape; "
-        "held: {} envelopes",
+        "[deform_others] released:{} | held: the domain wall and the input complex boundary "
+        "({} tubes); every face outside the band is plastic",
         released,
-        n_faces,
         m_tag_envelopes.size());
-    m_released_tube_dirty.store(true, std::memory_order_release);
-    released_envelope(); // built here, at a consistent moment, not at some mid-pass first query
 }
 
 std::shared_ptr<polysolve::nonlinear::Problem> TopoOffsetTriMesh::rest_energy_for_vertex(
     const size_t vid) const
 {
-    if (m_deform_tags.empty()) return nullptr;
-    // The final pass minimises equilateral AMIPS alone: the released boundaries it would
-    // otherwise pull toward their last stamped shape are held by the pass-wide tube instead.
-    // See m_final_pass_envelope.
-    if (m_final_pass_envelope) return nullptr;
+    // Off with the plastic medium: the final pass minimises equilateral AMIPS alone.
+    if (!m_plastic_active) return nullptr;
     std::vector<RestAMIPSEnergy2D::Cell> cells;
     for (const size_t fid : get_one_ring_fids_for_vertex(tuple_from_vertex(vid))) {
         // Released-band cells too: a released object's boundary inside the band has band-labeled
@@ -3730,6 +3620,8 @@ std::shared_ptr<SampleEnvelope> TopoOffsetTriMesh::released_envelope() const
     // alarms. Rebuilding on first query after a smoothing accept makes every consumer judge
     // against the boundary as it is now. Operations never set the flag, so op-by-op drift cannot
     // recenter its own container.
+    // WallComplex holds a released boundary with nothing, the operations included.
+    if (envelope_setup() == EnvelopeSetup::WallComplex) return nullptr;
     if (m_deform_tags.empty()) return nullptr;
     std::lock_guard<std::mutex> lock(m_released_mutex);
     if (!m_released_tube_dirty.load(std::memory_order_acquire)) return m_released_envelope;
@@ -3824,56 +3716,6 @@ void TopoOffsetTriMesh::rebuild_offset_envelope()
         eps,
         m_offset_params.offset_envelope_rel,
         m_offset_params.target_distance);
-}
-
-void TopoOffsetTriMesh::begin_final_pass_envelope()
-{
-    // The front first, where placement left it: the loop's last rebuild predates the last
-    // smoothing passes.
-    rebuild_offset_envelope();
-
-    // Every tracked segment that is not the front: tag boundaries, held or released, and the
-    // domain wall. Read off the edge attributes, which every operation maintains, not off the
-    // vertex masks, which deform_others clears on released boundaries.
-    std::vector<Eigen::Vector2i> segs;
-    for (const Tuple& e : get_edges()) {
-        const size_t eid = e.eid(*this);
-        if (!m_edge_attribute[eid].m_is_surface_fs || edge_is_offset(eid)) continue;
-        segs.emplace_back(int(e.vid(*this)), int(e.switch_vertex(*this).vid(*this)));
-    }
-    m_final_pass_envelope = nullptr;
-    m_final_pass_junction = nullptr;
-    if (!segs.empty()) {
-        std::vector<Eigen::Vector2d> verts(vert_capacity());
-        for (size_t i = 0; i < vert_capacity(); ++i) {
-            verts[i] = m_vertex_attribute[i].m_posf;
-        }
-        // The per-tag tubes' half-width, and exact for the same reason they are: the sampled
-        // test can pass a collapse's whole segment and fail a split's half of it.
-        const bool exact_ok = std::isfinite(m_envelope_eps) && m_envelope_eps > 0.;
-        m_final_pass_envelope = std::make_shared<SampleEnvelope>(/*exact=*/exact_ok);
-        m_final_pass_envelope->init(verts, segs, m_envelope_eps);
-        if (m_offset_envelope) {
-            m_final_pass_junction =
-                std::make_shared<IntersectionEnvelope>(std::vector<std::shared_ptr<SampleEnvelope>>{
-                    m_final_pass_envelope,
-                    m_offset_envelope});
-        } else {
-            m_final_pass_junction = m_final_pass_envelope;
-        }
-    }
-    logger().info(
-        "\t[final pass] envelopes fixed for the whole pass: {} region-boundary segments (eps "
-        "{:.6g} = envelope_size, {}) + the offset tube; rest-shape term off",
-        segs.size(),
-        m_envelope_eps,
-        (m_final_pass_envelope && m_final_pass_envelope->use_exact) ? "EXACT" : "sampled");
-}
-
-void TopoOffsetTriMesh::end_final_pass_envelope()
-{
-    m_final_pass_envelope = nullptr;
-    m_final_pass_junction = nullptr;
 }
 
 void TopoOffsetTriMesh::append_frame_label(const size_t idx, const std::string& label) const
@@ -4024,6 +3866,10 @@ void TopoOffsetTriMesh::optimize_offset_single_phase()
         if (ec.converged_single() && lowered_prev == 0) {
             m_energy_verdict = ec;
             m_converged = true;
+            // Provisional: the final pass below overwrites both when it runs. The verdict at the
+            // end of optimize_offset() requires this AND the front's.
+            m_quality_max_amips = amips;
+            m_quality_converged = amips < bar;
             logger().info(
                 "Single phase: the front is placed after {} iteration(s) (phi {:.4}x); max AMIPS "
                 "{:.4} against stop {:.4}",
@@ -4039,25 +3885,28 @@ void TopoOffsetTriMesh::optimize_offset_single_phase()
                     m_params.stop_energy);
                 m_ab_round = it + 2;
                 m_phase = OptPhase::A;
-                // One fixed set of envelopes for the whole pass -- the front's tube rebuilt from
-                // where placement left it, and one tube around every region boundary as it
-                // stands now -- and equilateral AMIPS alone: the plastic vertex path and the
-                // rest-shape term are both off. See m_final_pass_envelope.
-                begin_final_pass_envelope();
+                // The whole envelope setup rebuilt fresh from the mesh as placement left it --
+                // the front's tube, and the region-class tubes per envelope_setup() -- and held
+                // for the entire pass; equilateral AMIPS alone: the plastic vertex path and the
+                // rest-shape term are both off.
+                rebuild_offset_envelope();
+                build_boundary_envelopes("final pass", envelope_setup());
                 m_freeze_front = true;
                 const bool plastic_was = m_plastic_active;
                 m_plastic_active = false;
                 mesh_improvement(a_iters);
                 m_plastic_active = plastic_was;
                 m_freeze_front = false;
-                end_final_pass_envelope();
                 assign_band_regions();
                 const double final_amips = std::get<0>(optimization_quality_stats());
-                logger().info(
+                m_quality_max_amips = final_amips;
+                m_quality_converged = final_amips < m_params.stop_energy;
+                logger().log(
+                    m_quality_converged ? spdlog::level::info : spdlog::level::warn,
                     "\t[final pass] max element quality {:.4} (stop {:.4}) -> {}",
                     final_amips,
                     optimization_stop_metric(),
-                    final_amips < m_params.stop_energy ? "ok" : "STILL OVER");
+                    m_quality_converged ? "ok" : "STILL OVER: the run does not converge");
                 if (m_offset_params.debug_output) {
                     write_smoothing_debug_output(fmt::format("phase_{}A", it + 2));
                 }
@@ -4237,17 +4086,23 @@ void TopoOffsetTriMesh::optimize_offset(const std::filesystem::path& output_file
           g.max_in_edge}});
     log_worst_dist_vertex();
 
+    bool front_ok = false;
     {
         // Measured at convergence when the loop converged (see m_energy_verdict), else now.
         const EnergyCriterion ec = m_energy_verdict ? *m_energy_verdict : energy_criterion();
-        m_converged = ec.converged_single();
+        // Two criteria, both required: the front placed, and the final quality under
+        // stop_energy (the finishing pass's verdict; see m_quality_converged).
+        front_ok = ec.converged_single();
+        m_converged = front_ok && m_quality_converged;
         logger().log(
             m_converged ? spdlog::level::info : spdlog::level::warn,
-            "{}{}: front vertices placed {} / pressed {} / travelling {} / stuck {} | "
+            "{}{}: front {} -- vertices placed {} / pressed {} / travelling {} / stuck {} | "
             "chords to resolve {} (at the sizing floor {}) | accuracy front_conv_rel {} "
-            "x target_distance = {:.4} | (vertex test, informative: max {:.4}x its bar)",
+            "x target_distance = {:.4} | (vertex test, informative: max {:.4}x its bar) || "
+            "final quality {}: max AMIPS {:.4} vs stop_energy {}",
             m_converged ? "Converged" : "Optimization did not converge",
-            m_energy_verdict ? " (measured at convergence, before the finishing pass)" : "",
+            m_energy_verdict ? " (front measured at convergence, before the finishing pass)" : "",
+            front_ok ? "placed" : "NOT placed",
             ec.n_placed,
             ec.n_pressed_on,
             ec.n_travelling,
@@ -4256,15 +4111,23 @@ void TopoOffsetTriMesh::optimize_offset(const std::filesystem::path& output_file
             ec.n_at_floor,
             m_offset_params.front_conv_rel,
             ec.tube,
-            ec.max_vertex);
+            ec.max_vertex,
+            m_quality_converged ? "ok" : "OVER",
+            m_quality_max_amips,
+            m_params.stop_energy);
     }
 
     // Escalate to a hard failure if the caller asked for it, AFTER the warnings above so the log
     // still names which criterion missed before the throw.
     if (!m_converged && m_offset_params.throw_on_nonconvergence) {
         log_and_throw_error(
-            "Optimization did not converge and throw_on_nonconvergence is set. Ran {} of {} "
-            "iterations; see the warnings above for the criterion that failed.",
+            "Optimization did not converge and throw_on_nonconvergence is set: front {}, final "
+            "quality {} (max AMIPS {:.4} vs stop_energy {}). Ran {} of {} iterations; see the "
+            "warnings above.",
+            front_ok ? "placed" : "NOT placed",
+            m_quality_converged ? "ok" : "OVER",
+            m_quality_max_amips,
+            m_params.stop_energy,
             optimization_metrics.size(),
             m_offset_params.max_iterations);
     }

--- a/components/topological_offset/wmtk/components/topological_offset/Optimize2d.cpp
+++ b/components/topological_offset/wmtk/components/topological_offset/Optimize2d.cpp
@@ -567,6 +567,10 @@ std::shared_ptr<polysolve::nonlinear::Problem> TopoOffsetTriMesh::rest_energy_fo
     const size_t vid) const
 {
     if (m_deform_tags.empty()) return nullptr;
+    // The final pass minimises equilateral AMIPS alone: the released boundaries it would
+    // otherwise pull toward their last stamped shape are held by the pass-wide tube instead.
+    // See m_final_pass_envelope.
+    if (m_final_pass_envelope) return nullptr;
     std::vector<RestAMIPSEnergy2D::Cell> cells;
     for (const size_t fid : get_one_ring_fids_for_vertex(tuple_from_vertex(vid))) {
         // Released-band cells too: a released object's boundary inside the band has band-labeled
@@ -1624,8 +1628,14 @@ void TopoOffsetTriMesh::pre_optimize_input_mesh()
         std::vector<size_t> seeds;
         for (const Tuple& e : get_edges()) {
             const std::optional<Tuple> opp = e.switch_face(*this);
+            // A wall edge is not a complex boundary: with offset_in the whole background carries
+            // label 1, and treating the missing opposite face as "not complex" seeded the entire
+            // domain wall at delta. A wall vertex is seeded only through an interior edge where
+            // the complex meets a non-complex region, i.e. where a complex boundary reaches the
+            // wall; a vertex bordering only the complex and the wall keeps the default scalar.
+            if (!opp) continue;
             const bool in_a = m_face_extra[e.fid(*this)].label == 1;
-            const bool in_b = opp ? (m_face_extra[opp->fid(*this)].label == 1) : false;
+            const bool in_b = m_face_extra[opp->fid(*this)].label == 1;
             if (in_a == in_b) continue; // interior to the complex, or interior to the background
             for (const size_t vid : {e.vid(*this), e.switch_vertex(*this).vid(*this)}) {
                 double& sc = m_vertex_attribute[vid].m_sizing_scalar;
@@ -3816,6 +3826,56 @@ void TopoOffsetTriMesh::rebuild_offset_envelope()
         m_offset_params.target_distance);
 }
 
+void TopoOffsetTriMesh::begin_final_pass_envelope()
+{
+    // The front first, where placement left it: the loop's last rebuild predates the last
+    // smoothing passes.
+    rebuild_offset_envelope();
+
+    // Every tracked segment that is not the front: tag boundaries, held or released, and the
+    // domain wall. Read off the edge attributes, which every operation maintains, not off the
+    // vertex masks, which deform_others clears on released boundaries.
+    std::vector<Eigen::Vector2i> segs;
+    for (const Tuple& e : get_edges()) {
+        const size_t eid = e.eid(*this);
+        if (!m_edge_attribute[eid].m_is_surface_fs || edge_is_offset(eid)) continue;
+        segs.emplace_back(int(e.vid(*this)), int(e.switch_vertex(*this).vid(*this)));
+    }
+    m_final_pass_envelope = nullptr;
+    m_final_pass_junction = nullptr;
+    if (!segs.empty()) {
+        std::vector<Eigen::Vector2d> verts(vert_capacity());
+        for (size_t i = 0; i < vert_capacity(); ++i) {
+            verts[i] = m_vertex_attribute[i].m_posf;
+        }
+        // The per-tag tubes' half-width, and exact for the same reason they are: the sampled
+        // test can pass a collapse's whole segment and fail a split's half of it.
+        const bool exact_ok = std::isfinite(m_envelope_eps) && m_envelope_eps > 0.;
+        m_final_pass_envelope = std::make_shared<SampleEnvelope>(/*exact=*/exact_ok);
+        m_final_pass_envelope->init(verts, segs, m_envelope_eps);
+        if (m_offset_envelope) {
+            m_final_pass_junction =
+                std::make_shared<IntersectionEnvelope>(std::vector<std::shared_ptr<SampleEnvelope>>{
+                    m_final_pass_envelope,
+                    m_offset_envelope});
+        } else {
+            m_final_pass_junction = m_final_pass_envelope;
+        }
+    }
+    logger().info(
+        "\t[final pass] envelopes fixed for the whole pass: {} region-boundary segments (eps "
+        "{:.6g} = envelope_size, {}) + the offset tube; rest-shape term off",
+        segs.size(),
+        m_envelope_eps,
+        (m_final_pass_envelope && m_final_pass_envelope->use_exact) ? "EXACT" : "sampled");
+}
+
+void TopoOffsetTriMesh::end_final_pass_envelope()
+{
+    m_final_pass_envelope = nullptr;
+    m_final_pass_junction = nullptr;
+}
+
 void TopoOffsetTriMesh::append_frame_label(const size_t idx, const std::string& label) const
 {
     // See write_smoothing_debug_output(). Truncated on the first frame of the run, appended to
@@ -3979,20 +4039,18 @@ void TopoOffsetTriMesh::optimize_offset_single_phase()
                     m_params.stop_energy);
                 m_ab_round = it + 2;
                 m_phase = OptPhase::A;
-                // The tube first. Only smoothing moves the front -- an accepted operation cannot
-                // leave the tube -- so one rebuild after the smoothing passes is enough, which
-                // the loop above does at the top of every iteration. This pass is the exception:
-                // it starts after the last iteration's smoothing, so without this it would judge
-                // the front against a stale tube.
-                rebuild_offset_envelope();
+                // One fixed set of envelopes for the whole pass -- the front's tube rebuilt from
+                // where placement left it, and one tube around every region boundary as it
+                // stands now -- and equilateral AMIPS alone: the plastic vertex path and the
+                // rest-shape term are both off. See m_final_pass_envelope.
+                begin_final_pass_envelope();
                 m_freeze_front = true;
-                // Pure TriWild: the pass exists to reach stop_energy, and a rest-shape term pulls
-                // background vertices toward non-equilateral shapes. No plasticity here.
                 const bool plastic_was = m_plastic_active;
                 m_plastic_active = false;
                 mesh_improvement(a_iters);
                 m_plastic_active = plastic_was;
                 m_freeze_front = false;
+                end_final_pass_envelope();
                 assign_band_regions();
                 const double final_amips = std::get<0>(optimization_quality_stats());
                 logger().info(

--- a/components/topological_offset/wmtk/components/topological_offset/TopoOffsetTriMesh.cpp
+++ b/components/topological_offset/wmtk/components/topological_offset/TopoOffsetTriMesh.cpp
@@ -88,9 +88,10 @@ void TopoOffsetTriMesh::init_from_image(
     // complete and before init_surfaces_and_boundaries() seeds the vertex masks. Tags introduced
     // later (the band's output tag) get no bit: boundary membership is a property of the input
     // partition, which is why the masks are propagated rather than recomputed from current tags.
-    if (m_tag_id_to_name.size() > 64) {
+    if (m_tag_id_to_name.size() > 62) {
         log_and_throw_error(
-            "Per-tag boundary envelopes support at most 64 input tags, got {}",
+            "Per-tag boundary envelopes support at most 62 input tags (two mask bits are "
+            "reserved for the domain wall and the input complex boundary), got {}",
             m_tag_id_to_name.size());
     }
     m_tag_bit.clear();
@@ -98,6 +99,9 @@ void TopoOffsetTriMesh::init_from_image(
         const int bit = int(m_tag_bit.size());
         m_tag_bit[tag_id] = bit;
     }
+    // The two reserved bits of the WallComplex setup, see EnvelopeSetup.
+    m_tag_bit[m_wall_tag] = int(m_tag_bit.size());
+    m_tag_bit[m_complex_tag] = int(m_tag_bit.size());
 
     // propagate tags to faces
     auto faces = get_faces();
@@ -138,130 +142,31 @@ void TopoOffsetTriMesh::init_surfaces_and_boundaries()
     const auto edges = get_edges();
     logger().info("E = {}", edges.size());
 
-    // The domain wall is a region boundary: an edge with no opposite face bounds the ambient
-    // region against the unmeshed outside. Held in ambient's envelope, so it may be refined and
-    // its vertices may move within eps -- the same contract every other region boundary gets.
+    // Which edges are tracked region boundaries: an interior edge whose two faces carry different
+    // tag sets, an edge on the curve group, or a wall edge (no opposite face: the ambient region
+    // against the unmeshed outside). These flags are topology the operations maintain. Which
+    // tube holds an edge, and the vertex masks, are build_boundary_envelopes()'s.
     size_t n_edges_tracked = 0;
-    std::map<int64_t, std::vector<Eigen::Vector2i>> tag_edges; // per-tag boundary buckets
     for (const Tuple& e : edges) {
         const size_t eid = e.eid(*this);
-
-        // Whose boundary this edge is. Interior edge: every tag on exactly one side (the
-        // symmetric difference; a tag present on both sides has no boundary here). Wall edge:
-        // every tag of its single face, which is how ambient's envelope comes to hold the wall.
-        CellTag edge_tags;
         const bool on_curve = m_edge_extra[eid].on_curve;
-        if (on_curve) edge_tags.insert(m_curve_tag); // held in the curve group's tube too
         const std::optional<Tuple> f_opp = e.switch_face(*this);
         if (f_opp) {
             const auto& tag0 = m_face_attribute[e.fid(*this)].tags;
             const auto& tag1 = m_face_attribute[f_opp->fid(*this)].tags;
-            if (tag0 == tag1 && !on_curve) {
-                continue;
-            }
-            std::set_symmetric_difference(
-                tag0.begin(),
-                tag0.end(),
-                tag1.begin(),
-                tag1.end(),
-                std::inserter(edge_tags, edge_tags.begin()));
-        } else {
-            edge_tags = m_face_attribute[e.fid(*this)].tags;
+            if (tag0 == tag1 && !on_curve) continue;
         }
-
         m_edge_attribute[eid].m_is_surface_fs = true;
         ++n_edges_tracked;
-
         const size_t v1 = e.vid(*this);
         const size_t v2 = e.switch_vertex(*this).vid(*this);
-
-        // Seed the per-vertex boundary masks and the per-tag edge buckets from the same
-        // classification, so the dispatch (a segment is constrained by the AND of its ends'
-        // masks) and the envelopes it dispatches to can never disagree about what is where.
-        const uint64_t bits = tag_bits(edge_tags);
-        for (const size_t v : {v1, v2}) m_vertex_extra[v].m_boundary_mask |= bits;
-        for (const int64_t t : edge_tags) {
-            tag_edges[t].emplace_back(int(v1), int(v2));
-        }
-        // The region flag, for interior boundaries only: the wall carries none because
-        // vertex_is_on_region() reads it off on_bbox_faces. Not "on the input complex" -- that is
-        // mark_input_complex_vertices()'s job, from the labels, once label_input_complex() has run.
         if (f_opp) {
             for (const size_t v : {v1, v2}) m_vertex_extra[v].m_is_on_region = true;
         }
-        // The base's own flag, a different field from the ones above: those say which tracked
-        // surface a vertex belongs to, this says that it belongs to one at all. Every
-        // surface-aware path in the shared engine gates on it.
         m_vertex_attribute[v1].m_is_on_surface = true;
         m_vertex_attribute[v2].m_is_on_surface = true;
     }
-
-    if (!m_envelope && n_edges_tracked > 0) {
-        logger().info("Init per-tag envelopes from face tags");
-        std::vector<Eigen::Vector2d> tempV(vert_capacity());
-        for (size_t i = 0; i < vert_capacity(); ++i) {
-            tempV[i] = m_vertex_attribute[i].m_posf;
-        }
-
-        // From the parameters: otherwise m_envelope_eps keeps its -1 sentinel, the envelopes get a
-        // negative half-width, is_outside() answers true for every segment including the ones they
-        // were built from, and every boundary freezes solid. The n_edges_tracked guard is what lets
-        // a mesh be constructed without params.init() rather than throwing on a nonpositive eps.
-        m_envelope_eps = m_offset_params.envelope_size;
-
-        // One envelope per tag, from that tag's boundary bucket -- the input partition as it stands
-        // before offset construction rewrites tags, so E_t is a tube around the as-loaded geometry
-        // the offset potential also measures against. An edge between two regions enters both
-        // regions' envelopes; the wall enters its single face's tags'.
-        m_tag_envelopes.clear();
-        {
-            std::lock_guard<std::mutex> lock(m_isect_mutex);
-            m_isect_cache.clear();
-        }
-        std::vector<std::shared_ptr<SampleEnvelope>> members;
-        std::string per_tag_log;
-        // The polyline the tangential placement walks, in the same indexing the envelope is built
-        // in, so nearest_point_feature()'s feature_id indexes both. See TagPolyline2d.
-        m_env_polyline_V = tempV;
-        m_tag_polyline.clear();
-        for (const auto& [tag, bucket] : tag_edges) {
-            if (bucket.empty()) continue; // offset_output_tag ids with no faces yet
-            // Exact, not sampled: the sampled test decides by where its sample points fall, so a
-            // chord at the tube wall can pass the collapse's whole-segment test and fail the
-            // split's half-segment test, leaving an edge no operation may touch. SampleEnvelope's
-            // constructor flag selects the engine (true = exact predicates). Falls back to sampled
-            // without a valid half-width -- the exact 2D init segfaults on the uninitialised eps a
-            // mesh built without params.init() carries. The 3D offset still builds sampled.
-            const bool exact_ok = std::isfinite(m_envelope_eps) && m_envelope_eps > 0.;
-            auto env = std::make_shared<SampleEnvelope>(/*exact=*/exact_ok);
-            env->init(tempV, bucket, m_envelope_eps);
-            m_tag_envelopes[tag] = env;
-            members.push_back(env);
-            per_tag_log += fmt::format(" {}:{}", m_tag_id_to_name.at(tag), bucket.size());
-
-            TagPolyline2d pl;
-            pl.E = bucket;
-            pl.at_vertex.assign(tempV.size(), {});
-            for (int i = 0; i < int(bucket.size()); ++i) {
-                pl.at_vertex[bucket[i][0]].push_back(i);
-                pl.at_vertex[bucket[i][1]].push_back(i);
-            }
-            m_tag_polyline[tag] = std::move(pl);
-        }
-
-        // The base's pointer survives as the union of the members -- inside any tube -- because
-        // the shared engine's direct uses of it ask exactly that question. Everything else
-        // dispatches per simplex through envelope_for_mask().
-        m_envelope = std::make_shared<UnionEnvelope>(std::move(members));
-        logger().info(
-            "\tPer-tag boundary envelopes: {} segments total (tag boundaries + domain wall), "
-            "eps {:.6g}, {} |{}",
-            n_edges_tracked,
-            m_envelope_eps,
-            (std::isfinite(m_envelope_eps) && m_envelope_eps > 0.) ? "EXACT"
-                                                                   : "sampled (no valid eps)",
-            per_tag_log);
-    }
+    if (n_edges_tracked > 0) build_boundary_envelopes("load", EnvelopeSetup::PerTag);
 
     // track bounding box. box_min/box_max are only set by Parameters::init(), which a mesh built
     // from a default-constructed Parameters never calls -- skip rather than index out of bounds.
@@ -301,6 +206,135 @@ void TopoOffsetTriMesh::init_surfaces_and_boundaries()
     }
 }
 
+
+std::string TopoOffsetTriMesh::envelope_key_name(const int64_t tag) const
+{
+    if (tag == m_wall_tag) return "wall";
+    if (tag == m_complex_tag) return "input_complex";
+    const auto it = m_tag_id_to_name.find(tag);
+    return it == m_tag_id_to_name.end() ? fmt::format("tag#{}", tag) : it->second;
+}
+
+bool TopoOffsetTriMesh::edge_is_complex_boundary(const Tuple& e) const
+{
+    const bool a = m_face_extra[e.fid(*this)].label == 1;
+    const std::optional<Tuple> opp = e.switch_face(*this);
+    const bool b = opp ? (m_face_extra[opp->fid(*this)].label == 1) : false;
+    if (a != b) return true; // a face of the complex on exactly one side
+    if (a && b) return false; // interior to the complex
+    // No complex face on either side: the edge is itself a piece of the complex (a curve
+    // selection, or an edge the selection expression labelled), or it is not on it at all.
+    return m_edge_extra[e.eid(*this)].label == 1;
+}
+
+void TopoOffsetTriMesh::build_boundary_envelopes(const char* when, const EnvelopeSetup setup)
+{
+    m_envelope_eps = m_offset_params.envelope_size;
+
+    // Fresh: every mask from the tracked edges as they stand, nothing carried over.
+    for (const Tuple& v : get_vertices()) m_vertex_extra[v.vid(*this)].m_boundary_mask = 0;
+
+    std::map<int64_t, std::vector<Eigen::Vector2i>> buckets;
+    size_t n_tracked = 0, n_wall = 0, n_complex = 0, n_free = 0;
+    for (const Tuple& e : get_edges()) {
+        const size_t eid = e.eid(*this);
+        // Region-class tracked edges only: the front has its own tube.
+        if (!m_edge_attribute[eid].m_is_surface_fs || edge_is_offset(eid)) continue;
+        ++n_tracked;
+        const std::optional<Tuple> f_opp = e.switch_face(*this);
+        CellTag keys;
+        if (setup == EnvelopeSetup::WallComplex) {
+            if (!f_opp) {
+                keys.insert(m_wall_tag);
+                ++n_wall;
+            }
+            if (edge_is_complex_boundary(e)) {
+                keys.insert(m_complex_tag);
+                ++n_complex;
+            }
+            if (keys.empty()) ++n_free;
+        } else {
+            // Whose boundary this edge is. Interior edge: every tag on exactly one side (the
+            // symmetric difference; a tag present on both sides has no boundary here). Wall
+            // edge: every tag of its one face, which is how ambient's tube comes to hold the
+            // box. The curve group's edges are in its tube too.
+            if (m_edge_extra[eid].on_curve) keys.insert(m_curve_tag);
+            if (f_opp) {
+                const auto& tag0 = m_face_attribute[e.fid(*this)].tags;
+                const auto& tag1 = m_face_attribute[f_opp->fid(*this)].tags;
+                std::set_symmetric_difference(
+                    tag0.begin(),
+                    tag0.end(),
+                    tag1.begin(),
+                    tag1.end(),
+                    std::inserter(keys, keys.begin()));
+            } else {
+                keys = m_face_attribute[e.fid(*this)].tags;
+                ++n_wall;
+            }
+            // The band's output tags are not region boundaries: the front is the offset tube's.
+            for (const int64_t t : m_offset_output_tag_ids) keys.erase(t);
+        }
+        const size_t v1 = e.vid(*this);
+        const size_t v2 = e.switch_vertex(*this).vid(*this);
+        const uint64_t bits = tag_bits(keys);
+        for (const size_t v : {v1, v2}) m_vertex_extra[v].m_boundary_mask |= bits;
+        for (const int64_t t : keys) buckets[t].emplace_back(int(v1), int(v2));
+    }
+
+    std::vector<Eigen::Vector2d> tempV(vert_capacity());
+    for (size_t i = 0; i < vert_capacity(); ++i) tempV[i] = m_vertex_attribute[i].m_posf;
+
+    m_tag_envelopes.clear();
+    m_tag_polyline.clear();
+    m_env_polyline_V = tempV;
+    {
+        std::lock_guard<std::mutex> lock(m_isect_mutex);
+        m_isect_cache.clear();
+        m_offset_isect_cache.clear();
+    }
+    const bool exact_ok = std::isfinite(m_envelope_eps) && m_envelope_eps > 0.;
+    std::vector<std::shared_ptr<SampleEnvelope>> members;
+    std::string per_tag_log;
+    for (const auto& [tag, bucket] : buckets) {
+        if (bucket.empty()) continue;
+        auto env = std::make_shared<SampleEnvelope>(/*exact=*/exact_ok);
+        env->init(tempV, bucket, m_envelope_eps);
+        m_tag_envelopes[tag] = env;
+        members.push_back(env);
+        per_tag_log += fmt::format(" {}:{}", envelope_key_name(tag), bucket.size());
+
+        TagPolyline2d pl;
+        pl.E = bucket;
+        pl.at_vertex.assign(tempV.size(), {});
+        for (int i = 0; i < int(bucket.size()); ++i) {
+            pl.at_vertex[bucket[i][0]].push_back(i);
+            pl.at_vertex[bucket[i][1]].push_back(i);
+        }
+        m_tag_polyline[tag] = std::move(pl);
+    }
+    // The base's pointer survives as the union of the members -- inside any tube -- because
+    // the shared engine's direct uses of it ask exactly that question. Everything else
+    // dispatches per simplex through envelope_for_mask().
+    m_envelope = members.empty() ? nullptr : std::make_shared<UnionEnvelope>(std::move(members));
+
+    logger().info(
+        "\t[envelopes @ {}] {}: {} region-boundary segments tracked ({} on the wall), eps {:.6g}, "
+        "{} |{}{}",
+        when,
+        setup == EnvelopeSetup::WallComplex ? "wall + input complex" : "per tag",
+        n_tracked,
+        n_wall,
+        m_envelope_eps,
+        exact_ok ? "EXACT" : "sampled (no valid eps)",
+        per_tag_log,
+        setup == EnvelopeSetup::WallComplex
+            ? fmt::format(
+                  " | {} on the input complex boundary, {} held by nothing (plastic)",
+                  n_complex,
+                  n_free)
+            : std::string());
+}
 
 void TopoOffsetTriMesh::mark_input_complex_vertices()
 {

--- a/components/topological_offset/wmtk/components/topological_offset/TopoOffsetTriMesh.h
+++ b/components/topological_offset/wmtk/components/topological_offset/TopoOffsetTriMesh.h
@@ -417,28 +417,41 @@ public:
     bool m_freeze_front = false;
 
     /**
-     * @brief The final pass's containers, built ONCE when that pass starts and held unchanged
-     * until it ends.
+     * @brief Which boundaries the region-class envelopes hold, and how they are built.
      *
-     * m_final_pass_envelope is one exact tube, of the per-tag tubes' half-width m_envelope_eps,
-     * around every region-boundary segment as it stands at that moment: tag boundaries whether
-     * held or released by deform_others, and the domain wall. m_offset_envelope, rebuilt once
-     * just before, holds the front. m_final_pass_junction is their intersection, for a segment
-     * that is on both. While m_final_pass_envelope is non-null every containment query answers
-     * from these and nothing else -- surface_envelope_for_edge() for the operations,
-     * smoothing_energy_envelope() and smoothing_containment_envelope() for the smoother -- so
-     * the whole pass is TriWild against one fixed set of envelopes: no per-tag intersection
-     * built from the input, no released tube rebuilt behind the pass's back, no vertex left
-     * free because its mask was cleared. rest_energy_for_vertex() is null for the same span,
-     * so the pass minimises equilateral AMIPS alone. See begin_final_pass_envelope().
+     * PerTag (deform_others false): one exact tube per input tag around that tag's boundary
+     * segments, the domain wall in the tags of its wall faces. A vertex carries the bit of every
+     * tube it lies on and is contained in their intersection, so every region boundary -- the
+     * input complex and the wall included -- is held.
+     *
+     * WallComplex (deform_others true): exactly two tubes, the domain wall and the boundary of
+     * the input complex (any dimension, any manifoldness: it is a set of segments), under the
+     * pseudo-tags m_wall_tag / m_complex_tag. Every other region boundary carries no bit and is
+     * held by nothing; the medium around it is plastic, see face_is_plastic().
+     *
+     * Either way build_boundary_envelopes() derives the masks and tubes from the mesh as it
+     * stands when called: at load (PerTag, before the complex is labelled), when deform_others
+     * switches the setup at construction, and fresh at the start of the final pass. The offset
+     * tube is separate and unchanged.
      */
-    std::shared_ptr<SampleEnvelope> m_final_pass_envelope;
-    std::shared_ptr<SampleEnvelope> m_final_pass_junction;
-    /// Rebuild the offset tube, build m_final_pass_envelope from the current region-boundary
-    /// segments, log both. Called once, at the start of the final pass.
-    void begin_final_pass_envelope();
-    /// Drop both; the dispatch falls back to the per-tag machinery. Called once, at its end.
-    void end_final_pass_envelope();
+    enum class EnvelopeSetup { PerTag, WallComplex };
+    EnvelopeSetup envelope_setup() const
+    {
+        return m_offset_params.deform_others ? EnvelopeSetup::WallComplex : EnvelopeSetup::PerTag;
+    }
+    static constexpr int64_t m_wall_tag = -2; ///< pseudo-tag: the domain wall's tube
+    static constexpr int64_t m_complex_tag = -3; ///< pseudo-tag: the input complex boundary
+    /// The name a tag or pseudo-tag prints under.
+    std::string envelope_key_name(int64_t tag) const;
+    /// Whether this edge lies on the boundary of the input complex: exactly one incident face
+    /// carries label 1, or the edge itself does while neither face does (a curve or edge piece).
+    bool edge_is_complex_boundary(const Tuple& e) const;
+    /// Rebuild every region-class tube and every vertex's boundary mask from the current mesh
+    /// under `setup`. PerTag at load (the complex is not labelled yet, and the pre-optimize pass
+    /// holds every tag boundary as it always did), WallComplex when deform_others switches it at
+    /// construction, envelope_setup() fresh at the final pass. The tracked-edge flags are left
+    /// alone: they are the topology the operations maintain. `when` labels the log line.
+    void build_boundary_envelopes(const char* when, EnvelopeSetup setup);
 
     // No Phi test gates collapse and swap: the envelope is the constraint, and the offset
     // criterion belongs to Phase B's own placement. The coarsening bar is applied where 3D
@@ -689,7 +702,14 @@ public:
     mutable char m_debug_last_phase = '?';
     /// See offset_gradient_tolerance(). Nothing sets it on the single-phase path; it stays 0.
     double m_gradient_reference = 0.;
+    /// The run's verdict: the front placed AND the final quality under stop_energy. Read by the
+    /// report and by throw_on_nonconvergence.
     bool m_converged = false;
+    /// The finishing-pass half of the verdict: max AMIPS < stop_energy once the front is placed,
+    /// after the final pass when one ran. True when no pass was needed; false when the pass ended
+    /// still over. m_quality_max_amips is the value it was judged on.
+    bool m_quality_converged = true;
+    double m_quality_max_amips = 0.;
 
     /// Churn: split-born vertices that a collapse later removed, and the subset removed in the
     /// same pass-pair that created them.
@@ -1153,17 +1173,6 @@ public:
                 }
             }
         }
-        // The final pass: two fixed tubes and nothing else, see m_final_pass_envelope. The front
-        // (both ends on the offset, no region bit left after the class check above) is held by
-        // the offset tube; every other tracked segment is a region boundary -- held or released,
-        // masked or not -- and is held by the pass-wide region tube; a segment on both is held in
-        // their intersection. Only tracked segments are ever asked about, so there is no third
-        // kind here.
-        if (m_final_pass_envelope) {
-            if (all_offset && mask == 0) return m_offset_envelope;
-            if (!all_offset) return m_final_pass_envelope;
-            return m_final_pass_junction;
-        }
         // Both families compose: whatever holds this segment holds it at once. Phase A holds the
         // offset where Phase B left it; Phase B is what moves it, so it contributes nothing there
         // -- and null before the offset exists at all, which is the pre-pass.
@@ -1213,13 +1222,6 @@ public:
      */
     std::shared_ptr<SampleEnvelope> smoothing_energy_envelope(const size_t vid) const override
     {
-        // The final pass: a region-boundary vertex is pulled to the pass-wide region tube, a real
-        // SampleEnvelope, whatever its mask says (a released boundary's mask was cleared). A
-        // front vertex is frozen there and never reaches the smoother. See
-        // m_final_pass_envelope.
-        if (m_final_pass_envelope) {
-            return vertex_is_on_region(vid) ? m_final_pass_envelope : nullptr;
-        }
         if (m_vertex_extra[vid].m_is_on_offset && !vertex_is_on_region(vid)) {
             return nullptr;
         }
@@ -1268,17 +1270,6 @@ public:
         // out of one expression: pure-offset (mask 0) gives the offset tube in Phase A and null in
         // Phase B, pure-region gives its tubes' intersection in both, and a junction of the two
         // gives the intersection of everything.
-        //
-        // The final pass: the pass-wide region tube for every region-boundary vertex, the
-        // offset tube for a front vertex (frozen, so only diagnostics ask), their intersection
-        // for a vertex on both. See m_final_pass_envelope.
-        if (m_final_pass_envelope) {
-            const bool region = vertex_is_on_region(vid);
-            const bool offset = m_vertex_extra[vid].m_is_on_offset;
-            if (region && offset) return m_final_pass_junction;
-            if (region) return m_final_pass_envelope;
-            return offset ? m_offset_envelope : nullptr;
-        }
         return containment_for(vertex_boundary_mask(vid), m_vertex_extra[vid].m_is_on_offset);
     }
 
@@ -1358,8 +1349,7 @@ public:
     /// Whether this edge lies on a released region's boundary, by the incident faces' current
     /// tag symmetric difference -- the same test the release freed vertices by.
     bool edge_borders_released_boundary(const Tuple& e) const;
-    /// A face deforms when it is background (label 0), tagged, and every tag it carries was
-    /// released -- a face shared with a held region must not deform freely.
+    /// Under deform_others the same set as face_is_plastic(): every face outside the band.
     bool face_is_deformable(size_t fid) const;
     /// Plastic medium: under deform_others every background face -- ambient and the other objects
     /// alike -- is plastic, its rest shape re-stamped before every operation group, so smoothing
@@ -1369,9 +1359,9 @@ public:
     bool m_plastic_active = false; ///< set in optimize_offset() when deform_others
     bool face_is_plastic(size_t fid) const
     {
-        // Every background face, objects included: one material for the medium and the objects.
-        // Do not re-add the exclusion for released objects; measured no better -- see git history.
-        return m_plastic_active && m_face_extra[fid].label == 0;
+        // Everything outside the band: ambient, the other objects and the input complex's
+        // interior alike -- one material. The complex's boundary is what its tube holds.
+        return m_plastic_active && m_face_extra[fid].label != 2;
     }
     /// Stamp rest := current for every plastic face; called before every operation group.
     void stamp_plastic_rests();

--- a/components/topological_offset/wmtk/components/topological_offset/TopoOffsetTriMesh.h
+++ b/components/topological_offset/wmtk/components/topological_offset/TopoOffsetTriMesh.h
@@ -416,6 +416,30 @@ public:
     /// The final Phase A: front vertices are not smoothed (see smooth_before()).
     bool m_freeze_front = false;
 
+    /**
+     * @brief The final pass's containers, built ONCE when that pass starts and held unchanged
+     * until it ends.
+     *
+     * m_final_pass_envelope is one exact tube, of the per-tag tubes' half-width m_envelope_eps,
+     * around every region-boundary segment as it stands at that moment: tag boundaries whether
+     * held or released by deform_others, and the domain wall. m_offset_envelope, rebuilt once
+     * just before, holds the front. m_final_pass_junction is their intersection, for a segment
+     * that is on both. While m_final_pass_envelope is non-null every containment query answers
+     * from these and nothing else -- surface_envelope_for_edge() for the operations,
+     * smoothing_energy_envelope() and smoothing_containment_envelope() for the smoother -- so
+     * the whole pass is TriWild against one fixed set of envelopes: no per-tag intersection
+     * built from the input, no released tube rebuilt behind the pass's back, no vertex left
+     * free because its mask was cleared. rest_energy_for_vertex() is null for the same span,
+     * so the pass minimises equilateral AMIPS alone. See begin_final_pass_envelope().
+     */
+    std::shared_ptr<SampleEnvelope> m_final_pass_envelope;
+    std::shared_ptr<SampleEnvelope> m_final_pass_junction;
+    /// Rebuild the offset tube, build m_final_pass_envelope from the current region-boundary
+    /// segments, log both. Called once, at the start of the final pass.
+    void begin_final_pass_envelope();
+    /// Drop both; the dispatch falls back to the per-tag machinery. Called once, at its end.
+    void end_final_pass_envelope();
+
     // No Phi test gates collapse and swap: the envelope is the constraint, and the offset
     // criterion belongs to Phase B's own placement. The coarsening bar is applied where 3D
     // applies it -- absolute, and only in m_coarsen_mode.
@@ -1129,6 +1153,17 @@ public:
                 }
             }
         }
+        // The final pass: two fixed tubes and nothing else, see m_final_pass_envelope. The front
+        // (both ends on the offset, no region bit left after the class check above) is held by
+        // the offset tube; every other tracked segment is a region boundary -- held or released,
+        // masked or not -- and is held by the pass-wide region tube; a segment on both is held in
+        // their intersection. Only tracked segments are ever asked about, so there is no third
+        // kind here.
+        if (m_final_pass_envelope) {
+            if (all_offset && mask == 0) return m_offset_envelope;
+            if (!all_offset) return m_final_pass_envelope;
+            return m_final_pass_junction;
+        }
         // Both families compose: whatever holds this segment holds it at once. Phase A holds the
         // offset where Phase B left it; Phase B is what moves it, so it contributes nothing there
         // -- and null before the offset exists at all, which is the pre-pass.
@@ -1178,6 +1213,13 @@ public:
      */
     std::shared_ptr<SampleEnvelope> smoothing_energy_envelope(const size_t vid) const override
     {
+        // The final pass: a region-boundary vertex is pulled to the pass-wide region tube, a real
+        // SampleEnvelope, whatever its mask says (a released boundary's mask was cleared). A
+        // front vertex is frozen there and never reaches the smoother. See
+        // m_final_pass_envelope.
+        if (m_final_pass_envelope) {
+            return vertex_is_on_region(vid) ? m_final_pass_envelope : nullptr;
+        }
         if (m_vertex_extra[vid].m_is_on_offset && !vertex_is_on_region(vid)) {
             return nullptr;
         }
@@ -1226,6 +1268,17 @@ public:
         // out of one expression: pure-offset (mask 0) gives the offset tube in Phase A and null in
         // Phase B, pure-region gives its tubes' intersection in both, and a junction of the two
         // gives the intersection of everything.
+        //
+        // The final pass: the pass-wide region tube for every region-boundary vertex, the
+        // offset tube for a front vertex (frozen, so only diagnostics ask), their intersection
+        // for a vertex on both. See m_final_pass_envelope.
+        if (m_final_pass_envelope) {
+            const bool region = vertex_is_on_region(vid);
+            const bool offset = m_vertex_extra[vid].m_is_on_offset;
+            if (region && offset) return m_final_pass_junction;
+            if (region) return m_final_pass_envelope;
+            return offset ? m_offset_envelope : nullptr;
+        }
         return containment_for(vertex_boundary_mask(vid), m_vertex_extra[vid].m_is_on_offset);
     }
 

--- a/components/topological_offset/wmtk/components/topological_offset/scripts/visualize_offset.py
+++ b/components/topological_offset/wmtk/components/topological_offset/scripts/visualize_offset.py
@@ -85,6 +85,10 @@ TAG_COLORS = [((0.45, 0.16, 0.62), "purple"), ((0.55, 0.27, 0.07), "brown"),
 # The C++ sentinel for "degenerate, do not trust the number" -- wmtk::TriOptimizerMesh::MAX_ENERGY.
 MAX_ENERGY = 1e50
 
+# Per-cell scalars the .vtu writers emit next to the 0/1 tag fields; never memberships, so
+# read_groups_vtu() must not turn them into groups (see there).
+NON_GROUP_CELL_FIELDS = {"amips"}
+
 
 def eval_selection(expr, names):
     """The offset_selection boolean expression, on one cell's group memberships.
@@ -149,16 +153,28 @@ def read_groups_vtu(path):
     differently: write_vtu() emits one CELL FIELD per tag (1 where the cell carries it) plus
     `offset_tag`, which is 1 on the band and is derived from the construction LABEL rather than
     from the tags -- so it is the reliable band marker even where a tag was written elsewhere.
+
+    Only 0/1 INDICATOR fields are groups. The 2D writer also emits the per-cell scalar `amips`,
+    which is not a membership, and reading it as a group drew phantom regions: on the
+    pre-optimize frames only the faces a pass had touched carry a quality yet, so `amips`
+    selected a scattered subset of cells, which then showed up as a "tag boundary: amips" curve
+    and as region-boundary loops around every touched patch, and shifted every real tag's color
+    by one. Skipped by name (NON_GROUP_CELL_FIELDS), and any other cell field that is not
+    exactly 0/1 is skipped too.
     """
     m = meshio.read(str(path))
     kind, ncol = ("tetra", 4) if any(c.type == "tetra" for c in m.cells) else ("triangle", 3)
     cells = np.vstack([c.data for c in m.cells if c.type == kind])
     groups = {}
     for name, arrays in m.cell_data.items():
+        if name in NON_GROUP_CELL_FIELDS:
+            continue
         vals = np.concatenate([
             np.asarray(a).reshape(-1)
             for a, c in zip(arrays, m.cells) if c.type == kind
         ])
+        if not np.all((vals == 0.0) | (vals == 1.0)):
+            continue  # a per-cell scalar, not a membership
         sel = cells[vals > 0.5]
         if len(sel):
             groups[name] = sel


### PR DESCRIPTION

- Final TriWild pass: one exact tube around every region boundary, built once at pass start and used for the whole pass (plus the offset tube; an intersection at junctions). Rest-shape terms are off during the pass, so it minimises equilateral AMIPS only. Plasticity is suspended for the pass.
- Pre-optimize sizing seed: wall edges are no longer taken as complex boundary. With offset_in the whole background is label 1 and the missing opposite face made every wall edge look like a complex edge, seeding the entire domain boundary at target_distance. A wall vertex is now seeded only where a complex boundary reaches the wall.
- visualize_offset.py: the amips cell field is no longer read as a region membership (it produced phantom boundary curves in the viewer).
- data2 pin -> 1a130a3: the 2D dragon fixture moves to target_distance_rel 1e-3.